### PR TITLE
feat(run): enforce wall-clock and dispatch run budgets (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `load_error` / `load_warnings` text for missing path-based skill selectors.
 
 ### Fixed
+- Run budget declared-only contract (#593 / PR #864): document that hard
+  wall-clock / worker-dispatch ceilings apply only when a run carries
+  `run_budget` or `verification_contract.budget`; ordinary undeclared
+  `brigade run`, dogfood, and model-trial paths remain unbounded for
+  backward compatibility (no invented flags, defaults, or timeout→budget
+  mapping). Add undeclared-path regressions alongside the declared
+  enforcement test.
 - Run budget normal-run wiring (#593 / PR #864): persist declared
   verification-contract / run_budget through start and plan receipts so the
   coordinator enforces real wall-clock and dispatch ceilings; allocate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `load_error` / `load_warnings` text for missing path-based skill selectors.
 
 ### Fixed
+- Run budget restart reclaim (#593 / PR #864): evaluate the wall-clock ceiling
+  before reclaiming a durable pending dispatch can authorize external work, so
+  an expired run cannot relaunch attempt 1 after recovery.
 - Run budget declared-only contract (#593 / PR #864): document that hard
   wall-clock / worker-dispatch ceilings apply only when a run carries
   `run_budget` or `verification_contract.budget`; ordinary undeclared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `load_error` / `load_warnings` text for missing path-based skill selectors.
 
 ### Fixed
+- Run budget normal-run wiring (#593 / PR #864): persist declared
+  verification-contract / run_budget through start and plan receipts so the
+  coordinator enforces real wall-clock and dispatch ceilings; allocate
+  same-seat attempts inside the reservation lock so `worker_dispatch_count=1`
+  launches once; bridge optional `input_tokens` / `output_tokens` while keeping
+  aggregate `token_budget` distinct.
 - Run budget `token_budget` bridge (#593 / PR #864): preserve aggregate
   VerificationContract `token_budget` / receipt `tokens_used` semantics; do not
   map the legacy ceiling onto `observed.input_tokens`. Explicit `input_tokens` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `load_error` / `load_warnings` text for missing path-based skill selectors.
 
 ### Fixed
+- Run budget `token_budget` bridge (#593 / PR #864): preserve aggregate
+  VerificationContract `token_budget` / receipt `tokens_used` semantics; do not
+  map the legacy ceiling onto `observed.input_tokens`. Explicit `input_tokens` /
+  `output_tokens` remain separate observed dimensions.
 - Run budget dispatch reservations (#593 / PR #864): serialize parallel
   same-stage reservations under the coordinator lock; use stable
   `dispatch:{seat}:{attempt}` request identities with durable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `load_error` / `load_warnings` text for missing path-based skill selectors.
 
 ### Fixed
+- Run budget resume gate (#593 / PR #864): `brigade runs resume` evaluates the
+  persisted declaration, original `started_at`, and authoritative budget
+  lifecycle projection before `AppServer.start()`, refusing expired or
+  already-exhausted declared runs without provider or synthesis calls.
+  Undeclared and non-expired declared resumes keep existing recovery behavior.
 - Run budget restart reclaim (#593 / PR #864): evaluate the wall-clock ceiling
   before reclaiming a durable pending dispatch can authorize external work, so
   an expired run cannot relaunch attempt 1 after recovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `load_error` / `load_warnings` text for missing path-based skill selectors.
 
 ### Fixed
+- Run budget dispatch reservations (#593 / PR #864): serialize parallel
+  same-stage reservations under the coordinator lock; use stable
+  `dispatch:{seat}:{attempt}` request identities with durable
+  reservation→`run.dispatch.requested` ordering and restart-safe idempotency;
+  live Ctrl-C during dispatch terminalizes as `operator-cancelled` (not
+  infrastructure-neutral). Wall-clock, usage labels, compatibility diagnostics,
+  and #594 exclusion unchanged.
 - Claude harness readiness now fails when a global `core.excludesFile` rule
   such as `.claude/` hides the managed handoff `TEMPLATE.md`.
   `operator verify-harness --harness claude` returns `ready: no` with a nonzero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `brigade.run_event.v1` records and rejects raw JSON-RPC worker envelopes.
   Source runs remain unclassified until scrubbed; audit/replay still require
   `policy=local-only` for raw salvage.
+- Run budget enforcement first slice (#593): wall-clock and worker-dispatch
+  ceilings are reserved before new worker dispatch; durable
+  `run_budget.threshold_reached` / `reservation_denied` / `exhausted` /
+  `cancel_requested` / `cancelled` / `usage_reconciled` lifecycle events use
+  stable idempotency keys; restart-safe projection rebuilds remaining
+  allocation from the journal. Model/tool/token/cost stay observed unless an
+  adapter exposes an enforceable boundary. Budget exhaustion and operator
+  cancellation are terminal policy lifecycle states (`budget-exhausted` /
+  `operator-cancelled`), not #576 worker FailureClass values and not
+  infrastructure-neutral under #580. Child allocation remains #594.
 - Issue #846 R2 residual work-store characterization: extend the R1 harness
   with observed same-actor/guard/empty-filter, restart, schema coercion,
   backup/restore, install/cold-start/backup timing, resource, metrics-state,
@@ -98,8 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an independent verifier, failure/rollback path, and token/latency budget before
   execution (`brigade.verification_contract.v1`). Plan surfaces incompleteness;
   run refuses incomplete consequential templates. Receipts record `budget_use`
-  and `verification` separately from `model_completion`. Budget enforcement
-  remains #593.
+  and `verification` separately from `model_completion`. First-slice enforcement
+  of wall-clock and worker-dispatch ceilings lands in #593.
 - Optional dispatch annotations on work tasks (#815): `--seat-class`
   (`mechanical` | `judgment` | `review`) and `--spend-by` (ISO-8601 deadline)
   round-trip through `brigade work task add` / `brigade work task annotate` and

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -69,7 +69,7 @@ JSON Schema files.
 | `failure_class` | string | no | Receipt-level #474-style failure class when status is not completed |
 | `failure_kind` | string | no | Receipt-level failure kind paired with `failure_class` |
 | `verification_contract` | object | no | Declared `brigade.verification_contract.v1` when the verify manifest carried one (#500) |
-| `budget_use` | object | no | Observed latency/token use against the declared verification budget (#500; enforcement is #593) |
+| `budget_use` | object | no | Observed latency/token use against the declared verification budget (#500). Hard wall-clock / worker-dispatch enforcement is #593 (`run_budget.*` lifecycle events). |
 | `verification` | object | no | Verification outcome stamped separately from model completion (#500) |
 | `model_completion` | object | no | For contract-bearing verify receipts: `{status: not_applicable, detail}` because verify is verifier-owned |
 
@@ -86,7 +86,7 @@ explicit command and use `source: manifest_checks` (the manifest's own checks).
 | `schema_version` | integer | `1` |
 | `verifier` | object | `{source, command?\|argv?\|manifest_id?}` with `source` in `command`, `argv`, `manifest_id`, `manifest_checks` |
 | `rollback` | object | `{policy, command?}` with `policy` in `none`, `manual`, `command`, `git-restore` |
-| `budget` | object | `{latency_seconds, token_budget?}` — declaration only; #593 enforces ceilings |
+| `budget` | object | `{latency_seconds, token_budget?, wall_clock_seconds?, worker_dispatch_count?}` — #500 declaration; #593 enforces wall-clock and worker-dispatch ceilings before new work starts. `token_budget` stays observed unless an adapter exposes an enforceable reservation boundary. When `wall_clock_seconds` is unset, `latency_seconds` maps to the wall-clock ceiling. |
 
 **`budget_use` object**
 
@@ -348,6 +348,31 @@ original file is missing, corrupt, or not an object.
 | `journal_last_sequence` | integer | no | Last event sequence applied to this snapshot |
 | `journal_last_event_digest` | string / null | no | Digest at `journal_last_sequence`. Null only at sequence zero |
 | `approval_reference` | object | no | Redacted approval identity, source, fingerprints, and decision state |
+| `run_budget` | object | no | Optional projected `brigade.run_budget.v1` summary when a coordinator wrote one (#593). Journal events remain authoritative. |
+
+### Run budget lifecycle (`brigade.run_event.v1` event types, #593)
+
+Append-only facts under `events/lifecycle.jsonl`. Status-neutral in the run
+projector; the coordinator applies terminal policy via `run.failed` /
+`run.interrupted` (or receipt termination) using run-owned kinds
+`budget-exhausted` and `operator-cancelled`. These are **not** #576 worker
+`FailureClass` values and are **not** infrastructure-neutral under #580.
+
+| Event type | Payload keys | Notes |
+| --- | --- | --- |
+| `run_budget.threshold_reached` | `dimension`, `mode`, `declared`, `used`, `remaining`, `threshold_pct`, `reason_class` | Idempotent per dimension+threshold |
+| `run_budget.reservation_denied` | `dimension`, `mode`, `declared`, `used`, `remaining`, `request_id`, `reason_class` | Emitted before new work starts |
+| `run_budget.exhausted` | `dimension`, `mode`, `declared`, `used`, `remaining`, `reason_class` | Enforceable ceiling reached |
+| `run_budget.cancel_requested` | `request_id`, `reason_class`, `transport_capability`, `dimension` | Best-effort cancel request |
+| `run_budget.cancelled` | `request_id`, `reason_class`, `transport_capability`, `transport_result`, `active_remaining`, `dimension` | Cancel receipt; names work that could not be interrupted |
+| `run_budget.usage_reconciled` | `dimension`, `mode`, `usage_source`, `estimated_used`, `provider_used`, `used`, `request_id`, `reason_class` | Estimated and provider values stay distinct |
+
+Enforceable dimensions: `wall_clock_seconds`, `worker_dispatch_count`.
+Observed dimensions (never universal hard gates in this slice):
+`model_call_count`, `tool_call_count`, `input_tokens`, `output_tokens`,
+`estimated_cost_micros`, `provider_usage_units`. Child allocation is #594.
+Unknown schema versions or dimensions fail closed with a bounded diagnostic.
+Payloads never carry raw diagnostics.
 
 **Partial stale-recovery variant**
 

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -86,7 +86,7 @@ explicit command and use `source: manifest_checks` (the manifest's own checks).
 | `schema_version` | integer | `1` |
 | `verifier` | object | `{source, command?\|argv?\|manifest_id?}` with `source` in `command`, `argv`, `manifest_id`, `manifest_checks` |
 | `rollback` | object | `{policy, command?}` with `policy` in `none`, `manual`, `command`, `git-restore` |
-| `budget` | object | `{latency_seconds, token_budget?, wall_clock_seconds?, worker_dispatch_count?}` — #500 declaration; #593 enforces wall-clock and worker-dispatch ceilings before new work starts. Aggregate `token_budget` (receipt `tokens_used`) stays observed and is not reinterpreted as `input_tokens`; explicit input/output token caps use separate observed dimensions when declared. When `wall_clock_seconds` is unset, `latency_seconds` maps to the wall-clock ceiling. |
+| `budget` | object | `{latency_seconds, token_budget?, wall_clock_seconds?, worker_dispatch_count?, input_tokens?, output_tokens?}` — #500 declaration; #593 enforces wall-clock and worker-dispatch ceilings before new work starts. Aggregate `token_budget` (receipt `tokens_used`) stays observed and is not reinterpreted as `input_tokens`. Optional `input_tokens` / `output_tokens` declare explicit split observed caps. When `wall_clock_seconds` is unset, `latency_seconds` maps to the wall-clock ceiling. |
 
 **`budget_use` object**
 
@@ -94,8 +94,10 @@ explicit command and use `source: manifest_checks` (the manifest's own checks).
 | --- | --- | --- |
 | `latency_seconds_budget` | integer | Declared latency ceiling |
 | `latency_seconds_used` | number \| null | Observed wall time |
-| `token_budget` | integer \| null | Declared token ceiling when set |
-| `tokens_used` | integer \| null | Observed tokens when an adapter reports them |
+| `token_budget` | integer \| null | Declared aggregate token ceiling when set |
+| `tokens_used` | integer \| null | Observed aggregate tokens when an adapter reports them |
+| `input_tokens_budget` | integer | Declared input-token cap when set |
+| `output_tokens_budget` | integer | Declared output-token cap when set |
 | `exhausted` | boolean | Observation only; not an enforcement gate |
 
 **`subject_binding` object** (additive, manifest-selected runs)

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -86,7 +86,7 @@ explicit command and use `source: manifest_checks` (the manifest's own checks).
 | `schema_version` | integer | `1` |
 | `verifier` | object | `{source, command?\|argv?\|manifest_id?}` with `source` in `command`, `argv`, `manifest_id`, `manifest_checks` |
 | `rollback` | object | `{policy, command?}` with `policy` in `none`, `manual`, `command`, `git-restore` |
-| `budget` | object | `{latency_seconds, token_budget?, wall_clock_seconds?, worker_dispatch_count?}` — #500 declaration; #593 enforces wall-clock and worker-dispatch ceilings before new work starts. `token_budget` stays observed unless an adapter exposes an enforceable reservation boundary. When `wall_clock_seconds` is unset, `latency_seconds` maps to the wall-clock ceiling. |
+| `budget` | object | `{latency_seconds, token_budget?, wall_clock_seconds?, worker_dispatch_count?}` — #500 declaration; #593 enforces wall-clock and worker-dispatch ceilings before new work starts. Aggregate `token_budget` (receipt `tokens_used`) stays observed and is not reinterpreted as `input_tokens`; explicit input/output token caps use separate observed dimensions when declared. When `wall_clock_seconds` is unset, `latency_seconds` maps to the wall-clock ceiling. |
 
 **`budget_use` object**
 
@@ -370,7 +370,9 @@ projector; the coordinator applies terminal policy via `run.failed` /
 Enforceable dimensions: `wall_clock_seconds`, `worker_dispatch_count`.
 Observed dimensions (never universal hard gates in this slice):
 `model_call_count`, `tool_call_count`, `input_tokens`, `output_tokens`,
-`estimated_cost_micros`, `provider_usage_units`. Child allocation is #594.
+`estimated_cost_micros`, `provider_usage_units`. Legacy aggregate
+`token_budget` (paired with receipt `tokens_used`) is preserved on the
+declaration and is not an `input_tokens` alias. Child allocation is #594.
 Unknown schema versions or dimensions fail closed with a bounded diagnostic.
 Payloads never carry raw diagnostics.
 

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -378,6 +378,15 @@ declaration and is not an `input_tokens` alias. Child allocation is #594.
 Unknown schema versions or dimensions fail closed with a bounded diagnostic.
 Payloads never carry raw diagnostics.
 
+**Declared-only hard ceilings.** Only runs that carry a persisted
+`run_budget` declaration or a `verification_contract.budget` with enforceable
+fields receive hard wall-clock / worker-dispatch ceilings. Ordinary
+`brigade run`, dogfood, and model-trial paths that supply neither declaration
+remain unbounded for backward compatibility: Brigade does not invent CLI
+flags, default numeric ceilings, or a dogfood-timeout→budget mapping on those
+entry paths. Agent process timeouts (`timeout_seconds`) stay separate from
+run-budget enforcement.
+
 **Partial stale-recovery variant**
 
 When no valid original `run.json` object survives, `runguard._recover_run_artifact`

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -225,6 +225,13 @@ Use `brigade work import issue-repairs` when issue-backed local tasks need revie
 One orchestrator plans the work, Brigade dispatches assigned workers through their own CLIs, then the orchestrator synthesizes the final answer.
 It is intentionally bounded: two orchestrator calls plus the worker calls in the plan.
 
+Hard run-budget ceilings (`wall_clock_seconds`, `worker_dispatch_count`) apply
+only when a run persists `run_budget` or `verification_contract.budget` (#593).
+Ordinary `brigade run`, dogfood, and model-trial starts without those
+declarations stay unbounded for backward compatibility; per-agent
+`timeout_seconds` is not a run-budget declaration. See
+[`receipt-schemas.md`](receipt-schemas.md) (run budget lifecycle).
+
 Plans may include integer `stage` values. Assignments in the same stage run in parallel, stages run from lowest to highest, and later-stage workers receive earlier-stage worker results in their prompt. Plans that omit `stage` remain compatible and run as stage 1.
 
 When `--cwd` is a git worktree, write runs refuse to start on a dirty tree

--- a/schemas/verification-contract.v1.schema.json
+++ b/schemas/verification-contract.v1.schema.json
@@ -59,7 +59,9 @@
         "latency_seconds": {"type": "integer", "minimum": 1},
         "token_budget": {"type": "integer", "minimum": 0},
         "wall_clock_seconds": {"type": "integer", "minimum": 1},
-        "worker_dispatch_count": {"type": "integer", "minimum": 1}
+        "worker_dispatch_count": {"type": "integer", "minimum": 1},
+        "input_tokens": {"type": "integer", "minimum": 1},
+        "output_tokens": {"type": "integer", "minimum": 1}
       }
     }
   }

--- a/schemas/verification-contract.v1.schema.json
+++ b/schemas/verification-contract.v1.schema.json
@@ -57,7 +57,9 @@
       "required": ["latency_seconds"],
       "properties": {
         "latency_seconds": {"type": "integer", "minimum": 1},
-        "token_budget": {"type": "integer", "minimum": 0}
+        "token_budget": {"type": "integer", "minimum": 0},
+        "wall_clock_seconds": {"type": "integer", "minimum": 1},
+        "worker_dispatch_count": {"type": "integer", "minimum": 1}
       }
     }
   }

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2674,7 +2674,9 @@ def _build_budget_coordinator(
     Declaration sources (first match wins):
     1. ``run.json`` ``run_budget`` object
     2. ``run.json`` / plan ``verification_contract.budget`` (#500 bridge)
-    3. Empty declaration (no enforceable ceilings; observed reconcile still works)
+    3. Empty declaration (no enforceable ceilings; observed reconcile still
+       works). Ordinary undeclared ``brigade run`` / dogfood / model-trial
+       paths stay unbounded for backward compatibility.
 
     Returns ``None`` when the lifecycle journal is not enrolled so budget events
     are not appended into a missing journal.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -4277,15 +4277,12 @@ def run(
         if output_dir is None:
             return
         active_seat = active_seats[0] if len(active_seats) == 1 else None
-        # Operator cancellation remains outside the worker FailureClass enum
-        # (#576). Emit a durable run_budget cancel pair when the journal is
-        # active, then terminalize with the existing keyboard-interrupt kind so
-        # current receipt contracts stay stable. Policy kind operator-cancelled
-        # is used for explicit budget/policy cancel paths (#593).
+        # Live operator cancellation is a policy terminal (#593), not a worker
+        # FailureClass and not infrastructure-neutral under #580.
         if budget_coordinator is not None:
             try:
                 budget_coordinator.request_cancel(
-                    request_id=f"opcancel-{uuid4().hex[:12]}",
+                    request_id="opcancel:live-ctrl-c",
                     reason_class="operator_cancel",
                     transport_capability="process_cancel" if process_registry is not None else "none",
                     dimension="wall_clock_seconds",
@@ -4297,8 +4294,8 @@ def run(
             output_dir,
             status="canceled",
             failure_phase="dispatch",
-            failure_kind="keyboard-interrupt",
-            detail="run canceled by user",
+            failure_kind=run_budget.POLICY_KIND_OPERATOR_CANCELLED,
+            detail="run canceled by operator",
             seat=active_seat,
             active_seats=active_seats,
         )
@@ -4323,24 +4320,36 @@ def run(
 
     def dispatch_requested(agent: Agent) -> int | None:
         # Enforce wall-clock / worker-dispatch ceilings before new work starts (#593).
-        if budget_coordinator is not None:
-            request_id = f"dispatch-{agent.name}-{uuid4().hex[:10]}"
-            try:
-                budget_coordinator.reserve_worker_dispatch(request_id=request_id)
-            except run_budget.BudgetPolicyError as exc:
-                if exc.exhausted:
-                    try:
-                        budget_coordinator.request_cancel(
-                            request_id=f"budgetcancel-{uuid4().hex[:12]}",
-                            reason_class="budget_cancel",
-                            transport_capability="process_cancel" if process_registry is not None else "none",
-                            dimension=exc.dimension,
-                            cancel_fn=_budget_cancel_fn,
-                        )
-                    except (run_budget.BudgetError, run_lifecycle.LifecycleJournalError, OSError) as cancel_exc:
-                        print(f"warning: budget cancel receipt failed: {cancel_exc}", file=sys.stderr)
-                raise
-        return dispatch_fact("run.dispatch.requested", agent)
+        # Stable seat:attempt identity + durable requested ordering before the
+        # external transport call; retries reuse the same request id.
+        if budget_coordinator is None or output_dir is None:
+            return dispatch_fact("run.dispatch.requested", agent)
+        try:
+            attempt = run_lifecycle.next_dispatch_attempt(output_dir, agent.name)
+            request_id = run_budget.dispatch_reservation_request_id(agent.name, attempt)
+            return budget_coordinator.reserve_and_record_dispatch(
+                request_id=request_id,
+                seat=agent.name,
+                attempt=attempt,
+                record_requested=lambda: dispatch_fact("run.dispatch.requested", agent, attempt),
+            )
+        except run_budget.BudgetPolicyError as exc:
+            if exc.exhausted:
+                try:
+                    budget_coordinator.request_cancel(
+                        request_id=f"budgetcancel:{exc.dimension}",
+                        reason_class="budget_cancel",
+                        transport_capability="process_cancel" if process_registry is not None else "none",
+                        dimension=exc.dimension,
+                        cancel_fn=_budget_cancel_fn,
+                    )
+                except (run_budget.BudgetError, run_lifecycle.LifecycleJournalError, OSError) as cancel_exc:
+                    print(f"warning: budget cancel receipt failed: {cancel_exc}", file=sys.stderr)
+            raise
+        except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
+            # Mirror dispatch_fact fail-closed translation so enrollment gaps
+            # before the durable requested write retain the run lock.
+            raise runguard.RetainRunLockError(f"failed to record dispatch lifecycle fact: {exc}") from exc
 
     def dispatch_observed(agent: Agent, attempt: int) -> None:
         dispatch_fact("run.dispatch.observed", agent, attempt)
@@ -4450,8 +4459,8 @@ def run(
                     output_dir,
                     status="canceled",
                     failure_phase="dispatch",
-                    failure_kind="keyboard-interrupt",
-                    detail="run canceled by user",
+                    failure_kind=run_budget.POLICY_KIND_OPERATOR_CANCELLED,
+                    detail="run canceled by operator",
                     seat=active_seat,
                     active_seats=active_seats,
                 )

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2960,6 +2960,8 @@ def _run_payload(
     health: dict[str, object] | None = None,
     worker_failure_summary: dict[str, object] | None = None,
     transport_routing: dict[str, object] | None = None,
+    verification_contract_payload: Mapping[str, Any] | None = None,
+    run_budget_payload: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema": receipt_schema.RUN_RECEIPT_SCHEMA,
@@ -3053,6 +3055,10 @@ def _run_payload(
             payload["control_socket"] = control_transport.path
     elif control_socket is not None:
         payload["control_socket"] = str(control_socket)
+    if verification_contract_payload is not None:
+        payload["verification_contract"] = dict(verification_contract_payload)
+    if run_budget_payload is not None:
+        payload["run_budget"] = dict(run_budget_payload)
     return seat_health_policy.apply_health_fields(
         payload,
         health=health,
@@ -3091,6 +3097,8 @@ def record_run_start(
     codex_transport: str | None = None,
     started_at: datetime | None = None,
     scheduler: str | None = None,
+    verification_contract_payload: Mapping[str, Any] | None = None,
+    run_budget_payload: Mapping[str, Any] | None = None,
 ) -> bool:
     """Write the minimal typed receipt needed before optional or blocking work.
 
@@ -3107,6 +3115,8 @@ def record_run_start(
     run_json_exists = run_json.is_file()
     existing_lifecycle_requested = False
     existing_authority_requested = False
+    existing_verification_contract: dict[str, Any] | None = None
+    existing_run_budget: dict[str, Any] | None = None
     if run_json_exists:
         try:
             existing = json.loads(run_json.read_text(encoding="utf-8"))
@@ -3126,6 +3136,10 @@ def record_run_start(
             existing_lifecycle_requested = True
         if existing.get(_AUTHORITY_REQUEST_FIELD) is True:
             existing_authority_requested = True
+        if isinstance(existing.get("verification_contract"), dict):
+            existing_verification_contract = dict(existing["verification_contract"])
+        if isinstance(existing.get("run_budget"), dict):
+            existing_run_budget = dict(existing["run_budget"])
     # Every new run carries both durable request fields. Existing runs enroll
     # only from their stored run.json fields, so legacy snapshot-only runs stay
     # untouched. An authority request implies lifecycle journaling even when an
@@ -3133,6 +3147,12 @@ def record_run_start(
     new_run = not run_json_exists
     lifecycle_requested = existing_lifecycle_requested or existing_authority_requested or new_run
     authority_requested = existing_authority_requested or new_run
+    contract_payload = (
+        dict(verification_contract_payload)
+        if isinstance(verification_contract_payload, Mapping)
+        else existing_verification_contract
+    )
+    budget_payload = dict(run_budget_payload) if isinstance(run_budget_payload, Mapping) else existing_run_budget
     # The first run.json write activates the lifecycle journal and publishes a
     # recovery checkpoint BEFORE the atomic run.json replacement. If that final
     # replacement fails, durable journal/checkpoint state already exists without
@@ -3165,6 +3185,8 @@ def record_run_start(
                 ),
                 lifecycle_journal_requested=True if lifecycle_requested else None,
                 run_journal_authority_requested=True if authority_requested else None,
+                verification_contract_payload=contract_payload,
+                run_budget_payload=budget_payload,
             ),
         )
     except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
@@ -3532,6 +3554,8 @@ def run(
     fail_fast: bool = True,
     scheduler: str = "waves",
     defer_artifact_collection: bool = False,
+    verification_contract_payload: Mapping[str, Any] | None = None,
+    run_budget_payload: Mapping[str, Any] | None = None,
 ) -> int:
     started_at = datetime.now(timezone.utc)
     process_registry = proc.ProcessRegistry()
@@ -3610,6 +3634,12 @@ def run(
                         kwargs["health"] = dict(existing["health"])
                     if "transport_routing" not in kwargs and isinstance(existing.get("transport_routing"), dict):
                         kwargs["transport_routing"] = dict(existing["transport_routing"])
+                    if "verification_contract_payload" not in kwargs and isinstance(
+                        existing.get("verification_contract"), dict
+                    ):
+                        kwargs["verification_contract_payload"] = dict(existing["verification_contract"])
+                    if "run_budget_payload" not in kwargs and isinstance(existing.get("run_budget"), dict):
+                        kwargs["run_budget_payload"] = dict(existing["run_budget"])
         return _run_payload(
             lock_workspace=lock_workspace,
             pre_run_snapshot=pre_run_snapshot_payload,
@@ -3710,6 +3740,8 @@ def run(
             codex_transport=transport_for_payload,
             started_at=started_at,
             scheduler=scheduler,
+            verification_contract_payload=verification_contract_payload,
+            run_budget_payload=run_budget_payload,
         )
     if code_graph is None:
         code_graph = code_graph_brief(cwd, task) if code_graph_enabled else CodeGraphBrief(attached=False)
@@ -4001,10 +4033,18 @@ def run(
         if direct_worker:
             attempts_payload["mode"] = "direct-worker"
         _write_json(output_dir / "plan-attempts.json", attempts_payload)
-        _write_json(
-            output_dir / "plan.json",
-            receipt_schema.run_plan_document(_assignment_payload(assignments)),
-        )
+        plan_doc = receipt_schema.run_plan_document(_assignment_payload(assignments))
+        contract_for_plan = verification_contract_payload
+        if contract_for_plan is None:
+            try:
+                run_raw = json.loads((output_dir / "run.json").read_text())
+            except (OSError, json.JSONDecodeError):
+                run_raw = None
+            if isinstance(run_raw, dict) and isinstance(run_raw.get("verification_contract"), dict):
+                contract_for_plan = dict(run_raw["verification_contract"])
+        if isinstance(contract_for_plan, Mapping):
+            plan_doc["verification_contract"] = dict(contract_for_plan)
+        _write_json(output_dir / "plan.json", plan_doc)
 
     if cwd is not None and output_dir is not None:
         from . import candidate_set as candidate_set_mod
@@ -4028,10 +4068,16 @@ def run(
             plan_attempts=plan_attempts,
             allow_replan=not dry_run and not direct_worker,
         )
-        _write_json(
-            output_dir / "plan.json",
-            receipt_schema.run_plan_document(_assignment_payload(assignments)),
-        )
+        plan_doc = receipt_schema.run_plan_document(_assignment_payload(assignments))
+        try:
+            prior_plan = json.loads((output_dir / "plan.json").read_text())
+        except (OSError, json.JSONDecodeError):
+            prior_plan = None
+        if isinstance(prior_plan, dict) and isinstance(prior_plan.get("verification_contract"), dict):
+            plan_doc["verification_contract"] = dict(prior_plan["verification_contract"])
+        elif isinstance(verification_contract_payload, Mapping):
+            plan_doc["verification_contract"] = dict(verification_contract_payload)
+        _write_json(output_dir / "plan.json", plan_doc)
         if plan_attempts is not None:
             attempts_payload = {"attempts": plan_attempts or []}
             if direct_worker:
@@ -4320,18 +4366,15 @@ def run(
 
     def dispatch_requested(agent: Agent) -> int | None:
         # Enforce wall-clock / worker-dispatch ceilings before new work starts (#593).
-        # Stable seat:attempt identity + durable requested ordering before the
-        # external transport call; retries reuse the same request id.
+        # Attempt allocation and reservation share one lock; retries reclaim an
+        # open pending identity while concurrent same-seat callers mint anew.
         if budget_coordinator is None or output_dir is None:
             return dispatch_fact("run.dispatch.requested", agent)
         try:
-            attempt = run_lifecycle.next_dispatch_attempt(output_dir, agent.name)
-            request_id = run_budget.dispatch_reservation_request_id(agent.name, attempt)
             return budget_coordinator.reserve_and_record_dispatch(
-                request_id=request_id,
                 seat=agent.name,
-                attempt=attempt,
-                record_requested=lambda: dispatch_fact("run.dispatch.requested", agent, attempt),
+                allocate_attempt=lambda: run_lifecycle.allocate_next_dispatch_attempt(output_dir, agent.name),
+                record_requested=lambda attempt: dispatch_fact("run.dispatch.requested", agent, attempt),
             )
         except run_budget.BudgetPolicyError as exc:
             if exc.exhausted:

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -29,6 +29,7 @@ from . import localio
 from . import proc, receipt_schema, runguard
 from . import run_control
 from . import run_checkpoint
+from . import run_budget
 from . import run_events
 from . import run_journal
 from . import run_lifecycle
@@ -36,6 +37,7 @@ from . import run_projector
 from . import run_shadow
 from . import seat_health
 from . import seat_health_policy
+from . import verification_contract
 from .result_integrity import validate_final_output
 from .run_receipts import (
     agent_result_from_worker as _agent_result_from_worker,
@@ -2661,6 +2663,77 @@ def record_run_termination(
         raise runguard.RetainRunLockError(f"failed to write terminal run receipt: {exc}") from exc
 
 
+def _build_budget_coordinator(
+    output_dir: Path,
+    *,
+    started_at: datetime,
+    append_event: Callable[[str, Mapping[str, Any], str], Any],
+) -> run_budget.BudgetCoordinator | None:
+    """Build a budget coordinator when the run journal is active.
+
+    Declaration sources (first match wins):
+    1. ``run.json`` ``run_budget`` object
+    2. ``run.json`` / plan ``verification_contract.budget`` (#500 bridge)
+    3. Empty declaration (no enforceable ceilings; observed reconcile still works)
+
+    Returns ``None`` when the lifecycle journal is not enrolled so budget events
+    are not appended into a missing journal.
+    """
+    run_path = output_dir / "run.json"
+    try:
+        raw = json.loads(run_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        raw = {}
+    if not isinstance(raw, dict):
+        raw = {}
+    if raw.get("lifecycle_journal_requested") is not True and not (output_dir / "events" / "lifecycle.jsonl").is_file():
+        return None
+
+    declaration: run_budget.RunBudgetDeclaration
+    if isinstance(raw.get("run_budget"), dict):
+        # Full projected payload nests declaration; accept either shape.
+        nested = (
+            raw["run_budget"].get("declaration")
+            if isinstance(raw["run_budget"].get("declaration"), dict)
+            else raw["run_budget"]
+        )
+        declaration = run_budget.parse_declaration(nested if isinstance(nested, dict) else None)
+    else:
+        contract = verification_contract.extract_contract_payload(raw)
+        budget = contract.get("budget") if isinstance(contract, dict) else None
+        if not isinstance(budget, dict):
+            # Also accept a sibling plan.json contract when present.
+            plan_path = output_dir / "plan.json"
+            try:
+                plan_raw = json.loads(plan_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                plan_raw = None
+            if isinstance(plan_raw, dict):
+                contract = verification_contract.extract_contract_payload(plan_raw)
+                budget = contract.get("budget") if isinstance(contract, dict) else None
+        declaration = (
+            run_budget.declaration_from_verification_budget(budget)
+            if isinstance(budget, dict)
+            else run_budget.RunBudgetDeclaration()
+        )
+
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+    )
+    coordinator.set_started_at(started_at)
+    journal_path = output_dir / "events" / "lifecycle.jsonl"
+    if journal_path.is_file():
+        try:
+            report = run_journal.read_journal_bounded(journal_path)
+            if report.partial_tail is None and not report.chain_errors:
+                coordinator.reload(report.events)
+        except (OSError, run_journal.RunJournalError, run_events.CanonicalizationError):
+            # Leave empty projection; append path will fail closed if the journal is broken.
+            pass
+    return coordinator
+
+
 def record_approval_pause(output_dir: Path, approval_reference: Mapping[str, Any]) -> None:
     """Commit an approval wait and refresh its compatibility snapshot.
 
@@ -4150,6 +4223,49 @@ def run(
         close_server_resources()
         raise
 
+    budget_coordinator: run_budget.BudgetCoordinator | None = None
+
+    def _budget_cancel_fn() -> tuple[str, int]:
+        """Best-effort cancel of in-flight worker processes for budget/policy stops."""
+        if process_registry is None:
+            return "unsupported", len(active_seats)
+        process_registry.cancel()
+        # Cancellation is best effort; transports that cannot interrupt leave
+        # active_remaining as the count of seats that may still finish.
+        return "partial", max(0, len(active_seats) - 1)
+
+    def _append_budget_event(event_type: str, payload: Mapping[str, Any], idempotency_key: str) -> Any:
+        assert output_dir is not None
+        return run_lifecycle.record_lifecycle_event(
+            output_dir,
+            event_type=event_type,
+            payload=dict(payload),
+            idempotency_key=idempotency_key,
+            workspace=lock_workspace,
+        )
+
+    if output_dir is not None and lock_workspace is not None:
+        try:
+            budget_coordinator = _build_budget_coordinator(
+                output_dir,
+                started_at=started_at,
+                append_event=_append_budget_event,
+            )
+        except run_budget.BudgetCompatibilityError as exc:
+            # Unknown schema/dimension must stop recovery/dispatch with a bounded diagnostic.
+            active_seat = active_seats[0] if len(active_seats) == 1 else None
+            record_run_termination(
+                output_dir,
+                status="failed",
+                failure_phase="dispatch",
+                failure_kind="unexpected-error",
+                detail=f"run budget compatibility error: {exc.diagnostic}",
+                seat=active_seat,
+                active_seats=active_seats,
+            )
+            close_server_resources()
+            return 1
+
     def stage_started(stage: int, seats: tuple[str, ...]) -> None:
         nonlocal active_stage, active_seats
         active_stage = stage
@@ -4161,6 +4277,22 @@ def run(
         if output_dir is None:
             return
         active_seat = active_seats[0] if len(active_seats) == 1 else None
+        # Operator cancellation remains outside the worker FailureClass enum
+        # (#576). Emit a durable run_budget cancel pair when the journal is
+        # active, then terminalize with the existing keyboard-interrupt kind so
+        # current receipt contracts stay stable. Policy kind operator-cancelled
+        # is used for explicit budget/policy cancel paths (#593).
+        if budget_coordinator is not None:
+            try:
+                budget_coordinator.request_cancel(
+                    request_id=f"opcancel-{uuid4().hex[:12]}",
+                    reason_class="operator_cancel",
+                    transport_capability="process_cancel" if process_registry is not None else "none",
+                    dimension="wall_clock_seconds",
+                    cancel_fn=_budget_cancel_fn,
+                )
+            except (run_budget.BudgetError, run_lifecycle.LifecycleJournalError, OSError) as exc:
+                print(f"warning: budget cancel receipt failed: {exc}", file=sys.stderr)
         record_run_termination(
             output_dir,
             status="canceled",
@@ -4190,6 +4322,24 @@ def run(
         return recorded_attempt if isinstance(recorded_attempt, int) else None
 
     def dispatch_requested(agent: Agent) -> int | None:
+        # Enforce wall-clock / worker-dispatch ceilings before new work starts (#593).
+        if budget_coordinator is not None:
+            request_id = f"dispatch-{agent.name}-{uuid4().hex[:10]}"
+            try:
+                budget_coordinator.reserve_worker_dispatch(request_id=request_id)
+            except run_budget.BudgetPolicyError as exc:
+                if exc.exhausted:
+                    try:
+                        budget_coordinator.request_cancel(
+                            request_id=f"budgetcancel-{uuid4().hex[:12]}",
+                            reason_class="budget_cancel",
+                            transport_capability="process_cancel" if process_registry is not None else "none",
+                            dimension=exc.dimension,
+                            cancel_fn=_budget_cancel_fn,
+                        )
+                    except (run_budget.BudgetError, run_lifecycle.LifecycleJournalError, OSError) as cancel_exc:
+                        print(f"warning: budget cancel receipt failed: {cancel_exc}", file=sys.stderr)
+                raise
         return dispatch_fact("run.dispatch.requested", agent)
 
     def dispatch_observed(agent: Agent, attempt: int) -> None:
@@ -4277,6 +4427,22 @@ def run(
             )
         except runguard.RetainRunLockError:
             raise
+        except run_budget.BudgetPolicyError as exc:
+            active_seat = active_seats[0] if len(active_seats) == 1 else None
+            status, kind = run_budget.terminal_status_for_policy("budget_exhausted")
+            # Reservation denial without full exhaustion still terminalizes the
+            # run: new work cannot start under the declared ceiling.
+            if output_dir is not None:
+                record_run_termination(
+                    output_dir,
+                    status=status,
+                    failure_phase="dispatch",
+                    failure_kind=kind,
+                    detail=_one_line(str(exc)) or "run budget reservation denied",
+                    seat=active_seat,
+                    active_seats=active_seats,
+                )
+            return 1
         except KeyboardInterrupt:
             active_seat = active_seats[0] if len(active_seats) == 1 else None
             if output_dir is not None:

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2663,6 +2663,43 @@ def record_run_termination(
         raise runguard.RetainRunLockError(f"failed to write terminal run receipt: {exc}") from exc
 
 
+def _initial_verification_budget(container: Mapping[str, Any]) -> tuple[bool, Mapping[str, Any] | None]:
+    """Return a present, validated verification budget from an initial run artifact."""
+    if "verification_contract" not in container:
+        return False, None
+    contract = container["verification_contract"]
+    if not isinstance(contract, Mapping):
+        raise run_budget.BudgetCompatibilityError(
+            "verification_contract must be an object",
+            code="schema_incompatible",
+        )
+    schema = contract.get("schema")
+    if schema is not None and schema != verification_contract.VERIFICATION_CONTRACT_SCHEMA:
+        raise run_budget.BudgetCompatibilityError(
+            run_events._bound(f"unsupported verification_contract schema {schema!r}"),
+            code="schema_incompatible",
+        )
+    version = contract.get("schema_version")
+    if version is not None and (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION
+    ):
+        raise run_budget.BudgetCompatibilityError(
+            run_events._bound(f"unsupported verification_contract schema_version {version!r}"),
+            code="schema_incompatible",
+        )
+    if "budget" not in contract:
+        return False, None
+    budget = contract["budget"]
+    if not isinstance(budget, Mapping):
+        raise run_budget.BudgetCompatibilityError(
+            "verification_contract budget must be an object",
+            code="schema_incompatible",
+        )
+    return True, budget
+
+
 def _build_budget_coordinator(
     output_dir: Path,
     *,
@@ -2692,18 +2729,11 @@ def _build_budget_coordinator(
         return None
 
     declaration: run_budget.RunBudgetDeclaration
-    if isinstance(raw.get("run_budget"), dict):
-        # Full projected payload nests declaration; accept either shape.
-        nested = (
-            raw["run_budget"].get("declaration")
-            if isinstance(raw["run_budget"].get("declaration"), dict)
-            else raw["run_budget"]
-        )
-        declaration = run_budget.parse_declaration(nested if isinstance(nested, dict) else None)
+    if "run_budget" in raw:
+        declaration = run_budget.declaration_from_persisted_artifact(raw["run_budget"])
     else:
-        contract = verification_contract.extract_contract_payload(raw)
-        budget = contract.get("budget") if isinstance(contract, dict) else None
-        if not isinstance(budget, dict):
+        has_budget, budget = _initial_verification_budget(raw)
+        if not has_budget:
             # Also accept a sibling plan.json contract when present.
             plan_path = output_dir / "plan.json"
             try:
@@ -2711,13 +2741,8 @@ def _build_budget_coordinator(
             except (OSError, json.JSONDecodeError):
                 plan_raw = None
             if isinstance(plan_raw, dict):
-                contract = verification_contract.extract_contract_payload(plan_raw)
-                budget = contract.get("budget") if isinstance(contract, dict) else None
-        declaration = (
-            run_budget.declaration_from_verification_budget(budget)
-            if isinstance(budget, dict)
-            else run_budget.RunBudgetDeclaration()
-        )
+                has_budget, budget = _initial_verification_budget(plan_raw)
+        declaration = run_budget.declaration_from_verification_budget(budget)
 
     coordinator = run_budget.BudgetCoordinator(
         declaration=declaration,

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -17,8 +17,12 @@ Enforceable dimensions (hard gates before new work starts):
 Observed dimensions (recorded when an adapter reports reliable data; never
 universal hard gates in this slice):
   - ``model_call_count``, ``tool_call_count``
-  - ``input_tokens``, ``output_tokens``
+  - ``input_tokens``, ``output_tokens`` (explicit split dimensions only)
   - ``estimated_cost_micros``, ``provider_usage_units``
+
+Legacy VerificationContract ``token_budget`` is an **aggregate** token ceiling
+(paired with receipt ``tokens_used``). It is preserved as declaration
+``token_budget`` and must not be reinterpreted as ``input_tokens``.
 
 Child frame / durable child-run allocation belongs to #594 and is out of scope.
 Missing child-allocation fields default to "no child budget" and remain
@@ -209,6 +213,8 @@ class RunBudgetDeclaration:
     wall_clock_seconds: int | None = None
     worker_dispatch_count: int | None = None
     threshold_pct: int = DEFAULT_THRESHOLD_PCT
+    # Aggregate #500 token ceiling (receipt tokens_used). Not input_tokens.
+    token_budget: int | None = None
     # Observed-only declared caps (informational; never hard-gated here).
     observed_caps: Mapping[str, int | None] = field(default_factory=dict)
 
@@ -226,7 +232,7 @@ class RunBudgetDeclaration:
 
     def to_payload(self) -> dict[str, Any]:
         observed = {key: self.observed_caps.get(key) for key in sorted(OBSERVED_DIMENSIONS)}
-        return {
+        payload: dict[str, Any] = {
             "schema": RUN_BUDGET_SCHEMA,
             "schema_version": self.schema_version,
             "ceilings": {
@@ -236,6 +242,9 @@ class RunBudgetDeclaration:
             "observed": observed,
             "threshold_pct": self.threshold_pct,
         }
+        if self.token_budget is not None:
+            payload["token_budget"] = self.token_budget
+        return payload
 
 
 def parse_declaration(payload: Mapping[str, Any] | None) -> RunBudgetDeclaration:
@@ -298,11 +307,23 @@ def parse_declaration(payload: Mapping[str, Any] | None) -> RunBudgetDeclaration
         for key in OBSERVED_DIMENSIONS
         if key in observed_raw
     }
+    token_budget_raw = payload.get("token_budget")
+    token_budget: int | None
+    if token_budget_raw is None:
+        token_budget = None
+    elif isinstance(token_budget_raw, bool) or not isinstance(token_budget_raw, int) or token_budget_raw < 0:
+        raise BudgetCompatibilityError(
+            _bound("token_budget must be a non-negative integer when set"),
+            code="schema_incompatible",
+        )
+    else:
+        token_budget = token_budget_raw
     return RunBudgetDeclaration(
         schema_version=int(version),
         wall_clock_seconds=_opt_pos(ceilings.get("wall_clock_seconds"), field_name="wall_clock_seconds"),
         worker_dispatch_count=_opt_pos(ceilings.get("worker_dispatch_count"), field_name="worker_dispatch_count"),
         threshold_pct=threshold,
+        token_budget=token_budget,
         observed_caps=observed_caps,
     )
 
@@ -313,7 +334,9 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
     ``wall_clock_seconds`` / ``worker_dispatch_count`` are preferred when set.
     Otherwise ``latency_seconds`` maps to the enforceable wall-clock ceiling so
     existing contracts become enforceable without a template rewrite.
-    ``token_budget`` stays observed-only.
+    ``token_budget`` stays observed-only and aggregate (receipt ``tokens_used``);
+    it is never reinterpreted as ``input_tokens``. Explicit ``input_tokens`` /
+    ``output_tokens`` caps come only from those observed fields.
     """
     if not isinstance(budget, Mapping):
         return RunBudgetDeclaration()
@@ -321,12 +344,9 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
     if wall is None:
         wall = budget.get("latency_seconds")
     dispatch = budget.get("worker_dispatch_count")
-    observed: dict[str, int | None] = {}
     token = budget.get("token_budget")
-    if isinstance(token, int) and not isinstance(token, bool) and token >= 0:
-        # Informational observed cap on total tokens (input+output not split here).
-        observed["input_tokens"] = token
-    payload = {
+    token_budget = token if isinstance(token, int) and not isinstance(token, bool) and token >= 0 else None
+    payload: dict[str, Any] = {
         "schema": RUN_BUDGET_SCHEMA,
         "schema_version": RUN_BUDGET_SCHEMA_VERSION,
         "ceilings": {
@@ -335,9 +355,11 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
                 dispatch if isinstance(dispatch, int) and not isinstance(dispatch, bool) else None
             ),
         },
-        "observed": observed,
+        "observed": {},
         "threshold_pct": DEFAULT_THRESHOLD_PCT,
     }
+    if token_budget is not None:
+        payload["token_budget"] = token_budget
     return parse_declaration(payload)
 
 

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -336,7 +336,8 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
     existing contracts become enforceable without a template rewrite.
     ``token_budget`` stays observed-only and aggregate (receipt ``tokens_used``);
     it is never reinterpreted as ``input_tokens``. Explicit ``input_tokens`` /
-    ``output_tokens`` caps come only from those observed fields.
+    ``output_tokens`` caps bridge into ``observed_caps`` only when those fields
+    are set on the verification budget.
     """
     if not isinstance(budget, Mapping):
         return RunBudgetDeclaration()
@@ -344,6 +345,11 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
     if wall is None:
         wall = budget.get("latency_seconds")
     dispatch = budget.get("worker_dispatch_count")
+    observed: dict[str, int | None] = {}
+    for key in ("input_tokens", "output_tokens"):
+        value = budget.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            observed[key] = value
     token = budget.get("token_budget")
     token_budget = token if isinstance(token, int) and not isinstance(token, bool) and token >= 0 else None
     payload: dict[str, Any] = {
@@ -355,7 +361,7 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
                 dispatch if isinstance(dispatch, int) and not isinstance(dispatch, bool) else None
             ),
         },
-        "observed": {},
+        "observed": observed,
         "threshold_pct": DEFAULT_THRESHOLD_PCT,
     }
     if token_budget is not None:
@@ -929,6 +935,10 @@ class BudgetCoordinator:
     _events_cache: list[Any] = field(default_factory=list)
     _pending_dispatch_units: int = 0
     _reserved_request_ids: set[str] = field(default_factory=set)
+    # Identities already handed to a caller in this process for external launch.
+    # Distinct from ``_reserved_request_ids`` so restart can reclaim a durable
+    # pending identity once, while concurrent same-seat callers allocate anew.
+    _launch_claims: set[str] = field(default_factory=set)
     _lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
 
     def __post_init__(self) -> None:
@@ -943,6 +953,7 @@ class BudgetCoordinator:
             self._projection = project_budget_state(self.declaration, events)
             # Journal dispatch.requested facts supersede in-process reservations.
             self._pending_dispatch_units = 0
+            self._launch_claims = set()
             reserved: set[str] = set()
             for event in events:
                 event_type = _event_type(event)
@@ -1045,36 +1056,85 @@ class BudgetCoordinator:
                 return True
         return False
 
+    def _open_pending_attempt_unlocked(self, seat: str) -> int | None:
+        """Return the oldest open requested attempt for ``seat``, if any."""
+        pending: list[int] = []
+        closed: set[int] = set()
+        for event in self._events_cache:
+            event_type = _event_type(event)
+            payload = _event_payload(event)
+            if payload.get("seat") != seat:
+                continue
+            attempt = payload.get("attempt")
+            if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 1:
+                continue
+            if event_type == "run.dispatch.requested":
+                pending.append(attempt)
+            elif event_type in {"run.dispatch.observed", "run.dispatch.completed", "run.dispatch.failed"}:
+                closed.add(attempt)
+        for attempt in pending:
+            if attempt not in closed:
+                return attempt
+        return None
+
+    def _max_attempt_unlocked(self, seat: str) -> int:
+        attempts: list[int] = []
+        for event in self._events_cache:
+            payload = _event_payload(event)
+            if payload.get("seat") != seat:
+                continue
+            attempt = payload.get("attempt")
+            if isinstance(attempt, int) and not isinstance(attempt, bool) and attempt > 0:
+                attempts.append(attempt)
+        return max(attempts, default=0)
+
     def reserve_and_record_dispatch(
         self,
         *,
-        request_id: str,
         seat: str,
-        attempt: int,
-        record_requested: Callable[[], int | None],
+        allocate_attempt: Callable[[], int],
+        record_requested: Callable[[int], int | None],
     ) -> int | None:
-        """Reserve then durably record ``run.dispatch.requested`` before unlock.
+        """Atomically allocate attempt, reserve, and durably record requested.
 
-        Parallel same-stage workers serialize here. A retry with the same stable
-        ``request_id`` does not double-reserve. The dispatch.requested fact is
-        written before this method returns so external transport cannot start
-        without a durable reservation/request pair. If the durable write fails,
-        the in-process reservation is rolled back so a later retry can commit.
+        Attempt allocation and reservation share one lock so parallel same-seat
+        callers cannot both claim attempt 1. A durable open pending identity is
+        reclaimed once per process (crash/retry); concurrent callers then
+        allocate a fresh attempt. The durable ``run.dispatch.requested`` fact is
+        written before unlock so external transport cannot start without it.
         """
+        if not isinstance(seat, str) or not seat:
+            raise BudgetError("seat must be a non-empty string", code="reservation_invalid")
         with self._lock:
-            if self._has_durable_dispatch_requested(seat, attempt):
-                self._reserved_request_ids.add(request_id)
-                return attempt
+            pending = self._open_pending_attempt_unlocked(seat)
+            if pending is not None:
+                pending_id = dispatch_reservation_request_id(seat, pending)
+                if pending_id not in self._launch_claims and self._has_durable_dispatch_requested(seat, pending):
+                    # Restart/recovery: reclaim the unfinished durable identity once.
+                    self._launch_claims.add(pending_id)
+                    self._reserved_request_ids.add(pending_id)
+                    return pending
+
+            attempt = allocate_attempt()
+            if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 1:
+                raise BudgetError("attempt must be a positive integer", code="reservation_invalid")
+            # Guard against a stale allocator that reuses an already-claimed id.
+            while True:
+                request_id = dispatch_reservation_request_id(seat, attempt)
+                if request_id not in self._launch_claims and not self._has_durable_dispatch_requested(seat, attempt):
+                    break
+                attempt = max(attempt, self._max_attempt_unlocked(seat)) + 1
+
+            request_id = dispatch_reservation_request_id(seat, attempt)
             decision = self._reserve_unlocked(request_id=request_id, units=1)
             try:
-                recorded_attempt = record_requested()
+                recorded_attempt = record_requested(attempt)
             except Exception:
                 if not decision.replayed:
                     self._unreserve_unlocked(request_id=request_id, units=1)
                 raise
             if recorded_attempt is None:
                 recorded_attempt = attempt
-            # Durable requested supersedes the in-process pending unit.
             if self._pending_dispatch_units > 0:
                 self._pending_dispatch_units -= 1
             self._events_cache.append(
@@ -1084,7 +1144,9 @@ class BudgetCoordinator:
                 }
             )
             self._projection = project_budget_state(self.declaration, self._events_cache)
-            self._reserved_request_ids.add(dispatch_reservation_request_id(seat, recorded_attempt))
+            recorded_id = dispatch_reservation_request_id(seat, recorded_attempt)
+            self._reserved_request_ids.add(recorded_id)
+            self._launch_claims.add(recorded_id)
             return recorded_attempt
 
     def request_cancel(

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -54,6 +54,21 @@ from brigade.run_events import MAX_DIAGNOSTIC_LEN, MAX_IDEMPOTENCY_KEY_LEN
 
 RUN_BUDGET_SCHEMA = "brigade.run_budget.v1"
 RUN_BUDGET_SCHEMA_VERSION = 1
+RUN_BUDGET_PROJECTION_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "declaration",
+        "modes",
+        "used",
+        "estimated_used",
+        "provider_used",
+        "remaining",
+        "exhausted_dimensions",
+        "terminal_policy",
+        "cancel_receipts",
+    }
+)
 
 # Run-owned policy terminal kinds (not FailureClass / not infrastructure).
 POLICY_KIND_BUDGET_EXHAUSTED = "budget-exhausted"
@@ -280,7 +295,7 @@ def parse_declaration(payload: Mapping[str, Any] | None) -> RunBudgetDeclaration
             code="schema_incompatible",
         )
     version = payload.get("schema_version", RUN_BUDGET_SCHEMA_VERSION)
-    if version != RUN_BUDGET_SCHEMA_VERSION:
+    if isinstance(version, bool) or not isinstance(version, int) or version != RUN_BUDGET_SCHEMA_VERSION:
         raise BudgetCompatibilityError(
             _bound(f"unsupported run_budget schema_version {version!r}"),
             code="schema_incompatible",
@@ -339,7 +354,7 @@ def parse_declaration(payload: Mapping[str, Any] | None) -> RunBudgetDeclaration
     else:
         token_budget = token_budget_raw
     return RunBudgetDeclaration(
-        schema_version=int(version),
+        schema_version=version,
         wall_clock_seconds=_opt_pos(ceilings.get("wall_clock_seconds"), field_name="wall_clock_seconds"),
         worker_dispatch_count=_opt_pos(ceilings.get("worker_dispatch_count"), field_name="worker_dispatch_count"),
         threshold_pct=threshold,
@@ -355,6 +370,45 @@ def declaration_has_budget_content(declaration: RunBudgetDeclaration) -> bool:
     if declaration.token_budget is not None:
         return True
     return any(value is not None for value in declaration.observed_caps.values())
+
+
+def declaration_from_persisted_artifact(payload: Mapping[str, Any]) -> RunBudgetDeclaration:
+    """Parse a persisted run_budget declaration or its projected outer envelope.
+
+    A projected envelope is authoritative state, so validate its schema and
+    closed field set before selecting its nested declaration. A direct
+    declaration remains accepted for compatibility with pre-projection runs.
+    """
+    if not isinstance(payload, Mapping):
+        raise BudgetCompatibilityError("run_budget must be an object", code="schema_incompatible")
+    if "declaration" not in payload:
+        return parse_declaration(payload)
+
+    unknown = set(payload.keys()) - RUN_BUDGET_PROJECTION_FIELDS
+    if unknown:
+        raise BudgetCompatibilityError(
+            _bound(f"unknown persisted run_budget envelope fields: {sorted(unknown)}"),
+            code="schema_incompatible",
+        )
+    schema = payload.get("schema")
+    if schema != RUN_BUDGET_SCHEMA:
+        raise BudgetCompatibilityError(
+            _bound(f"unsupported persisted run_budget schema {schema!r}"),
+            code="schema_incompatible",
+        )
+    version = payload.get("schema_version")
+    if isinstance(version, bool) or not isinstance(version, int) or version != RUN_BUDGET_SCHEMA_VERSION:
+        raise BudgetCompatibilityError(
+            _bound(f"unsupported persisted run_budget schema_version {version!r}"),
+            code="schema_incompatible",
+        )
+    declaration = payload.get("declaration")
+    if not isinstance(declaration, Mapping):
+        raise BudgetCompatibilityError(
+            "run_budget.declaration must be an object when set",
+            code="schema_incompatible",
+        )
+    return parse_declaration(declaration)
 
 
 def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> RunBudgetDeclaration:
@@ -391,9 +445,12 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
             _bound(f"unsupported verification budget schema {budget.get('schema')!r}"),
             code="schema_incompatible",
         )
-    if "schema_version" in budget and budget.get("schema_version") != RUN_BUDGET_SCHEMA_VERSION:
+    version = budget.get("schema_version")
+    if "schema_version" in budget and (
+        isinstance(version, bool) or not isinstance(version, int) or version != RUN_BUDGET_SCHEMA_VERSION
+    ):
         raise BudgetCompatibilityError(
-            _bound(f"unsupported verification budget schema_version {budget.get('schema_version')!r}"),
+            _bound(f"unsupported verification budget schema_version {version!r}"),
             code="schema_incompatible",
         )
 

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -344,28 +344,55 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
     it is never reinterpreted as ``input_tokens``. Explicit ``input_tokens`` /
     ``output_tokens`` caps bridge into ``observed_caps`` only when those fields
     are set on the verification budget.
+
+    Present-but-malformed ceiling or token fields fail closed with
+    ``BudgetCompatibilityError`` rather than silently becoming undeclared.
     """
-    if not isinstance(budget, Mapping):
+    if budget is None:
         return RunBudgetDeclaration()
-    wall = budget.get("wall_clock_seconds")
-    if wall is None:
-        wall = budget.get("latency_seconds")
-    dispatch = budget.get("worker_dispatch_count")
+    if not isinstance(budget, Mapping):
+        raise BudgetCompatibilityError(
+            "verification budget must be an object",
+            code="schema_incompatible",
+        )
+
+    def _opt_pos(value: object, *, field_name: str) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise BudgetCompatibilityError(
+                _bound(f"{field_name} must be a positive integer when set"),
+                code="schema_incompatible",
+            )
+        return value
+
+    def _opt_nonneg(value: object, *, field_name: str) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise BudgetCompatibilityError(
+                _bound(f"{field_name} must be a non-negative integer when set"),
+                code="schema_incompatible",
+            )
+        return value
+
+    wall_raw = budget.get("wall_clock_seconds")
+    if wall_raw is None:
+        wall = _opt_pos(budget.get("latency_seconds"), field_name="latency_seconds")
+    else:
+        wall = _opt_pos(wall_raw, field_name="wall_clock_seconds")
+    dispatch = _opt_pos(budget.get("worker_dispatch_count"), field_name="worker_dispatch_count")
     observed: dict[str, int | None] = {}
     for key in ("input_tokens", "output_tokens"):
-        value = budget.get(key)
-        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
-            observed[key] = value
-    token = budget.get("token_budget")
-    token_budget = token if isinstance(token, int) and not isinstance(token, bool) and token >= 0 else None
+        if key in budget:
+            observed[key] = _opt_pos(budget.get(key), field_name=key)
+    token_budget = _opt_nonneg(budget.get("token_budget"), field_name="token_budget")
     payload: dict[str, Any] = {
         "schema": RUN_BUDGET_SCHEMA,
         "schema_version": RUN_BUDGET_SCHEMA_VERSION,
         "ceilings": {
-            "wall_clock_seconds": wall if isinstance(wall, int) and not isinstance(wall, bool) else None,
-            "worker_dispatch_count": (
-                dispatch if isinstance(dispatch, int) and not isinstance(dispatch, bool) else None
-            ),
+            "wall_clock_seconds": wall,
+            "worker_dispatch_count": dispatch,
         },
         "observed": observed,
         "threshold_pct": DEFAULT_THRESHOLD_PCT,

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -123,6 +123,20 @@ RUN_BUDGET_EVENT_TYPES = frozenset(
 
 DEFAULT_THRESHOLD_PCT = 80
 
+# VerificationBudget fields bridged into run_budget. Unknown keys (including
+# child-allocation dimensions owned by #594) fail closed rather than drop.
+VERIFICATION_BUDGET_FIELDS = frozenset(
+    {
+        "latency_seconds",
+        "token_budget",
+        "wall_clock_seconds",
+        "worker_dispatch_count",
+        "input_tokens",
+        "output_tokens",
+    }
+)
+VERIFICATION_BUDGET_META_FIELDS = frozenset({"schema", "schema_version"})
+
 # Payload allowlists mirrored into run_events.EVENT_TYPES.
 RUN_BUDGET_EVENT_PAYLOADS: dict[str, frozenset[str]] = {
     EVENT_THRESHOLD: frozenset({"dimension", "mode", "declared", "used", "remaining", "threshold_pct", "reason_class"}),
@@ -334,6 +348,15 @@ def parse_declaration(payload: Mapping[str, Any] | None) -> RunBudgetDeclaration
     )
 
 
+def declaration_has_budget_content(declaration: RunBudgetDeclaration) -> bool:
+    """True when a declaration carries at least one known budget field."""
+    if declaration.wall_clock_seconds is not None or declaration.worker_dispatch_count is not None:
+        return True
+    if declaration.token_budget is not None:
+        return True
+    return any(value is not None for value in declaration.observed_caps.values())
+
+
 def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> RunBudgetDeclaration:
     """Bridge #500 VerificationBudget into a run_budget declaration.
 
@@ -345,7 +368,8 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
     ``output_tokens`` caps bridge into ``observed_caps`` only when those fields
     are set on the verification budget.
 
-    Present-but-malformed ceiling or token fields fail closed with
+    Present-but-malformed ceiling or token fields, unknown dimensions (including
+    child-only keys), and unsupported schema/version markers fail closed with
     ``BudgetCompatibilityError`` rather than silently becoming undeclared.
     """
     if budget is None:
@@ -353,6 +377,23 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
     if not isinstance(budget, Mapping):
         raise BudgetCompatibilityError(
             "verification budget must be an object",
+            code="schema_incompatible",
+        )
+
+    unknown = set(budget.keys()) - VERIFICATION_BUDGET_FIELDS - VERIFICATION_BUDGET_META_FIELDS
+    if unknown:
+        raise BudgetCompatibilityError(
+            _bound(f"unknown verification budget dimensions: {sorted(unknown)}"),
+            code="unknown_dimension",
+        )
+    if "schema" in budget and budget.get("schema") != RUN_BUDGET_SCHEMA:
+        raise BudgetCompatibilityError(
+            _bound(f"unsupported verification budget schema {budget.get('schema')!r}"),
+            code="schema_incompatible",
+        )
+    if "schema_version" in budget and budget.get("schema_version") != RUN_BUDGET_SCHEMA_VERSION:
+        raise BudgetCompatibilityError(
+            _bound(f"unsupported verification budget schema_version {budget.get('schema_version')!r}"),
             code="schema_incompatible",
         )
 

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -1103,7 +1103,9 @@ class BudgetCoordinator:
         """
         if self.declaration.wall_clock_seconds is None:
             return
-        wall_only = replace(self._projection_unlocked(), declaration=replace(self.declaration, worker_dispatch_count=None))
+        wall_only = replace(
+            self._projection_unlocked(), declaration=replace(self.declaration, worker_dispatch_count=None)
+        )
         decision = evaluate_dispatch_reservation(
             wall_only,
             request_id=request_id,

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -34,6 +34,7 @@ Standard library only. Brigade is zero-runtime-dependency.
 from __future__ import annotations
 
 import hashlib
+import threading
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Sequence
@@ -545,6 +546,35 @@ class ReservationDecision:
     exhausted: bool
     projection: BudgetProjection
     events: tuple[dict[str, Any], ...]  # event_type + payload + idempotency_key triples as dicts
+    replayed: bool = False
+
+
+def dispatch_reservation_request_id(seat: str, attempt: int) -> str:
+    """Stable reservation identity for one seat attempt (retry/crash safe)."""
+    if not isinstance(seat, str) or not seat:
+        raise BudgetError("seat must be a non-empty string", code="reservation_invalid")
+    if isinstance(attempt, bool) or not isinstance(attempt, int) or attempt < 1:
+        raise BudgetError("attempt must be a positive integer", code="reservation_invalid")
+    return f"dispatch:{seat}:{attempt}"
+
+
+def parse_dispatch_reservation_request_id(request_id: str) -> tuple[str, int] | None:
+    """Return ``(seat, attempt)`` when ``request_id`` uses the stable dispatch form."""
+    if not isinstance(request_id, str) or not request_id.startswith("dispatch:"):
+        return None
+    parts = request_id.split(":")
+    if len(parts) != 3:
+        return None
+    _, seat, attempt_raw = parts
+    if not seat:
+        return None
+    try:
+        attempt = int(attempt_raw)
+    except ValueError:
+        return None
+    if attempt < 1:
+        return None
+    return seat, attempt
 
 
 def evaluate_dispatch_reservation(
@@ -862,6 +892,11 @@ class BudgetCoordinator:
 
     Callers that hold the run lock append events through ``append_event``.
     Projection is rebuilt from the journal on ``reload`` so restarts are safe.
+
+    ``reserve_worker_dispatch`` is synchronized so parallel same-stage workers
+    cannot both observe the same used count and exceed a ceiling. Reservation
+    request ids are idempotent: a retry/crash replay of the same stable id does
+    not double-reserve.
     """
 
     declaration: RunBudgetDeclaration
@@ -871,6 +906,8 @@ class BudgetCoordinator:
     _started_at: datetime | None = None
     _events_cache: list[Any] = field(default_factory=list)
     _pending_dispatch_units: int = 0
+    _reserved_request_ids: set[str] = field(default_factory=set)
+    _lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
 
     def __post_init__(self) -> None:
         self._projection = BudgetProjection(declaration=self.declaration)
@@ -879,14 +916,36 @@ class BudgetCoordinator:
         self._started_at = started_at
 
     def reload(self, events: Sequence[Any]) -> BudgetProjection:
-        self._events_cache = list(events)
-        self._projection = project_budget_state(self.declaration, events)
-        # Journal dispatch.requested facts supersede in-process reservations.
-        self._pending_dispatch_units = 0
-        return self._projection
+        with self._lock:
+            self._events_cache = list(events)
+            self._projection = project_budget_state(self.declaration, events)
+            # Journal dispatch.requested facts supersede in-process reservations.
+            self._pending_dispatch_units = 0
+            reserved: set[str] = set()
+            for event in events:
+                event_type = _event_type(event)
+                payload = _event_payload(event)
+                if event_type != "run.dispatch.requested":
+                    continue
+                seat = payload.get("seat")
+                attempt = payload.get("attempt")
+                if (
+                    isinstance(seat, str)
+                    and seat
+                    and isinstance(attempt, int)
+                    and not isinstance(attempt, bool)
+                    and attempt > 0
+                ):
+                    reserved.add(dispatch_reservation_request_id(seat, attempt))
+            self._reserved_request_ids = reserved
+            return self._projection
 
     @property
     def projection(self) -> BudgetProjection:
+        with self._lock:
+            return self._projection_unlocked()
+
+    def _projection_unlocked(self) -> BudgetProjection:
         if self._pending_dispatch_units <= 0:
             return self._projection
         used = dict(self._projection.used)
@@ -900,10 +959,29 @@ class BudgetCoordinator:
             self._events_cache.append(synthetic)
         self._projection = project_budget_state(self.declaration, self._events_cache)
 
-    def reserve_worker_dispatch(self, *, request_id: str, units: int = 1) -> ReservationDecision:
-        """Reserve enforceable dispatch units before new work starts."""
+    def _reserve_unlocked(self, *, request_id: str, units: int = 1) -> ReservationDecision:
+        if request_id in self._projection.denied_request_ids:
+            exhausted = bool(self._projection.exhausted_dimensions)
+            raise BudgetPolicyError(
+                _bound(f"run budget reservation previously denied for {request_id}"),
+                code="budget_exhausted" if exhausted else "reservation_denied",
+                dimension=next(iter(self._projection.exhausted_dimensions), "worker_dispatch_count"),
+                exhausted=exhausted,
+                request_id=request_id,
+            )
+        if request_id in self._reserved_request_ids:
+            # Idempotent replay of the same stable dispatch identity.
+            return ReservationDecision(
+                allowed=True,
+                dimension="worker_dispatch_count",
+                request_id=request_id,
+                exhausted=False,
+                projection=self._projection_unlocked(),
+                events=(),
+                replayed=True,
+            )
         decision = evaluate_dispatch_reservation(
-            self.projection,
+            self._projection_unlocked(),
             request_id=request_id,
             now=self.clock(),
             started_at=self._started_at,
@@ -922,8 +1000,70 @@ class BudgetCoordinator:
                 exhausted=decision.exhausted,
                 request_id=request_id,
             )
+        self._reserved_request_ids.add(request_id)
         self._pending_dispatch_units += units
         return decision
+
+    def reserve_worker_dispatch(self, *, request_id: str, units: int = 1) -> ReservationDecision:
+        """Reserve enforceable dispatch units before new work starts."""
+        with self._lock:
+            return self._reserve_unlocked(request_id=request_id, units=units)
+
+    def _unreserve_unlocked(self, *, request_id: str, units: int = 1) -> None:
+        self._reserved_request_ids.discard(request_id)
+        if self._pending_dispatch_units > 0:
+            self._pending_dispatch_units = max(0, self._pending_dispatch_units - units)
+
+    def _has_durable_dispatch_requested(self, seat: str, attempt: int) -> bool:
+        for event in self._events_cache:
+            if _event_type(event) != "run.dispatch.requested":
+                continue
+            payload = _event_payload(event)
+            if payload.get("seat") == seat and payload.get("attempt") == attempt:
+                return True
+        return False
+
+    def reserve_and_record_dispatch(
+        self,
+        *,
+        request_id: str,
+        seat: str,
+        attempt: int,
+        record_requested: Callable[[], int | None],
+    ) -> int | None:
+        """Reserve then durably record ``run.dispatch.requested`` before unlock.
+
+        Parallel same-stage workers serialize here. A retry with the same stable
+        ``request_id`` does not double-reserve. The dispatch.requested fact is
+        written before this method returns so external transport cannot start
+        without a durable reservation/request pair. If the durable write fails,
+        the in-process reservation is rolled back so a later retry can commit.
+        """
+        with self._lock:
+            if self._has_durable_dispatch_requested(seat, attempt):
+                self._reserved_request_ids.add(request_id)
+                return attempt
+            decision = self._reserve_unlocked(request_id=request_id, units=1)
+            try:
+                recorded_attempt = record_requested()
+            except Exception:
+                if not decision.replayed:
+                    self._unreserve_unlocked(request_id=request_id, units=1)
+                raise
+            if recorded_attempt is None:
+                recorded_attempt = attempt
+            # Durable requested supersedes the in-process pending unit.
+            if self._pending_dispatch_units > 0:
+                self._pending_dispatch_units -= 1
+            self._events_cache.append(
+                {
+                    "event_type": "run.dispatch.requested",
+                    "payload": {"seat": seat, "attempt": recorded_attempt, "detail": "requested"},
+                }
+            )
+            self._projection = project_budget_state(self.declaration, self._events_cache)
+            self._reserved_request_ids.add(dispatch_reservation_request_id(seat, recorded_attempt))
+            return recorded_attempt
 
     def request_cancel(
         self,
@@ -938,35 +1078,35 @@ class BudgetCoordinator:
 
         ``cancel_fn`` returns ``(transport_result, active_remaining)``.
         """
-        requested = build_cancel_requested_event(
-            request_id=request_id,
-            reason_class=reason_class,
-            transport_capability=transport_capability,
-            dimension=dimension,
-        )
-        self._commit([requested])
-        transport_result = "unsupported"
-        active_remaining = 0
-        if cancel_fn is not None:
-            transport_result, active_remaining = cancel_fn()
-        cancelled = build_cancelled_event(
-            request_id=request_id,
-            reason_class=reason_class,
-            transport_capability=transport_capability,
-            transport_result=transport_result,
-            active_remaining=active_remaining,
-            dimension=dimension,
-        )
-        self._commit([cancelled])
-        receipt = CancelReceipt(
-            request_id=request_id,
-            reason_class=reason_class,
-            transport_capability=transport_capability,
-            transport_result=transport_result,
-            active_remaining=active_remaining,
-            dimension=dimension,
-        )
-        return receipt
+        with self._lock:
+            requested = build_cancel_requested_event(
+                request_id=request_id,
+                reason_class=reason_class,
+                transport_capability=transport_capability,
+                dimension=dimension,
+            )
+            self._commit([requested])
+            transport_result = "unsupported"
+            active_remaining = 0
+            if cancel_fn is not None:
+                transport_result, active_remaining = cancel_fn()
+            cancelled = build_cancelled_event(
+                request_id=request_id,
+                reason_class=reason_class,
+                transport_capability=transport_capability,
+                transport_result=transport_result,
+                active_remaining=active_remaining,
+                dimension=dimension,
+            )
+            self._commit([cancelled])
+            return CancelReceipt(
+                request_id=request_id,
+                reason_class=reason_class,
+                transport_capability=transport_capability,
+                transport_result=transport_result,
+                active_remaining=active_remaining,
+                dimension=dimension,
+            )
 
     def reconcile_usage(
         self,
@@ -979,22 +1119,20 @@ class BudgetCoordinator:
         provider_used: int | None = None,
     ) -> None:
         """Record observed usage; estimated and provider values stay distinct."""
-        if dimension in ENFORCEABLE_DIMENSIONS and mode_for_dimension(dimension) == "enforceable":
-            # Wall-clock / dispatch remain coordinator-owned; still allow
-            # observed reconciliation records labeled with their mode.
-            pass
-        else:
-            # Observed dimensions are never hard-gated here.
-            _ = mode_for_dimension(dimension)
-        event = build_usage_reconciled_event(
-            dimension=dimension,
-            usage_source=usage_source,
-            used=used,
-            request_id=request_id,
-            estimated_used=estimated_used,
-            provider_used=provider_used,
-        )
-        self._commit([event])
+        with self._lock:
+            if dimension in ENFORCEABLE_DIMENSIONS and mode_for_dimension(dimension) == "enforceable":
+                pass
+            else:
+                _ = mode_for_dimension(dimension)
+            event = build_usage_reconciled_event(
+                dimension=dimension,
+                usage_source=usage_source,
+                used=used,
+                request_id=request_id,
+                estimated_used=estimated_used,
+                provider_used=provider_used,
+            )
+            self._commit([event])
 
 
 def terminal_status_for_policy(terminal_policy: str | None) -> tuple[str, str]:

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -14,6 +14,12 @@ Enforceable dimensions (hard gates before new work starts):
   - ``wall_clock_seconds``
   - ``worker_dispatch_count``
 
+Hard ceilings apply only when a run carries a persisted ``run_budget``
+declaration or ``verification_contract.budget`` with those fields. Ordinary
+``brigade run``, dogfood, and model-trial paths without a declaration remain
+unbounded for backward compatibility (no invented defaults, CLI flags, or
+timeout→budget mapping).
+
 Observed dimensions (recorded when an adapter reports reliable data; never
 universal hard gates in this slice):
   - ``model_call_count``, ``tool_call_count``

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -1,0 +1,1006 @@
+"""Run budget ceilings, durable lifecycle events, and restart-safe projection.
+
+Issue #593 first enforceable slice.
+
+Taxonomy decision (locked for this slice):
+  Budget exhaustion and operator cancellation are **terminal lifecycle / policy
+  states**, not members of the #576 worker ``FailureClass`` enum. They surface
+  as run-owned kinds ``budget-exhausted`` and ``operator-cancelled``. They must
+  not be treated as infrastructure under #580, and they must not be forced into
+  the worker-failure taxonomy (which would incorrectly neutralize preventable
+  planning or policy exhaustion).
+
+Enforceable dimensions (hard gates before new work starts):
+  - ``wall_clock_seconds``
+  - ``worker_dispatch_count``
+
+Observed dimensions (recorded when an adapter reports reliable data; never
+universal hard gates in this slice):
+  - ``model_call_count``, ``tool_call_count``
+  - ``input_tokens``, ``output_tokens``
+  - ``estimated_cost_micros``, ``provider_usage_units``
+
+Child frame / durable child-run allocation belongs to #594 and is out of scope.
+Missing child-allocation fields default to "no child budget" and remain
+readable.
+
+Lifecycle events use stable idempotency keys and at-least-once recovery
+semantics. Payloads carry safe summaries and classified artifact digests only
+— never raw diagnostics, prompts, tool args, or provider bodies.
+
+Standard library only. Brigade is zero-runtime-dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Sequence
+
+from brigade import run_events
+from brigade.run_events import MAX_DIAGNOSTIC_LEN, MAX_IDEMPOTENCY_KEY_LEN
+
+RUN_BUDGET_SCHEMA = "brigade.run_budget.v1"
+RUN_BUDGET_SCHEMA_VERSION = 1
+
+# Run-owned policy terminal kinds (not FailureClass / not infrastructure).
+POLICY_KIND_BUDGET_EXHAUSTED = "budget-exhausted"
+POLICY_KIND_OPERATOR_CANCELLED = "operator-cancelled"
+POLICY_TERMINAL_KINDS = frozenset(
+    {
+        POLICY_KIND_BUDGET_EXHAUSTED,
+        POLICY_KIND_OPERATOR_CANCELLED,
+    }
+)
+
+ENFORCEABLE_DIMENSIONS = frozenset({"wall_clock_seconds", "worker_dispatch_count"})
+OBSERVED_DIMENSIONS = frozenset(
+    {
+        "model_call_count",
+        "tool_call_count",
+        "input_tokens",
+        "output_tokens",
+        "estimated_cost_micros",
+        "provider_usage_units",
+    }
+)
+ALL_DIMENSIONS = ENFORCEABLE_DIMENSIONS | OBSERVED_DIMENSIONS
+
+BUDGET_MODES = frozenset({"enforceable", "observed"})
+USAGE_SOURCES = frozenset({"estimated", "provider_reconciled"})
+TRANSPORT_CAPABILITIES = frozenset({"interrupt", "process_cancel", "none"})
+TRANSPORT_RESULTS = frozenset(
+    {
+        "interrupted",
+        "not_interruptible",
+        "partial",
+        "unsupported",
+        "requested",
+    }
+)
+REASON_CLASSES = frozenset(
+    {
+        "threshold",
+        "reservation_denied",
+        "exhausted",
+        "operator_cancel",
+        "budget_cancel",
+        "usage_reconcile",
+        "unknown_dimension",
+        "schema_incompatible",
+    }
+)
+
+EVENT_THRESHOLD = "run_budget.threshold_reached"
+EVENT_DENIED = "run_budget.reservation_denied"
+EVENT_EXHAUSTED = "run_budget.exhausted"
+EVENT_CANCEL_REQUESTED = "run_budget.cancel_requested"
+EVENT_CANCELLED = "run_budget.cancelled"
+EVENT_RECONCILED = "run_budget.usage_reconciled"
+
+RUN_BUDGET_EVENT_TYPES = frozenset(
+    {
+        EVENT_THRESHOLD,
+        EVENT_DENIED,
+        EVENT_EXHAUSTED,
+        EVENT_CANCEL_REQUESTED,
+        EVENT_CANCELLED,
+        EVENT_RECONCILED,
+    }
+)
+
+DEFAULT_THRESHOLD_PCT = 80
+
+# Payload allowlists mirrored into run_events.EVENT_TYPES.
+RUN_BUDGET_EVENT_PAYLOADS: dict[str, frozenset[str]] = {
+    EVENT_THRESHOLD: frozenset({"dimension", "mode", "declared", "used", "remaining", "threshold_pct", "reason_class"}),
+    EVENT_DENIED: frozenset({"dimension", "mode", "declared", "used", "remaining", "request_id", "reason_class"}),
+    EVENT_EXHAUSTED: frozenset({"dimension", "mode", "declared", "used", "remaining", "reason_class"}),
+    EVENT_CANCEL_REQUESTED: frozenset({"request_id", "reason_class", "transport_capability", "dimension"}),
+    EVENT_CANCELLED: frozenset(
+        {
+            "request_id",
+            "reason_class",
+            "transport_capability",
+            "transport_result",
+            "active_remaining",
+            "dimension",
+        }
+    ),
+    EVENT_RECONCILED: frozenset(
+        {
+            "dimension",
+            "mode",
+            "usage_source",
+            "estimated_used",
+            "provider_used",
+            "used",
+            "request_id",
+            "reason_class",
+        }
+    ),
+}
+
+
+class BudgetError(RuntimeError):
+    """Bounded run-budget failure with a stable ``code``."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.diagnostic = _bound(message)
+
+
+class BudgetCompatibilityError(BudgetError):
+    """Unknown schema version or dimension; recovery must stop."""
+
+
+class BudgetPolicyError(BudgetError):
+    """Enforceable ceiling blocked new work (denial or exhaustion)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        dimension: str,
+        exhausted: bool,
+        request_id: str,
+    ) -> None:
+        super().__init__(message, code=code)
+        self.dimension = dimension
+        self.exhausted = exhausted
+        self.request_id = request_id
+
+
+def _bound(msg: str) -> str:
+    if len(msg) <= MAX_DIAGNOSTIC_LEN:
+        return msg
+    return msg[: MAX_DIAGNOSTIC_LEN - 1] + "\u2026"
+
+
+def _idempotency_key(*parts: str) -> str:
+    key = ":".join(parts)
+    if len(key) <= MAX_IDEMPOTENCY_KEY_LEN:
+        return key
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+    keep = MAX_IDEMPOTENCY_KEY_LEN - 17
+    return f"{key[:keep]}:{digest}"
+
+
+def mode_for_dimension(dimension: str) -> str:
+    if dimension in ENFORCEABLE_DIMENSIONS:
+        return "enforceable"
+    if dimension in OBSERVED_DIMENSIONS:
+        return "observed"
+    raise BudgetCompatibilityError(
+        _bound(f"unknown budget dimension {dimension!r}"),
+        code="unknown_dimension",
+    )
+
+
+@dataclass(frozen=True)
+class RunBudgetDeclaration:
+    """Declared ceilings and observation policy for one run."""
+
+    schema_version: int = RUN_BUDGET_SCHEMA_VERSION
+    wall_clock_seconds: int | None = None
+    worker_dispatch_count: int | None = None
+    threshold_pct: int = DEFAULT_THRESHOLD_PCT
+    # Observed-only declared caps (informational; never hard-gated here).
+    observed_caps: Mapping[str, int | None] = field(default_factory=dict)
+
+    def ceiling(self, dimension: str) -> int | None:
+        if dimension == "wall_clock_seconds":
+            return self.wall_clock_seconds
+        if dimension == "worker_dispatch_count":
+            return self.worker_dispatch_count
+        if dimension in OBSERVED_DIMENSIONS:
+            return self.observed_caps.get(dimension)
+        raise BudgetCompatibilityError(
+            _bound(f"unknown budget dimension {dimension!r}"),
+            code="unknown_dimension",
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        observed = {key: self.observed_caps.get(key) for key in sorted(OBSERVED_DIMENSIONS)}
+        return {
+            "schema": RUN_BUDGET_SCHEMA,
+            "schema_version": self.schema_version,
+            "ceilings": {
+                "wall_clock_seconds": self.wall_clock_seconds,
+                "worker_dispatch_count": self.worker_dispatch_count,
+            },
+            "observed": observed,
+            "threshold_pct": self.threshold_pct,
+        }
+
+
+def parse_declaration(payload: Mapping[str, Any] | None) -> RunBudgetDeclaration:
+    """Parse a run_budget declaration; unknown versions/dimensions fail closed."""
+    if payload is None:
+        return RunBudgetDeclaration()
+    if not isinstance(payload, Mapping):
+        raise BudgetCompatibilityError("run_budget declaration must be an object", code="schema_incompatible")
+    schema = payload.get("schema")
+    if schema is not None and schema != RUN_BUDGET_SCHEMA:
+        raise BudgetCompatibilityError(
+            _bound(f"unsupported run_budget schema {schema!r}"),
+            code="schema_incompatible",
+        )
+    version = payload.get("schema_version", RUN_BUDGET_SCHEMA_VERSION)
+    if version != RUN_BUDGET_SCHEMA_VERSION:
+        raise BudgetCompatibilityError(
+            _bound(f"unsupported run_budget schema_version {version!r}"),
+            code="schema_incompatible",
+        )
+    ceilings = payload.get("ceilings", {})
+    if ceilings is None:
+        ceilings = {}
+    if not isinstance(ceilings, Mapping):
+        raise BudgetCompatibilityError("ceilings must be an object", code="schema_incompatible")
+    unknown_ceilings = set(ceilings.keys()) - ENFORCEABLE_DIMENSIONS
+    # Child allocation keys are owned by #594; tolerate absence, refuse unknown.
+    if unknown_ceilings:
+        raise BudgetCompatibilityError(
+            _bound(f"unknown enforceable budget dimensions: {sorted(unknown_ceilings)}"),
+            code="unknown_dimension",
+        )
+    observed_raw = payload.get("observed", {})
+    if observed_raw is None:
+        observed_raw = {}
+    if not isinstance(observed_raw, Mapping):
+        raise BudgetCompatibilityError("observed must be an object", code="schema_incompatible")
+    unknown_observed = set(observed_raw.keys()) - OBSERVED_DIMENSIONS
+    if unknown_observed:
+        raise BudgetCompatibilityError(
+            _bound(f"unknown observed budget dimensions: {sorted(unknown_observed)}"),
+            code="unknown_dimension",
+        )
+    threshold = payload.get("threshold_pct", DEFAULT_THRESHOLD_PCT)
+    if not isinstance(threshold, int) or isinstance(threshold, bool) or not (1 <= threshold <= 100):
+        raise BudgetCompatibilityError("threshold_pct must be an integer 1..100", code="schema_incompatible")
+
+    def _opt_pos(value: object, *, field_name: str) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise BudgetCompatibilityError(
+                _bound(f"{field_name} must be a positive integer when set"),
+                code="schema_incompatible",
+            )
+        return value
+
+    observed_caps = {
+        key: _opt_pos(observed_raw.get(key), field_name=f"observed.{key}")
+        for key in OBSERVED_DIMENSIONS
+        if key in observed_raw
+    }
+    return RunBudgetDeclaration(
+        schema_version=int(version),
+        wall_clock_seconds=_opt_pos(ceilings.get("wall_clock_seconds"), field_name="wall_clock_seconds"),
+        worker_dispatch_count=_opt_pos(ceilings.get("worker_dispatch_count"), field_name="worker_dispatch_count"),
+        threshold_pct=threshold,
+        observed_caps=observed_caps,
+    )
+
+
+def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> RunBudgetDeclaration:
+    """Bridge #500 VerificationBudget into a run_budget declaration.
+
+    ``wall_clock_seconds`` / ``worker_dispatch_count`` are preferred when set.
+    Otherwise ``latency_seconds`` maps to the enforceable wall-clock ceiling so
+    existing contracts become enforceable without a template rewrite.
+    ``token_budget`` stays observed-only.
+    """
+    if not isinstance(budget, Mapping):
+        return RunBudgetDeclaration()
+    wall = budget.get("wall_clock_seconds")
+    if wall is None:
+        wall = budget.get("latency_seconds")
+    dispatch = budget.get("worker_dispatch_count")
+    observed: dict[str, int | None] = {}
+    token = budget.get("token_budget")
+    if isinstance(token, int) and not isinstance(token, bool) and token >= 0:
+        # Informational observed cap on total tokens (input+output not split here).
+        observed["input_tokens"] = token
+    payload = {
+        "schema": RUN_BUDGET_SCHEMA,
+        "schema_version": RUN_BUDGET_SCHEMA_VERSION,
+        "ceilings": {
+            "wall_clock_seconds": wall if isinstance(wall, int) and not isinstance(wall, bool) else None,
+            "worker_dispatch_count": (
+                dispatch if isinstance(dispatch, int) and not isinstance(dispatch, bool) else None
+            ),
+        },
+        "observed": observed,
+        "threshold_pct": DEFAULT_THRESHOLD_PCT,
+    }
+    return parse_declaration(payload)
+
+
+@dataclass(frozen=True)
+class CancelReceipt:
+    request_id: str
+    reason_class: str
+    transport_capability: str
+    transport_result: str
+    active_remaining: int
+    dimension: str
+
+
+@dataclass(frozen=True)
+class BudgetProjection:
+    """Restart-safe allocation view rebuilt from declaration + journal events."""
+
+    declaration: RunBudgetDeclaration
+    used: dict[str, int] = field(default_factory=dict)
+    estimated_used: dict[str, int] = field(default_factory=dict)
+    provider_used: dict[str, int] = field(default_factory=dict)
+    thresholds_emitted: frozenset[tuple[str, int]] = field(default_factory=frozenset)
+    exhausted_dimensions: frozenset[str] = field(default_factory=frozenset)
+    denied_request_ids: frozenset[str] = field(default_factory=frozenset)
+    cancel_receipts: tuple[CancelReceipt, ...] = ()
+    terminal_policy: str | None = None  # budget_exhausted | operator_cancelled
+
+    def remaining(self, dimension: str) -> int | None:
+        ceiling = self.declaration.ceiling(dimension)
+        if ceiling is None:
+            return None
+        return max(0, ceiling - self.used.get(dimension, 0))
+
+    def to_payload(self) -> dict[str, Any]:
+        """Safe summary for receipts/readers — no raw diagnostics."""
+        used_payload = {dim: int(self.used.get(dim, 0)) for dim in sorted(ALL_DIMENSIONS)}
+        remaining_payload: dict[str, int | None] = {dim: self.remaining(dim) for dim in sorted(ENFORCEABLE_DIMENSIONS)}
+        modes = {dim: mode_for_dimension(dim) for dim in sorted(ALL_DIMENSIONS)}
+        return {
+            "schema": RUN_BUDGET_SCHEMA,
+            "schema_version": self.declaration.schema_version,
+            "declaration": self.declaration.to_payload(),
+            "modes": modes,
+            "used": used_payload,
+            "estimated_used": {k: int(v) for k, v in sorted(self.estimated_used.items())},
+            "provider_used": {k: int(v) for k, v in sorted(self.provider_used.items())},
+            "remaining": remaining_payload,
+            "exhausted_dimensions": sorted(self.exhausted_dimensions),
+            "terminal_policy": self.terminal_policy,
+            "cancel_receipts": [
+                {
+                    "request_id": receipt.request_id,
+                    "reason_class": receipt.reason_class,
+                    "transport_capability": receipt.transport_capability,
+                    "transport_result": receipt.transport_result,
+                    "active_remaining": receipt.active_remaining,
+                    "dimension": receipt.dimension,
+                }
+                for receipt in self.cancel_receipts
+            ],
+        }
+
+
+def _event_type(event: Any) -> str | None:
+    if isinstance(event, Mapping):
+        value = event.get("event_type")
+        return value if isinstance(value, str) else None
+    value = getattr(event, "event_type", None)
+    return value if isinstance(value, str) else None
+
+
+def _event_payload(event: Any) -> Mapping[str, Any]:
+    if isinstance(event, Mapping):
+        payload = event.get("payload")
+        return payload if isinstance(payload, Mapping) else {}
+    payload = getattr(event, "payload", None)
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def project_budget_state(
+    declaration: RunBudgetDeclaration,
+    events: Sequence[Any],
+) -> BudgetProjection:
+    """Rebuild allocation from durable lifecycle events (restart-safe)."""
+    used: dict[str, int] = {dim: 0 for dim in ALL_DIMENSIONS}
+    estimated_used: dict[str, int] = {}
+    provider_used: dict[str, int] = {}
+    thresholds: set[tuple[str, int]] = set()
+    exhausted: set[str] = set()
+    denied: set[str] = set()
+    cancels: list[CancelReceipt] = []
+    terminal_policy: str | None = None
+
+    for event in events:
+        event_type = _event_type(event)
+        if event_type not in RUN_BUDGET_EVENT_TYPES:
+            continue
+        payload = _event_payload(event)
+        dimension = payload.get("dimension")
+        if isinstance(dimension, str) and dimension not in ALL_DIMENSIONS and dimension != "":
+            raise BudgetCompatibilityError(
+                _bound(f"unknown budget dimension in journal: {dimension!r}"),
+                code="unknown_dimension",
+            )
+
+        if event_type == EVENT_THRESHOLD:
+            if isinstance(dimension, str) and isinstance(payload.get("threshold_pct"), int):
+                thresholds.add((dimension, int(payload["threshold_pct"])))
+            if (
+                isinstance(dimension, str)
+                and dimension != "worker_dispatch_count"
+                and isinstance(payload.get("used"), int)
+                and not isinstance(payload.get("used"), bool)
+            ):
+                used[dimension] = max(used.get(dimension, 0), int(payload["used"]))
+        elif event_type == EVENT_DENIED:
+            request_id = payload.get("request_id")
+            if isinstance(request_id, str):
+                denied.add(request_id)
+            if (
+                isinstance(dimension, str)
+                and dimension != "worker_dispatch_count"
+                and isinstance(payload.get("used"), int)
+                and not isinstance(payload.get("used"), bool)
+            ):
+                used[dimension] = max(used.get(dimension, 0), int(payload["used"]))
+        elif event_type == EVENT_EXHAUSTED:
+            if isinstance(dimension, str):
+                exhausted.add(dimension)
+                if (
+                    dimension != "worker_dispatch_count"
+                    and isinstance(payload.get("used"), int)
+                    and not isinstance(payload.get("used"), bool)
+                ):
+                    used[dimension] = max(used.get(dimension, 0), int(payload["used"]))
+            terminal_policy = "budget_exhausted"
+        elif event_type == EVENT_CANCEL_REQUESTED:
+            reason = payload.get("reason_class")
+            if reason == "operator_cancel":
+                terminal_policy = "operator_cancelled"
+            elif reason == "budget_cancel" and terminal_policy is None:
+                terminal_policy = "budget_exhausted"
+        elif event_type == EVENT_CANCELLED:
+            receipt = CancelReceipt(
+                request_id=str(payload.get("request_id") or ""),
+                reason_class=str(payload.get("reason_class") or "budget_cancel"),
+                transport_capability=str(payload.get("transport_capability") or "none"),
+                transport_result=str(payload.get("transport_result") or "unsupported"),
+                active_remaining=int(payload["active_remaining"])
+                if isinstance(payload.get("active_remaining"), int)
+                and not isinstance(payload.get("active_remaining"), bool)
+                else 0,
+                dimension=str(payload.get("dimension") or ""),
+            )
+            cancels.append(receipt)
+            if receipt.reason_class == "operator_cancel":
+                terminal_policy = "operator_cancelled"
+            elif receipt.reason_class == "budget_cancel" and terminal_policy is None:
+                terminal_policy = "budget_exhausted"
+        elif event_type == EVENT_RECONCILED:
+            if not isinstance(dimension, str):
+                continue
+            usage_source = payload.get("usage_source")
+            est = payload.get("estimated_used")
+            if isinstance(est, int) and not isinstance(est, bool):
+                estimated_used[dimension] = est
+            prov = payload.get("provider_used")
+            if isinstance(prov, int) and not isinstance(prov, bool):
+                provider_used[dimension] = prov
+            # Enforceable used counters are coordinator-owned (dispatch.requested
+            # count / wall-clock elapsed). Observed dimensions take reconcile.
+            if dimension in ENFORCEABLE_DIMENSIONS:
+                continue
+            used_val = payload.get("used")
+            if isinstance(used_val, int) and not isinstance(used_val, bool):
+                used[dimension] = max(used.get(dimension, 0), used_val)
+            if usage_source == "provider_reconciled" and dimension in provider_used:
+                used[dimension] = provider_used[dimension]
+
+    # Enforceable dispatch usage: count durable run.dispatch.requested facts.
+    dispatch_used = 0
+    for event in events:
+        if _event_type(event) == "run.dispatch.requested":
+            dispatch_used += 1
+    if dispatch_used:
+        used["worker_dispatch_count"] = max(used.get("worker_dispatch_count", 0), dispatch_used)
+
+    return BudgetProjection(
+        declaration=declaration,
+        used=used,
+        estimated_used=estimated_used,
+        provider_used=provider_used,
+        thresholds_emitted=frozenset(thresholds),
+        exhausted_dimensions=frozenset(exhausted),
+        denied_request_ids=frozenset(denied),
+        cancel_receipts=tuple(cancels),
+        terminal_policy=terminal_policy,
+    )
+
+
+@dataclass(frozen=True)
+class ReservationDecision:
+    allowed: bool
+    dimension: str
+    request_id: str
+    exhausted: bool
+    projection: BudgetProjection
+    events: tuple[dict[str, Any], ...]  # event_type + payload + idempotency_key triples as dicts
+
+
+def evaluate_dispatch_reservation(
+    projection: BudgetProjection,
+    *,
+    request_id: str,
+    now: datetime,
+    started_at: datetime | None,
+    units: int = 1,
+) -> ReservationDecision:
+    """Decide whether a new worker dispatch may start.
+
+    Checks wall-clock first, then dispatch count. Does not mutate projection;
+    returns events the caller must append (idempotent under recovery).
+    """
+    if units <= 0:
+        raise BudgetError("reservation units must be positive", code="reservation_invalid")
+    declaration = projection.declaration
+    events: list[dict[str, Any]] = []
+
+    # Wall-clock: observed elapsed against enforceable ceiling.
+    wall_ceiling = declaration.wall_clock_seconds
+    if wall_ceiling is not None and started_at is not None:
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        elapsed = max(0, int((now - started_at).total_seconds()))
+        used = dict(projection.used)
+        used["wall_clock_seconds"] = max(used.get("wall_clock_seconds", 0), elapsed)
+        wall_proj = BudgetProjection(
+            declaration=declaration,
+            used=used,
+            estimated_used=dict(projection.estimated_used),
+            provider_used=dict(projection.provider_used),
+            thresholds_emitted=projection.thresholds_emitted,
+            exhausted_dimensions=projection.exhausted_dimensions,
+            denied_request_ids=projection.denied_request_ids,
+            cancel_receipts=projection.cancel_receipts,
+            terminal_policy=projection.terminal_policy,
+        )
+        events.extend(
+            _maybe_threshold_events(wall_proj, dimension="wall_clock_seconds", used=elapsed, declared=wall_ceiling)
+        )
+        if elapsed >= wall_ceiling:
+            exhausted_payload = {
+                "dimension": "wall_clock_seconds",
+                "mode": "enforceable",
+                "declared": wall_ceiling,
+                "used": elapsed,
+                "remaining": 0,
+                "reason_class": "exhausted",
+            }
+            events.append(
+                {
+                    "event_type": EVENT_EXHAUSTED,
+                    "payload": exhausted_payload,
+                    "idempotency_key": _idempotency_key(EVENT_EXHAUSTED, "wall_clock_seconds"),
+                }
+            )
+            denied_payload = {
+                "dimension": "wall_clock_seconds",
+                "mode": "enforceable",
+                "declared": wall_ceiling,
+                "used": elapsed,
+                "remaining": 0,
+                "request_id": request_id,
+                "reason_class": "reservation_denied",
+            }
+            events.append(
+                {
+                    "event_type": EVENT_DENIED,
+                    "payload": denied_payload,
+                    "idempotency_key": _idempotency_key(EVENT_DENIED, request_id),
+                }
+            )
+            return ReservationDecision(
+                allowed=False,
+                dimension="wall_clock_seconds",
+                request_id=request_id,
+                exhausted=True,
+                projection=wall_proj,
+                events=tuple(events),
+            )
+        projection = wall_proj
+
+    dispatch_ceiling = declaration.worker_dispatch_count
+    if dispatch_ceiling is not None:
+        current = projection.used.get("worker_dispatch_count", 0)
+        events.extend(
+            _maybe_threshold_events(
+                projection,
+                dimension="worker_dispatch_count",
+                used=current,
+                declared=dispatch_ceiling,
+            )
+        )
+        if current + units > dispatch_ceiling:
+            remaining = max(0, dispatch_ceiling - current)
+            exhausted = current >= dispatch_ceiling
+            if exhausted or remaining == 0:
+                events.append(
+                    {
+                        "event_type": EVENT_EXHAUSTED,
+                        "payload": {
+                            "dimension": "worker_dispatch_count",
+                            "mode": "enforceable",
+                            "declared": dispatch_ceiling,
+                            "used": current,
+                            "remaining": 0,
+                            "reason_class": "exhausted",
+                        },
+                        "idempotency_key": _idempotency_key(EVENT_EXHAUSTED, "worker_dispatch_count"),
+                    }
+                )
+                exhausted = True
+            events.append(
+                {
+                    "event_type": EVENT_DENIED,
+                    "payload": {
+                        "dimension": "worker_dispatch_count",
+                        "mode": "enforceable",
+                        "declared": dispatch_ceiling,
+                        "used": current,
+                        "remaining": remaining,
+                        "request_id": request_id,
+                        "reason_class": "reservation_denied",
+                    },
+                    "idempotency_key": _idempotency_key(EVENT_DENIED, request_id),
+                }
+            )
+            return ReservationDecision(
+                allowed=False,
+                dimension="worker_dispatch_count",
+                request_id=request_id,
+                exhausted=exhausted,
+                projection=projection,
+                events=tuple(events),
+            )
+        # Allowed: emit threshold for post-reserve level when crossing.
+        next_used = current + units
+        events.extend(
+            _maybe_threshold_events(
+                projection,
+                dimension="worker_dispatch_count",
+                used=next_used,
+                declared=dispatch_ceiling,
+            )
+        )
+
+    return ReservationDecision(
+        allowed=True,
+        dimension="worker_dispatch_count",
+        request_id=request_id,
+        exhausted=False,
+        projection=projection,
+        events=tuple(events),
+    )
+
+
+def _maybe_threshold_events(
+    projection: BudgetProjection,
+    *,
+    dimension: str,
+    used: int,
+    declared: int,
+) -> list[dict[str, Any]]:
+    pct = projection.declaration.threshold_pct
+    if declared <= 0:
+        return []
+    if used * 100 < declared * pct:
+        return []
+    if (dimension, pct) in projection.thresholds_emitted:
+        return []
+    remaining = max(0, declared - used)
+    return [
+        {
+            "event_type": EVENT_THRESHOLD,
+            "payload": {
+                "dimension": dimension,
+                "mode": mode_for_dimension(dimension),
+                "declared": declared,
+                "used": used,
+                "remaining": remaining,
+                "threshold_pct": pct,
+                "reason_class": "threshold",
+            },
+            "idempotency_key": _idempotency_key(EVENT_THRESHOLD, dimension, str(pct)),
+        }
+    ]
+
+
+def build_cancel_requested_event(
+    *,
+    request_id: str,
+    reason_class: str,
+    transport_capability: str,
+    dimension: str,
+) -> dict[str, Any]:
+    if reason_class not in {"operator_cancel", "budget_cancel"}:
+        raise BudgetError("invalid cancel reason_class", code="cancel_invalid")
+    if transport_capability not in TRANSPORT_CAPABILITIES:
+        raise BudgetError("invalid transport_capability", code="cancel_invalid")
+    return {
+        "event_type": EVENT_CANCEL_REQUESTED,
+        "payload": {
+            "request_id": request_id,
+            "reason_class": reason_class,
+            "transport_capability": transport_capability,
+            "dimension": dimension,
+        },
+        "idempotency_key": _idempotency_key(EVENT_CANCEL_REQUESTED, request_id),
+    }
+
+
+def build_cancelled_event(
+    *,
+    request_id: str,
+    reason_class: str,
+    transport_capability: str,
+    transport_result: str,
+    active_remaining: int,
+    dimension: str,
+) -> dict[str, Any]:
+    if transport_result not in TRANSPORT_RESULTS:
+        raise BudgetError("invalid transport_result", code="cancel_invalid")
+    if not isinstance(active_remaining, int) or isinstance(active_remaining, bool) or active_remaining < 0:
+        raise BudgetError("active_remaining must be a non-negative integer", code="cancel_invalid")
+    return {
+        "event_type": EVENT_CANCELLED,
+        "payload": {
+            "request_id": request_id,
+            "reason_class": reason_class,
+            "transport_capability": transport_capability,
+            "transport_result": transport_result,
+            "active_remaining": active_remaining,
+            "dimension": dimension,
+        },
+        "idempotency_key": _idempotency_key(EVENT_CANCELLED, request_id),
+    }
+
+
+def build_usage_reconciled_event(
+    *,
+    dimension: str,
+    usage_source: str,
+    used: int,
+    request_id: str,
+    estimated_used: int | None = None,
+    provider_used: int | None = None,
+) -> dict[str, Any]:
+    if dimension not in ALL_DIMENSIONS:
+        raise BudgetCompatibilityError(
+            _bound(f"unknown budget dimension {dimension!r}"),
+            code="unknown_dimension",
+        )
+    if usage_source not in USAGE_SOURCES:
+        raise BudgetError("invalid usage_source", code="reconcile_invalid")
+    mode = mode_for_dimension(dimension)
+    # Enforceable dimensions may only reconcile as observed telemetry when an
+    # adapter reports them; hard gates still own reservation.
+    return {
+        "event_type": EVENT_RECONCILED,
+        "payload": {
+            "dimension": dimension,
+            "mode": mode,
+            "usage_source": usage_source,
+            "estimated_used": estimated_used,
+            "provider_used": provider_used,
+            "used": used,
+            "request_id": request_id,
+            "reason_class": "usage_reconcile",
+        },
+        "idempotency_key": _idempotency_key(EVENT_RECONCILED, dimension, usage_source, request_id),
+    }
+
+
+def validate_run_budget_payload(event_type: str, payload: Mapping[str, Any]) -> None:
+    """Extra closed-enum checks invoked from run_events._validate_payload."""
+    if event_type not in RUN_BUDGET_EVENT_TYPES:
+        return
+    dimension = payload.get("dimension")
+    if dimension is not None:
+        if not isinstance(dimension, str) or (dimension and dimension not in ALL_DIMENSIONS):
+            raise run_events.CanonicalizationError(_bound(f"invalid run_budget dimension {dimension!r}"))
+    mode = payload.get("mode")
+    if mode is not None and mode not in BUDGET_MODES:
+        raise run_events.CanonicalizationError(_bound(f"invalid run_budget mode {mode!r}"))
+    reason = payload.get("reason_class")
+    if reason is not None and reason not in REASON_CLASSES:
+        raise run_events.CanonicalizationError(_bound(f"invalid run_budget reason_class {reason!r}"))
+    if event_type == EVENT_RECONCILED:
+        source = payload.get("usage_source")
+        if source not in USAGE_SOURCES:
+            raise run_events.CanonicalizationError("run_budget.usage_reconciled usage_source is invalid")
+    if event_type in {EVENT_CANCEL_REQUESTED, EVENT_CANCELLED}:
+        cap = payload.get("transport_capability")
+        if cap not in TRANSPORT_CAPABILITIES:
+            raise run_events.CanonicalizationError("run_budget cancel transport_capability is invalid")
+    if event_type == EVENT_CANCELLED:
+        result = payload.get("transport_result")
+        if result not in TRANSPORT_RESULTS:
+            raise run_events.CanonicalizationError("run_budget.cancelled transport_result is invalid")
+        active = payload.get("active_remaining")
+        if not isinstance(active, int) or isinstance(active, bool) or active < 0:
+            raise run_events.CanonicalizationError("run_budget.cancelled active_remaining is invalid")
+
+
+AppendEvent = Callable[[str, Mapping[str, Any], str], Any]
+
+
+@dataclass
+class BudgetCoordinator:
+    """Coordinator-owned remaining allocation for one run.
+
+    Callers that hold the run lock append events through ``append_event``.
+    Projection is rebuilt from the journal on ``reload`` so restarts are safe.
+    """
+
+    declaration: RunBudgetDeclaration
+    append_event: AppendEvent
+    clock: Callable[[], datetime] = field(default=lambda: datetime.now(timezone.utc))
+    _projection: BudgetProjection = field(init=False)
+    _started_at: datetime | None = None
+    _events_cache: list[Any] = field(default_factory=list)
+    _pending_dispatch_units: int = 0
+
+    def __post_init__(self) -> None:
+        self._projection = BudgetProjection(declaration=self.declaration)
+
+    def set_started_at(self, started_at: datetime | None) -> None:
+        self._started_at = started_at
+
+    def reload(self, events: Sequence[Any]) -> BudgetProjection:
+        self._events_cache = list(events)
+        self._projection = project_budget_state(self.declaration, events)
+        # Journal dispatch.requested facts supersede in-process reservations.
+        self._pending_dispatch_units = 0
+        return self._projection
+
+    @property
+    def projection(self) -> BudgetProjection:
+        if self._pending_dispatch_units <= 0:
+            return self._projection
+        used = dict(self._projection.used)
+        used["worker_dispatch_count"] = used.get("worker_dispatch_count", 0) + self._pending_dispatch_units
+        return replace(self._projection, used=used)
+
+    def _commit(self, event_specs: Sequence[Mapping[str, Any]]) -> None:
+        for spec in event_specs:
+            self.append_event(str(spec["event_type"]), dict(spec["payload"]), str(spec["idempotency_key"]))
+            synthetic = {"event_type": spec["event_type"], "payload": dict(spec["payload"])}
+            self._events_cache.append(synthetic)
+        self._projection = project_budget_state(self.declaration, self._events_cache)
+
+    def reserve_worker_dispatch(self, *, request_id: str, units: int = 1) -> ReservationDecision:
+        """Reserve enforceable dispatch units before new work starts."""
+        decision = evaluate_dispatch_reservation(
+            self.projection,
+            request_id=request_id,
+            now=self.clock(),
+            started_at=self._started_at,
+            units=units,
+        )
+        if decision.events:
+            self._commit(decision.events)
+        if not decision.allowed:
+            raise BudgetPolicyError(
+                _bound(
+                    f"run budget reservation denied for {decision.dimension}"
+                    + (" (exhausted)" if decision.exhausted else "")
+                ),
+                code="reservation_denied" if not decision.exhausted else "budget_exhausted",
+                dimension=decision.dimension,
+                exhausted=decision.exhausted,
+                request_id=request_id,
+            )
+        self._pending_dispatch_units += units
+        return decision
+
+    def request_cancel(
+        self,
+        *,
+        request_id: str,
+        reason_class: str,
+        transport_capability: str,
+        dimension: str,
+        cancel_fn: Callable[[], tuple[str, int]] | None = None,
+    ) -> CancelReceipt:
+        """Best-effort cancel of active work with durable cancel receipts.
+
+        ``cancel_fn`` returns ``(transport_result, active_remaining)``.
+        """
+        requested = build_cancel_requested_event(
+            request_id=request_id,
+            reason_class=reason_class,
+            transport_capability=transport_capability,
+            dimension=dimension,
+        )
+        self._commit([requested])
+        transport_result = "unsupported"
+        active_remaining = 0
+        if cancel_fn is not None:
+            transport_result, active_remaining = cancel_fn()
+        cancelled = build_cancelled_event(
+            request_id=request_id,
+            reason_class=reason_class,
+            transport_capability=transport_capability,
+            transport_result=transport_result,
+            active_remaining=active_remaining,
+            dimension=dimension,
+        )
+        self._commit([cancelled])
+        receipt = CancelReceipt(
+            request_id=request_id,
+            reason_class=reason_class,
+            transport_capability=transport_capability,
+            transport_result=transport_result,
+            active_remaining=active_remaining,
+            dimension=dimension,
+        )
+        return receipt
+
+    def reconcile_usage(
+        self,
+        *,
+        dimension: str,
+        usage_source: str,
+        used: int,
+        request_id: str,
+        estimated_used: int | None = None,
+        provider_used: int | None = None,
+    ) -> None:
+        """Record observed usage; estimated and provider values stay distinct."""
+        if dimension in ENFORCEABLE_DIMENSIONS and mode_for_dimension(dimension) == "enforceable":
+            # Wall-clock / dispatch remain coordinator-owned; still allow
+            # observed reconciliation records labeled with their mode.
+            pass
+        else:
+            # Observed dimensions are never hard-gated here.
+            _ = mode_for_dimension(dimension)
+        event = build_usage_reconciled_event(
+            dimension=dimension,
+            usage_source=usage_source,
+            used=used,
+            request_id=request_id,
+            estimated_used=estimated_used,
+            provider_used=provider_used,
+        )
+        self._commit([event])
+
+
+def terminal_status_for_policy(terminal_policy: str | None) -> tuple[str, str]:
+    """Return ``(run.json status, failure_kind)`` for a policy terminal."""
+    if terminal_policy == "operator_cancelled":
+        return "canceled", POLICY_KIND_OPERATOR_CANCELLED
+    if terminal_policy == "budget_exhausted":
+        return "failed", POLICY_KIND_BUDGET_EXHAUSTED
+    raise BudgetError(f"unknown terminal policy {terminal_policy!r}", code="terminal_invalid")

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -1094,6 +1094,37 @@ class BudgetCoordinator:
                 attempts.append(attempt)
         return max(attempts, default=0)
 
+    def _ensure_wall_clock_allows_unlocked(self, *, request_id: str) -> None:
+        """Deny authorization when the wall-clock ceiling is already exhausted.
+
+        Used by restart reclaim before handing a durable pending identity back
+        to the caller for external launch. Dispatch-count is not re-checked:
+        the durable ``run.dispatch.requested`` already owns that unit.
+        """
+        if self.declaration.wall_clock_seconds is None:
+            return
+        wall_only = replace(self._projection_unlocked(), declaration=replace(self.declaration, worker_dispatch_count=None))
+        decision = evaluate_dispatch_reservation(
+            wall_only,
+            request_id=request_id,
+            now=self.clock(),
+            started_at=self._started_at,
+            units=1,
+        )
+        if decision.events:
+            self._commit(decision.events)
+        if not decision.allowed:
+            raise BudgetPolicyError(
+                _bound(
+                    f"run budget reservation denied for {decision.dimension}"
+                    + (" (exhausted)" if decision.exhausted else "")
+                ),
+                code="reservation_denied" if not decision.exhausted else "budget_exhausted",
+                dimension=decision.dimension,
+                exhausted=decision.exhausted,
+                request_id=request_id,
+            )
+
     def reserve_and_record_dispatch(
         self,
         *,
@@ -1105,9 +1136,10 @@ class BudgetCoordinator:
 
         Attempt allocation and reservation share one lock so parallel same-seat
         callers cannot both claim attempt 1. A durable open pending identity is
-        reclaimed once per process (crash/retry); concurrent callers then
-        allocate a fresh attempt. The durable ``run.dispatch.requested`` fact is
-        written before unlock so external transport cannot start without it.
+        reclaimed once per process (crash/retry) only after the wall-clock
+        ceiling still allows authorization; concurrent callers then allocate a
+        fresh attempt. The durable ``run.dispatch.requested`` fact is written
+        before unlock so external transport cannot start without it.
         """
         if not isinstance(seat, str) or not seat:
             raise BudgetError("seat must be a non-empty string", code="reservation_invalid")
@@ -1116,7 +1148,9 @@ class BudgetCoordinator:
             if pending is not None:
                 pending_id = dispatch_reservation_request_id(seat, pending)
                 if pending_id not in self._launch_claims and self._has_durable_dispatch_requested(seat, pending):
-                    # Restart/recovery: reclaim the unfinished durable identity once.
+                    # Restart/recovery: reclaim the unfinished durable identity
+                    # once, but never authorize launch past a wall-clock ceiling.
+                    self._ensure_wall_clock_allows_unlocked(request_id=pending_id)
                     self._launch_claims.add(pending_id)
                     self._reserved_request_ids.add(pending_id)
                     return pending

--- a/src/brigade/run_events.py
+++ b/src/brigade/run_events.py
@@ -122,6 +122,38 @@ EVENT_TYPES: dict[str, frozenset[str]] = {
     "control.requested": frozenset({"op", "worker", "text_digest", "turn_id", "request_id"}),
     "control.observed": frozenset({"op", "worker", "turn_id", "request_id", "detail"}),
     "control.failed": frozenset({"op", "worker", "turn_id", "request_id", "error_class", "detail_digest"}),
+    # Run budget lifecycle (issue #593). Safe summaries only — never raw
+    # diagnostics, prompts, tool args, or provider bodies.
+    "run_budget.threshold_reached": frozenset(
+        {"dimension", "mode", "declared", "used", "remaining", "threshold_pct", "reason_class"}
+    ),
+    "run_budget.reservation_denied": frozenset(
+        {"dimension", "mode", "declared", "used", "remaining", "request_id", "reason_class"}
+    ),
+    "run_budget.exhausted": frozenset({"dimension", "mode", "declared", "used", "remaining", "reason_class"}),
+    "run_budget.cancel_requested": frozenset({"request_id", "reason_class", "transport_capability", "dimension"}),
+    "run_budget.cancelled": frozenset(
+        {
+            "request_id",
+            "reason_class",
+            "transport_capability",
+            "transport_result",
+            "active_remaining",
+            "dimension",
+        }
+    ),
+    "run_budget.usage_reconciled": frozenset(
+        {
+            "dimension",
+            "mode",
+            "usage_source",
+            "estimated_used",
+            "provider_used",
+            "used",
+            "request_id",
+            "reason_class",
+        }
+    ),
 }
 CONTROL_FAILURE_CLASSES = frozenset({"transport_exception", "transport_rejected", "transport_protocol_error"})
 APPROVAL_DECISION_STATES = frozenset({"pending", "approved", "rejected", "held", "consumed"})
@@ -363,6 +395,10 @@ def _validate_payload(event_type: str, payload: Any) -> None:
         detail_digest = payload.get("detail_digest")
         if not isinstance(detail_digest, str) or not _HEX64.fullmatch(detail_digest):
             raise CanonicalizationError("control.failed detail_digest is invalid")
+    if event_type.startswith("run_budget."):
+        from brigade import run_budget
+
+        run_budget.validate_run_budget_payload(event_type, payload)
 
 
 def validate_event(env: Any) -> list[str]:

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -368,6 +368,28 @@ def next_dispatch_attempt(run_dir: Path, seat: str) -> int:
     for pending_seat, pending_attempt in pending_dispatch_requests(report.events):
         if pending_seat == seat and pending_attempt is not None:
             return pending_attempt
+    return allocate_next_dispatch_attempt(run_dir, seat)
+
+
+def allocate_next_dispatch_attempt(run_dir: Path, seat: str) -> int:
+    """Allocate ``max(prior attempts)+1`` for ``seat`` without pending reuse.
+
+    Used inside the budget reservation lock so concurrent same-seat callers
+    mint distinct identities. Crash/retry reclaim of an open pending identity is
+    owned by ``BudgetCoordinator.reserve_and_record_dispatch``.
+    """
+    if not isinstance(seat, str) or not seat:
+        raise LifecycleJournalError(run_events._bound("dispatch fact seat must be non-empty"))
+    run_dir = Path(run_dir).expanduser().resolve()
+    journal_path = _dispatch_journal_path(run_dir)
+    if journal_path is None:
+        return 1
+    try:
+        report = run_journal.read_journal_bounded(journal_path)
+    except (OSError, run_journal.RunJournalError):
+        return 1
+    if report.partial_tail is not None or report.chain_errors:
+        raise LifecycleJournalError(run_events._bound(_CHAIN_CATEGORY))
     attempts: list[int] = []
     for prior_event in report.events:
         if prior_event.payload.get("seat") != seat:
@@ -939,6 +961,7 @@ __all__ = [
     "LifecycleJournalError",
     "STATUS_EVENT_TYPE",
     "approval_idempotency_key",
+    "allocate_next_dispatch_attempt",
     "checkpoint_event_pair",
     "is_lifecycle_journaling_enabled",
     "next_dispatch_attempt",

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -345,6 +345,39 @@ def pending_dispatch_requests(events: list[run_journal.RunEvent]) -> list[tuple[
     return pending
 
 
+def next_dispatch_attempt(run_dir: Path, seat: str) -> int:
+    """Return the stable attempt id for the next reservation of ``seat``.
+
+    Reuses an open pending ``run.dispatch.requested`` for the seat when one
+    exists so crash/retry before observed/completed/failed keeps the same
+    budget reservation identity. Otherwise allocates ``max(prior)+1``.
+    Missing or inactive journals start at attempt 1.
+    """
+    if not isinstance(seat, str) or not seat:
+        raise LifecycleJournalError(run_events._bound("dispatch fact seat must be non-empty"))
+    run_dir = Path(run_dir).expanduser().resolve()
+    journal_path = _dispatch_journal_path(run_dir)
+    if journal_path is None:
+        return 1
+    try:
+        report = run_journal.read_journal_bounded(journal_path)
+    except (OSError, run_journal.RunJournalError):
+        return 1
+    if report.partial_tail is not None or report.chain_errors:
+        raise LifecycleJournalError(run_events._bound(_CHAIN_CATEGORY))
+    for pending_seat, pending_attempt in pending_dispatch_requests(report.events):
+        if pending_seat == seat and pending_attempt is not None:
+            return pending_attempt
+    attempts: list[int] = []
+    for prior_event in report.events:
+        if prior_event.payload.get("seat") != seat:
+            continue
+        candidate = prior_event.payload.get("attempt")
+        if isinstance(candidate, int) and not isinstance(candidate, bool) and candidate > 0:
+            attempts.append(candidate)
+    return max(attempts, default=0) + 1
+
+
 def record_dispatch_fact(
     run_dir: Path,
     *,
@@ -908,6 +941,7 @@ __all__ = [
     "approval_idempotency_key",
     "checkpoint_event_pair",
     "is_lifecycle_journaling_enabled",
+    "next_dispatch_attempt",
     "normalize_approval_reference",
     "pending_dispatch_requests",
     "prepare_lifecycle_journal",

--- a/src/brigade/run_projector.py
+++ b/src/brigade/run_projector.py
@@ -60,6 +60,8 @@ PRESERVED_FIELDS: frozenset[str] = frozenset(
         "lifecycle_journal_requested",
         "run_journal_authority_requested",
         "approval_reference",
+        "verification_contract",
+        "run_budget",
         # Timing
         "started_at",
         "status_started_at",

--- a/src/brigade/run_projector.py
+++ b/src/brigade/run_projector.py
@@ -153,6 +153,14 @@ _STATUS_NEUTRAL_EVENT_TYPES: frozenset[str] = frozenset(
         "control.requested",
         "control.observed",
         "control.failed",
+        # Run-budget lifecycle facts are status-neutral; terminal policy is
+        # applied by the coordinator via run.failed / run.interrupted (issue #593).
+        "run_budget.threshold_reached",
+        "run_budget.reservation_denied",
+        "run_budget.exhausted",
+        "run_budget.cancel_requested",
+        "run_budget.cancelled",
+        "run_budget.usage_reconciled",
     }
 )
 

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -59,6 +59,21 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _persisted_budget_artifact(run_dir: Path, run_meta: dict) -> bool:
+    """True when run artifacts carry a persisted budget declaration object."""
+    if isinstance(run_meta.get("run_budget"), dict):
+        return True
+    contract = verification_contract.extract_contract_payload(run_meta)
+    if isinstance(contract, dict) and isinstance(contract.get("budget"), dict):
+        return True
+    plan = _load_json(run_dir, "plan.json")
+    if isinstance(plan, dict):
+        contract = verification_contract.extract_contract_payload(plan)
+        if isinstance(contract, dict) and isinstance(contract.get("budget"), dict):
+            return True
+    return False
+
+
 def _declaration_from_run_artifacts(run_dir: Path, run_meta: dict) -> run_budget.RunBudgetDeclaration:
     """Load the persisted run_budget / verification_contract declaration for resume."""
     if isinstance(run_meta.get("run_budget"), dict):
@@ -81,15 +96,40 @@ def _declaration_from_run_artifacts(run_dir: Path, run_meta: dict) -> run_budget
     return run_budget.RunBudgetDeclaration()
 
 
-def _lifecycle_events_for_budget_projection(run_dir: Path) -> list[object]:
+def _lifecycle_events_for_budget_projection(
+    run_dir: Path,
+    *,
+    require_trusted: bool,
+) -> list[object]:
+    """Load lifecycle events for budget projection.
+
+    When ``require_trusted`` is set (persisted declared budget), journal read,
+    chain, partial-tail, and compatibility failures fail closed instead of
+    degrading to an empty event list.
+    """
     journal_path = run_dir / "events" / "lifecycle.jsonl"
     if not journal_path.is_file():
         return []
     try:
         report = run_journal.read_journal_bounded(journal_path)
-    except (OSError, run_journal.RunJournalError, run_events.CanonicalizationError):
+    except (OSError, run_journal.RunJournalError, run_events.CanonicalizationError) as exc:
+        if require_trusted:
+            detail = getattr(exc, "diagnostic", None) or str(exc)
+            raise run_budget.BudgetCompatibilityError(
+                f"lifecycle journal unreadable for declared budget: {detail}",
+                code="journal_untrusted",
+            ) from exc
         return []
     if report.partial_tail is not None or report.chain_errors:
+        if require_trusted:
+            if report.partial_tail is not None:
+                reason = "partial tail"
+            else:
+                reason = "; ".join(report.chain_errors[:3]) or "chain error"
+            raise run_budget.BudgetCompatibilityError(
+                f"lifecycle journal untrusted for declared budget: {reason}",
+                code="journal_untrusted",
+            )
         return []
     return list(report.events)
 
@@ -100,15 +140,22 @@ def _resume_budget_blocked(run_dir: Path, run_meta: dict, *, now: datetime | Non
     Uses the persisted declaration, original ``started_at``, and authoritative
     lifecycle projection. Undeclared runs stay unbounded. Already exhausted or
     newly expired declared ceilings refuse before ``AppServer.start()``.
+    Persisted declarations also fail closed when the lifecycle journal cannot be
+    read and trusted or when budget fields are malformed/incompatible.
     """
+    persisted = _persisted_budget_artifact(run_dir, run_meta)
     try:
         declaration = _declaration_from_run_artifacts(run_dir, run_meta)
     except run_budget.BudgetCompatibilityError as exc:
         return f"run budget declaration is incompatible: {exc.diagnostic}"
 
     has_enforceable = declaration.wall_clock_seconds is not None or declaration.worker_dispatch_count is not None
-    events = _lifecycle_events_for_budget_projection(run_dir)
-    projection = run_budget.project_budget_state(declaration, events)
+    require_trusted = persisted or has_enforceable
+    try:
+        events = _lifecycle_events_for_budget_projection(run_dir, require_trusted=require_trusted)
+        projection = run_budget.project_budget_state(declaration, events)
+    except run_budget.BudgetCompatibilityError as exc:
+        return f"run budget lifecycle projection is untrusted: {exc.diagnostic}"
     if projection.terminal_policy == "budget_exhausted" or projection.exhausted_dimensions:
         return "run budget exhausted; resume refused"
     if not has_enforceable:

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -101,13 +101,7 @@ def _declaration_from_run_artifacts(run_dir: Path, run_meta: dict) -> run_budget
                 "run_budget must be an object",
                 code="schema_incompatible",
             )
-        if "declaration" in raw_budget and not isinstance(raw_budget.get("declaration"), dict):
-            raise run_budget.BudgetCompatibilityError(
-                "run_budget.declaration must be an object when set",
-                code="schema_incompatible",
-            )
-        nested = raw_budget["declaration"] if isinstance(raw_budget.get("declaration"), dict) else raw_budget
-        return _require_declaration_content(run_budget.parse_declaration(nested))
+        return _require_declaration_content(run_budget.declaration_from_persisted_artifact(raw_budget))
 
     for container in (run_meta, _load_json(run_dir, "plan.json")):
         if not isinstance(container, dict) or "verification_contract" not in container:
@@ -125,7 +119,11 @@ def _declaration_from_run_artifacts(run_dir: Path, run_meta: dict) -> run_budget
                 code="schema_incompatible",
             )
         version = contract.get("schema_version")
-        if version is not None and version != verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION:
+        if version is not None and (
+            isinstance(version, bool)
+            or not isinstance(version, int)
+            or version != verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION
+        ):
             raise run_budget.BudgetCompatibilityError(
                 f"unsupported verification_contract schema_version {version!r}",
                 code="schema_incompatible",

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -60,39 +60,89 @@ def _utc_now() -> datetime:
 
 
 def _persisted_budget_artifact(run_dir: Path, run_meta: dict) -> bool:
-    """True when run artifacts carry a persisted budget declaration object."""
-    if isinstance(run_meta.get("run_budget"), dict):
+    """True when run artifacts carry a persisted budget declaration marker."""
+    if "run_budget" in run_meta:
         return True
-    contract = verification_contract.extract_contract_payload(run_meta)
-    if isinstance(contract, dict) and isinstance(contract.get("budget"), dict):
-        return True
+    if "verification_contract" in run_meta:
+        contract = run_meta.get("verification_contract")
+        if not isinstance(contract, dict):
+            return True
+        if "budget" in contract:
+            return True
     plan = _load_json(run_dir, "plan.json")
-    if isinstance(plan, dict):
-        contract = verification_contract.extract_contract_payload(plan)
-        if isinstance(contract, dict) and isinstance(contract.get("budget"), dict):
+    if isinstance(plan, dict) and "verification_contract" in plan:
+        contract = plan.get("verification_contract")
+        if not isinstance(contract, dict):
+            return True
+        if "budget" in contract:
             return True
     return False
 
 
-def _declaration_from_run_artifacts(run_dir: Path, run_meta: dict) -> run_budget.RunBudgetDeclaration:
-    """Load the persisted run_budget / verification_contract declaration for resume."""
-    if isinstance(run_meta.get("run_budget"), dict):
-        nested = (
-            run_meta["run_budget"].get("declaration")
-            if isinstance(run_meta["run_budget"].get("declaration"), dict)
-            else run_meta["run_budget"]
+def _require_declaration_content(declaration: run_budget.RunBudgetDeclaration) -> run_budget.RunBudgetDeclaration:
+    if not run_budget.declaration_has_budget_content(declaration):
+        raise run_budget.BudgetCompatibilityError(
+            "persisted budget declaration is empty or unknown-only",
+            code="schema_incompatible",
         )
-        return run_budget.parse_declaration(nested if isinstance(nested, dict) else None)
+    return declaration
 
-    contract = verification_contract.extract_contract_payload(run_meta)
-    budget = contract.get("budget") if isinstance(contract, dict) else None
-    if not isinstance(budget, dict):
-        plan = _load_json(run_dir, "plan.json")
-        if isinstance(plan, dict):
-            contract = verification_contract.extract_contract_payload(plan)
-            budget = contract.get("budget") if isinstance(contract, dict) else None
-    if isinstance(budget, dict):
-        return run_budget.declaration_from_verification_budget(budget)
+
+def _declaration_from_run_artifacts(run_dir: Path, run_meta: dict) -> run_budget.RunBudgetDeclaration:
+    """Load the persisted run_budget / verification_contract declaration for resume.
+
+    Wrong-type markers, invalid nested declaration objects, empty/unknown-only
+    declarations, and unsupported verification-budget shapes fail closed.
+    """
+    if "run_budget" in run_meta:
+        raw_budget = run_meta.get("run_budget")
+        if not isinstance(raw_budget, dict):
+            raise run_budget.BudgetCompatibilityError(
+                "run_budget must be an object",
+                code="schema_incompatible",
+            )
+        if "declaration" in raw_budget and not isinstance(raw_budget.get("declaration"), dict):
+            raise run_budget.BudgetCompatibilityError(
+                "run_budget.declaration must be an object when set",
+                code="schema_incompatible",
+            )
+        nested = raw_budget["declaration"] if isinstance(raw_budget.get("declaration"), dict) else raw_budget
+        return _require_declaration_content(run_budget.parse_declaration(nested))
+
+    for container in (run_meta, _load_json(run_dir, "plan.json")):
+        if not isinstance(container, dict) or "verification_contract" not in container:
+            continue
+        contract = container.get("verification_contract")
+        if not isinstance(contract, dict):
+            raise run_budget.BudgetCompatibilityError(
+                "verification_contract must be an object",
+                code="schema_incompatible",
+            )
+        schema = contract.get("schema")
+        if schema is not None and schema != verification_contract.VERIFICATION_CONTRACT_SCHEMA:
+            raise run_budget.BudgetCompatibilityError(
+                f"unsupported verification_contract schema {schema!r}",
+                code="schema_incompatible",
+            )
+        version = contract.get("schema_version")
+        if version is not None and version != verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION:
+            raise run_budget.BudgetCompatibilityError(
+                f"unsupported verification_contract schema_version {version!r}",
+                code="schema_incompatible",
+            )
+        if "budget" not in contract:
+            raise run_budget.BudgetCompatibilityError(
+                "verification_contract budget is required when contract is persisted",
+                code="schema_incompatible",
+            )
+        budget = contract.get("budget")
+        if not isinstance(budget, dict):
+            raise run_budget.BudgetCompatibilityError(
+                "verification_contract budget must be an object",
+                code="schema_incompatible",
+            )
+        return _require_declaration_content(run_budget.declaration_from_verification_budget(budget))
+
     return run_budget.RunBudgetDeclaration()
 
 
@@ -103,12 +153,17 @@ def _lifecycle_events_for_budget_projection(
 ) -> list[object]:
     """Load lifecycle events for budget projection.
 
-    When ``require_trusted`` is set (persisted declared budget), journal read,
-    chain, partial-tail, and compatibility failures fail closed instead of
-    degrading to an empty event list.
+    When ``require_trusted`` is set (persisted declared budget), missing journal,
+    journal read, chain, partial-tail, and compatibility failures fail closed
+    instead of degrading to an empty event list.
     """
     journal_path = run_dir / "events" / "lifecycle.jsonl"
     if not journal_path.is_file():
+        if require_trusted:
+            raise run_budget.BudgetCompatibilityError(
+                "lifecycle journal missing for declared budget",
+                code="journal_untrusted",
+            )
         return []
     try:
         report = run_journal.read_journal_bounded(journal_path)
@@ -157,6 +212,9 @@ def _resume_budget_blocked(run_dir: Path, run_meta: dict, *, now: datetime | Non
     except run_budget.BudgetCompatibilityError as exc:
         return f"run budget lifecycle projection is untrusted: {exc.diagnostic}"
     if projection.terminal_policy == "budget_exhausted" or projection.exhausted_dimensions:
+        return "run budget exhausted; resume refused"
+    dispatch_ceiling = declaration.worker_dispatch_count
+    if dispatch_ceiling is not None and projection.used.get("worker_dispatch_count", 0) >= dispatch_ceiling:
         return "run budget exhausted; resume refused"
     if not has_enforceable:
         return None

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -17,9 +18,13 @@ from . import (
     agents,
     codex_appserver,
     receipt_schema,
+    run_budget,
+    run_events,
+    run_journal,
     run_lifecycle,
     runguard,
     seat_health,
+    verification_contract,
     worker_events,
 )
 from .roster import Agent, Roster, _as_bool, _as_env
@@ -48,6 +53,83 @@ def _load_json(run_dir: Path, name: str) -> dict | None:
     except (OSError, json.JSONDecodeError):
         return None
     return data if isinstance(data, dict) else None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _declaration_from_run_artifacts(run_dir: Path, run_meta: dict) -> run_budget.RunBudgetDeclaration:
+    """Load the persisted run_budget / verification_contract declaration for resume."""
+    if isinstance(run_meta.get("run_budget"), dict):
+        nested = (
+            run_meta["run_budget"].get("declaration")
+            if isinstance(run_meta["run_budget"].get("declaration"), dict)
+            else run_meta["run_budget"]
+        )
+        return run_budget.parse_declaration(nested if isinstance(nested, dict) else None)
+
+    contract = verification_contract.extract_contract_payload(run_meta)
+    budget = contract.get("budget") if isinstance(contract, dict) else None
+    if not isinstance(budget, dict):
+        plan = _load_json(run_dir, "plan.json")
+        if isinstance(plan, dict):
+            contract = verification_contract.extract_contract_payload(plan)
+            budget = contract.get("budget") if isinstance(contract, dict) else None
+    if isinstance(budget, dict):
+        return run_budget.declaration_from_verification_budget(budget)
+    return run_budget.RunBudgetDeclaration()
+
+
+def _lifecycle_events_for_budget_projection(run_dir: Path) -> list[object]:
+    journal_path = run_dir / "events" / "lifecycle.jsonl"
+    if not journal_path.is_file():
+        return []
+    try:
+        report = run_journal.read_journal_bounded(journal_path)
+    except (OSError, run_journal.RunJournalError, run_events.CanonicalizationError):
+        return []
+    if report.partial_tail is not None or report.chain_errors:
+        return []
+    return list(report.events)
+
+
+def _resume_budget_blocked(run_dir: Path, run_meta: dict, *, now: datetime | None = None) -> str | None:
+    """Return an error when resume must not start provider work under #593.
+
+    Uses the persisted declaration, original ``started_at``, and authoritative
+    lifecycle projection. Undeclared runs stay unbounded. Already exhausted or
+    newly expired declared ceilings refuse before ``AppServer.start()``.
+    """
+    try:
+        declaration = _declaration_from_run_artifacts(run_dir, run_meta)
+    except run_budget.BudgetCompatibilityError as exc:
+        return f"run budget declaration is incompatible: {exc.diagnostic}"
+
+    has_enforceable = declaration.wall_clock_seconds is not None or declaration.worker_dispatch_count is not None
+    events = _lifecycle_events_for_budget_projection(run_dir)
+    projection = run_budget.project_budget_state(declaration, events)
+    if projection.terminal_policy == "budget_exhausted" or projection.exhausted_dimensions:
+        return "run budget exhausted; resume refused"
+    if not has_enforceable:
+        return None
+
+    started_at = aboyeur._parse_iso_datetime(run_meta.get("started_at"))
+    if declaration.wall_clock_seconds is not None:
+        if started_at is None:
+            return "run budget wall-clock ceiling requires original started_at; resume refused"
+        clock = now if now is not None else _utc_now()
+        wall_only = replace(projection, declaration=replace(declaration, worker_dispatch_count=None))
+        decision = run_budget.evaluate_dispatch_reservation(
+            wall_only,
+            request_id="resume:wall-clock-gate",
+            now=clock,
+            started_at=started_at,
+            units=1,
+        )
+        if not decision.allowed:
+            return "run wall-clock budget exhausted; resume refused"
+    return None
 
 
 def _interrupted_appserver_results(run_dir: Path) -> dict | None:
@@ -360,6 +442,11 @@ def _resume_locked(
         )
     if not resumable:
         print("error: no resumable workers in this run", file=sys.stderr)
+        return 2
+
+    budget_block = _resume_budget_blocked(run_dir, run_meta)
+    if budget_block is not None:
+        print(f"error: {budget_block}", file=sys.stderr)
         return 2
 
     read_only = bool(run_meta.get("read_only"))

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Callable, Protocol
 from urllib.parse import urlparse
 
-from . import agents, proc, receipt_schema, run_control, runguard
+from . import agents, proc, receipt_schema, run_budget, run_control, runguard
 from .roster import Agent, Roster, is_cli_allowed, timeout_for
 from .seat_health_policy import SeatQuarantineState, decide_retry, failure_for_worker_result
 
@@ -896,6 +896,8 @@ def dispatch(
                     stage_results_by_index[index] = future.result()
                 except runguard.RetainRunLockError:
                     raise
+                except run_budget.BudgetPolicyError:
+                    raise
                 except Exception as exc:  # pragma: no cover - defensive boundary
                     assignment = stage_assignments[index]
                     stage_results_by_index[index] = WorkerResult(
@@ -1123,6 +1125,8 @@ def _dag_dispatch(
                 finished = done.result()
                 results[i] = finished
             except runguard.RetainRunLockError:
+                raise
+            except run_budget.BudgetPolicyError:
                 raise
             except Exception as exc:
                 finished = WorkerResult(

--- a/src/brigade/verification_contract.py
+++ b/src/brigade/verification_contract.py
@@ -7,8 +7,9 @@ verification outcome separately from model/step completion. Budget
 *enforcement* is owned by #593; this module owns declaration and recording.
 Optional ``wall_clock_seconds`` and ``worker_dispatch_count`` are the first-slice
 enforceable ceilings. When unset, ``latency_seconds`` maps to wall-clock for
-enforcement. ``token_budget`` remains observed-only until an adapter exposes an
-enforceable reservation boundary.
+enforcement. Aggregate ``token_budget`` remains observed-only (receipt
+``tokens_used``) and is never an input-token alias. Optional ``input_tokens`` /
+``output_tokens`` declare explicit split observed caps when present.
 """
 
 from __future__ import annotations
@@ -29,6 +30,8 @@ class VerificationBudget:
     token_budget: int | None = None
     wall_clock_seconds: int | None = None
     worker_dispatch_count: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
 
 @dataclass(frozen=True)
@@ -69,6 +72,10 @@ class VerificationContract:
             budget["wall_clock_seconds"] = self.budget.wall_clock_seconds
         if self.budget.worker_dispatch_count is not None:
             budget["worker_dispatch_count"] = self.budget.worker_dispatch_count
+        if self.budget.input_tokens is not None:
+            budget["input_tokens"] = self.budget.input_tokens
+        if self.budget.output_tokens is not None:
+            budget["output_tokens"] = self.budget.output_tokens
         return {
             "schema": VERIFICATION_CONTRACT_SCHEMA,
             "schema_version": VERIFICATION_CONTRACT_SCHEMA_VERSION,
@@ -202,6 +209,10 @@ def validate_contract_payload(
             _positive_int(budget.get("wall_clock_seconds"), field="budget.wall_clock_seconds", errors=errors)
         if "worker_dispatch_count" in budget:
             _positive_int(budget.get("worker_dispatch_count"), field="budget.worker_dispatch_count", errors=errors)
+        if "input_tokens" in budget:
+            _positive_int(budget.get("input_tokens"), field="budget.input_tokens", errors=errors)
+        if "output_tokens" in budget:
+            _positive_int(budget.get("output_tokens"), field="budget.output_tokens", errors=errors)
 
     return errors
 
@@ -300,6 +311,8 @@ def contract_from_payload(
     token_budget = budget_raw.get("token_budget")
     wall_clock = budget_raw.get("wall_clock_seconds")
     dispatch_count = budget_raw.get("worker_dispatch_count")
+    input_tokens = budget_raw.get("input_tokens")
+    output_tokens = budget_raw.get("output_tokens")
     budget = VerificationBudget(
         latency_seconds=int(budget_raw["latency_seconds"]),
         token_budget=int(token_budget)
@@ -310,6 +323,12 @@ def contract_from_payload(
         else None,
         worker_dispatch_count=int(dispatch_count)
         if isinstance(dispatch_count, int) and not isinstance(dispatch_count, bool)
+        else None,
+        input_tokens=int(input_tokens)
+        if isinstance(input_tokens, int) and not isinstance(input_tokens, bool)
+        else None,
+        output_tokens=int(output_tokens)
+        if isinstance(output_tokens, int) and not isinstance(output_tokens, bool)
         else None,
     )
     return VerificationContract(verifier=verifier, rollback=rollback, budget=budget)
@@ -388,6 +407,10 @@ def budget_use_payload(
         "tokens_used": tokens_used,
         "exhausted": exhausted,
     }
+    if contract.budget.input_tokens is not None:
+        payload["input_tokens_budget"] = contract.budget.input_tokens
+    if contract.budget.output_tokens is not None:
+        payload["output_tokens_budget"] = contract.budget.output_tokens
     return payload
 
 

--- a/src/brigade/verification_contract.py
+++ b/src/brigade/verification_contract.py
@@ -135,7 +135,9 @@ def validate_contract_payload(
     if schema is not None and schema != VERIFICATION_CONTRACT_SCHEMA:
         errors.append(f"schema must be {VERIFICATION_CONTRACT_SCHEMA!r}")
     version = payload.get("schema_version")
-    if version is not None and version != VERIFICATION_CONTRACT_SCHEMA_VERSION:
+    if version is not None and (
+        isinstance(version, bool) or not isinstance(version, int) or version != VERIFICATION_CONTRACT_SCHEMA_VERSION
+    ):
         errors.append(f"schema_version must be {VERIFICATION_CONTRACT_SCHEMA_VERSION}")
 
     verifier = payload.get("verifier")

--- a/src/brigade/verification_contract.py
+++ b/src/brigade/verification_contract.py
@@ -5,6 +5,10 @@ a failure/rollback path, and a token/latency budget up front. Plan surfaces
 incompleteness before anything runs. Receipts record budget use and
 verification outcome separately from model/step completion. Budget
 *enforcement* is owned by #593; this module owns declaration and recording.
+Optional ``wall_clock_seconds`` and ``worker_dispatch_count`` are the first-slice
+enforceable ceilings. When unset, ``latency_seconds`` maps to wall-clock for
+enforcement. ``token_budget`` remains observed-only until an adapter exposes an
+enforceable reservation boundary.
 """
 
 from __future__ import annotations
@@ -23,6 +27,8 @@ VERIFIER_SOURCES = frozenset({"command", "argv", "manifest_id", "manifest_checks
 class VerificationBudget:
     latency_seconds: int
     token_budget: int | None = None
+    wall_clock_seconds: int | None = None
+    worker_dispatch_count: int | None = None
 
 
 @dataclass(frozen=True)
@@ -59,6 +65,10 @@ class VerificationContract:
         budget: dict[str, Any] = {"latency_seconds": self.budget.latency_seconds}
         if self.budget.token_budget is not None:
             budget["token_budget"] = self.budget.token_budget
+        if self.budget.wall_clock_seconds is not None:
+            budget["wall_clock_seconds"] = self.budget.wall_clock_seconds
+        if self.budget.worker_dispatch_count is not None:
+            budget["worker_dispatch_count"] = self.budget.worker_dispatch_count
         return {
             "schema": VERIFICATION_CONTRACT_SCHEMA,
             "schema_version": VERIFICATION_CONTRACT_SCHEMA_VERSION,
@@ -188,6 +198,10 @@ def validate_contract_payload(
         _positive_int(budget.get("latency_seconds"), field="budget.latency_seconds", errors=errors)
         if "token_budget" in budget:
             _optional_non_negative_int(budget.get("token_budget"), field="budget.token_budget", errors=errors)
+        if "wall_clock_seconds" in budget:
+            _positive_int(budget.get("wall_clock_seconds"), field="budget.wall_clock_seconds", errors=errors)
+        if "worker_dispatch_count" in budget:
+            _positive_int(budget.get("worker_dispatch_count"), field="budget.worker_dispatch_count", errors=errors)
 
     return errors
 
@@ -284,10 +298,18 @@ def contract_from_payload(
     budget_raw = payload["budget"]
     assert isinstance(budget_raw, dict)
     token_budget = budget_raw.get("token_budget")
+    wall_clock = budget_raw.get("wall_clock_seconds")
+    dispatch_count = budget_raw.get("worker_dispatch_count")
     budget = VerificationBudget(
         latency_seconds=int(budget_raw["latency_seconds"]),
         token_budget=int(token_budget)
         if isinstance(token_budget, int) and not isinstance(token_budget, bool)
+        else None,
+        wall_clock_seconds=int(wall_clock)
+        if isinstance(wall_clock, int) and not isinstance(wall_clock, bool)
+        else None,
+        worker_dispatch_count=int(dispatch_count)
+        if isinstance(dispatch_count, int) and not isinstance(dispatch_count, bool)
         else None,
     )
     return VerificationContract(verifier=verifier, rollback=rollback, budget=budget)

--- a/src/brigade/worker_failure.py
+++ b/src/brigade/worker_failure.py
@@ -225,6 +225,7 @@ _RUN_OWNED_FAILURE_KINDS = frozenset(
     {
         "agent-error",
         "branch-head-drift",
+        "budget-exhausted",
         "collection-error",
         "dirty-worktree",
         "early-exit",
@@ -234,6 +235,7 @@ _RUN_OWNED_FAILURE_KINDS = frozenset(
         "invalid-plan",
         "isolation-breach",
         "keyboard-interrupt",
+        "operator-cancelled",
         "orchestrator-error",
         "planner-failure",
         "receipt-update-error",
@@ -243,6 +245,15 @@ _RUN_OWNED_FAILURE_KINDS = frozenset(
         "unexpected-error",
         "verification-failure",
         "worker-failure",
+    }
+)
+
+# Issue #593: policy terminals are run-owned lifecycle states, not worker
+# FailureClass values and not infrastructure under #580.
+RUN_POLICY_TERMINAL_FAILURE_KINDS = frozenset(
+    {
+        "budget-exhausted",
+        "operator-cancelled",
     }
 )
 
@@ -528,6 +539,7 @@ def _is_run_catch_all_failure_kind(kind: str) -> bool:
     return (
         kind not in RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS
         and kind not in RUN_MODEL_CONTRACT_FAILURE_KINDS
+        and kind not in RUN_POLICY_TERMINAL_FAILURE_KINDS
         and kind != "worker-failure"
     )
 
@@ -541,6 +553,10 @@ def run_failure_is_infrastructure_at_read_time(kind: str | None, phase: str | No
 
     if kind is None:
         return None
+    if kind in RUN_POLICY_TERMINAL_FAILURE_KINDS:
+        # Budget exhaustion and operator cancellation are policy lifecycle
+        # terminals (#593). They must not neutralize under #580.
+        return False
     if is_model_quality_failure_kind(kind):
         return False
     if kind in RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS:

--- a/tests/run_test_helpers.py
+++ b/tests/run_test_helpers.py
@@ -90,6 +90,8 @@ def run_aboyeur_guarded(*args: Any, **kwargs: Any) -> int:
         lock_workspace=workspace_path,
         codex_transport=kwargs.get("codex_transport") or roster.codex_transport,
         scheduler=kwargs.get("scheduler", "waves"),
+        verification_contract_payload=kwargs.get("verification_contract_payload"),
+        run_budget_payload=kwargs.get("run_budget_payload"),
     )
     with runguard.run_lock(workspace_path, run_dir=run_dir):
         return aboyeur.run(*args, **kwargs)

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1254,6 +1254,75 @@ def test_lifecycle_run_dispatch_emits_only_identified_worker_dispatch_facts(monk
     assert any(event.event_type == "run.dispatching.started" for event in events)
 
 
+def test_normal_run_persists_and_enforces_declared_dispatch_ceiling(monkeypatch, tmp_path):
+    """Declared ceilings survive start/plan and refuse a second same-stage dispatch."""
+    from brigade import run_journal, run_lifecycle, verification_contract
+
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    calls: list[str] = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        calls.append(str(cli_ref))
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps(
+                    {
+                        "assignments": [
+                            {"stage": 1, "worker": "coder", "task": "implement"},
+                            {"stage": 1, "worker": "reviewer", "task": "review"},
+                        ]
+                    }
+                ),
+                ok=True,
+            )
+        return agents.AgentResult(text="done", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    output_dir = tmp_path / "run"
+    contract = {
+        "schema": verification_contract.VERIFICATION_CONTRACT_SCHEMA,
+        "schema_version": verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION,
+        "verifier": {"source": "command", "command": "true"},
+        "rollback": {"policy": "none"},
+        "budget": {
+            "latency_seconds": 3600,
+            "wall_clock_seconds": 3600,
+            "worker_dispatch_count": 1,
+        },
+    }
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            cwd=tmp_path,
+            output_dir=output_dir,
+            route_enabled=False,
+            code_graph_enabled=False,
+            evidence_enabled=False,
+            verification_contract_payload=contract,
+        )
+        == 1
+    )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["verification_contract"]["budget"]["worker_dispatch_count"] == 1
+    assert run_meta["verification_contract"]["budget"]["wall_clock_seconds"] == 3600
+    plan = json.loads((output_dir / "plan.json").read_text())
+    assert plan["verification_contract"]["budget"]["worker_dispatch_count"] == 1
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure"]["kind"] == "budget-exhausted"
+    assert run_meta["failure"]["phase"] == "dispatch"
+
+    events = run_journal.read_journal(run_lifecycle._journal_path(output_dir)).events
+    requested = [event for event in events if event.event_type == "run.dispatch.requested"]
+    denied = [event for event in events if event.event_type == "run_budget.reservation_denied"]
+    exhausted = [event for event in events if event.event_type == "run_budget.exhausted"]
+    assert len(requested) == 1
+    assert denied
+    assert exhausted
+
+
 def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_path):
     def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
         return agents.AgentResult(

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1323,6 +1323,67 @@ def test_normal_run_persists_and_enforces_declared_dispatch_ceiling(monkeypatch,
     assert exhausted
 
 
+def test_undeclared_ordinary_run_invents_no_hard_ceiling(monkeypatch, tmp_path):
+    """Undeclared brigade-run shape: no verification_contract/run_budget → no ceiling."""
+    from brigade import run_journal, run_lifecycle
+
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    calls: list[str] = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        calls.append(str(cli_ref))
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps(
+                    {
+                        "assignments": [
+                            {"stage": 1, "worker": "coder", "task": "implement"},
+                            {"stage": 1, "worker": "reviewer", "task": "review"},
+                        ]
+                    }
+                ),
+                ok=True,
+            )
+        return agents.AgentResult(text="done", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    output_dir = tmp_path / "run"
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            cwd=tmp_path,
+            output_dir=output_dir,
+            route_enabled=False,
+            code_graph_enabled=False,
+            evidence_enabled=False,
+        )
+        == 0
+    )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert "verification_contract" not in run_meta
+    # Coordinator must not invent enforceable ceilings on undeclared runs.
+    if isinstance(run_meta.get("run_budget"), dict):
+        nested = run_meta["run_budget"].get("declaration", run_meta["run_budget"])
+        ceilings = nested.get("ceilings", {}) if isinstance(nested, dict) else {}
+        assert ceilings.get("wall_clock_seconds") is None
+        assert ceilings.get("worker_dispatch_count") is None
+    assert run_meta["status"] == "ok"
+
+    events = run_journal.read_journal(run_lifecycle._journal_path(output_dir)).events
+    requested = [event for event in events if event.event_type == "run.dispatch.requested"]
+    denied = [event for event in events if event.event_type == "run_budget.reservation_denied"]
+    exhausted = [event for event in events if event.event_type == "run_budget.exhausted"]
+    assert len(requested) == 2
+    assert denied == []
+    assert exhausted == []
+    # Chef plan + two worker CLIs + chef synthesize (cli refs, not seat names).
+    assert "ollama:llama3.3" in calls
+    assert calls.count("codex") >= 2
+
+
 def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_path):
     def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
         return agents.AgentResult(

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1384,6 +1384,63 @@ def test_undeclared_ordinary_run_invents_no_hard_ceiling(monkeypatch, tmp_path):
     assert calls.count("codex") >= 2
 
 
+@pytest.mark.parametrize(
+    "run_meta",
+    [
+        {"run_budget": "not-an-object"},
+        {"run_budget": {"declaration": "not-an-object"}},
+        {
+            "run_budget": {
+                "schema": "unsupported.run_budget.v2",
+                "schema_version": 1,
+                "declaration": {
+                    "schema": "brigade.run_budget.v1",
+                    "schema_version": 1,
+                    "ceilings": {"worker_dispatch_count": 1},
+                },
+            }
+        },
+        {
+            "verification_contract": {
+                "schema": "brigade.verification_contract.v1",
+                "schema_version": 1,
+                "budget": "not-an-object",
+            }
+        },
+        {"verification_contract": "not-an-object"},
+        {
+            "verification_contract": {
+                "schema": "unsupported.verification_contract.v2",
+                "schema_version": 1,
+                "budget": {"worker_dispatch_count": 1},
+            }
+        },
+        *[
+            {
+                "verification_contract": {
+                    "schema": "brigade.verification_contract.v1",
+                    "schema_version": schema_version,
+                    "budget": {"worker_dispatch_count": 1},
+                }
+            }
+            for schema_version in (99, True, 1.0)
+        ],
+    ],
+)
+def test_initial_budget_coordinator_refuses_malformed_declarations_before_dispatch(tmp_path, run_meta):
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    payload = {"lifecycle_journal_requested": True, **run_meta}
+    (output_dir / "run.json").write_text(json.dumps(payload))
+
+    with pytest.raises(aboyeur.run_budget.BudgetCompatibilityError):
+        aboyeur._build_budget_coordinator(
+            output_dir,
+            started_at=datetime(2026, 8, 11, tzinfo=timezone.utc),
+            append_event=lambda *_args: (_ for _ in ()).throw(AssertionError("worker dispatch")),
+        )
+
+
 def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_path):
     def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
         return agents.AgentResult(

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -2006,8 +2006,8 @@ def test_run_stage_two_interruption_records_current_stage_seat(monkeypatch, tmp_
     assert run_meta["status_started_at"].endswith("Z")
     assert run_meta["failure"] == {
         "phase": "dispatch",
-        "kind": "keyboard-interrupt",
-        "detail": "run canceled by user",
+        "kind": "operator-cancelled",
+        "detail": "run canceled by operator",
         "seat": "reviewer",
     }
 

--- a/tests/test_dogfood_cmd.py
+++ b/tests/test_dogfood_cmd.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import nullcontext
 
 from brigade import aboyeur
 from brigade import agents
@@ -441,6 +442,34 @@ def test_dogfood_next_reports_missing_step(tmp_path, capsys):
 
     assert dogfood_cmd.next_step(target=tmp_path) == 1
     assert "no next step found" in capsys.readouterr().err
+
+
+def test_dogfood_ordinary_path_does_not_declare_run_budget(tmp_path, monkeypatch):
+    """Dogfood CLI start must not invent verification_contract / run_budget payloads."""
+    dogfood_cmd.init(target=tmp_path, inspect=False, timeout_seconds=12)
+    start_kwargs: list[dict] = []
+    run_kwargs: list[dict] = []
+
+    def fake_record_run_start(output_dir, **kwargs):
+        start_kwargs.append(dict(kwargs))
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "run.json").write_text(json.dumps({"status": "started", "task": kwargs.get("task")}))
+
+    def fake_run(*args, **kwargs):
+        run_kwargs.append(dict(kwargs))
+        return 0
+
+    monkeypatch.setattr(aboyeur, "record_run_start", fake_record_run_start)
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    monkeypatch.setattr(dogfood_cmd.runguard, "run_lock", lambda *a, **k: nullcontext())
+
+    assert dogfood_cmd.run(None, target=tmp_path) == 0
+    assert start_kwargs
+    assert "verification_contract_payload" not in start_kwargs[0]
+    assert "run_budget_payload" not in start_kwargs[0]
+    assert run_kwargs
+    assert "verification_contract_payload" not in run_kwargs[0]
+    assert "run_budget_payload" not in run_kwargs[0]
 
 
 def test_dogfood_latest_uses_configured_artifacts(tmp_path, monkeypatch):

--- a/tests/test_model_trials.py
+++ b/tests/test_model_trials.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import nullcontext
 
 from brigade import agents
 from brigade import cli
@@ -224,6 +225,42 @@ def test_execute_writes_running_marker_before_aboyeur_run(tmp_path, monkeypatch)
     final = json.loads((root / "cells" / cell.cell_id / "cell.json").read_text())
     assert final["state"] == "accepted"
     assert final["started_at"] == started_at_seen[0]
+
+
+def test_model_trial_ordinary_path_does_not_declare_run_budget(tmp_path, monkeypatch):
+    """Model-trial cell starts must not invent verification_contract / run_budget payloads."""
+    manifest = _manifest()
+    manifest["trials"] = 1
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(manifest))
+    root = tmp_path / "results"
+    start_kwargs: list[dict] = []
+    run_kwargs: list[dict] = []
+
+    def fake_record_run_start(output_dir, **kwargs):
+        start_kwargs.append(dict(kwargs))
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "run.json").write_text(json.dumps({"status": "started"}))
+
+    def fake_run(task, roster, **kwargs):
+        run_kwargs.append(dict(kwargs))
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok", "duration_seconds": 0.5}))
+        return 0
+
+    monkeypatch.setattr(model_trials.aboyeur, "record_run_start", fake_record_run_start)
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    monkeypatch.setattr(model_trials.runguard, "run_lock", lambda *a, **k: nullcontext())
+
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 0
+    assert start_kwargs
+    assert "verification_contract_payload" not in start_kwargs[0]
+    assert "run_budget_payload" not in start_kwargs[0]
+    assert run_kwargs
+    assert "verification_contract_payload" not in run_kwargs[0]
+    assert "run_budget_payload" not in run_kwargs[0]
 
 
 def test_resume_does_not_skip_running_cells(tmp_path, monkeypatch):

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -672,6 +672,72 @@ def test_stable_reservation_identity_is_idempotent_across_retry_and_restart():
     assert final.projection.used["worker_dispatch_count"] == 1
 
 
+def test_expired_wall_clock_blocks_reclaim_of_pending_durable_dispatch():
+    """Restart reclaim must not authorize work after the wall-clock ceiling."""
+    recorded: list[dict] = []
+
+    def append_event(event_type: str, payload: dict, idempotency_key: str):
+        recorded.append({"event_type": event_type, "payload": dict(payload), "idempotency_key": idempotency_key})
+        return recorded[-1]
+
+    declaration = run_budget.RunBudgetDeclaration(wall_clock_seconds=5, worker_dispatch_count=10)
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=1),
+    )
+    coordinator.set_started_at(started)
+    attempt = coordinator.reserve_and_record_dispatch(
+        seat="coder",
+        allocate_attempt=lambda: 1,
+        record_requested=lambda value: value,
+    )
+    assert attempt == 1
+    durable = [event for event in coordinator._events_cache if event["event_type"] == "run.dispatch.requested"]
+    assert len(durable) == 1
+    assert durable[0]["payload"]["attempt"] == 1
+
+    # Restart with recovered clock past the 5s ceiling while attempt 1 is still open.
+    restarted = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=10),
+    )
+    restarted.set_started_at(started)
+    restarted.reload(list(coordinator._events_cache))
+    assert restarted._open_pending_attempt_unlocked("coder") == 1
+
+    with pytest.raises(run_budget.BudgetPolicyError) as exc:
+        restarted.reserve_and_record_dispatch(
+            seat="coder",
+            allocate_attempt=lambda: (_ for _ in ()).throw(AssertionError("must not allocate")),
+            record_requested=lambda _attempt: (_ for _ in ()).throw(AssertionError("must not re-record")),
+        )
+    assert exc.value.dimension == "wall_clock_seconds"
+    assert exc.value.exhausted is True
+    assert "dispatch:coder:1" not in restarted._launch_claims
+    assert any(event["event_type"] == "run_budget.exhausted" for event in recorded)
+    assert any(event["event_type"] == "run_budget.reservation_denied" for event in recorded)
+
+    # Undeclared wall-clock still reclaims open pending (declared-only contract).
+    unbounded = run_budget.BudgetCoordinator(
+        declaration=run_budget.RunBudgetDeclaration(worker_dispatch_count=10),
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=10),
+    )
+    unbounded.set_started_at(started)
+    unbounded.reload(list(durable))
+    assert (
+        unbounded.reserve_and_record_dispatch(
+            seat="coder",
+            allocate_attempt=lambda: (_ for _ in ()).throw(AssertionError("must not allocate")),
+            record_requested=lambda _attempt: (_ for _ in ()).throw(AssertionError("must not re-record")),
+        )
+        == 1
+    )
+
+
 def test_parallel_same_seat_dispatch_count_one_launches_once():
     """Concurrent same-seat callers with count=1 launch exactly one reservation."""
     import threading

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -462,3 +462,177 @@ def test_schema_constants_stable():
     assert run_budget.RUN_BUDGET_SCHEMA_VERSION == 1
     assert RUN_EVENT_SCHEMA == "brigade.run_event.v1"
     assert RUN_EVENT_SCHEMA_VERSION == 1
+
+
+def test_parallel_same_stage_reservations_respect_dispatch_ceiling():
+    """Two threads observing the same used count must not both exceed the ceiling."""
+    import threading
+
+    recorded: list[tuple[str, str]] = []
+    lock = threading.Lock()
+
+    def append_event(event_type: str, payload: dict, idempotency_key: str):
+        with lock:
+            recorded.append((event_type, idempotency_key))
+        return {"event_type": event_type, "payload": payload, "idempotency_key": idempotency_key}
+
+    declaration = run_budget.RunBudgetDeclaration(worker_dispatch_count=1)
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=1),
+    )
+    coordinator.set_started_at(started)
+
+    results: list[str] = []
+    barrier = threading.Barrier(2)
+
+    def worker(seat: str) -> None:
+        barrier.wait()
+        request_id = run_budget.dispatch_reservation_request_id(seat, 1)
+        try:
+            coordinator.reserve_worker_dispatch(request_id=request_id)
+            results.append(f"ok:{seat}")
+        except run_budget.BudgetPolicyError:
+            results.append(f"denied:{seat}")
+
+    threads = [threading.Thread(target=worker, args=("alpha",)), threading.Thread(target=worker, args=("beta",))]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sum(1 for item in results if item.startswith("ok:")) == 1
+    assert any(item.startswith("denied:") for item in results)
+    assert coordinator.projection.used["worker_dispatch_count"] == 1
+
+
+def test_stable_reservation_identity_is_idempotent_across_retry_and_restart():
+    """Crash/retry before durable requested must not double-reserve the same dispatch."""
+    recorded: list[dict] = []
+
+    def append_event(event_type: str, payload: dict, idempotency_key: str):
+        recorded.append({"event_type": event_type, "payload": dict(payload), "idempotency_key": idempotency_key})
+        return recorded[-1]
+
+    declaration = run_budget.RunBudgetDeclaration(worker_dispatch_count=2)
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=1),
+    )
+    coordinator.set_started_at(started)
+
+    request_id = run_budget.dispatch_reservation_request_id("coder", 1)
+    first = coordinator.reserve_worker_dispatch(request_id=request_id)
+    assert first.allowed is True and first.replayed is False
+    assert coordinator.projection.used["worker_dispatch_count"] == 1
+
+    # In-process retry of the same stable identity must not consume another unit.
+    replay = coordinator.reserve_worker_dispatch(request_id=request_id)
+    assert replay.allowed is True and replay.replayed is True
+    assert coordinator.projection.used["worker_dispatch_count"] == 1
+
+    # Simulate crash before run.dispatch.requested: rebuild from durable events only.
+    # Pending units are lost; the same stable identity re-reserves exactly once.
+    restarted = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=2),
+    )
+    restarted.set_started_at(started)
+    restarted.reload(recorded)  # no dispatch.requested yet
+    assert restarted.projection.used["worker_dispatch_count"] == 0
+
+    after_restart = restarted.reserve_and_record_dispatch(
+        request_id=request_id,
+        seat="coder",
+        attempt=1,
+        record_requested=lambda: 1,
+    )
+    assert after_restart == 1
+    assert restarted.projection.used["worker_dispatch_count"] == 1
+
+    # Second restart sees durable requested and treats the identity as already reserved.
+    final = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=3),
+    )
+    final.set_started_at(started)
+    final.reload(list(restarted._events_cache))
+    assert final.projection.used["worker_dispatch_count"] == 1
+    replayed = final.reserve_worker_dispatch(request_id=request_id)
+    assert replayed.replayed is True
+    assert final.projection.used["worker_dispatch_count"] == 1
+
+    # Crash after durable requested must not mint a second reservation for the
+    # still-open seat/attempt when reserve_and_record_dispatch is replayed.
+    again = final.reserve_and_record_dispatch(
+        request_id=request_id,
+        seat="coder",
+        attempt=1,
+        record_requested=lambda: (_ for _ in ()).throw(AssertionError("must not re-record")),
+    )
+    assert again == 1
+    assert final.projection.used["worker_dispatch_count"] == 1
+
+
+def test_reserve_and_record_rolls_back_when_durable_write_fails():
+    recorded: list[dict] = []
+
+    def append_event(event_type: str, payload: dict, idempotency_key: str):
+        recorded.append({"event_type": event_type, "payload": dict(payload), "idempotency_key": idempotency_key})
+        return recorded[-1]
+
+    declaration = run_budget.RunBudgetDeclaration(worker_dispatch_count=1)
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=1),
+    )
+    coordinator.set_started_at(started)
+    request_id = run_budget.dispatch_reservation_request_id("coder", 1)
+
+    with pytest.raises(OSError, match="disk full"):
+        coordinator.reserve_and_record_dispatch(
+            request_id=request_id,
+            seat="coder",
+            attempt=1,
+            record_requested=lambda: (_ for _ in ()).throw(OSError("disk full")),
+        )
+    assert coordinator.projection.used.get("worker_dispatch_count", 0) == 0
+
+    recorded_attempt = coordinator.reserve_and_record_dispatch(
+        request_id=request_id,
+        seat="coder",
+        attempt=1,
+        record_requested=lambda: 1,
+    )
+    assert recorded_attempt == 1
+    assert coordinator.projection.used["worker_dispatch_count"] == 1
+
+
+def test_operator_cancelled_live_ctrl_c_kind_is_not_infrastructure():
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("operator-cancelled", "dispatch") is False
+    assert (
+        outcome.run_capture_signal_value(
+            "canceled",
+            infrastructure_only=False,
+            verifier_failed=False,
+        )
+        == 0
+    )
+    # Even if a reader incorrectly set infrastructure_only, canceled is outside
+    # the #580 neutralization status set.
+    assert (
+        outcome.run_capture_signal_value(
+            "canceled",
+            infrastructure_only=True,
+            verifier_failed=False,
+        )
+        == 0
+    )

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -435,6 +435,25 @@ def test_missing_child_allocation_defaults_remain_readable():
     assert "child" not in payload["declaration"]["ceilings"]
 
 
+def test_empty_declaration_allows_unlimited_dispatch_reservations():
+    """Undeclared ceilings stay None; many dispatches are allowed."""
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=run_budget.RunBudgetDeclaration(),
+        append_event=lambda *_args, **_kwargs: None,
+    )
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    coordinator.set_started_at(started)
+    for index in range(5):
+        decision = coordinator.reserve_worker_dispatch(
+            request_id=f"dispatch:worker:{index + 1}",
+        )
+        assert decision.allowed is True
+        assert decision.exhausted is False
+    assert coordinator.declaration.wall_clock_seconds is None
+    assert coordinator.declaration.worker_dispatch_count is None
+    assert coordinator.projection.used.get("worker_dispatch_count", 0) == 5
+
+
 def test_estimated_and_provider_usage_remain_distinct_in_projection_payload():
     declaration = run_budget.RunBudgetDeclaration()
     events = [

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -322,6 +322,45 @@ def test_verification_budget_bridge_maps_latency_to_wall_clock_tokens_observed()
     assert explicit.wall_clock_seconds == 90
 
 
+def test_verification_budget_bridge_fails_closed_on_malformed_ceiling_fields():
+    with pytest.raises(run_budget.BudgetCompatibilityError) as exc:
+        run_budget.declaration_from_verification_budget(
+            {
+                "latency_seconds": 30,
+                "wall_clock_seconds": "3600",
+                "worker_dispatch_count": 2,
+            }
+        )
+    assert "wall_clock_seconds" in exc.value.diagnostic
+
+    with pytest.raises(run_budget.BudgetCompatibilityError) as exc:
+        run_budget.declaration_from_verification_budget(
+            {
+                "latency_seconds": "forty-five",
+                "token_budget": 100,
+            }
+        )
+    assert "latency_seconds" in exc.value.diagnostic
+
+    with pytest.raises(run_budget.BudgetCompatibilityError) as exc:
+        run_budget.declaration_from_verification_budget(
+            {
+                "latency_seconds": 30,
+                "worker_dispatch_count": True,
+            }
+        )
+    assert "worker_dispatch_count" in exc.value.diagnostic
+
+    with pytest.raises(run_budget.BudgetCompatibilityError) as exc:
+        run_budget.declaration_from_verification_budget(
+            {
+                "latency_seconds": 30,
+                "token_budget": "100",
+            }
+        )
+    assert "token_budget" in exc.value.diagnostic
+
+
 def test_legacy_token_budget_is_aggregate_not_input_only():
     """token_budget=100 stays aggregate (tokens_used), never input_tokens."""
     declaration = run_budget.declaration_from_verification_budget(

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -1,0 +1,464 @@
+"""Tests for run budget enforcement and lifecycle events (#593)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brigade import outcome, run_budget, run_events, run_projector, worker_failure
+from brigade.receipt_schema import RUN_EVENT_SCHEMA, RUN_EVENT_SCHEMA_VERSION
+
+RUN_ID = "20260810-210000-budget593"
+RECORDED_AT = "2026-08-10T21:00:00.000000Z"
+
+
+def _build_event(sequence: int, event_type: str, payload: dict, key: str, recorded_at: str, previous: str | None):
+    return run_events.build_event(
+        run_id=RUN_ID,
+        sequence=sequence,
+        event_type=event_type,
+        payload=payload,
+        idempotency_key=key,
+        recorded_at=recorded_at,
+        previous_digest=previous,
+    )
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    sorted(run_budget.RUN_BUDGET_EVENT_TYPES),
+)
+def test_run_budget_event_types_registered_with_closed_payloads(event_type):
+    assert event_type in run_events.EVENT_TYPES
+    assert run_events.EVENT_TYPES[event_type] == run_budget.RUN_BUDGET_EVENT_PAYLOADS[event_type]
+
+
+def test_run_budget_events_reject_raw_diagnostic_payload_keys():
+    with pytest.raises(run_events.CanonicalizationError) as exc:
+        run_events.build_event(
+            run_id=RUN_ID,
+            sequence=1,
+            event_type="run_budget.exhausted",
+            payload={
+                "dimension": "wall_clock_seconds",
+                "mode": "enforceable",
+                "declared": 30,
+                "used": 30,
+                "remaining": 0,
+                "reason_class": "exhausted",
+                "stack_trace": "traceback",
+            },
+            idempotency_key="run_budget.exhausted:wall_clock_seconds",
+            recorded_at=RECORDED_AT,
+            previous_digest=None,
+        )
+    assert "forbidden" in str(exc.value) or "unknown payload" in str(exc.value)
+    assert len(str(exc.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_run_budget_events_are_status_neutral_in_projector():
+    created = _build_event(1, "run.created", {"status": "started"}, "create-1", RECORDED_AT, None)
+    exhausted = _build_event(
+        2,
+        "run_budget.exhausted",
+        {
+            "dimension": "worker_dispatch_count",
+            "mode": "enforceable",
+            "declared": 1,
+            "used": 1,
+            "remaining": 0,
+            "reason_class": "exhausted",
+        },
+        "run_budget.exhausted:worker_dispatch_count",
+        "2026-08-10T21:00:01.000000Z",
+        created["event_digest"],
+    )
+    projection = run_projector.project_run_snapshot(
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "started",
+            "task": "fixture",
+            "dry_run": False,
+            "read_only": False,
+        },
+        [created, exhausted],
+        journal_present=True,
+    )
+    assert projection.status == "started"
+    assert projection.last_sequence == 2
+
+
+def test_wall_clock_and_dispatch_enforced_before_new_work():
+    declaration = run_budget.RunBudgetDeclaration(wall_clock_seconds=10, worker_dispatch_count=1)
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    projection = run_budget.BudgetProjection(declaration=declaration)
+
+    # First dispatch allowed.
+    first = run_budget.evaluate_dispatch_reservation(
+        projection,
+        request_id="req-1",
+        now=started + timedelta(seconds=1),
+        started_at=started,
+        units=1,
+    )
+    assert first.allowed is True
+
+    # After one dispatch is accounted, second is denied/exhausted.
+    used = dict(projection.used)
+    used["worker_dispatch_count"] = 1
+    after_one = run_budget.BudgetProjection(declaration=declaration, used=used)
+    second = run_budget.evaluate_dispatch_reservation(
+        after_one,
+        request_id="req-2",
+        now=started + timedelta(seconds=2),
+        started_at=started,
+        units=1,
+    )
+    assert second.allowed is False
+    assert second.exhausted is True
+    assert second.dimension == "worker_dispatch_count"
+    assert any(spec["event_type"] == "run_budget.reservation_denied" for spec in second.events)
+    assert any(spec["event_type"] == "run_budget.exhausted" for spec in second.events)
+
+    # Wall-clock exhaustion blocks even with dispatch remaining.
+    wall_decl = run_budget.RunBudgetDeclaration(wall_clock_seconds=5, worker_dispatch_count=10)
+    wall = run_budget.evaluate_dispatch_reservation(
+        run_budget.BudgetProjection(declaration=wall_decl),
+        request_id="req-wall",
+        now=started + timedelta(seconds=5),
+        started_at=started,
+        units=1,
+    )
+    assert wall.allowed is False
+    assert wall.dimension == "wall_clock_seconds"
+    assert wall.exhausted is True
+
+
+def test_threshold_denial_exhaustion_cancel_reconcile_idempotent_under_recovery():
+    recorded: list[tuple[str, str]] = []
+
+    def append_event(event_type: str, payload: dict, idempotency_key: str):
+        recorded.append((event_type, idempotency_key))
+        return {"event_type": event_type, "payload": payload, "idempotency_key": idempotency_key}
+
+    declaration = run_budget.RunBudgetDeclaration(
+        worker_dispatch_count=2,
+        threshold_pct=50,
+    )
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    clock_times = [
+        started + timedelta(seconds=1),
+        started + timedelta(seconds=2),
+        started + timedelta(seconds=3),
+    ]
+    clock_iter = iter(clock_times)
+
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: next(clock_iter, started + timedelta(seconds=9)),
+    )
+    coordinator.set_started_at(started)
+
+    coordinator.reserve_worker_dispatch(request_id="req-a")
+    # Threshold should fire once at 50% (1/2).
+    threshold_keys = [key for etype, key in recorded if etype == "run_budget.threshold_reached"]
+    assert threshold_keys == ["run_budget.threshold_reached:worker_dispatch_count:50"]
+
+    coordinator.reserve_worker_dispatch(request_id="req-b")
+    with pytest.raises(run_budget.BudgetPolicyError) as denied:
+        coordinator.reserve_worker_dispatch(request_id="req-c")
+    assert denied.value.exhausted is True
+
+    # Replay the same denial/exhaustion keys — idempotent event specs.
+    projection = coordinator.projection
+    replay = run_budget.evaluate_dispatch_reservation(
+        projection,
+        request_id="req-c",
+        now=started + timedelta(seconds=4),
+        started_at=started,
+        units=1,
+    )
+    assert {spec["idempotency_key"] for spec in replay.events} <= {
+        "run_budget.exhausted:worker_dispatch_count",
+        "run_budget.reservation_denied:req-c",
+        "run_budget.threshold_reached:worker_dispatch_count:50",
+    }
+
+    receipt = coordinator.request_cancel(
+        request_id="cancel-1",
+        reason_class="budget_cancel",
+        transport_capability="process_cancel",
+        dimension="worker_dispatch_count",
+        cancel_fn=lambda: ("partial", 1),
+    )
+    assert receipt.transport_capability == "process_cancel"
+    assert receipt.transport_result == "partial"
+    assert receipt.active_remaining == 1
+
+    coordinator.reconcile_usage(
+        dimension="input_tokens",
+        usage_source="estimated",
+        used=100,
+        request_id="recon-est",
+        estimated_used=100,
+    )
+    coordinator.reconcile_usage(
+        dimension="input_tokens",
+        usage_source="provider_reconciled",
+        used=90,
+        request_id="recon-prov",
+        estimated_used=100,
+        provider_used=90,
+    )
+
+    # Restart-safe projection from the in-memory event cache.
+    rebuilt = run_budget.project_budget_state(declaration, coordinator._events_cache)
+    assert rebuilt.terminal_policy == "budget_exhausted"
+    assert rebuilt.estimated_used["input_tokens"] == 100
+    assert rebuilt.provider_used["input_tokens"] == 90
+    assert rebuilt.used["input_tokens"] == 90  # provider wins for observed
+    assert len(rebuilt.cancel_receipts) == 1
+    assert rebuilt.cancel_receipts[0].active_remaining == 1
+
+    # Re-append with same idempotency keys is safe at the coordinator event-spec layer.
+    cancel_again = run_budget.build_cancelled_event(
+        request_id="cancel-1",
+        reason_class="budget_cancel",
+        transport_capability="process_cancel",
+        transport_result="partial",
+        active_remaining=1,
+        dimension="worker_dispatch_count",
+    )
+    assert cancel_again["idempotency_key"] == "run_budget.cancelled:cancel-1"
+
+
+def test_observed_dimensions_are_labeled_and_not_hard_gated():
+    declaration = run_budget.RunBudgetDeclaration(
+        worker_dispatch_count=5,
+        observed_caps={"input_tokens": 10},
+    )
+    projection = run_budget.BudgetProjection(
+        declaration=declaration,
+        used={"input_tokens": 100, "worker_dispatch_count": 0},
+    )
+    # Observed overage does not deny dispatch.
+    decision = run_budget.evaluate_dispatch_reservation(
+        projection,
+        request_id="obs-1",
+        now=datetime(2026, 8, 10, 21, 0, 1, tzinfo=timezone.utc),
+        started_at=datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc),
+        units=1,
+    )
+    assert decision.allowed is True
+    assert run_budget.mode_for_dimension("input_tokens") == "observed"
+    assert run_budget.mode_for_dimension("model_call_count") == "observed"
+    assert run_budget.mode_for_dimension("wall_clock_seconds") == "enforceable"
+
+
+def test_unknown_dimension_and_schema_version_fail_closed():
+    with pytest.raises(run_budget.BudgetCompatibilityError) as exc:
+        run_budget.parse_declaration(
+            {
+                "schema": run_budget.RUN_BUDGET_SCHEMA,
+                "schema_version": 99,
+                "ceilings": {},
+            }
+        )
+    assert exc.value.code == "schema_incompatible"
+    assert len(exc.value.diagnostic) <= run_events.MAX_DIAGNOSTIC_LEN
+
+    with pytest.raises(run_budget.BudgetCompatibilityError):
+        run_budget.parse_declaration(
+            {
+                "schema": run_budget.RUN_BUDGET_SCHEMA,
+                "schema_version": 1,
+                "ceilings": {"child_frame_count": 3},
+            }
+        )
+
+    with pytest.raises(run_budget.BudgetCompatibilityError):
+        run_budget.project_budget_state(
+            run_budget.RunBudgetDeclaration(),
+            [
+                {
+                    "event_type": "run_budget.exhausted",
+                    "payload": {
+                        "dimension": "child_frame_count",
+                        "mode": "enforceable",
+                        "declared": 1,
+                        "used": 1,
+                        "remaining": 0,
+                        "reason_class": "exhausted",
+                    },
+                }
+            ],
+        )
+
+
+def test_verification_budget_bridge_maps_latency_to_wall_clock_tokens_observed():
+    declaration = run_budget.declaration_from_verification_budget(
+        {
+            "latency_seconds": 45,
+            "token_budget": 1000,
+            "worker_dispatch_count": 3,
+        }
+    )
+    assert declaration.wall_clock_seconds == 45
+    assert declaration.worker_dispatch_count == 3
+    assert declaration.observed_caps.get("input_tokens") == 1000
+
+    explicit = run_budget.declaration_from_verification_budget(
+        {
+            "latency_seconds": 45,
+            "wall_clock_seconds": 90,
+            "worker_dispatch_count": 2,
+        }
+    )
+    assert explicit.wall_clock_seconds == 90
+
+
+def test_budget_exhaustion_and_operator_cancel_are_policy_terminals_not_infra():
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("budget-exhausted", "dispatch") is False
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("operator-cancelled", "dispatch") is False
+    # capacity-exhausted remains infrastructure (provider/seat capacity), distinct from policy budget.
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("capacity-exhausted", "dispatch") is True
+
+    assert (
+        outcome.run_capture_signal_value(
+            "failed",
+            infrastructure_only=False,
+            verifier_failed=False,
+        )
+        == -1
+    )
+    assert "budget-exhausted" in worker_failure.RUN_POLICY_TERMINAL_FAILURE_KINDS
+    assert "operator-cancelled" in worker_failure.RUN_POLICY_TERMINAL_FAILURE_KINDS
+
+    # Worker taxonomy still excludes canceled statuses.
+    assert (
+        worker_failure.normalized_failure(
+            status="canceled",
+            failure_kind="operator-cancelled",
+            failure_phase="dispatch",
+            detail="operator cancelled",
+        )
+        is None
+    )
+
+
+def test_missing_child_allocation_defaults_remain_readable():
+    declaration = run_budget.parse_declaration(
+        {
+            "schema": run_budget.RUN_BUDGET_SCHEMA,
+            "schema_version": 1,
+            "ceilings": {"wall_clock_seconds": 30},
+        }
+    )
+    projection = run_budget.project_budget_state(declaration, [])
+    payload = projection.to_payload()
+    assert payload["remaining"]["wall_clock_seconds"] == 30
+    assert payload["remaining"]["worker_dispatch_count"] is None
+    assert payload["terminal_policy"] is None
+    # No child allocation keys required.
+    assert "child" not in payload["declaration"]["ceilings"]
+
+
+def test_estimated_and_provider_usage_remain_distinct_in_projection_payload():
+    declaration = run_budget.RunBudgetDeclaration()
+    events = [
+        {
+            "event_type": "run_budget.usage_reconciled",
+            "payload": {
+                "dimension": "estimated_cost_micros",
+                "mode": "observed",
+                "usage_source": "estimated",
+                "estimated_used": 5000,
+                "provider_used": None,
+                "used": 5000,
+                "request_id": "e1",
+                "reason_class": "usage_reconcile",
+            },
+        },
+        {
+            "event_type": "run_budget.usage_reconciled",
+            "payload": {
+                "dimension": "estimated_cost_micros",
+                "mode": "observed",
+                "usage_source": "provider_reconciled",
+                "estimated_used": 5000,
+                "provider_used": 4200,
+                "used": 4200,
+                "request_id": "e2",
+                "reason_class": "usage_reconcile",
+            },
+        },
+    ]
+    projection = run_budget.project_budget_state(declaration, events)
+    assert projection.estimated_used["estimated_cost_micros"] == 5000
+    assert projection.provider_used["estimated_cost_micros"] == 4200
+    assert projection.used["estimated_cost_micros"] == 4200
+    payload = projection.to_payload()
+    assert payload["estimated_used"]["estimated_cost_micros"] == 5000
+    assert payload["provider_used"]["estimated_cost_micros"] == 4200
+
+
+def test_dispatch_requested_facts_drive_restart_safe_dispatch_usage():
+    declaration = run_budget.RunBudgetDeclaration(worker_dispatch_count=2)
+    events = [
+        {"event_type": "run.dispatch.requested", "payload": {"seat": "a", "attempt": 1, "detail": ""}},
+        {"event_type": "run.dispatch.requested", "payload": {"seat": "b", "attempt": 1, "detail": ""}},
+    ]
+    projection = run_budget.project_budget_state(declaration, events)
+    assert projection.used["worker_dispatch_count"] == 2
+    assert projection.remaining("worker_dispatch_count") == 0
+    denied = run_budget.evaluate_dispatch_reservation(
+        projection,
+        request_id="after-restart",
+        now=datetime(2026, 8, 10, 21, 0, 5, tzinfo=timezone.utc),
+        started_at=datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc),
+        units=1,
+    )
+    assert denied.allowed is False
+    assert denied.exhausted is True
+
+
+def test_build_event_rejects_invalid_run_budget_reason_class():
+    with pytest.raises(run_events.CanonicalizationError):
+        run_events.build_event(
+            run_id=RUN_ID,
+            sequence=1,
+            event_type="run_budget.threshold_reached",
+            payload={
+                "dimension": "wall_clock_seconds",
+                "mode": "enforceable",
+                "declared": 10,
+                "used": 8,
+                "remaining": 2,
+                "threshold_pct": 80,
+                "reason_class": "not-a-reason",
+            },
+            idempotency_key="bad-reason",
+            recorded_at=RECORDED_AT,
+            previous_digest=None,
+        )
+
+
+def test_terminal_status_helpers():
+    assert run_budget.terminal_status_for_policy("budget_exhausted") == (
+        "failed",
+        "budget-exhausted",
+    )
+    assert run_budget.terminal_status_for_policy("operator_cancelled") == (
+        "canceled",
+        "operator-cancelled",
+    )
+
+
+def test_schema_constants_stable():
+    assert run_budget.RUN_BUDGET_SCHEMA == "brigade.run_budget.v1"
+    assert run_budget.RUN_BUDGET_SCHEMA_VERSION == 1
+    assert RUN_EVENT_SCHEMA == "brigade.run_event.v1"
+    assert RUN_EVENT_SCHEMA_VERSION == 1

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -298,6 +298,25 @@ def test_unknown_dimension_and_schema_version_fail_closed():
         )
 
 
+@pytest.mark.parametrize("schema_version", [True, 1.0])
+def test_schema_version_requires_a_real_integer(schema_version):
+    with pytest.raises(run_budget.BudgetCompatibilityError):
+        run_budget.parse_declaration(
+            {
+                "schema": run_budget.RUN_BUDGET_SCHEMA,
+                "schema_version": schema_version,
+                "ceilings": {},
+            }
+        )
+    with pytest.raises(run_budget.BudgetCompatibilityError):
+        run_budget.declaration_from_verification_budget(
+            {
+                "schema": run_budget.RUN_BUDGET_SCHEMA,
+                "schema_version": schema_version,
+            }
+        )
+
+
 def test_verification_budget_bridge_maps_latency_to_wall_clock_tokens_observed():
     declaration = run_budget.declaration_from_verification_budget(
         {

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -356,6 +356,18 @@ def test_legacy_token_budget_is_aggregate_not_input_only():
     assert split.ceiling("input_tokens") == 40
     assert split.ceiling("output_tokens") == 60
 
+    bridged = run_budget.declaration_from_verification_budget(
+        {
+            "latency_seconds": 30,
+            "token_budget": 100,
+            "input_tokens": 40,
+            "output_tokens": 60,
+        }
+    )
+    assert bridged.token_budget == 100
+    assert bridged.observed_caps.get("input_tokens") == 40
+    assert bridged.observed_caps.get("output_tokens") == 60
+
     contract = verification_contract.VerificationContract(
         verifier=verification_contract.VerificationVerifier(source="command", command="true"),
         rollback=verification_contract.VerificationRollback(policy="none"),
@@ -603,16 +615,21 @@ def test_stable_reservation_identity_is_idempotent_across_retry_and_restart():
     restarted.reload(recorded)  # no dispatch.requested yet
     assert restarted.projection.used["worker_dispatch_count"] == 0
 
+    attempts = {"n": 0}
+
+    def allocate() -> int:
+        attempts["n"] += 1
+        return attempts["n"]
+
     after_restart = restarted.reserve_and_record_dispatch(
-        request_id=request_id,
         seat="coder",
-        attempt=1,
-        record_requested=lambda: 1,
+        allocate_attempt=allocate,
+        record_requested=lambda attempt: attempt,
     )
     assert after_restart == 1
     assert restarted.projection.used["worker_dispatch_count"] == 1
 
-    # Second restart sees durable requested and treats the identity as already reserved.
+    # Second restart sees durable requested and reclaims the open identity once.
     final = run_budget.BudgetCoordinator(
         declaration=declaration,
         append_event=append_event,
@@ -628,13 +645,71 @@ def test_stable_reservation_identity_is_idempotent_across_retry_and_restart():
     # Crash after durable requested must not mint a second reservation for the
     # still-open seat/attempt when reserve_and_record_dispatch is replayed.
     again = final.reserve_and_record_dispatch(
-        request_id=request_id,
         seat="coder",
-        attempt=1,
-        record_requested=lambda: (_ for _ in ()).throw(AssertionError("must not re-record")),
+        allocate_attempt=lambda: (_ for _ in ()).throw(AssertionError("must not allocate")),
+        record_requested=lambda attempt: (_ for _ in ()).throw(AssertionError("must not re-record")),
     )
     assert again == 1
     assert final.projection.used["worker_dispatch_count"] == 1
+
+
+def test_parallel_same_seat_dispatch_count_one_launches_once():
+    """Concurrent same-seat callers with count=1 launch exactly one reservation."""
+    import threading
+
+    recorded: list[dict] = []
+    lock = threading.Lock()
+    launches: list[int] = []
+
+    def append_event(event_type: str, payload: dict, idempotency_key: str):
+        with lock:
+            recorded.append({"event_type": event_type, "payload": dict(payload), "idempotency_key": idempotency_key})
+        return recorded[-1]
+
+    declaration = run_budget.RunBudgetDeclaration(worker_dispatch_count=1)
+    started = datetime(2026, 8, 10, 21, 0, 0, tzinfo=timezone.utc)
+    coordinator = run_budget.BudgetCoordinator(
+        declaration=declaration,
+        append_event=append_event,
+        clock=lambda: started + timedelta(seconds=1),
+    )
+    coordinator.set_started_at(started)
+    counter = {"n": 0}
+    counter_lock = threading.Lock()
+
+    def allocate() -> int:
+        with counter_lock:
+            counter["n"] += 1
+            return counter["n"]
+
+    results: list[str] = []
+    barrier = threading.Barrier(2)
+
+    def worker() -> None:
+        barrier.wait()
+        try:
+            attempt = coordinator.reserve_and_record_dispatch(
+                seat="coder",
+                allocate_attempt=allocate,
+                record_requested=lambda attempt: attempt,
+            )
+            with lock:
+                launches.append(attempt if attempt is not None else -1)
+            results.append("ok")
+        except run_budget.BudgetPolicyError:
+            results.append("denied")
+
+    threads = [threading.Thread(target=worker), threading.Thread(target=worker)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results.count("ok") == 1
+    assert results.count("denied") == 1
+    assert launches == [1]
+    assert coordinator.projection.used["worker_dispatch_count"] == 1
+    assert sum(1 for event in coordinator._events_cache if event.get("event_type") == "run.dispatch.requested") == 1
 
 
 def test_reserve_and_record_rolls_back_when_durable_write_fails():
@@ -652,22 +727,19 @@ def test_reserve_and_record_rolls_back_when_durable_write_fails():
         clock=lambda: started + timedelta(seconds=1),
     )
     coordinator.set_started_at(started)
-    request_id = run_budget.dispatch_reservation_request_id("coder", 1)
 
     with pytest.raises(OSError, match="disk full"):
         coordinator.reserve_and_record_dispatch(
-            request_id=request_id,
             seat="coder",
-            attempt=1,
-            record_requested=lambda: (_ for _ in ()).throw(OSError("disk full")),
+            allocate_attempt=lambda: 1,
+            record_requested=lambda attempt: (_ for _ in ()).throw(OSError("disk full")),
         )
     assert coordinator.projection.used.get("worker_dispatch_count", 0) == 0
 
     recorded_attempt = coordinator.reserve_and_record_dispatch(
-        request_id=request_id,
         seat="coder",
-        attempt=1,
-        record_requested=lambda: 1,
+        allocate_attempt=lambda: 1,
+        record_requested=lambda attempt: attempt,
     )
     assert recorded_attempt == 1
     assert coordinator.projection.used["worker_dispatch_count"] == 1

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -361,6 +361,27 @@ def test_verification_budget_bridge_fails_closed_on_malformed_ceiling_fields():
     assert "token_budget" in exc.value.diagnostic
 
 
+def test_verification_budget_bridge_fails_closed_on_unknown_dimension_and_schema():
+    with pytest.raises(run_budget.BudgetCompatibilityError) as exc:
+        run_budget.declaration_from_verification_budget(
+            {
+                "latency_seconds": 30,
+                "child_worker_dispatch_count": 1,
+            }
+        )
+    assert "unknown" in exc.value.diagnostic
+
+    with pytest.raises(run_budget.BudgetCompatibilityError) as exc:
+        run_budget.declaration_from_verification_budget(
+            {
+                "latency_seconds": 30,
+                "schema": "brigade.run_budget.v1",
+                "schema_version": 99,
+            }
+        )
+    assert "schema_version" in exc.value.diagnostic
+
+
 def test_legacy_token_budget_is_aggregate_not_input_only():
     """token_budget=100 stays aggregate (tokens_used), never input_tokens."""
     declaration = run_budget.declaration_from_verification_budget(

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from brigade import outcome, run_budget, run_events, run_projector, worker_failure
+from brigade import outcome, run_budget, run_events, run_projector, verification_contract, worker_failure
 from brigade.receipt_schema import RUN_EVENT_SCHEMA, RUN_EVENT_SCHEMA_VERSION
 
 RUN_ID = "20260810-210000-budget593"
@@ -308,7 +308,9 @@ def test_verification_budget_bridge_maps_latency_to_wall_clock_tokens_observed()
     )
     assert declaration.wall_clock_seconds == 45
     assert declaration.worker_dispatch_count == 3
-    assert declaration.observed_caps.get("input_tokens") == 1000
+    assert declaration.token_budget == 1000
+    assert declaration.observed_caps.get("input_tokens") is None
+    assert declaration.observed_caps.get("output_tokens") is None
 
     explicit = run_budget.declaration_from_verification_budget(
         {
@@ -318,6 +320,61 @@ def test_verification_budget_bridge_maps_latency_to_wall_clock_tokens_observed()
         }
     )
     assert explicit.wall_clock_seconds == 90
+
+
+def test_legacy_token_budget_is_aggregate_not_input_only():
+    """token_budget=100 stays aggregate (tokens_used), never input_tokens."""
+    declaration = run_budget.declaration_from_verification_budget(
+        {
+            "latency_seconds": 30,
+            "token_budget": 100,
+        }
+    )
+    assert declaration.token_budget == 100
+    assert declaration.ceiling("input_tokens") is None
+    assert declaration.ceiling("output_tokens") is None
+    payload = declaration.to_payload()
+    assert payload["token_budget"] == 100
+    assert payload["observed"].get("input_tokens") is None
+    assert payload["observed"].get("output_tokens") is None
+    rebuilt = run_budget.parse_declaration(payload)
+    assert rebuilt.token_budget == 100
+    assert rebuilt.observed_caps.get("input_tokens") is None
+
+    # Explicit split dimensions remain independent of aggregate token_budget.
+    split = run_budget.parse_declaration(
+        {
+            "schema": run_budget.RUN_BUDGET_SCHEMA,
+            "schema_version": run_budget.RUN_BUDGET_SCHEMA_VERSION,
+            "ceilings": {},
+            "observed": {"input_tokens": 40, "output_tokens": 60},
+            "threshold_pct": 80,
+            "token_budget": 100,
+        }
+    )
+    assert split.token_budget == 100
+    assert split.ceiling("input_tokens") == 40
+    assert split.ceiling("output_tokens") == 60
+
+    contract = verification_contract.VerificationContract(
+        verifier=verification_contract.VerificationVerifier(source="command", command="true"),
+        rollback=verification_contract.VerificationRollback(policy="none"),
+        budget=verification_contract.VerificationBudget(latency_seconds=30, token_budget=100),
+    )
+    within = verification_contract.budget_use_payload(contract, latency_seconds_used=1.0, tokens_used=100)
+    assert within == {
+        "latency_seconds_budget": 30,
+        "latency_seconds_used": 1.0,
+        "token_budget": 100,
+        "tokens_used": 100,
+        "exhausted": False,
+    }
+    over = verification_contract.budget_use_payload(contract, latency_seconds_used=1.0, tokens_used=101)
+    assert over["token_budget"] == 100
+    assert over["tokens_used"] == 101
+    assert over["exhausted"] is True
+    assert "input_tokens" not in over
+    assert "output_tokens" not in over
 
 
 def test_budget_exhaustion_and_operator_cancel_are_policy_terminals_not_infra():

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1816,8 +1816,8 @@ def test_run_cli_terminalizes_keyboard_interrupt_during_dispatch(tmp_path, monke
     assert run_meta["finished_at"].endswith("Z")
     assert run_meta["failure"] == {
         "phase": "dispatch",
-        "kind": "keyboard-interrupt",
-        "detail": "run canceled by user",
+        "kind": "operator-cancelled",
+        "detail": "run canceled by operator",
         "seat": "coder",
     }
     assert not (repo / ".brigade" / "run.lock").exists()
@@ -1826,7 +1826,7 @@ def test_run_cli_terminalizes_keyboard_interrupt_during_dispatch(tmp_path, monke
 @pytest.mark.parametrize(
     ("sig", "expected_code", "failure_kind"),
     [
-        (signal.SIGINT, 128 + signal.SIGINT, "keyboard-interrupt"),
+        (signal.SIGINT, 128 + signal.SIGINT, "operator-cancelled"),
         (signal.SIGTERM, 128 + signal.SIGTERM, "signal"),
     ],
 )

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -2540,6 +2540,37 @@ def test_authority_dispatch_checkpoint_is_base_stripped_and_recovers_exact_tail(
     assert repaired["projector_version"] == run_projector.PROJECTOR_VERSION
 
 
+def test_authoritative_projection_and_checkpoint_recovery_preserve_budget_declarations(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+    verification_contract = {
+        "schema": "brigade.verification_contract.v1",
+        "schema_version": 1,
+        "budget": {"worker_dispatch_count": 2},
+    }
+    run_budget = {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": 1,
+        "ceilings": {"worker_dispatch_count": 2},
+    }
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        payload = _apply_authority_request(run_dir, _run_payload("dispatching", lock_workspace=repo))
+        payload["verification_contract"] = verification_contract
+        payload["run_budget"] = run_budget
+        aboyeur._write_json(run_dir / "run.json", payload)
+
+    projected = json.loads((run_dir / "run.json").read_text())
+    assert projected["verification_contract"] == verification_contract
+    assert projected["run_budget"] == run_budget
+
+    (run_dir / "run.json").unlink()
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert repaired["verification_contract"] == verification_contract
+    assert repaired["run_budget"] == run_budget
+
+
 def test_authoritative_dispatch_requested_recovers_exact_old_ceiling_checkpoint(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -514,6 +514,34 @@ def test_dispatch_facts_pair_each_real_attempt_without_reusing_pending_identity(
     assert run_lifecycle.pending_dispatch_requests(events) == [("coder", 2)]
 
 
+def test_next_dispatch_attempt_reuses_open_pending_request(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started", lock_workspace=repo)
+    _write_run_json_locked(repo, run_dir, "started", lock_workspace=repo)
+    _write_run_json_locked(repo, run_dir, "dispatching", lock_workspace=repo)
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        first = run_lifecycle.record_dispatch_fact(
+            run_dir,
+            workspace=repo,
+            event_type="run.dispatch.requested",
+            seat="coder",
+            attempt=1,
+        )
+        assert first is not None
+        assert run_lifecycle.next_dispatch_attempt(run_dir, "coder") == 1
+        run_lifecycle.record_dispatch_fact(
+            run_dir,
+            workspace=repo,
+            event_type="run.dispatch.failed",
+            seat="coder",
+            attempt=1,
+        )
+        assert run_lifecycle.next_dispatch_attempt(run_dir, "coder") == 2
+
+
 def test_artifact_collection_intermediate_appends_the_second_a(enabled, tmp_path):
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)

--- a/tests/test_run_projector.py
+++ b/tests/test_run_projector.py
@@ -103,6 +103,16 @@ def _full_base_snapshot() -> dict:
             "source": "daily",
             "fingerprint": "approval-fingerprint",
         },
+        "verification_contract": {
+            "schema": "brigade.verification_contract.v1",
+            "schema_version": 1,
+            "budget": {"worker_dispatch_count": 2},
+        },
+        "run_budget": {
+            "schema": "brigade.run_budget.v1",
+            "schema_version": 1,
+            "ceilings": {"worker_dispatch_count": 2},
+        },
         "started_at": "2026-07-27T15:30:00.000000Z",
         "status_started_at": "2026-07-27T15:30:00.000000Z",
         "finished_at": None,
@@ -527,7 +537,7 @@ def test_dataclasses_replace_mutation_of_typed_run_event_raises_event_chain_erro
 
 def test_full_field_fixture_preserves_deep_equality_and_copies_nested_values():
     base = _full_base_snapshot()
-    assert len(PRESERVED_FIELDS) == 50
+    assert len(PRESERVED_FIELDS) == 52
     assert DERIVED_FIELDS == {
         "status",
         "projector_version",

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -909,10 +909,28 @@ def _declared_contract(*, wall_clock_seconds: int | None = 3600, worker_dispatch
 
 class _GuardServer(_StubServer):
     started = 0
+    provider_turns = 0
 
     def start(self):
         type(self).started += 1
         raise AssertionError("AppServer.start must not run when resume budget gate denies")
+
+    def resume_thread(self, thread_id, *, cwd, model=None, sandbox=None):
+        type(self).provider_turns += 1
+        raise AssertionError("provider turn must not run when resume budget gate denies")
+
+
+def _patch_resume_denied(monkeypatch) -> None:
+    _GuardServer.started = 0
+    _GuardServer.provider_turns = 0
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _GuardServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("synthesis must not run")),
+    )
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
 
 
 def test_resume_refuses_expired_declared_wall_clock_before_appserver(tmp_path, monkeypatch, capsys):
@@ -928,20 +946,13 @@ def test_resume_refuses_expired_declared_wall_clock_before_appserver(tmp_path, m
     plan["verification_contract"] = meta["verification_contract"]
     (run_dir / "plan.json").write_text(json.dumps(plan))
 
-    _GuardServer.started = 0
     monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
-    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _GuardServer)
-    monkeypatch.setattr(
-        run_resume.agents,
-        "run_agent",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("synthesis must not run")),
-    )
-    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
-    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
+    _patch_resume_denied(monkeypatch)
 
     assert run_resume.resume(run_dir) == 2
     assert "wall-clock budget exhausted" in capsys.readouterr().err
     assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
     assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
 
 
@@ -981,19 +992,93 @@ def test_resume_refuses_budget_exhausted_projection_before_appserver(tmp_path, m
         recorded_at="2026-07-03T00:00:01.000000Z",
     )
 
-    _GuardServer.started = 0
-    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _GuardServer)
-    monkeypatch.setattr(
-        run_resume.agents,
-        "run_agent",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("synthesis must not run")),
-    )
-    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
-    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
+    _patch_resume_denied(monkeypatch)
 
     assert run_resume.resume(run_dir) == 2
     assert "run budget exhausted" in capsys.readouterr().err
     assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_resume_refuses_corrupt_lifecycle_journal_before_appserver(tmp_path, monkeypatch, capsys):
+    """Declared resume must fail closed when exhausted prefix is followed by a corrupt tail."""
+    from datetime import datetime, timedelta, timezone
+
+    from brigade import run_journal
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    started = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+    meta["started_at"] = started.isoformat()
+    # Non-expired wall-clock so a fail-open empty projection would otherwise allow resume.
+    meta["verification_contract"] = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=1)
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    plan = json.loads((run_dir / "plan.json").read_text())
+    plan["verification_contract"] = meta["verification_contract"]
+    (run_dir / "plan.json").write_text(json.dumps(plan))
+
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    run_journal.append_event(
+        journal,
+        run_id=run_dir.name,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="create-1",
+        expected_previous_sequence=0,
+        recorded_at="2026-07-03T00:00:00.000000Z",
+    )
+    run_journal.append_event(
+        journal,
+        run_id=run_dir.name,
+        event_type="run_budget.exhausted",
+        payload={
+            "dimension": "worker_dispatch_count",
+            "mode": "enforceable",
+            "declared": 1,
+            "used": 1,
+            "remaining": 0,
+            "reason_class": "exhausted",
+        },
+        idempotency_key="run_budget.exhausted:worker_dispatch_count",
+        expected_previous_sequence=1,
+        recorded_at="2026-07-03T00:00:01.000000Z",
+    )
+    # Corrupt partial tail after a valid exhausted prefix (no terminating newline).
+    with journal.open("ab") as handle:
+        handle.write(b'{"event_type":"not-a-valid-envelope"')
+
+    monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    err = capsys.readouterr().err
+    assert "untrusted" in err or "incompatible" in err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_resume_refuses_malformed_persisted_budget_before_appserver(tmp_path, monkeypatch, capsys):
+    """Malformed ceiling values must not silently become undeclared/unbounded."""
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    contract = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=10)
+    contract["budget"]["wall_clock_seconds"] = "not-an-int"
+    contract["budget"]["worker_dispatch_count"] = "also-bad"
+    meta["verification_contract"] = contract
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    plan = json.loads((run_dir / "plan.json").read_text())
+    plan["verification_contract"] = contract
+    (run_dir / "plan.json").write_text(json.dumps(plan))
+
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
     assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
 
 

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -1246,6 +1246,84 @@ def test_resume_refuses_unsupported_verification_budget_schema_version(tmp_path,
     assert _GuardServer.provider_turns == 0
 
 
+@pytest.mark.parametrize("schema_version", [True, 1.0])
+def test_resume_refuses_non_integer_budget_schema_version_before_appserver(
+    tmp_path, monkeypatch, capsys, schema_version
+):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["run_budget"] = {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": schema_version,
+        "ceilings": {"worker_dispatch_count": 1},
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+
+
+@pytest.mark.parametrize(
+    "outer_budget",
+    [
+        {
+            "schema": "brigade.run_budget.v1",
+            "schema_version": 99,
+            "declaration": {
+                "schema": "brigade.run_budget.v1",
+                "schema_version": 1,
+                "ceilings": {"worker_dispatch_count": 1},
+            },
+        },
+        {
+            "schema": "brigade.run_budget.v1",
+            "schema_version": 1,
+            "declaration": {
+                "schema": "brigade.run_budget.v1",
+                "schema_version": 1,
+                "ceilings": {"worker_dispatch_count": 1},
+            },
+            "unexpected": True,
+        },
+    ],
+)
+def test_resume_refuses_incompatible_outer_run_budget_before_appserver(tmp_path, monkeypatch, capsys, outer_budget):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["run_budget"] = outer_budget
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+
+
+@pytest.mark.parametrize("schema_version", [True, 1.0])
+def test_resume_refuses_non_integer_parent_contract_schema_version_before_appserver(
+    tmp_path, monkeypatch, capsys, schema_version
+):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    contract = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=1)
+    contract["schema_version"] = schema_version
+    meta["verification_contract"] = contract
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+
+
 def test_resume_allows_non_expired_declared_budget(tmp_path, monkeypatch):
     from datetime import datetime, timedelta, timezone
 

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -874,3 +874,164 @@ def test_authority_resume_successful_synthesis_receipt_write_retains_lock(tmp_pa
         run_resume.resume(run_dir)
     lock_path = tmp_path / ".brigade" / "run.lock"
     assert lock_path.exists()
+
+
+# -- Issue #593: resume must honor declared run budgets before AppServer.start ----
+
+
+_RESUMABLE_COOK = {
+    "worker": "cook",
+    "task": "write code",
+    "ok": False,
+    "detail": "timeout",
+    "text": "part",
+    "thread_id": "t-1",
+    "status": "interrupted",
+}
+
+
+def _declared_contract(*, wall_clock_seconds: int | None = 3600, worker_dispatch_count: int | None = 10) -> dict:
+    from brigade import verification_contract
+
+    budget: dict = {"latency_seconds": wall_clock_seconds or 3600}
+    if wall_clock_seconds is not None:
+        budget["wall_clock_seconds"] = wall_clock_seconds
+    if worker_dispatch_count is not None:
+        budget["worker_dispatch_count"] = worker_dispatch_count
+    return {
+        "schema": verification_contract.VERIFICATION_CONTRACT_SCHEMA,
+        "schema_version": verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION,
+        "verifier": {"source": "command", "command": "true"},
+        "rollback": {"policy": "none"},
+        "budget": budget,
+    }
+
+
+class _GuardServer(_StubServer):
+    started = 0
+
+    def start(self):
+        type(self).started += 1
+        raise AssertionError("AppServer.start must not run when resume budget gate denies")
+
+
+def test_resume_refuses_expired_declared_wall_clock_before_appserver(tmp_path, monkeypatch, capsys):
+    from datetime import datetime, timedelta, timezone
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    started = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+    meta["started_at"] = started.isoformat()
+    meta["verification_contract"] = _declared_contract(wall_clock_seconds=5, worker_dispatch_count=10)
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    plan = json.loads((run_dir / "plan.json").read_text())
+    plan["verification_contract"] = meta["verification_contract"]
+    (run_dir / "plan.json").write_text(json.dumps(plan))
+
+    _GuardServer.started = 0
+    monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _GuardServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("synthesis must not run")),
+    )
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "wall-clock budget exhausted" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_resume_refuses_budget_exhausted_projection_before_appserver(tmp_path, monkeypatch, capsys):
+    from brigade import run_journal
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["verification_contract"] = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=1)
+    meta["failure"] = {"phase": "dispatch", "kind": "budget-exhausted", "detail": "dispatch ceiling"}
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    run_journal.append_event(
+        journal,
+        run_id=run_dir.name,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="create-1",
+        expected_previous_sequence=0,
+        recorded_at="2026-07-03T00:00:00.000000Z",
+    )
+    run_journal.append_event(
+        journal,
+        run_id=run_dir.name,
+        event_type="run_budget.exhausted",
+        payload={
+            "dimension": "worker_dispatch_count",
+            "mode": "enforceable",
+            "declared": 1,
+            "used": 1,
+            "remaining": 0,
+            "reason_class": "exhausted",
+        },
+        idempotency_key="run_budget.exhausted:worker_dispatch_count",
+        expected_previous_sequence=1,
+        recorded_at="2026-07-03T00:00:01.000000Z",
+    )
+
+    _GuardServer.started = 0
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _GuardServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("synthesis must not run")),
+    )
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "run budget exhausted" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_resume_allows_non_expired_declared_budget(tmp_path, monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    started = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+    meta["started_at"] = started.isoformat()
+    meta["verification_contract"] = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=10)
+    (run_dir / "run.json").write_text(json.dumps(meta))
+
+    monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(text="final synthesis", ok=True),
+    )
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
+
+    assert run_resume.resume(run_dir) == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+    assert (run_dir / "final.txt").read_text().strip() == "final synthesis"
+
+
+def test_resume_allows_undeclared_budget_for_backward_compatibility(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(text="final synthesis", ok=True),
+    )
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
+
+    assert run_resume.resume(run_dir) == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -933,6 +933,23 @@ def _patch_resume_denied(monkeypatch) -> None:
     monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
 
 
+def _write_trusted_lifecycle_prefix(run_dir: Path) -> Path:
+    from brigade import run_journal
+
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    run_journal.append_event(
+        journal,
+        run_id=run_dir.name,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="create-1",
+        expected_previous_sequence=0,
+        recorded_at="2026-07-03T00:00:00.000000Z",
+    )
+    return journal
+
+
 def test_resume_refuses_expired_declared_wall_clock_before_appserver(tmp_path, monkeypatch, capsys):
     from datetime import datetime, timedelta, timezone
 
@@ -945,6 +962,7 @@ def test_resume_refuses_expired_declared_wall_clock_before_appserver(tmp_path, m
     plan = json.loads((run_dir / "plan.json").read_text())
     plan["verification_contract"] = meta["verification_contract"]
     (run_dir / "plan.json").write_text(json.dumps(plan))
+    _write_trusted_lifecycle_prefix(run_dir)
 
     monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
     _patch_resume_denied(monkeypatch)
@@ -1082,6 +1100,152 @@ def test_resume_refuses_malformed_persisted_budget_before_appserver(tmp_path, mo
     assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
 
 
+def test_resume_refuses_missing_lifecycle_journal_for_declared_budget(tmp_path, monkeypatch, capsys):
+    """Persisted declared resume must fail closed when the lifecycle journal is absent."""
+    from datetime import datetime, timedelta, timezone
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    started = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+    meta["started_at"] = started.isoformat()
+    meta["verification_contract"] = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=10)
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    plan = json.loads((run_dir / "plan.json").read_text())
+    plan["verification_contract"] = meta["verification_contract"]
+    (run_dir / "plan.json").write_text(json.dumps(plan))
+    assert not (run_dir / "events" / "lifecycle.jsonl").exists()
+
+    monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    err = capsys.readouterr().err
+    assert "journal" in err.lower() or "untrusted" in err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_resume_refuses_wrong_type_budget_shape_before_appserver(tmp_path, monkeypatch, capsys):
+    """Wrong-type / empty / invalid declaration markers must not degrade to undeclared."""
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["verification_contract"] = {
+        "schema": "brigade.verification_contract.v1",
+        "schema_version": 1,
+        "verifier": {"source": "command", "command": "true"},
+        "rollback": {"policy": "none"},
+        "budget": "not-an-object",
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+
+
+def test_resume_refuses_empty_persisted_run_budget_before_appserver(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["run_budget"] = {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": 1,
+        "ceilings": {},
+        "observed": {},
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+
+
+def test_resume_refuses_projected_usage_exhaustion_without_exhausted_event(tmp_path, monkeypatch, capsys):
+    """Crash after the last allowed dispatch must refuse even without run_budget.exhausted."""
+    from datetime import datetime, timedelta, timezone
+
+    from brigade import run_journal
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    started = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+    meta["started_at"] = started.isoformat()
+    meta["verification_contract"] = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=1)
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    plan = json.loads((run_dir / "plan.json").read_text())
+    plan["verification_contract"] = meta["verification_contract"]
+    (run_dir / "plan.json").write_text(json.dumps(plan))
+
+    journal = _write_trusted_lifecycle_prefix(run_dir)
+    run_journal.append_event(
+        journal,
+        run_id=run_dir.name,
+        event_type="run.dispatch.requested",
+        payload={"seat": "cook", "attempt": 1, "detail": "dispatch"},
+        idempotency_key="dispatch:cook:1",
+        expected_previous_sequence=1,
+        recorded_at="2026-07-03T00:00:01.000000Z",
+    )
+
+    monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "budget exhausted" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_resume_refuses_unknown_verification_budget_dimension_before_appserver(tmp_path, monkeypatch, capsys):
+    from datetime import datetime, timedelta, timezone
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    started = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+    meta["started_at"] = started.isoformat()
+    contract = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=10)
+    contract["budget"]["child_worker_dispatch_count"] = 2
+    meta["verification_contract"] = contract
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
+    monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+
+
+def test_resume_refuses_unsupported_verification_budget_schema_version(tmp_path, monkeypatch, capsys):
+    from datetime import datetime, timedelta, timezone
+
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    started = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+    meta["started_at"] = started.isoformat()
+    contract = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=10)
+    contract["budget"]["schema"] = "brigade.run_budget.v1"
+    contract["budget"]["schema_version"] = 99
+    meta["verification_contract"] = contract
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
+    monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
+    _patch_resume_denied(monkeypatch)
+
+    assert run_resume.resume(run_dir) == 2
+    assert "incompatible" in capsys.readouterr().err
+    assert _GuardServer.started == 0
+    assert _GuardServer.provider_turns == 0
+
+
 def test_resume_allows_non_expired_declared_budget(tmp_path, monkeypatch):
     from datetime import datetime, timedelta, timezone
 
@@ -1091,6 +1255,7 @@ def test_resume_allows_non_expired_declared_budget(tmp_path, monkeypatch):
     meta["started_at"] = started.isoformat()
     meta["verification_contract"] = _declared_contract(wall_clock_seconds=3600, worker_dispatch_count=10)
     (run_dir / "run.json").write_text(json.dumps(meta))
+    _write_trusted_lifecycle_prefix(run_dir)
 
     monkeypatch.setattr(run_resume, "_utc_now", lambda: started + timedelta(seconds=10))
     monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
@@ -1099,7 +1264,6 @@ def test_resume_allows_non_expired_declared_budget(tmp_path, monkeypatch):
         "run_agent",
         lambda *a, **k: agents.AgentResult(text="final synthesis", ok=True),
     )
-    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *a, **k: nullcontext())
     monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *a, **k: False)
 
     assert run_resume.resume(run_dir) == 0

--- a/tests/test_verification_contract.py
+++ b/tests/test_verification_contract.py
@@ -63,6 +63,34 @@ def test_budget_use_and_verification_separate_from_model_completion():
     assert set(verification).isdisjoint({"model_status"}) or True
 
 
+def test_optional_input_output_token_fields_parse_and_report_without_aliasing_token_budget():
+    payload = _valid_contract(
+        budget={
+            "latency_seconds": 30,
+            "token_budget": 100,
+            "input_tokens": 40,
+            "output_tokens": 60,
+            "wall_clock_seconds": 90,
+            "worker_dispatch_count": 2,
+        }
+    )
+    assert verification_contract.validate_contract_payload(payload) == []
+    contract = verification_contract.contract_from_payload(payload)
+    assert contract.budget.token_budget == 100
+    assert contract.budget.input_tokens == 40
+    assert contract.budget.output_tokens == 60
+    round_trip = contract.to_payload()["budget"]
+    assert round_trip["token_budget"] == 100
+    assert round_trip["input_tokens"] == 40
+    assert round_trip["output_tokens"] == 60
+    use = verification_contract.budget_use_payload(contract, latency_seconds_used=1.0, tokens_used=50)
+    assert use["token_budget"] == 100
+    assert use["tokens_used"] == 50
+    assert use["input_tokens_budget"] == 40
+    assert use["output_tokens_budget"] == 60
+    assert "input_tokens" not in use
+
+
 def test_runbook_plan_blocks_consequential_without_contract(tmp_path, capsys):
     runbook = tmp_path / "runbook.json"
     runbook.write_text(

--- a/tests/test_verification_contract.py
+++ b/tests/test_verification_contract.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from brigade import runbook_cmd, verification_contract, verify_manifest
 
 
@@ -30,6 +32,13 @@ def test_contract_requires_verifier_rollback_and_budget():
     assert contract.rollback.policy == "none"
     assert contract.budget.latency_seconds == 30
     assert contract.budget.token_budget == 1000
+
+
+@pytest.mark.parametrize("schema_version", [True, 1.0])
+def test_contract_schema_version_requires_a_real_integer(schema_version):
+    assert verification_contract.validate_contract_payload(_valid_contract(schema_version=schema_version)) == [
+        "schema_version must be 1"
+    ]
 
 
 def test_contract_plan_view_blocks_consequential_without_contract():


### PR DESCRIPTION
## What and why

First enforceable slice of #593: the coordinator reserves **wall-clock** and **worker-dispatch** ceilings before new worker work starts, appends durable idempotent `run_budget.*` lifecycle events, and rebuilds remaining allocation from the journal on restart.

**Taxonomy decision (locked):** budget exhaustion and operator cancellation are terminal **policy lifecycle states** (`budget-exhausted` / `operator-cancelled`), not #576 worker `FailureClass` values and not infrastructure-neutral under #580. Provider/seat `capacity-exhausted` remains infrastructure.

Child frame / durable child-run allocation stays out of scope (#594).

**Repairs:**
- Parallel reservations + stable `dispatch:{seat}:{attempt}` identity + live Ctrl-C → `operator-cancelled` (comment 5247794372)
- Aggregate `token_budget` preserved, not aliased to `input_tokens` (comment 5248440501)
- Normal-run wiring, atomic same-seat attempt+reservation, truthful optional input/output schema/bridge (comment 5248588004)
- Declared-only hard ceilings documented; ordinary undeclared `brigade run` / dogfood / model-trial paths remain unbounded for backward compatibility—no invented flags, defaults, or timeout→budget mapping (comment 5249038705)
- Restart reclaim evaluates wall-clock before authorizing a durable pending dispatch so an expired run cannot relaunch attempt 1 (comment 5249411385)
- `brigade runs resume` gates on persisted declaration + original `started_at` + authoritative budget lifecycle projection before `AppServer.start()`, refusing expired/exhausted declared runs without provider/synthesis calls (comment 5249824510)
- Persisted declared resumes fail closed on untrusted lifecycle journals (read/chain/partial-tail/compatibility) and malformed verification-budget ceiling fields (comment 5250113662)
- Four remaining recovery bypasses closed: missing journal for declared runs, incompatible/empty budget shapes, projected dispatch usage exhaustion without an exhausted event, and unknown verification-budget dimensions/schema versions (comment 5251293454)
- Post-parking hardening: strict persisted `run_budget` envelope validation (closed field set, non-bool integer schema versions), fail-closed initial verification-contract budget parsing, and projector preservation of `verification_contract` / `run_budget` across rewrites

Rebased onto main `ce8e7f1e` (#871 import-provenance merge); no file overlap with the branch, focused and full suites re-verified post-rebase.

## Type of change

- [x] New feature (run budget enforcement)
- [x] Bug fix (wiring / atomicity / token / reclaim / resume gates)
- [x] Docs

## Acceptance mapping

| Criterion | How met |
| --- | --- |
| Declared ceilings on normal runs | `verification_contract` / `run_budget` persist through start + plan; coordinator reads them |
| Undeclared ordinary paths | No invented ceilings; dogfood/model-trial/`brigade run` without declaration stay unbounded |
| Dispatch refused at ceiling | E2E refuses second same-stage dispatch; `BudgetPolicyError` propagates from transport |
| Expired reclaim blocked | Wall-clock gate before reclaim authorizes pending durable dispatch |
| Resume budget gate | Expired/exhausted declared resume denied before AppServer; non-expired/undeclared allowed |
| Resume fail-closed | Missing/corrupt journal, malformed/empty shape, projected usage exhaustion, unknown dimensions refuse before AppServer/provider/synthesis |
| Same-seat count=1 launches once | Attempt allocation inside reservation lock + `_launch_claims` |
| Aggregate `token_budget` | Declaration field + receipt `tokens_used`; not `input_tokens` |
| Policy terminals + infra neutrality | `operator-cancelled` / `budget-exhausted`; capacity-exhausted stays infra |

## Follow-ups (out of scope for this slice)

Known gaps were triaged when this PR was parked and are tracked as issues against #593; none change the correctness of the declared wall-clock/dispatch slice shipped here:

- #884 — adapter capability contract for enforcing observed dimensions (model/tool calls, split tokens, cost) at reservation boundaries; this slice keeps them observation-only by design.
- #885 — an explicit, versioned budget-declaration source for ordinary `brigade run` / dogfood / model-trial entry points; undeclared invocations intentionally remain unbounded here.
- #886 — truthful per-seat cancellation outcomes; the current live integration derives `active_remaining` from the active-seat count rather than observed per-transport results, so the cancellation-receipt acceptance item of #593 completes there.
- #594 — durable child-run lineage; the cascade allocation slice of #593 lands after it.

Because #886 tracks an open #593 acceptance item, this PR is **part of #593**, not its closer.

## Verification

Post-rebase onto `ce8e7f1e`, from a fresh repo-local `.venv`, run through Brigade work verify:

- Focused run-budget suite (`test_run_budget`, `test_run_resume`, `test_run_lifecycle`, `test_run_projector`, `test_verification_contract`, `test_budgets`): receipt `20260812-163851-work-verify-629fe5`, exit 0.
- Full gate `./scripts/verify`: receipt `20260812-163911-work-verify-426918` — ruff, format, mypy, version sync, and snapshot checks all pass; pytest 7,160 passed / 3 failed, all three failures host-environmental (bare uv venv lacks pip for `test_publish_workflow`; `crontab -n` broken by `/var/spool/cron` permissions on this host — reproduce independent of this branch).
- Full pytest with pip/pyyaml provisioned and only the two host-broken crontab tests deselected (deselects explicit in the receipt command): receipt `20260812-165257-work-verify-6a9e79`, exit 0, coverage above the 78% floor.
- GitHub Actions on this head is the canonical cross-platform gate.

Part of #593
