### PR TITLE
docs(worker-events): document Codex notification envelope matrix (Refs #592)

### DIFF
--- a/.grok/memory-handoffs/2026-08-10-pr-862-terra-recorder-matrix-repair.md
+++ b/.grok/memory-handoffs/2026-08-10-pr-862-terra-recorder-matrix-repair.md
@@ -1,0 +1,41 @@
+# Memory Handoff
+
+## Type
+
+project-context
+
+## Title
+
+PR #862 Terra recorder-to-matrix contract repair
+
+## Summary
+
+Repair docs and add a recorder-to-matrix contract regression so #862 no longer implies a closed raw-capture allowlist for Codex app-server notifications.
+
+## Durable facts
+
+- codex_appserver forwards every non-delta notification; aboyeur records raw; deltas are salvage-only
+- classification_matrix methods are scrub/export only; unknown methods remain unclassified and fail scrub/export
+- docs/worker-event-streams.md now has Raw capture vs scrub matrix; section retitled Methods classified for scrubbed projection
+
+## Evidence
+
+- files changed: docs/worker-event-streams.md, src/brigade/worker_events.py, tests/test_worker_events.py, CHANGELOG.md
+- commands run: brigade work verify run 20260810-221823-work-verify-1ff7bb; ./scripts/verify
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/FEATURE_REQUESTS.md
+
+## Suggested document content
+
+### Terra repair on PR 862
+
+Document that raw Codex app-server capture is open-ended for non-delta
+methods while the classification matrix remains the closed scrub/export
+contract. Unknown methods stay local/unclassified and are rejected from
+scrub/export. Recorder behavior was intentionally not narrowed.

--- a/.grok/memory-handoffs/2026-08-10-worker-event-streams-592-closeout.md
+++ b/.grok/memory-handoffs/2026-08-10-worker-event-streams-592-closeout.md
@@ -1,0 +1,42 @@
+# Memory Handoff
+
+## Type
+
+project-context
+
+## Title
+
+Worker event streams #592 first-slice closeout
+
+## Summary
+
+Close out #592 by documenting the full Codex app-server item-type classification matrix and adding adversarial golden fixtures for every matrix item type on top of the existing fail-closed scrubber.
+
+## Durable facts
+
+- Module brigade.worker_events already enforced fail-closed scrubbing for turn/started|completed and item/started|completed plus requestApproval#auto-declined
+- docs/worker-event-streams.md now tables every matrix item type and maps #592 acceptance criteria to enforcement points
+- Golden fixture worker-events-appserver.v1.golden.json includes item_completed_<type>_adversarial cases for all 14 item types
+- First slice still excludes legacy backfill and export/archive scrubbed-sidecar wiring
+
+## Evidence
+
+- files changed: docs/worker-event-streams.md, src/brigade/fixtures/worker-events-appserver.v1.golden.json, tests/test_worker_events.py, CHANGELOG.md
+- commands run: brigade code impact scrub_event; brigade work verify run (ruff+pytest worker_events); ./scripts/verify
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/FEATURE_REQUESTS.md
+
+## Suggested document content
+
+### Closeout
+
+Issue #592 first slice was already library-complete on main via #823; this
+closeout expands the documented item-type matrix, adds adversarial golden
+cases for every matrix item type, and opens a PR that closes the still-open
+issue. Legacy backfill and export/archive sidecar wiring remain out of scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,13 +150,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Task Scheduler equivalents instead of silently no-oping; tampered blocks are
   reported and not clobbered without `--adopt`.
 - Worker event stream field classification and fail-closed scrubbed projections
-  for the Codex app-server transport (#592): closed classification matrix
-  (documented for every recorded method and item type), scrubber with
-  adversarial golden fixtures per matrix item type, distinct raw/scrubbed media
-  types and artifact classes, and audit/replay rejection of raw streams unless
-  an explicit local-only policy allows salvage. Legacy raw streams stay locally
-  inspectable and marked unclassified until scrubbed. First slice keeps legacy
-  backfill and export/archive sidecar wiring out.
+  for the Codex app-server transport (#592): closed scrub/export classification
+  matrix (documented for every known method and item type; raw non-delta capture
+  remains open-ended and is not a recorder allowlist), scrubber with adversarial
+  golden fixtures per matrix item type, distinct raw/scrubbed media types and
+  artifact classes, and audit/replay rejection of raw streams unless an explicit
+  local-only policy allows salvage. Legacy raw streams stay locally inspectable
+  and marked unclassified until scrubbed. First slice keeps legacy backfill and
+  export/archive sidecar wiring out.
 - Work verify plan ranks candidate verification commands from GraphTrail
   affected-test impact (#486): `brigade work verify plan` attaches
   `graph_impact` / `ranked_candidates` with hop-distance confidence and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,11 +150,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Task Scheduler equivalents instead of silently no-oping; tampered blocks are
   reported and not clobbered without `--adopt`.
 - Worker event stream field classification and fail-closed scrubbed projections
-  for the Codex app-server transport (#592): closed classification matrix,
-  scrubber with adversarial golden fixtures, distinct raw/scrubbed media types
-  and artifact classes, and audit/replay rejection of raw streams unless an
-  explicit local-only policy allows salvage. Legacy raw streams stay locally
-  inspectable and marked unclassified until scrubbed.
+  for the Codex app-server transport (#592): closed classification matrix
+  (documented for every recorded method and item type), scrubber with
+  adversarial golden fixtures per matrix item type, distinct raw/scrubbed media
+  types and artifact classes, and audit/replay rejection of raw streams unless
+  an explicit local-only policy allows salvage. Legacy raw streams stay locally
+  inspectable and marked unclassified until scrubbed. First slice keeps legacy
+  backfill and export/archive sidecar wiring out.
 - Work verify plan ranks candidate verification commands from GraphTrail
   affected-test impact (#486): `brigade work verify plan` attaches
   `graph_impact` / `ranked_candidates` with hop-distance confidence and

--- a/docs/worker-event-streams.md
+++ b/docs/worker-event-streams.md
@@ -44,7 +44,9 @@ is the audit/replay gate.
 ## Field-classification matrix
 
 Source of truth: `worker_events.FIELD_CLASSIFICATION_MATRIX` /
-`worker_events.classification_matrix()`.
+`worker_events.classification_matrix()`. The tables below document that closed
+matrix for the Codex app-server notification envelope currently recorded by
+Brigade.
 
 ### Envelope
 
@@ -71,12 +73,47 @@ Delta methods (`item/*/delta`, …) are never recorded by Brigade and are
 intentionally absent. Unknown methods or fields fail scrubbing with a bounded
 diagnostic.
 
+### Turn fields
+
+| Field | Class |
+| --- | --- |
+| `id` | public_metadata |
+| `status` | public_metadata |
+| `items` | public_metadata (each element via item-type matrix) |
+| `error` | prohibited |
+
 ### Item types
 
 Every supported item type keeps `id` and `type` as public metadata. Content
-fields (`text`, `content`, `command`, `cwd`, `changes`, `arguments`, `result`,
-`query`, `path`, `review`, `prompt`, …) are private or prohibited. See
-`classification_matrix()["item_types"]` for the closed per-type key set.
+fields are private or prohibited. Closed per-type key set:
+
+| Item type | Public fields | Stripped fields |
+| --- | --- | --- |
+| `userMessage` | `id`, `type`, `clientId` | `content` |
+| `agentMessage` | `id`, `type`, `phase` | `text` |
+| `plan` | `id`, `type` | `text` |
+| `reasoning` | `id`, `type` | `summary`, `content` |
+| `commandExecution` | `id`, `type`, `status`, `exitCode`, `durationMs` | `command`, `cwd`, `commandActions`, `aggregatedOutput` |
+| `fileChange` | `id`, `type`, `status` | `changes` |
+| `mcpToolCall` | `id`, `type`, `server`, `tool`, `status`, `pluginId` | `arguments`, `appContext`, `result`, `error`, `mcpAppResourceUri` |
+| `dynamicToolCall` | `id`, `type`, `tool`, `status`, `success`, `durationMs` | `arguments`, `contentItems` |
+| `collabToolCall` | `id`, `type`, `tool`, `status`, `senderThreadId`, `receiverThreadId`, `newThreadId`, `agentStatus` | `prompt` |
+| `webSearch` | `id`, `type` | `query`, `action` |
+| `imageView` | `id`, `type` | `path` |
+| `enteredReviewMode` | `id`, `type` | `review` |
+| `exitedReviewMode` | `id`, `type` | `review` |
+| `contextCompaction` | `id`, `type` | _(none)_ |
+
+### Global secret keys
+
+These keys are secret wherever they appear under `params` (including nested
+objects that would otherwise be public): `authorization`, `Authorization`,
+`cookie`, `Cookie`, `cookies`, `set-cookie`, `Set-Cookie`, `credentials`,
+`apiKey`, `api_key`, `token`, `accessToken`, `refreshToken`, `password`,
+`secret`, `env`, `environment`, `headers`.
+
+Absolute home paths travel in `cwd` / `path` / `grantRoot` and are classified
+`private_content`. Provider error bodies are `prohibited`.
 
 ## Schemas
 
@@ -85,6 +122,19 @@ fields (`text`, `content`, `command`, `cwd`, `changes`, `arguments`, `result`,
 
 Golden adversarial fixtures:
 `src/brigade/fixtures/worker-events-appserver.v1.golden.json`.
+
+## Acceptance mapping (#592 first slice)
+
+| Criterion | Enforcement |
+| --- | --- |
+| Documented matrix covers recorded Codex app-server events | this document + `classification_matrix()` |
+| Unknown types/fields fail closed with bounded diagnostics | `WorkerEventError` / `MAX_DIAGNOSTIC_LEN` |
+| Credentials, headers, cookies, env, prompts, private content, home paths, provider error bodies absent | scrub omit + `scrubbed_projection_omits_sensitive_material` + adversarial goldens |
+| Order, stable IDs, safe operation names, schema versions, source digests preserved | scrubbed stream document + golden stream case |
+| Distinct raw/scrubbed media types and artifact classes | `media_types()` / `artifact_classes()` |
+| Audit/replay reject raw unless `local-only` | `load_stream_for_consumer`, `run_audit.reject_raw_worker_stream_evidence` |
+| Adversarial goldens for the supported transport | fixture cases for every matrix item type |
+| Legacy streams inspectable and unclassified until scrubbed | `inspect_stream_file` |
 
 ## Non-goals (first slice)
 

--- a/docs/worker-event-streams.md
+++ b/docs/worker-event-streams.md
@@ -41,12 +41,26 @@ Library entry points live in `brigade.worker_events` (`scrub_event`,
 `require_consumer_policy`). `brigade.run_audit.reject_raw_worker_stream_evidence`
 is the audit/replay gate.
 
+## Raw capture vs scrub matrix
+
+Raw Codex app-server notification capture is intentionally open-ended for
+non-delta methods. `codex_appserver` forwards every non-delta notification to
+`on_event`, and the worker event writer appends that payload to
+`events/<worker>.jsonl`. Delta methods (`item/*/delta`, …) are consumed for
+salvage only and are never written.
+
+That recorder path is **not** a closed allowlist. Unknown non-delta methods may
+appear in the raw local stream. They remain local/`unclassified` until
+classified, and scrub/export consumers reject them fail-closed with a bounded
+diagnostic. The field-classification matrix below is the closed scrub/export
+contract for known methods and item types only; it must not be read as the set
+of methods the recorder is allowed to capture.
+
 ## Field-classification matrix
 
 Source of truth: `worker_events.FIELD_CLASSIFICATION_MATRIX` /
-`worker_events.classification_matrix()`. The tables below document that closed
-matrix for the Codex app-server notification envelope currently recorded by
-Brigade.
+`worker_events.classification_matrix()`. The tables below document the closed
+scrub/export matrix for known Codex app-server notification shapes.
 
 ### Envelope
 
@@ -56,7 +70,7 @@ Brigade.
 | `method` | public_metadata |
 | `params` | public_metadata (nested matrix below) |
 
-### Methods recorded by the app-server transport
+### Methods classified for scrubbed projection
 
 | Method | Public params | Stripped (private/secret/prohibited) |
 | --- | --- | --- |
@@ -66,12 +80,10 @@ Brigade.
 | `item/completed` | same as started, plus `completedAtMs` | same as started |
 | `item/commandExecution/requestApproval#auto-declined` | `threadId`, `turnId`, `itemId`, `availableDecisions` | `command`, `cwd`, `reason`, headers, cookies, env, credentials, prompts, grant roots |
 
-Only the recorded approval auto-decline method above is accepted. Other
-`*#auto-declined` bases fail closed.
-
-Delta methods (`item/*/delta`, …) are never recorded by Brigade and are
-intentionally absent. Unknown methods or fields fail scrubbing with a bounded
-diagnostic.
+Only the classified approval auto-decline method above is accepted by the
+scrubber. Other `*#auto-declined` bases fail closed. Unknown methods or fields
+likewise fail scrubbing with a bounded diagnostic and stay rejected from
+scrub/export.
 
 ### Turn fields
 
@@ -127,7 +139,8 @@ Golden adversarial fixtures:
 
 | Criterion | Enforcement |
 | --- | --- |
-| Documented matrix covers recorded Codex app-server events | this document + `classification_matrix()` |
+| Documented scrub matrix covers known Codex app-server methods/item types | this document + `classification_matrix()` |
+| Raw capture is open-ended for non-delta methods; matrix is not a recorder allowlist | docs + recorder-to-matrix contract test |
 | Unknown types/fields fail closed with bounded diagnostics | `WorkerEventError` / `MAX_DIAGNOSTIC_LEN` |
 | Credentials, headers, cookies, env, prompts, private content, home paths, provider error bodies absent | scrub omit + `scrubbed_projection_omits_sensitive_material` + adversarial goldens |
 | Order, stable IDs, safe operation names, schema versions, source digests preserved | scrubbed stream document + golden stream case |

--- a/src/brigade/fixtures/worker-events-appserver.v1.golden.json
+++ b/src/brigade/fixtures/worker-events-appserver.v1.golden.json
@@ -211,6 +211,586 @@
       "source_digest": "2e039f1e09b76ea65dccd2b08c1c09edb091c408d7c431d8936482d0309f272f"
     },
     {
+      "name": "item_completed_agentMessage_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "agentMessage-1",
+            "phase": "final_answer",
+            "text": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "agentMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "agentMessage-1",
+            "phase": "final_answer",
+            "type": "agentMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "3a5a67cd65ec66d6c6e2d45f712d0be9c0a46b07b3873ca89eae414f97d0fa65",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "3a5a67cd65ec66d6c6e2d45f712d0be9c0a46b07b3873ca89eae414f97d0fa65"
+    },
+    {
+      "name": "item_completed_collabToolCall_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "agentStatus": "safe-agentStatus",
+            "id": "collabToolCall-1",
+            "newThreadId": "safe-newThreadId",
+            "prompt": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "receiverThreadId": "safe-receiverThreadId",
+            "senderThreadId": "safe-senderThreadId",
+            "status": "completed",
+            "tool": "safe-tool",
+            "type": "collabToolCall"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "agentStatus": "safe-agentStatus",
+            "id": "collabToolCall-1",
+            "newThreadId": "safe-newThreadId",
+            "receiverThreadId": "safe-receiverThreadId",
+            "senderThreadId": "safe-senderThreadId",
+            "status": "completed",
+            "tool": "safe-tool",
+            "type": "collabToolCall"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "bb3ac89ced7f9d3cd9d324c5cf56fe5fe5928ad11491501727dc8ac424236449",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "bb3ac89ced7f9d3cd9d324c5cf56fe5fe5928ad11491501727dc8ac424236449"
+    },
+    {
+      "name": "item_completed_commandExecution_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "aggregatedOutput": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "command": "curl https://example.invalid -H 'Authorization: Bearer sk-live-EXAMPLESECRETVALUE99'",
+            "commandActions": {
+              "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+              "path": "/home/example-user/project",
+              "secret": "sk-live-EXAMPLESECRETVALUE99"
+            },
+            "cwd": "/home/example-user/project",
+            "durationMs": 12,
+            "exitCode": 0,
+            "id": "commandExecution-1",
+            "status": "completed",
+            "type": "commandExecution"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "durationMs": 12,
+            "exitCode": 0,
+            "id": "commandExecution-1",
+            "status": "completed",
+            "type": "commandExecution"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "7b440e4d12693dd3bb0088f8def70069687962fc343963a02d0dbbb4bbbfdfac",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "7b440e4d12693dd3bb0088f8def70069687962fc343963a02d0dbbb4bbbfdfac"
+    },
+    {
+      "name": "item_completed_contextCompaction_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "contextCompaction-1",
+            "type": "contextCompaction"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "contextCompaction-1",
+            "type": "contextCompaction"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "bc6dec2a5b9fba4250726478598be2e29ba1f218f0ff74735fcf94369c8aa039",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "bc6dec2a5b9fba4250726478598be2e29ba1f218f0ff74735fcf94369c8aa039"
+    },
+    {
+      "name": "item_completed_dynamicToolCall_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "arguments": {
+              "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+              "path": "/home/example-user/project",
+              "secret": "sk-live-EXAMPLESECRETVALUE99"
+            },
+            "contentItems": {
+              "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+              "path": "/home/example-user/project",
+              "secret": "sk-live-EXAMPLESECRETVALUE99"
+            },
+            "durationMs": 12,
+            "id": "dynamicToolCall-1",
+            "status": "completed",
+            "success": true,
+            "tool": "safe-tool",
+            "type": "dynamicToolCall"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "durationMs": 12,
+            "id": "dynamicToolCall-1",
+            "status": "completed",
+            "success": true,
+            "tool": "safe-tool",
+            "type": "dynamicToolCall"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "68d4d4e2b2c346f616b9d6150cc5bb5748f45199d4bfb6034dfac3d800a2e65a",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "68d4d4e2b2c346f616b9d6150cc5bb5748f45199d4bfb6034dfac3d800a2e65a"
+    },
+    {
+      "name": "item_completed_enteredReviewMode_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "enteredReviewMode-1",
+            "review": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "enteredReviewMode"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "enteredReviewMode-1",
+            "type": "enteredReviewMode"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "62b6796e93235e249345189e4a83d08abaae92087ca09f05291b9b07826ece3e",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "62b6796e93235e249345189e4a83d08abaae92087ca09f05291b9b07826ece3e"
+    },
+    {
+      "name": "item_completed_exitedReviewMode_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "exitedReviewMode-1",
+            "review": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "exitedReviewMode"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "exitedReviewMode-1",
+            "type": "exitedReviewMode"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "a883135a0dcd3fabdd85d2c3576716985381242b235b322416b0031c4a46a2c8",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "a883135a0dcd3fabdd85d2c3576716985381242b235b322416b0031c4a46a2c8"
+    },
+    {
+      "name": "item_completed_fileChange_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "changes": {
+              "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+              "path": "/home/example-user/project",
+              "secret": "sk-live-EXAMPLESECRETVALUE99"
+            },
+            "id": "fileChange-1",
+            "status": "completed",
+            "type": "fileChange"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "fileChange-1",
+            "status": "completed",
+            "type": "fileChange"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "9db5214db848d6421146dcd11d2afcfe1b2bddb500db8d1b83216fad26416346",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "9db5214db848d6421146dcd11d2afcfe1b2bddb500db8d1b83216fad26416346"
+    },
+    {
+      "name": "item_completed_imageView_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "imageView-1",
+            "path": "/home/example-user/project/.ssh/id_rsa",
+            "type": "imageView"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "imageView-1",
+            "type": "imageView"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "44139890ae435c09c9623451c25329041065dcde83a10473032d69a1d91c937b",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "44139890ae435c09c9623451c25329041065dcde83a10473032d69a1d91c937b"
+    },
+    {
+      "name": "item_completed_mcpToolCall_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "appContext": {
+              "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+              "path": "/home/example-user/project",
+              "secret": "sk-live-EXAMPLESECRETVALUE99"
+            },
+            "arguments": {
+              "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+              "path": "/home/example-user/project",
+              "secret": "sk-live-EXAMPLESECRETVALUE99"
+            },
+            "error": {
+              "body": "provider dump with Cookie: session=abc",
+              "message": "upstream 401 Authorization: Bearer sk-live-EXAMPLESECRETVALUE99"
+            },
+            "id": "mcpToolCall-1",
+            "mcpAppResourceUri": "/home/example-user/project",
+            "pluginId": "safe-pluginId",
+            "result": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "server": "safe-server",
+            "status": "completed",
+            "tool": "safe-tool",
+            "type": "mcpToolCall"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "mcpToolCall-1",
+            "pluginId": "safe-pluginId",
+            "server": "safe-server",
+            "status": "completed",
+            "tool": "safe-tool",
+            "type": "mcpToolCall"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "236022a2bf95fe15566a37e4c3e2352fa59ff6e0ab806f4ecb919706b260108d",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "236022a2bf95fe15566a37e4c3e2352fa59ff6e0ab806f4ecb919706b260108d"
+    },
+    {
+      "name": "item_completed_plan_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "plan-1",
+            "text": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "plan"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "plan-1",
+            "type": "plan"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "86f16834161141d84a3d80d7c844c0e9723a1daec7b435c91788ed8a19b4e860",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "86f16834161141d84a3d80d7c844c0e9723a1daec7b435c91788ed8a19b4e860"
+    },
+    {
+      "name": "item_completed_reasoning_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "content": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "id": "reasoning-1",
+            "summary": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "reasoning"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "reasoning-1",
+            "type": "reasoning"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "b901db23e7c7b25cc000c8c05047c0deb6952d5800e672145782bdb7ac1ae663",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "b901db23e7c7b25cc000c8c05047c0deb6952d5800e672145782bdb7ac1ae663"
+    },
+    {
+      "name": "item_completed_userMessage_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "clientId": "safe-clientId",
+            "content": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "id": "userMessage-1",
+            "type": "userMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "clientId": "safe-clientId",
+            "id": "userMessage-1",
+            "type": "userMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "947009e139c8978b49342fa14db30ea1537998bd85c2f97d82279cc0f8edd1f2",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "947009e139c8978b49342fa14db30ea1537998bd85c2f97d82279cc0f8edd1f2"
+    },
+    {
+      "name": "item_completed_webSearch_adversarial",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "action": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "id": "webSearch-1",
+            "query": "raw user prompt with private retrieved content token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "webSearch"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 42,
+          "item": {
+            "id": "webSearch-1",
+            "type": "webSearch"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "37be10e11f88d2dbd615ae060cfa6d0e746bb4f1b8640a497746a36f5abdf431",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "37be10e11f88d2dbd615ae060cfa6d0e746bb4f1b8640a497746a36f5abdf431"
+    },
+    {
       "expect_diagnostic_substring": null,
       "expect_error_category": "unknown-method",
       "name": "unknown_method_fails_closed",

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -304,11 +304,14 @@ FIELD_CLASSIFICATION_MATRIX: dict[str, Any] = {
     "item_types": {name: dict(fields) for name, fields in sorted(_ITEM_TYPE_FIELDS.items())},
     "global_secret_keys": dict(_GLOBAL_SECRET_KEYS),
     "notes": (
-        "Delta methods are never recorded by Brigade and are intentionally absent. "
-        "Unknown methods or fields fail closed. Only "
-        "item/commandExecution/requestApproval#auto-declined is accepted; other "
-        "*#auto-declined bases fail closed. Absolute home paths travel in cwd/path/"
-        "grantRoot and are classified private_content. Provider error bodies are prohibited."
+        "Raw Codex app-server capture is open-ended for non-delta notifications; "
+        "this matrix is the closed scrub/export contract, not a recorder allowlist. "
+        "Delta methods are never written to events/<worker>.jsonl and are intentionally "
+        "absent here. Unknown methods remain local/unclassified and fail scrub/export "
+        "closed. Only item/commandExecution/requestApproval#auto-declined is accepted; "
+        "other *#auto-declined bases fail closed. Absolute home paths travel in "
+        "cwd/path/grantRoot and are classified private_content. Provider error bodies "
+        "are prohibited."
     ),
 }
 

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -7,10 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from brigade import run_audit, worker_events
+from brigade import codex_appserver, run_audit, worker_events
 
 FIXTURES = Path(__file__).resolve().parents[1] / "src" / "brigade" / "fixtures"
 GOLDEN_PATH = FIXTURES / "worker-events-appserver.v1.golden.json"
+DOCS_PATH = Path(__file__).resolve().parents[1] / "docs" / "worker-event-streams.md"
 
 
 def _golden():
@@ -45,6 +46,47 @@ def test_classification_matrix_covers_recorded_app_server_methods():
         for classification in fields.values():
             assert classification in worker_events.FIELD_CLASSES
         assert item_type  # non-empty
+
+
+def test_recorder_to_matrix_contract_keeps_raw_capture_open_ended(tmp_path: Path):
+    """Matrix is a scrub allowlist only; raw non-delta capture stays open-ended."""
+    docs = " ".join(DOCS_PATH.read_text(encoding="utf-8").split())
+    assert "Raw capture vs scrub matrix" in docs
+    assert "intentionally open-ended for non-delta methods" in docs
+    assert "must not be read as the set of methods the recorder is allowed to capture" in docs
+    assert "Methods classified for scrubbed projection" in docs
+    assert "Methods recorded by the app-server transport" not in docs
+
+    matrix = worker_events.classification_matrix()
+    scrub_methods = set(matrix["methods"])
+    assert scrub_methods.isdisjoint(codex_appserver._DELTA_METHODS)
+    assert "totally/unknown" not in scrub_methods
+    assert "open-ended" in matrix["notes"]
+    assert "not a recorder allowlist" in matrix["notes"]
+
+    unknown = {
+        "jsonrpc": "2.0",
+        "method": "totally/unknown",
+        "params": {"threadId": "thread-demo-1", "mystery": True},
+    }
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    raw_path = events_dir / "coder.jsonl"
+    raw_path.write_text(json.dumps(unknown) + "\n", encoding="utf-8")
+
+    info = worker_events.inspect_stream_file(raw_path)
+    assert info.status == worker_events.STATUS_UNCLASSIFIED
+    assert info.artifact_class == worker_events.UNCLASSIFIED_ARTIFACT_CLASS
+
+    with pytest.raises(worker_events.WorkerEventError) as scrub_exc:
+        worker_events.scrub_event(unknown)
+    assert scrub_exc.value.category == "unknown-method"
+    assert len(scrub_exc.value.diagnostic) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+    with pytest.raises(worker_events.WorkerEventPolicyError):
+        worker_events.load_stream_for_consumer(raw_path, consumer="run_audit")
+    with pytest.raises(worker_events.WorkerEventPolicyError):
+        run_audit.reject_raw_worker_stream_evidence(tmp_path)
 
 
 def test_golden_covers_adversarial_case_for_every_matrix_item_type():

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -47,6 +47,19 @@ def test_classification_matrix_covers_recorded_app_server_methods():
         assert item_type  # non-empty
 
 
+def test_golden_covers_adversarial_case_for_every_matrix_item_type():
+    matrix = worker_events.classification_matrix()
+    covered = {
+        case["raw"]["params"]["item"]["type"]
+        for case in _golden()["cases"]
+        if case["name"].endswith("_adversarial")
+        and case["raw"].get("method") == "item/completed"
+        and isinstance(case["raw"].get("params"), dict)
+        and isinstance(case["raw"]["params"].get("item"), dict)
+    }
+    assert covered == set(matrix["item_types"])
+
+
 def test_golden_scrubbed_projections_match_and_omit_sensitive_material():
     for case in _golden()["cases"]:
         if "expect_error_category" in case:


### PR DESCRIPTION
## What and why

Issue #592 first slice (fail-closed Codex app-server worker-event classification/scrubbing) already landed on main via #823, but the issue stayed open. This closeout completes the documented field-classification matrix for every recorded item type, adds adversarial golden fixtures for all 14 matrix item types, and maps acceptance criteria to enforcement points so the issue can close cleanly.

Terra review on `aa354fa4` (comment 5246656635) blocked one docs/contract issue: the docs presented a closed recorded-method list while `codex_appserver` forwards every non-delta notification and the writer records it raw. Head `c54da6ea` repairs that without narrowing the recorder.

Refs #592

## Type of change

- [x] Docs
- [x] Tests / fixtures

## Terra repair (bounded)

- Document raw Codex notification capture as open-ended for non-delta methods.
- Document that unknown methods remain local/`unclassified` and are rejected from scrub/export.
- Add `test_recorder_to_matrix_contract_keeps_raw_capture_open_ended` so docs cannot imply a closed recorder allowlist.
- Preserve the 14 item-type matrix, adversarial fixtures, fail-closed scrubber, media/artifact classes, legacy behavior, and docs-only/runtime boundary. Recorder path unchanged.

## Acceptance mapping (#592 first slice)

- Documented scrub matrix covers known methods/item types (`docs/worker-event-streams.md` + `classification_matrix()`).
- Raw capture is open-ended for non-delta methods; matrix is scrub/export-only (docs + recorder-to-matrix contract test).
- Unknown methods/fields fail closed with bounded diagnostics.
- Credentials, headers, cookies, env values, raw prompts, private retrieved content, absolute home paths, and provider error bodies absent from scrubbed projections.
- Scrubbed projections preserve order, stable IDs, safe operation names, schema versions, and source digests.
- Distinct raw/scrubbed media types and artifact classes.
- Audit/replay reject raw unless `policy=local-only`.
- Legacy streams remain inspectable and unclassified until scrubbed.

## Out of scope

- Legacy backfill of historical streams
- Export/archive scrubbed-sidecar wiring
- Narrowing the working recorder allowlist
- Memory/provenance surfaces (#850/#851) and publish workflow (#750)

## Verification

Focused:

```console
$ brigade work verify run --target /workspace \
    --command "ruff check src/brigade/worker_events.py tests/test_worker_events.py" \
    --command "ruff format --check ..." \
    --command "python -m pytest tests/test_worker_events.py tests/test_codex_appserver.py::test_events_are_streamed_without_deltas -q --tb=short"
status: completed
run_id: 20260810-221823-work-verify-1ff7bb
```

Full gate:

```console
$ ./scripts/verify
6698 passed, 5 skipped, 68 subtests passed
Required test coverage of 78% reached. Total coverage: 83.10%
```

Exact head: `c54da6eaecbd10223d5e2555ee880c04e1bb6183`

## Checklist

- [x] `./scripts/verify` passes locally
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md`
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages (Cursor co-author trailer)

Export and archive enforcement remains tracked in #592; this documentation and fixture slice does not close it.