### PR TITLE
feat(evidence-ledger): harden E2 one-live read paths and safe show (#843)

### DIFF
--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -14,11 +14,16 @@ Releases before this changelog was started are on the [releases page](https://gi
   content-hash versions (and drop their FTS rows) so each
   `(source, collection, external_id)` has one default-live version; generic
   search/explain/evidence and session search exclude tombstones and non-latest
-  rows; Markdown export, session list/metadata/preview/transcript/stats, and
+  rows; latest-live filtering runs inside the bounded FTS candidate CTE so
+  pre-E2 superseded rows cannot fill the 1,000-row pool and hide a live hit;
+  Markdown export, session list/metadata/preview/transcript/stats, and
   evidence related-item expansion use the same latest-live predicate (including
-  pre-E2 duplicate live rows); `doctor --archive` ignores intentional
-  tombstones in `archive_items_missing_fts`; generic `show --json` exposes
-  qualified relation targets (`target_source_kind`,
+  pre-E2 duplicate live rows); Markdown export stages under
+  `.miseledger-export-stage`, records managed basenames in
+  `.miseledger-export-files`, and reconciles obsolete managed `*.md` when
+  reusing `--out` after the last live item is tombstoned; `doctor --archive`
+  ignores intentional tombstones in `archive_items_missing_fts`; generic
+  `show --json` exposes qualified relation targets (`target_source_kind`,
   `target_collection_external_id`, `target_external_id`, nullable
   `target_item_id`) plus live/tombstone state and omits quarantined
   `injection=pending` body/raw unless `--include-untrusted-body` /

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -14,12 +14,15 @@ Releases before this changelog was started are on the [releases page](https://gi
   content-hash versions (and drop their FTS rows) so each
   `(source, collection, external_id)` has one default-live version; generic
   search/explain/evidence and session search exclude tombstones and non-latest
-  rows; `doctor --archive` ignores intentional tombstones in
-  `archive_items_missing_fts`; generic `show --json` exposes qualified relation
-  targets (`target_source_kind`, `target_collection_external_id`,
-  `target_external_id`, nullable `target_item_id`) plus live/tombstone state and
-  omits quarantined `injection=pending` body/raw unless
-  `--include-untrusted-body` / `include_untrusted_body` is set.
+  rows; Markdown export, session list/metadata/preview/transcript/stats, and
+  evidence related-item expansion use the same latest-live predicate (including
+  pre-E2 duplicate live rows); `doctor --archive` ignores intentional
+  tombstones in `archive_items_missing_fts`; generic `show --json` exposes
+  qualified relation targets (`target_source_kind`,
+  `target_collection_external_id`, `target_external_id`, nullable
+  `target_item_id`) plus live/tombstone state and omits quarantined
+  `injection=pending` body/raw unless `--include-untrusted-body` /
+  `include_untrusted_body` is set.
 
 ### Added
 

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -8,6 +8,19 @@ Releases before this changelog was started are on the [releases page](https://gi
 
 ## [Unreleased]
 
+### Changed
+
+- Memory projection E2 read-path hardening (#843): soft-tombstone superseded
+  content-hash versions (and drop their FTS rows) so each
+  `(source, collection, external_id)` has one default-live version; generic
+  search/explain/evidence and session search exclude tombstones and non-latest
+  rows; `doctor --archive` ignores intentional tombstones in
+  `archive_items_missing_fts`; generic `show --json` exposes qualified relation
+  targets (`target_source_kind`, `target_collection_external_id`,
+  `target_external_id`, nullable `target_item_id`) plus live/tombstone state and
+  omits quarantined `injection=pending` body/raw unless
+  `--include-untrusted-body` / `include_untrusted_body` is set.
+
 ### Added
 
 - Provenance persistence Slice 2: ingest stamps indexed `provenance.*` projections,

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -1889,25 +1889,27 @@ func searchCandidateLimit(limit int) int {
 
 // buildSearchQuery ranks FTS matches first in a bounded, materialized
 // candidate pool, then joins and applies the remaining filters and the
-// relations boost over that pool only. On large archives this bounds the
+// relations boost over that pool only. Latest-live filtering runs inside the
+// candidate CTE so pre-E2 superseded versions cannot fill the 1,000-row cap
+// and hide a matching live item. On large archives this still bounds the
 // per-row relations probe that previously ran for every FTS match. The
 // tradeoff: filters applied only after pooling (collection, from/to, project,
 // tags) can miss rows whose bm25 rank falls below the candidate cap, so a
 // heavily filtered query may return fewer results than an exhaustive scan.
 func buildSearchQuery(opts SearchOpts) (string, []any) {
 	limit := normalizedSearchLimit(opts.Limit)
-	candidateWhere := []string{"item_fts match ?"}
+	candidateWhere := []string{"item_fts match ?", liveDefaultItemPredicate}
 	params := []any{ftsQuery(opts.Query)}
 	if opts.Source != "" {
-		candidateWhere = append(candidateWhere, "source_kind = ?")
+		candidateWhere = append(candidateWhere, "item_fts.source_kind = ?")
 		params = append(params, opts.Source)
 	}
 	if opts.Kind != "" {
-		candidateWhere = append(candidateWhere, "item_kind = ?")
+		candidateWhere = append(candidateWhere, "item_fts.item_kind = ?")
 		params = append(params, opts.Kind)
 	}
 	if opts.ActorType != "" {
-		candidateWhere = append(candidateWhere, "actor_type = ?")
+		candidateWhere = append(candidateWhere, "item_fts.actor_type = ?")
 		params = append(params, opts.ActorType)
 	}
 	params = append(params, searchCandidateLimit(limit))
@@ -1918,8 +1920,9 @@ func buildSearchQuery(opts SearchOpts) (string, []any) {
 	// CROSS JOIN pins the candidate pool as the outer loop. A reorder through
 	// sources and items evaluates correlated filters against the whole archive.
 	sqlText := `with fts_candidates as materialized (
-  select item_id, snippet(item_fts, 5, '[', ']', '...', 20) as snippet, bm25(item_fts) as fts_score
+  select item_fts.item_id as item_id, snippet(item_fts, 5, '[', ']', '...', 20) as snippet, bm25(item_fts) as fts_score
   from item_fts
+  join items i on i.id = item_fts.item_id
   where ` + strings.Join(candidateWhere, " and ") + `
   order by fts_score, item_id
   limit ?
@@ -2736,9 +2739,19 @@ order by s.kind, c.name, i.created_at, i.id`)
 		key := r.source + "/" + r.collectionKind + "/" + r.collection
 		grouped[key] = append(grouped[key], r)
 	}
+
+	stageDir := filepath.Join(outDir, exportStageDirName)
+	_ = os.RemoveAll(stageDir)
+	if err := security.EnsurePrivateDir(stageDir); err != nil {
+		return 0, err
+	}
+	defer func() { _ = os.RemoveAll(stageDir) }()
+
+	managed := map[string]struct{}{}
 	count := 0
 	for key, rows := range grouped {
-		path := filepath.Join(outDir, safeName(key)+".md")
+		name := safeName(key) + ".md"
+		managed[name] = struct{}{}
 		var b strings.Builder
 		fmt.Fprintf(&b, "# %s\n\n", key)
 		for _, r := range rows {
@@ -2753,12 +2766,90 @@ order by s.kind, c.name, i.created_at, i.id`)
 				fmt.Fprintf(&b, "Summary: %s\n\n", r.summary)
 			}
 		}
-		if err := security.WritePrivateFileAtomic(path, []byte(b.String())); err != nil {
+		if err := security.WritePrivateFileAtomic(filepath.Join(stageDir, name), []byte(b.String())); err != nil {
 			return count, err
 		}
 		count++
 	}
+
+	previous, err := readManagedExportManifest(outDir)
+	if err != nil {
+		return count, err
+	}
+	for name := range managed {
+		data, err := os.ReadFile(filepath.Join(stageDir, name))
+		if err != nil {
+			return count, err
+		}
+		if err := security.WritePrivateFileAtomic(filepath.Join(outDir, name), data); err != nil {
+			return count, err
+		}
+	}
+	for name := range previous {
+		if _, keep := managed[name]; keep {
+			continue
+		}
+		if !isManagedExportBasename(name) {
+			continue
+		}
+		path := filepath.Join(outDir, name)
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return count, err
+		}
+	}
+	if err := writeManagedExportManifest(outDir, managed); err != nil {
+		return count, err
+	}
 	return count, nil
+}
+
+const (
+	exportManifestName = ".miseledger-export-files"
+	exportStageDirName = ".miseledger-export-stage"
+)
+
+func isManagedExportBasename(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, `\`) || strings.Contains(name, "..") {
+		return false
+	}
+	return strings.HasSuffix(name, ".md")
+}
+
+func readManagedExportManifest(outDir string) (map[string]struct{}, error) {
+	path := filepath.Join(outDir, exportManifestName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]struct{}{}, nil
+		}
+		return nil, err
+	}
+	out := map[string]struct{}{}
+	for _, line := range strings.Split(string(data), "\n") {
+		name := strings.TrimSpace(line)
+		if !isManagedExportBasename(name) {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out, nil
+}
+
+func writeManagedExportManifest(outDir string, managed map[string]struct{}) error {
+	names := make([]string, 0, len(managed))
+	for name := range managed {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, name := range names {
+		b.WriteString(name)
+		b.WriteByte('\n')
+	}
+	return security.WritePrivateFileAtomic(filepath.Join(outDir, exportManifestName), []byte(b.String()))
 }
 
 var unsafeName = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -1936,7 +1936,7 @@ limit ?`
 	return sqlText, params
 }
 
-// liveDefaultItemPredicate keeps default search/evidence on one live content
+// liveDefaultItemPredicate keeps default read paths on one live content
 // version per (source, collection, external_id). Tombstones and superseded
 // content-hash rows are excluded even if a stale FTS row remains.
 const liveDefaultItemPredicate = `i.tombstoned_at is null and i.id = (
@@ -1948,6 +1948,23 @@ const liveDefaultItemPredicate = `i.tombstoned_at is null and i.id = (
   order by i2.ingest_seq desc, i2.id desc
   limit 1
 )`
+
+// liveDefaultItemPredicateFor returns the shared latest-live predicate for an
+// items-table alias other than "i" (for example "t", "fi", or "ii").
+func liveDefaultItemPredicateFor(alias string) string {
+	if alias == "" || alias == "i" {
+		return liveDefaultItemPredicate
+	}
+	return fmt.Sprintf(`%s.tombstoned_at is null and %s.id = (
+  select i2.id from items i2
+  where i2.source_id = %s.source_id
+    and i2.collection_id = %s.collection_id
+    and i2.external_id = %s.external_id
+    and i2.tombstoned_at is null
+  order by i2.ingest_seq desc, i2.id desc
+  limit 1
+)`, alias, alias, alias, alias, alias)
+}
 
 func appendSearchResultFilters(opts SearchOpts, where []string, params []any) ([]string, []any) {
 	if opts.Source != "" {
@@ -2479,15 +2496,19 @@ func listEvidenceBundles() ([]map[string]any, error) {
 }
 
 func relatedItems(db *sql.DB, itemID string) []map[string]any {
+	liveT := liveDefaultItemPredicateFor("t")
+	liveI := liveDefaultItemPredicate
 	return queryMaps(db, `select r.relation_type, r.target_external_id, coalesce(t.id,'') as target_item_id, coalesce(t.kind,'') as target_kind, coalesce(t.created_at,'') as target_created_at
 from relations r
 left join items t on t.id = r.target_item_id
 where r.source_item_id = ?
+  and (r.target_item_id is null or (`+liveT+`))
 union all
 select r.relation_type, r.target_external_id, coalesce(i.id,'') as target_item_id, coalesce(i.kind,'') as target_kind, coalesce(i.created_at,'') as target_created_at
 from relations r
 join items i on i.id = r.source_item_id
 where r.target_item_id = ?
+  and (`+liveI+`)
 order by relation_type, target_item_id, target_external_id
 limit 20`, itemID, itemID)
 }
@@ -2699,6 +2720,7 @@ from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 left join actors a on a.id = i.actor_id
+where `+liveDefaultItemPredicate+`
 order by s.kind, c.name, i.created_at, i.id`)
 	if err != nil {
 		return 0, err

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -392,7 +392,7 @@ func archiveDoctorChecks(db *sql.DB) []doctorCheck {
 	checkCount("archive_orphan_relations", `select count(*) from relations r where not exists(select 1 from items i where i.id = r.source_item_id)`)
 	checkCount("archive_missing_relation_targets", `select count(*) from relations r where r.target_item_id is not null and not exists(select 1 from items i where i.id = r.target_item_id)`)
 	add("archive_unresolved_relations", unresolvedRelationCount(db) == 0, fmt.Sprintf("count=%d", unresolvedRelationCount(db)))
-	checkCount("archive_items_missing_fts", `select count(*) from items i where not exists(select 1 from item_fts f where f.item_id = i.id)`)
+	checkCount("archive_items_missing_fts", `select count(*) from items i where i.tombstoned_at is null and not exists(select 1 from item_fts f where f.item_id = i.id)`)
 	checkCount("archive_orphan_fts", `select count(*) from item_fts f where not exists(select 1 from items i where i.id = f.item_id)`)
 
 	missingScans := 0
@@ -1912,7 +1912,7 @@ func buildSearchQuery(opts SearchOpts) (string, []any) {
 	}
 	params = append(params, searchCandidateLimit(limit))
 
-	where, params := appendSearchResultFilters(opts, []string{"1=1"}, params)
+	where, params := appendSearchResultFilters(opts, []string{liveDefaultItemPredicate}, params)
 	params = append(params, limit)
 
 	// CROSS JOIN pins the candidate pool as the outer loop. A reorder through
@@ -1935,6 +1935,19 @@ order by (fc.fts_score - case when exists(select 1 from relations rr where rr.so
 limit ?`
 	return sqlText, params
 }
+
+// liveDefaultItemPredicate keeps default search/evidence on one live content
+// version per (source, collection, external_id). Tombstones and superseded
+// content-hash rows are excluded even if a stale FTS row remains.
+const liveDefaultItemPredicate = `i.tombstoned_at is null and i.id = (
+  select i2.id from items i2
+  where i2.source_id = i.source_id
+    and i2.collection_id = i.collection_id
+    and i2.external_id = i.external_id
+    and i2.tombstoned_at is null
+  order by i2.ingest_seq desc, i2.id desc
+  limit 1
+)`
 
 func appendSearchResultFilters(opts SearchOpts, where []string, params []any) ([]string, []any) {
 	if opts.Source != "" {
@@ -2037,6 +2050,7 @@ func searchExactCodeReference(db *sql.DB, opts SearchOpts) ([]SearchResult, erro
 	}
 	params := []any{reference.Schema, reference.Repository, reference.Revision.Commit, reference.FilePath, reference.QualifiedName, reference.SymbolKind, reference.ChangeKind}
 	where, params = appendSearchResultFilters(opts, where, params)
+	where = append(where, liveDefaultItemPredicate)
 	params = append(params, opts.Limit)
 	sqlText := `select i.id, s.kind, c.name, c.kind, i.kind, coalesce(a.type,''), coalesce(a.name,''), coalesce(i.created_at,''), code_reference.value, i.content_hash
 from items i
@@ -2175,24 +2189,26 @@ func explainSearch(db *sql.DB, opts SearchOpts) (map[string]any, error) {
 }
 
 func cmdShow(args []string, out, errw io.Writer) int {
-	_, bools, rest, err := splitFlags(args, nil, map[string]bool{"json": true})
+	_, bools, rest, err := splitFlags(args, nil, map[string]bool{"json": true, "include-untrusted-body": true})
 	if err != nil {
 		return fatalf(errw, "show: %s", err)
 	}
 	if len(rest) != 1 {
-		return fatalf(errw, "usage: miseledger show <item-id>")
+		return fatalf(errw, "usage: miseledger show <item-id> [--json] [--include-untrusted-body]")
 	}
 	db, _, err := openMigrated()
 	if err != nil {
 		return fatalf(errw, "show: %s", err)
 	}
 	defer db.Close()
-	item, err := showItem(db, rest[0])
+	item, err := showItem(db, rest[0], showItemOpts{IncludeUntrustedBody: bools["include-untrusted-body"]})
 	if err != nil {
 		return fatalf(errw, "show: %s", err)
 	}
 	if bools["json"] {
 		writeJSON(out, item)
+	} else if omitted, _ := item["untrusted_body_omitted"].(bool); omitted {
+		fmt.Fprintf(out, "%s\nlive=%v untrusted_body_omitted=true (pass --include-untrusted-body to reveal text/raw)\n", item["id"], item["live"])
 	} else {
 		fmt.Fprintf(out, "%s\n%s\n", item["id"], item["text"])
 	}
@@ -2487,44 +2503,95 @@ func writeEvidenceMarkdown(w io.Writer, bundle map[string]any) {
 	}
 }
 
-func showItem(db *sql.DB, id string) (map[string]any, error) {
-	row := db.QueryRow(`select i.id, i.external_id, i.kind, coalesce(i.created_at,''), coalesce(i.text,''), coalesce(i.summary,''), i.content_hash, i.metadata_json, i.raw_json, coalesce(i.raw_hash,''), coalesce(i.raw_path,''), coalesce(i.raw_ordinal,0), s.kind, s.name, c.external_id, c.kind, c.name, coalesce(a.external_id,''), coalesce(a.type,''), coalesce(a.name,'')
+func showItem(db *sql.DB, id string, opts showItemOpts) (map[string]any, error) {
+	row := db.QueryRow(`select i.id, i.external_id, i.kind, coalesce(i.created_at,''), coalesce(i.text,''), coalesce(i.summary,''), i.content_hash, i.metadata_json, i.raw_json, coalesce(i.raw_hash,''), coalesce(i.raw_path,''), coalesce(i.raw_ordinal,0), coalesce(i.tombstoned_at,''), s.kind, s.name, c.external_id, c.kind, c.name, coalesce(a.external_id,''), coalesce(a.type,''), coalesce(a.name,''),
+  case when i.tombstoned_at is null and i.id = (
+    select i2.id from items i2
+    where i2.source_id = i.source_id
+      and i2.collection_id = i.collection_id
+      and i2.external_id = i.external_id
+      and i2.tombstoned_at is null
+    order by i2.ingest_seq desc, i2.id desc
+    limit 1
+  ) then 1 else 0 end
 from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 left join actors a on a.id = i.actor_id
 where i.id = ?`, id)
-	var itemID, externalID, kind, createdAt, text, summary, contentHash, metadataJSON, rawJSON, rawHash, rawPath, sourceKind, sourceName, collectionExternalID, collectionKind, collectionName, actorExternalID, actorType, actorName string
+	var itemID, externalID, kind, createdAt, text, summary, contentHash, metadataJSON, rawJSON, rawHash, rawPath, tombstonedAt, sourceKind, sourceName, collectionExternalID, collectionKind, collectionName, actorExternalID, actorType, actorName string
 	var rawOrdinal int64
-	if err := row.Scan(&itemID, &externalID, &kind, &createdAt, &text, &summary, &contentHash, &metadataJSON, &rawJSON, &rawHash, &rawPath, &rawOrdinal, &sourceKind, &sourceName, &collectionExternalID, &collectionKind, &collectionName, &actorExternalID, &actorType, &actorName); err != nil {
+	var liveInt int
+	if err := row.Scan(&itemID, &externalID, &kind, &createdAt, &text, &summary, &contentHash, &metadataJSON, &rawJSON, &rawHash, &rawPath, &rawOrdinal, &tombstonedAt, &sourceKind, &sourceName, &collectionExternalID, &collectionKind, &collectionName, &actorExternalID, &actorType, &actorName, &liveInt); err != nil {
 		return nil, err
 	}
 	artifacts := queryMaps(db, `select id, external_id, kind, path, url, mime_type, content_hash from artifacts where item_id = ? order by id`, id)
-	relations := queryMaps(db, `select id, target_item_id, target_external_id, relation_type, confidence from relations where source_item_id = ? order by id`, id)
+	relations := queryMaps(db, `select id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence from relations where source_item_id = ? order by id`, id)
+	for _, rel := range relations {
+		targetID, _ := rel["target_item_id"].(string)
+		if targetID == "" {
+			rel["target_live"] = nil
+			rel["target_tombstoned"] = nil
+			continue
+		}
+		var targetTombstone string
+		var targetLive int
+		err := db.QueryRow(`select coalesce(tombstoned_at,''),
+  case when tombstoned_at is null and id = (
+    select i2.id from items i2
+    where i2.source_id = items.source_id
+      and i2.collection_id = items.collection_id
+      and i2.external_id = items.external_id
+      and i2.tombstoned_at is null
+    order by i2.ingest_seq desc, i2.id desc
+    limit 1
+  ) then 1 else 0 end
+from items where id = ?`, targetID).Scan(&targetTombstone, &targetLive)
+		if err != nil {
+			rel["target_live"] = nil
+			rel["target_tombstoned"] = nil
+			continue
+		}
+		rel["target_live"] = targetLive == 1
+		rel["target_tombstoned"] = targetTombstone != ""
+	}
 	var raw any
 	_ = json.Unmarshal([]byte(rawJSON), &raw)
 	var metadata map[string]any
 	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil || metadata == nil {
 		metadata = map[string]any{}
 	}
+	live := liveInt == 1
 	out := map[string]any{
 		"id":           itemID,
 		"external_id":  externalID,
 		"kind":         kind,
 		"created_at":   createdAt,
-		"text":         text,
-		"summary":      summary,
 		"content_hash": contentHash,
 		"metadata":     metadata,
+		"live":         live,
+		"tombstoned":   tombstonedAt != "",
 		"source":       map[string]any{"kind": sourceKind, "name": sourceName},
 		"collection":   map[string]any{"external_id": collectionExternalID, "kind": collectionKind, "name": collectionName},
 		"actor":        map[string]any{"external_id": actorExternalID, "type": actorType, "name": actorName},
 		"artifacts":    artifacts,
 		"relations":    relations,
 		"raw_ref":      map[string]any{"hash": rawHash, "path": rawPath, "ordinal": rawOrdinal},
-		"raw":          raw,
+	}
+	if tombstonedAt == "" {
+		out["tombstoned_at"] = nil
+	} else {
+		out["tombstoned_at"] = tombstonedAt
 	}
 	attachShowProvenance(out, metadata)
+	omitBody := !opts.IncludeUntrustedBody && isQuarantinedInjectionPending(metadata)
+	if omitBody {
+		out["untrusted_body_omitted"] = true
+	} else {
+		out["text"] = text
+		out["summary"] = summary
+		out["raw"] = raw
+	}
 	return out, nil
 }
 
@@ -2540,6 +2607,32 @@ func attachShowProvenance(out map[string]any, metadata map[string]any) {
 	if _, err := ingest.ParseRetainableEnvelope(rawEnv); err != nil {
 		out["provenance_warning"] = "malformed provenance: " + err.Error()
 	}
+}
+
+type showItemOpts struct {
+	IncludeUntrustedBody bool
+}
+
+func isQuarantinedInjectionPending(metadata map[string]any) bool {
+	if metadata == nil {
+		return false
+	}
+	prov, ok := metadata["provenance"].(map[string]any)
+	if !ok {
+		return false
+	}
+	trust, ok := prov["trust"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if fmt.Sprint(trust["label"]) != "quarantined" {
+		return false
+	}
+	injection, ok := trust["injection"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return fmt.Sprint(injection["status"]) == "pending"
 }
 
 func queryMaps(db *sql.DB, sqlText string, args ...any) []map[string]any {

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -2111,6 +2111,9 @@ func TestSearchPlanBoundsFTSCandidatesBeforeJoins(t *testing.T) {
 
 	opts := SearchOpts{Query: "needle", Limit: 5}
 	sqlText, params := buildSearchQuery(opts)
+	if !strings.Contains(sqlText, "join items i on i.id = item_fts.item_id") {
+		t.Fatalf("candidate CTE must join items for latest-live filtering:\n%s", sqlText)
+	}
 	plan := explainPlan(t, db, sqlText, params...)
 	for _, want := range []string{
 		"MATERIALIZE fts_candidates",
@@ -2135,7 +2138,12 @@ func TestSearchPlanBoundsFTSCandidatesBeforeJoins(t *testing.T) {
 			t.Fatalf("project filter plan missing %q:\n%s", want, projectPlan)
 		}
 	}
-	if strings.Index(projectPlan, "SCAN fc") > strings.Index(projectPlan, "SEARCH i USING") {
+	// Latest-live filtering joins items inside the CTE, so SEARCH i may appear
+	// before SCAN fc. Post-pool filters (project metadata) must still run after
+	// the materialized candidate scan.
+	scanFC := strings.Index(projectPlan, "SCAN fc")
+	searchIM := strings.Index(projectPlan, "SEARCH im USING COVERING INDEX")
+	if scanFC < 0 || searchIM < 0 || scanFC > searchIM {
 		t.Fatalf("project filter plan does not keep FTS candidates outermost:\n%s", projectPlan)
 	}
 

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -180,7 +180,7 @@ func TestAdapterImportSearchShowExportAndIdempotency(t *testing.T) {
 	}
 	first := results[0].(map[string]any)
 	id := first["id"].(string)
-	show := runJSON(t, "show", id, "--json")
+	show := runJSON(t, "show", id, "--json", "--include-untrusted-body")
 	if show["id"] != id {
 		t.Fatalf("show id = %v, want %s", show["id"], id)
 	}

--- a/engines/evidence-ledger/internal/app/e2_readpath_test.go
+++ b/engines/evidence-ledger/internal/app/e2_readpath_test.go
@@ -1,0 +1,301 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/escoffier-labs/miseledger/internal/ingest"
+)
+
+// E2 (#843): generic search/show/evidence/doctor read-path contract after E1.
+func TestE2OneLiveVersionSearchOmitsSupersededAndTombstones(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-e2live00-1111-4222-8333-444444444444"
+	path := filepath.Join(cards, "edit.md")
+	oldUnique := "UNIQUE_OLD_TOKEN_E2_ABSENT_AFTER_EDIT"
+	newUnique := "UNIQUE_NEW_TOKEN_E2_ONLY_LIVE"
+	if err := os.WriteFile(path, []byte("---\nid: "+cardID+"\ntopic: e2\n---\n\n# Body\n\n"+oldUnique+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "crawl", "memory", ws, "--json")
+	if err := os.WriteFile(path, []byte("---\nid: "+cardID+"\ntopic: e2\n---\n\n# Body\n\n"+newUnique+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "crawl", "memory", ws, "--json")
+
+	oldSearch := runJSON(t, "search", oldUnique, "--source", ingest.MemorySourceKind, "--json")
+	if len(oldSearch["results"].([]any)) != 0 {
+		t.Fatalf("old unique text must leave default search after edit: %v", oldSearch)
+	}
+	newSearch := runJSON(t, "search", newUnique, "--source", ingest.MemorySourceKind, "--json")
+	results := newSearch["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("expected exactly one live search hit, got %v", newSearch)
+	}
+
+	db := openTestDB(t)
+	defer db.Close()
+	var ftsOld int
+	if err := db.QueryRow(`select count(*) from item_fts where item_fts match ?`, `"`+oldUnique+`"`).Scan(&ftsOld); err != nil {
+		t.Fatal(err)
+	}
+	if ftsOld != 0 {
+		t.Fatalf("old unique text still present in FTS rows: count=%d", ftsOld)
+	}
+	var live, tombstoned int
+	if err := db.QueryRow(`
+select
+  sum(case when i.tombstoned_at is null then 1 else 0 end),
+  sum(case when i.tombstoned_at is not null then 1 else 0 end)
+from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ?`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&live, &tombstoned); err != nil {
+		t.Fatal(err)
+	}
+	if live != 1 || tombstoned < 1 {
+		t.Fatalf("expected one live + superseded tombstone, live=%d tombstoned=%d", live, tombstoned)
+	}
+
+	// Completed removal: deleted card must not appear in search and doctor must
+	// not flag the intentional tombstone as missing FTS.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "crawl", "memory", ws, "--json")
+	removedSearch := runJSON(t, "search", newUnique, "--source", ingest.MemorySourceKind, "--json")
+	if len(removedSearch["results"].([]any)) != 0 {
+		t.Fatalf("completed-removal tombstone must not appear in search: %v", removedSearch)
+	}
+	evidence := runJSON(t, "evidence", newUnique, "--source", ingest.MemorySourceKind, "--json")
+	if len(evidence["results"].([]any)) != 0 {
+		t.Fatalf("completed-removal tombstone must not appear in evidence: %v", evidence)
+	}
+
+	code, out, errb := run("doctor", "--archive", "--json")
+	_ = code
+	_ = errb
+	var doctor map[string]any
+	if err := json.Unmarshal([]byte(out), &doctor); err != nil {
+		t.Fatalf("doctor json: %v\n%s", err, out)
+	}
+	checks := doctor["checks"].([]any)
+	foundFTS := false
+	for _, raw := range checks {
+		check := raw.(map[string]any)
+		if check["name"] == "archive_items_missing_fts" {
+			foundFTS = true
+			if check["ok"] != true {
+				t.Fatalf("intentional tombstones must be excluded from archive_items_missing_fts: %v", check)
+			}
+		}
+	}
+	if !foundFTS {
+		t.Fatalf("archive_items_missing_fts check missing: %v", checks)
+	}
+}
+
+func TestE2ShowQualifiedRelationsLiveStateAndSafeDefaultBody(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := copyEngineMemoryFixtures(t)
+	receiptFixture := repoPath(t, "testdata/adapters/memory/brigade-receipt.fixture.jsonl")
+	runOK(t, "import", "adapter", receiptFixture, "--json")
+	crawl := runJSON(t, "crawl", "memory", ws, "--json")
+	if crawl["status"] != "completed" {
+		t.Fatalf("crawl = %v", crawl)
+	}
+
+	// Injection-like card: default show omits body/raw; opt-in restores them.
+	injSearch := runJSON(t, "search", "IGNORE ALL PREVIOUS", "--source", ingest.MemorySourceKind, "--kind", "memory_card", "--json")
+	if len(injSearch["results"].([]any)) == 0 {
+		t.Fatalf("injection fixture should still be searchable by metadata/text index: %v", injSearch)
+	}
+	injID := injSearch["results"].([]any)[0].(map[string]any)["id"].(string)
+	safe := runJSON(t, "show", injID, "--json")
+	if safe["untrusted_body_omitted"] != true {
+		t.Fatalf("default show must omit quarantined injection-pending body: %v", safe)
+	}
+	if _, ok := safe["text"]; ok {
+		t.Fatalf("default show leaked text: %v", safe)
+	}
+	if _, ok := safe["raw"]; ok {
+		t.Fatalf("default show leaked raw: %v", safe)
+	}
+	if safe["live"] != true || safe["tombstoned"] != false {
+		t.Fatalf("live/tombstone state missing: %v", safe)
+	}
+	revealed := runJSON(t, "show", injID, "--json", "--include-untrusted-body")
+	if revealed["untrusted_body_omitted"] == true {
+		t.Fatalf("opt-in must reveal body: %v", revealed)
+	}
+	text, _ := revealed["text"].(string)
+	if !strings.Contains(text, "IGNORE ALL PREVIOUS") {
+		t.Fatalf("opt-in text missing injection fixture body: %v", revealed)
+	}
+
+	// Unresolved qualified relation target fields on show --json.
+	unresolvedSearch := runJSON(t, "search", "Points at a missing receipt", "--source", ingest.MemorySourceKind, "--json")
+	if len(unresolvedSearch["results"].([]any)) == 0 {
+		t.Fatalf("unresolved relation card missing: %v", unresolvedSearch)
+	}
+	unresolvedID := unresolvedSearch["results"].([]any)[0].(map[string]any)["id"].(string)
+	unresolvedShow := runJSON(t, "show", unresolvedID, "--json")
+	rels := unresolvedShow["relations"].([]any)
+	if len(rels) == 0 {
+		t.Fatalf("expected outbound relation: %v", unresolvedShow)
+	}
+	foundUnresolved := false
+	for _, raw := range rels {
+		rel := raw.(map[string]any)
+		if rel["target_external_id"] == "receipt:does-not-exist" {
+			foundUnresolved = true
+			if rel["target_source_kind"] != "brigade" {
+				t.Fatalf("target_source_kind = %v", rel["target_source_kind"])
+			}
+			if rel["target_collection_external_id"] != "brigade:receipts" {
+				t.Fatalf("target_collection_external_id = %v", rel["target_collection_external_id"])
+			}
+			if rel["target_item_id"] != nil && rel["target_item_id"] != "" {
+				t.Fatalf("unresolved target_item_id must be null/empty: %v", rel)
+			}
+			if rel["target_live"] != nil {
+				t.Fatalf("unresolved target_live must be null: %v", rel)
+			}
+		}
+	}
+	if !foundUnresolved {
+		t.Fatalf("qualified unresolved relation missing: %v", unresolvedShow)
+	}
+
+	// Resolved qualified cross-source relation (card -> receipt).
+	db := openTestDB(t)
+	defer db.Close()
+	var cardWithReceipt string
+	if err := db.QueryRow(`
+select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+join relations r on r.source_item_id = i.id
+where s.kind = ? and c.external_id = ? and i.kind = 'memory_card'
+  and i.tombstoned_at is null and r.target_item_id is not null
+  and coalesce(r.target_source_kind,'') != ''
+limit 1`, ingest.MemorySourceKind, testMemoryNamespace).Scan(&cardWithReceipt); err != nil {
+		t.Fatalf("need a live memory card with resolved qualified relation: %v", err)
+	}
+	resolvedShow := runJSON(t, "show", cardWithReceipt, "--json")
+	foundResolved := false
+	for _, raw := range resolvedShow["relations"].([]any) {
+		rel := raw.(map[string]any)
+		if rel["target_item_id"] == nil || rel["target_item_id"] == "" {
+			continue
+		}
+		if rel["target_source_kind"] == nil || rel["target_source_kind"] == "" {
+			t.Fatalf("resolved relation missing target_source_kind: %v", rel)
+		}
+		if rel["target_collection_external_id"] == nil || rel["target_collection_external_id"] == "" {
+			t.Fatalf("resolved relation missing target_collection_external_id: %v", rel)
+		}
+		if rel["target_external_id"] == nil || rel["target_external_id"] == "" {
+			t.Fatalf("resolved relation missing target_external_id: %v", rel)
+		}
+		if rel["target_live"] != true {
+			t.Fatalf("resolved live target expected target_live=true: %v", rel)
+		}
+		foundResolved = true
+		break
+	}
+	if !foundResolved {
+		t.Fatalf("qualified resolved relation missing: %v", resolvedShow)
+	}
+
+	// Tombstoned target: show of a relation whose target was removed.
+	targetPath := filepath.Join(ws, "memory", "cards", "valid-explicit.md")
+	targetBytes, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var targetID string
+	for _, line := range strings.Split(string(targetBytes), "\n") {
+		if strings.HasPrefix(line, "id:") {
+			targetID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+			break
+		}
+	}
+	if targetID == "" {
+		t.Fatal("fixture card id missing")
+	}
+	support := map[string]any{
+		"schema": "miseledger.adapter.v1",
+		"source": map[string]any{"kind": "brigade", "name": "Brigade"},
+		"collection": map[string]any{
+			"external_id": "brigade:receipts",
+			"kind":        "brigade_receipt",
+			"name":        "receipts",
+		},
+		"item": map[string]any{
+			"external_id": "receipt:e2-tombstone-probe",
+			"kind":        "receipt",
+			"created_at":  "2026-01-01T00:00:00Z",
+			"text":        "e2 tombstone probe",
+		},
+		"relations": []map[string]any{{
+			"type": "supports",
+			"target": map[string]any{
+				"source":     ingest.MemorySourceKind,
+				"collection": testMemoryNamespace,
+				"external_id": targetID,
+			},
+		}},
+		"raw": map[string]any{"format": "json", "path": "e2.json", "ordinal": 1},
+	}
+	supportBytes, _ := json.Marshal(support)
+	supportPath := filepath.Join(t.TempDir(), "support.jsonl")
+	if err := os.WriteFile(supportPath, append(supportBytes, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", supportPath, "--json")
+	if err := os.Remove(targetPath); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "crawl", "memory", ws, "--json")
+
+	probeSearch := runJSON(t, "search", "e2 tombstone probe", "--json")
+	if len(probeSearch["results"].([]any)) == 0 {
+		t.Fatalf("probe receipt missing: %v", probeSearch)
+	}
+	probeID := probeSearch["results"].([]any)[0].(map[string]any)["id"].(string)
+	probeShow := runJSON(t, "show", probeID, "--json")
+	foundTombstonedTarget := false
+	for _, raw := range probeShow["relations"].([]any) {
+		rel := raw.(map[string]any)
+		if rel["target_external_id"] != targetID {
+			continue
+		}
+		foundTombstonedTarget = true
+		if rel["target_source_kind"] != ingest.MemorySourceKind {
+			t.Fatalf("tombstoned target_source_kind = %v", rel["target_source_kind"])
+		}
+		if rel["target_collection_external_id"] != testMemoryNamespace {
+			t.Fatalf("tombstoned target_collection_external_id = %v", rel["target_collection_external_id"])
+		}
+		// Completed removal clears target_item_id; qualified identity remains.
+		if rel["target_item_id"] != nil && rel["target_item_id"] != "" {
+			t.Fatalf("tombstoned target should be unresolved after removal: %v", rel)
+		}
+	}
+	if !foundTombstonedTarget {
+		t.Fatalf("expected qualified tombstoned/unresolved target on probe: %v", probeShow)
+	}
+}

--- a/engines/evidence-ledger/internal/app/e2_readpath_test.go
+++ b/engines/evidence-ledger/internal/app/e2_readpath_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -297,5 +299,202 @@ limit 1`, ingest.MemorySourceKind, testMemoryNamespace).Scan(&cardWithReceipt); 
 	}
 	if !foundTombstonedTarget {
 		t.Fatalf("expected qualified tombstoned/unresolved target on probe: %v", probeShow)
+	}
+}
+
+func TestE2ExportOmitsSupersededAndTombstonedBodies(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-e2export-1111-4222-8333-444444444444"
+	path := filepath.Join(cards, "export.md")
+	oldUnique := "EXPORT_OLD_BODY_TOKEN_E2"
+	newUnique := "EXPORT_NEW_BODY_TOKEN_E2"
+	if err := os.WriteFile(path, []byte("---\nid: "+cardID+"\ntopic: export\n---\n\n"+oldUnique+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "crawl", "memory", ws, "--json")
+	if err := os.WriteFile(path, []byte("---\nid: "+cardID+"\ntopic: export\n---\n\n"+newUnique+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "crawl", "memory", ws, "--json")
+
+	outDir := filepath.Join(t.TempDir(), "export")
+	runJSON(t, "export", "markdown", "--out", outDir)
+	exported := readExportTree(t, outDir)
+	if strings.Contains(exported, oldUnique) {
+		t.Fatalf("markdown export leaked superseded body:\n%s", exported)
+	}
+	if !strings.Contains(exported, newUnique) {
+		t.Fatalf("markdown export missing live body:\n%s", exported)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "crawl", "memory", ws, "--json")
+	outDir2 := filepath.Join(t.TempDir(), "export2")
+	runJSON(t, "export", "markdown", "--out", outDir2)
+	exported2 := readExportTree(t, outDir2)
+	if strings.Contains(exported2, newUnique) || strings.Contains(exported2, oldUnique) {
+		t.Fatalf("completed-removal tombstone leaked into export:\n%s", exported2)
+	}
+}
+
+func TestE2SessionsAndRelatedFilterDuplicateLiveAndTombstones(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+
+	db := openTestDB(t)
+	seedPreE2DuplicateSessionArchive(t, db)
+	db.Close()
+
+	listed := runJSON(t, "sessions", "list", "--source", "codex", "--json")
+	sessions := listed["sessions"].([]any)
+	if len(sessions) != 1 {
+		t.Fatalf("sessions list = %v", listed)
+	}
+	row := sessions[0].(map[string]any)
+	// Two distinct live external_ids (msg:e2 latest + msg:e2-peer); superseded
+	// duplicate and tombstone must not inflate the count.
+	if int(row["item_count"].(float64)) != 2 {
+		t.Fatalf("session item_count must count only latest-live versions, got %v", row)
+	}
+	preview, _ := row["preview"].(string)
+	if strings.Contains(preview, "SESSION_OLD_UNIQUE_E2") || strings.Contains(preview, "SESSION_TOMB_UNIQUE_E2") {
+		t.Fatalf("session preview leaked non-live text: %q", preview)
+	}
+	if !strings.Contains(preview, "SESSION_NEW_UNIQUE_E2") {
+		t.Fatalf("session preview missing live text: %q", preview)
+	}
+
+	searched := runJSON(t, "sessions", "search", "SESSION_OLD_UNIQUE_E2", "--source", "codex", "--json")
+	if len(searched["sessions"].([]any)) != 0 {
+		t.Fatalf("sessions search must not hit superseded duplicate live row: %v", searched)
+	}
+	tombSearch := runJSON(t, "sessions", "search", "SESSION_TOMB_UNIQUE_E2", "--source", "codex", "--json")
+	if len(tombSearch["sessions"].([]any)) != 0 {
+		t.Fatalf("sessions search must not hit tombstone: %v", tombSearch)
+	}
+	searchedNew := runJSON(t, "sessions", "search", "SESSION_NEW_UNIQUE_E2", "--source", "codex", "--json")
+	if len(searchedNew["sessions"].([]any)) != 1 {
+		t.Fatalf("sessions search missing live row: %v", searchedNew)
+	}
+	liveSession := searchedNew["sessions"].([]any)[0].(map[string]any)
+	if int(liveSession["item_count"].(float64)) != 2 {
+		t.Fatalf("search stats item_count=%v want 2", liveSession["item_count"])
+	}
+
+	db = openTestDB(t)
+	defer db.Close()
+	items, err := sessionItems(db, "session:e2-dup", "codex", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("transcript must expose only latest-live items, got %#v", items)
+	}
+	joined := ""
+	for _, item := range items {
+		joined += fmt.Sprint(item["text"]) + "\n"
+	}
+	if strings.Contains(joined, "SESSION_OLD_UNIQUE_E2") || strings.Contains(joined, "SESSION_TOMB_UNIQUE_E2") {
+		t.Fatalf("transcript leaked non-live text: %s", joined)
+	}
+	if !strings.Contains(joined, "SESSION_NEW_UNIQUE_E2") || !strings.Contains(joined, "SESSION_PEER_UNIQUE_E2") {
+		t.Fatalf("transcript missing live texts: %s", joined)
+	}
+	count, first, last, err := sessionStats(db, "collection-e2-dup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 || first == "" || last == "" {
+		t.Fatalf("sessionStats=%d %q %q", count, first, last)
+	}
+
+	// Related expansion: live root must not pull superseded/tombstoned neighbors.
+	related := relatedItems(db, "item-e2-live")
+	for _, rel := range related {
+		target := fmt.Sprint(rel["target_item_id"])
+		if target == "item-e2-old" || target == "item-e2-tomb" {
+			t.Fatalf("related expansion re-entered non-live row: %#v", related)
+		}
+	}
+	if len(related) != 1 || fmt.Sprint(related[0]["target_item_id"]) != "item-e2-peer" {
+		t.Fatalf("expected only live peer relation, got %#v", related)
+	}
+
+	outDir := filepath.Join(t.TempDir(), "export-dup")
+	if _, err := exportMarkdown(db, outDir); err != nil {
+		t.Fatal(err)
+	}
+	exported := readExportTree(t, outDir)
+	if strings.Contains(exported, "SESSION_OLD_UNIQUE_E2") || strings.Contains(exported, "SESSION_TOMB_UNIQUE_E2") {
+		t.Fatalf("export leaked duplicate/tombstone session text:\n%s", exported)
+	}
+	if !strings.Contains(exported, "SESSION_NEW_UNIQUE_E2") {
+		t.Fatalf("export missing live session text:\n%s", exported)
+	}
+}
+
+func readExportTree(t *testing.T, dir string) string {
+	t.Helper()
+	var b strings.Builder
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(data)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// seedPreE2DuplicateSessionArchive writes a pre-E2 shape: two non-tombstoned
+// content-hash versions for one external_id plus an intentional tombstone, with
+// FTS rows still present for the superseded/tombstoned text.
+func seedPreE2DuplicateSessionArchive(t *testing.T, db *sql.DB) {
+	t.Helper()
+	stmts := []string{
+		`insert into sources(id, kind, name, version, created_at, updated_at) values('source-e2','codex','Codex','1','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')`,
+		`insert into collections(id, source_id, external_id, kind, name, created_at, updated_at) values('collection-e2-dup','source-e2','session:e2-dup','agent_session','dup','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')`,
+		`insert into actors(id, source_id, external_id, type, name) values('actor-e2','source-e2','actor:e2','human','Human')`,
+		`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq, tombstoned_at)
+values('item-e2-old','source-e2','collection-e2-dup','actor-e2','msg:e2','message','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','SESSION_OLD_UNIQUE_E2','sha256:old','{}','{}',1,null)`,
+		`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq, tombstoned_at)
+values('item-e2-live','source-e2','collection-e2-dup','actor-e2','msg:e2','message','2026-01-01T00:00:01Z','2026-01-01T00:00:01Z','SESSION_NEW_UNIQUE_E2','sha256:new','{}','{}',2,null)`,
+		`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq, tombstoned_at)
+values('item-e2-tomb','source-e2','collection-e2-dup','actor-e2','msg:e2-tomb','message','2026-01-01T00:00:02Z','2026-01-01T00:00:02Z','SESSION_TOMB_UNIQUE_E2','sha256:tomb','{}','{}',3,'2026-01-02T00:00:00Z')`,
+		`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq, tombstoned_at)
+values('item-e2-peer','source-e2','collection-e2-dup','actor-e2','msg:e2-peer','message','2026-01-01T00:00:03Z','2026-01-01T00:00:03Z','SESSION_PEER_UNIQUE_E2','sha256:peer','{}','{}',4,null)`,
+		`insert into item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) values
+('item-e2-old','codex','agent_session','message','human','SESSION_OLD_UNIQUE_E2'),
+('item-e2-live','codex','agent_session','message','human','SESSION_NEW_UNIQUE_E2'),
+('item-e2-tomb','codex','agent_session','message','human','SESSION_TOMB_UNIQUE_E2'),
+('item-e2-peer','codex','agent_session','message','human','SESSION_PEER_UNIQUE_E2')`,
+		`insert into item_metadata(item_id, key, value) values
+('item-e2-old','project','miseledger'),
+('item-e2-live','project','miseledger'),
+('item-e2-live','model','gpt-test'),
+('item-e2-tomb','project','miseledger')`,
+		`insert into relations(id, source_item_id, target_item_id, target_external_id, relation_type, confidence) values
+('rel-e2-old','item-e2-live','item-e2-old','msg:e2','derived_from',1.0),
+('rel-e2-tomb','item-e2-live','item-e2-tomb','msg:e2-tomb','derived_from',1.0),
+('rel-e2-peer','item-e2-live','item-e2-peer','msg:e2-peer','derived_from',1.0)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed failed on %s: %v", stmt, err)
+		}
 	}
 }

--- a/engines/evidence-ledger/internal/app/e2_readpath_test.go
+++ b/engines/evidence-ledger/internal/app/e2_readpath_test.go
@@ -333,16 +333,54 @@ func TestE2ExportOmitsSupersededAndTombstonedBodies(t *testing.T) {
 	if !strings.Contains(exported, newUnique) {
 		t.Fatalf("markdown export missing live body:\n%s", exported)
 	}
+	managedBefore := managedExportMarkdownBasenames(t, outDir)
+	if len(managedBefore) == 0 {
+		t.Fatal("expected at least one managed markdown file after live export")
+	}
+	userOwned := filepath.Join(outDir, "user-owned-notes.txt")
+	if err := os.WriteFile(userOwned, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := os.Remove(path); err != nil {
 		t.Fatal(err)
 	}
 	runOK(t, "crawl", "memory", ws, "--json")
-	outDir2 := filepath.Join(t.TempDir(), "export2")
-	runJSON(t, "export", "markdown", "--out", outDir2)
-	exported2 := readExportTree(t, outDir2)
+	// Reuse the original destination: managed markdown must be reconciled away
+	// after the last live item is tombstoned; non-managed files stay put.
+	runJSON(t, "export", "markdown", "--out", outDir)
+	exported2 := readExportTree(t, outDir)
 	if strings.Contains(exported2, newUnique) || strings.Contains(exported2, oldUnique) {
-		t.Fatalf("completed-removal tombstone leaked into export:\n%s", exported2)
+		t.Fatalf("completed-removal tombstone leaked into reused export out:\n%s", exported2)
+	}
+	for _, name := range managedBefore {
+		if _, err := os.Stat(filepath.Join(outDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("managed export file %q still present after empty reconcile: err=%v", name, err)
+		}
+	}
+	if data, err := os.ReadFile(userOwned); err != nil || string(data) != "keep me\n" {
+		t.Fatalf("non-managed file was disturbed: err=%v data=%q", err, data)
+	}
+}
+
+func TestE2SearchKeepsLiveWhenFTSCandidatePoolExceedsCap(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	db := openTestDB(t)
+	defer db.Close()
+
+	token := "E2_FTS_POOL_TOKEN_OVER_CAP"
+	seedPreE2OverCapStaleFTSPool(t, db, token, searchCandidateLimit(0)+1)
+
+	results, err := search(db, SearchOpts{Query: token, Limit: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("live hit must survive >candidate-cap stale FTS rows, got %#v", results)
+	}
+	if results[0].ID != "item-e2-pool-live" {
+		t.Fatalf("expected live item id, got %#v", results)
 	}
 }
 
@@ -458,6 +496,97 @@ func readExportTree(t *testing.T, dir string) string {
 		b.WriteByte('\n')
 	}
 	return b.String()
+}
+
+func managedExportMarkdownBasenames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		name := e.Name()
+		if isManagedExportBasename(name) {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// seedPreE2OverCapStaleFTSPool builds >candidateCap superseded non-tombstoned
+// FTS hits that would fill the materialize LIMIT before a matching live row if
+// latest-live filtering ran only after candidate selection.
+func seedPreE2OverCapStaleFTSPool(t *testing.T, db *sql.DB, token string, staleCount int) {
+	t.Helper()
+	if staleCount < 1 {
+		t.Fatalf("staleCount must be positive, got %d", staleCount)
+	}
+	stmts := []string{
+		`insert into sources(id, kind, name, version, created_at, updated_at) values('source-e2-pool','codex','Codex','1','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')`,
+		`insert into collections(id, source_id, external_id, kind, name, created_at, updated_at) values('collection-e2-pool','source-e2-pool','session:e2-pool','agent_session','pool','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')`,
+		`insert into actors(id, source_id, external_id, type, name) values('actor-e2-pool','source-e2-pool','actor:e2-pool','human','Human')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed header failed on %s: %v", stmt, err)
+		}
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	itemStmt, err := tx.Prepare(`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq, tombstoned_at)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,null)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer itemStmt.Close()
+	ftsStmt, err := tx.Prepare(`insert into item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) values(?,?,?,?,?,?)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ftsStmt.Close()
+
+	for i := 0; i < staleCount; i++ {
+		ext := fmt.Sprintf("msg:e2-pool-%04d", i)
+		staleID := fmt.Sprintf("item-e2-pool-stale-%04d", i)
+		liveID := fmt.Sprintf("item-e2-pool-curr-%04d", i)
+		// Lexicographically early stale ids + identical bm25 text fill the
+		// ordered candidate LIMIT ahead of the later live hit when the live
+		// predicate is applied only after materialize.
+		if _, err := itemStmt.Exec(staleID, "source-e2-pool", "collection-e2-pool", "actor-e2-pool", ext, "message",
+			"2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", token, fmt.Sprintf("sha256:stale-%04d", i), "{}", "{}", i*2+1); err != nil {
+			t.Fatalf("insert stale item %d: %v", i, err)
+		}
+		if _, err := ftsStmt.Exec(staleID, "codex", "agent_session", "message", "human", token); err != nil {
+			t.Fatalf("insert stale fts %d: %v", i, err)
+		}
+		currText := fmt.Sprintf("current body without shared token %04d", i)
+		if _, err := itemStmt.Exec(liveID, "source-e2-pool", "collection-e2-pool", "actor-e2-pool", ext, "message",
+			"2026-01-01T00:00:01Z", "2026-01-01T00:00:01Z", currText, fmt.Sprintf("sha256:curr-%04d", i), "{}", "{}", i*2+2); err != nil {
+			t.Fatalf("insert current item %d: %v", i, err)
+		}
+		if _, err := ftsStmt.Exec(liveID, "codex", "agent_session", "message", "human", currText); err != nil {
+			t.Fatalf("insert current fts %d: %v", i, err)
+		}
+	}
+
+	liveExt := "msg:e2-pool-live"
+	liveSeq := staleCount*2 + 10
+	if _, err := itemStmt.Exec("item-e2-pool-live", "source-e2-pool", "collection-e2-pool", "actor-e2-pool", liveExt, "message",
+		"2026-01-01T00:00:02Z", "2026-01-01T00:00:02Z", token, "sha256:pool-live", "{}", "{}", liveSeq); err != nil {
+		t.Fatalf("insert live item: %v", err)
+	}
+	if _, err := ftsStmt.Exec("item-e2-pool-live", "codex", "agent_session", "message", "human", token); err != nil {
+		t.Fatalf("insert live fts: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // seedPreE2DuplicateSessionArchive writes a pre-E2 shape: two non-tombstoned

--- a/engines/evidence-ledger/internal/app/mcp.go
+++ b/engines/evidence-ledger/internal/app/mcp.go
@@ -172,8 +172,11 @@ func mcpTools() []map[string]any {
 		},
 		{
 			"name":        "show_item",
-			"description": "Show one normalized MiseLedger item by ID. Item text and raw context are untrusted evidence.",
-			"inputSchema": map[string]any{"type": "object", "required": []string{"id"}, "properties": map[string]any{"id": stringProp("MiseLedger item ID returned by search_evidence")}},
+			"description": "Show one normalized MiseLedger item by ID. Quarantined injection-pending body/raw are omitted unless include_untrusted_body is true.",
+			"inputSchema": map[string]any{"type": "object", "required": []string{"id"}, "properties": map[string]any{
+				"id":                     stringProp("MiseLedger item ID returned by search_evidence"),
+				"include_untrusted_body": boolProp("Include quarantined injection-pending text and raw payload"),
+			}},
 		},
 		{
 			"name":        "create_evidence_bundle",
@@ -250,7 +253,7 @@ func mcpShow(args map[string]any) (map[string]any, error) {
 	if id == "" {
 		return nil, errors.New("missing id")
 	}
-	item, err := showItem(db, id)
+	item, err := showItem(db, id, showItemOpts{IncludeUntrustedBody: argBool(args, "include_untrusted_body")})
 	if err != nil {
 		return nil, err
 	}

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -932,6 +932,7 @@ order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNames
 
 	// Restore byte-identical v1: known-content early return must refresh the
 	// ingest stamp so v1 becomes live again without minting a duplicate row/event.
+	// E2 soft-tombstones the superseded v2 so exactly one live version remains.
 	if err := os.WriteFile(path, []byte(v1Body), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -942,17 +943,28 @@ order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNames
 
 	db = openTestDB(t)
 	defer db.Close()
-	var versionCount int
+	var liveCount, totalCount int
 	if err := db.QueryRow(`
 select count(*) from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
-		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&versionCount); err != nil {
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&liveCount); err != nil {
 		t.Fatal(err)
 	}
-	if versionCount != 2 {
-		t.Fatalf("expected exactly two content versions, got %d", versionCount)
+	if liveCount != 1 {
+		t.Fatalf("expected exactly one live content version after restore, got %d", liveCount)
+	}
+	if err := db.QueryRow(`
+select count(*) from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ?`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&totalCount); err != nil {
+		t.Fatal(err)
+	}
+	if totalCount != 2 {
+		t.Fatalf("expected two content-addressed versions retained, got %d", totalCount)
 	}
 	var liveID, liveHash, liveStamp string
 	if err := db.QueryRow(`
@@ -1128,8 +1140,8 @@ order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNames
 	}
 	db.Close()
 
-	// Non-rebuild edit: content-addressed import creates a second item id while
-	// the prior version stays untombstoned (same external id still observed).
+	// Non-rebuild edit: content-addressed import creates a second item id and
+	// E2 soft-tombstones the prior version so default search sees one live row.
 	// Drop the unresolved outbound relation on v2.
 	if err := os.WriteFile(cardPath, []byte("---\nid: "+cardID+"\ntopic: edit\n---\n\n# Edited body\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -1141,17 +1153,28 @@ order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNames
 
 	db = openTestDB(t)
 	defer db.Close()
-	var versionCount int
+	var liveCount, totalCount int
 	if err := db.QueryRow(`
 select count(*) from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
-		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&versionCount); err != nil {
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&liveCount); err != nil {
 		t.Fatal(err)
 	}
-	if versionCount < 2 {
-		t.Fatalf("expected prior+latest content-addressed versions, got %d", versionCount)
+	if liveCount != 1 {
+		t.Fatalf("expected exactly one live content-addressed version, got %d", liveCount)
+	}
+	if err := db.QueryRow(`
+select count(*) from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ?`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&totalCount); err != nil {
+		t.Fatal(err)
+	}
+	if totalCount < 2 {
+		t.Fatalf("expected prior+latest content-addressed versions retained, got %d", totalCount)
 	}
 	var v2ID, v2Hash, v2Updated string
 	if err := db.QueryRow(`

--- a/engines/evidence-ledger/internal/app/server.go
+++ b/engines/evidence-ledger/internal/app/server.go
@@ -243,7 +243,11 @@ func handleItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer db.Close()
-	item, err := showItem(db, id)
+	includeBody := false
+	if q := r.URL.Query().Get("include_untrusted_body"); q == "1" || strings.EqualFold(q, "true") {
+		includeBody = true
+	}
+	item, err := showItem(db, id, showItemOpts{IncludeUntrustedBody: includeBody})
 	if err != nil {
 		httpError(w, http.StatusNotFound, err.Error())
 		return

--- a/engines/evidence-ledger/internal/app/sessions.go
+++ b/engines/evidence-ledger/internal/app/sessions.go
@@ -285,7 +285,7 @@ func searchSessions(db *sql.DB, query string, filters SessionFilters, limit int)
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
-	where := []string{"item_fts match ?", "c.kind in ('agent_session','conversation')"}
+	where := []string{"item_fts match ?", "c.kind in ('agent_session','conversation')", "i.tombstoned_at is null"}
 	params := []any{ftsQuery(query)}
 	where, params = appendSessionFilters(where, params, filters)
 	params = append(params, limit*10)

--- a/engines/evidence-ledger/internal/app/sessions.go
+++ b/engines/evidence-ledger/internal/app/sessions.go
@@ -128,6 +128,7 @@ func writeSessions(rows []SessionResult, asJSON bool, out io.Writer) {
 }
 
 func appendSessionFilters(where []string, params []any, filters SessionFilters) ([]string, []any) {
+	liveFI := liveDefaultItemPredicateFor("fi")
 	if filters.Source != "" {
 		where = append(where, "s.kind = ?")
 		params = append(params, filters.Source)
@@ -137,6 +138,7 @@ func appendSessionFilters(where []string, params []any, filters SessionFilters) 
 select 1 from items fi
 join item_metadata fm on fm.item_id = fi.id
 where fi.collection_id = c.id
+  and (`+liveFI+`)
   and fm.key in ('project','workspace','workspace_dir','cwd')
   and (fm.value = ? or fm.value like ?)
 )`)
@@ -147,6 +149,7 @@ where fi.collection_id = c.id
 select 1 from items fi
 join item_metadata fm on fm.item_id = fi.id
 where fi.collection_id = c.id
+  and (`+liveFI+`)
   and fm.key = 'model'
   and (fm.value = ? or fm.value like ?)
 )`)
@@ -179,6 +182,7 @@ coalesce(min(case when im.key = 'harness' then im.value end),'')
 from item_metadata im
 join items i on i.id = im.item_id
 where i.collection_id = ?1
+  and (`+liveDefaultItemPredicate+`)
   and im.key in ('project','workspace','workspace_dir','cwd','model','harness')
   and im.value != ''`, collectionID, filters.Project, "%"+filters.Project+"%", filters.Model, "%"+filters.Model+"%").Scan(
 		&result.Project,
@@ -192,14 +196,15 @@ func listSessions(db *sql.DB, filters SessionFilters, limit int) ([]SessionResul
 	if limit <= 0 || limit > 200 {
 		limit = 50
 	}
-	where := []string{"c.kind in ('agent_session','conversation')"}
+	liveII := liveDefaultItemPredicateFor("ii")
+	where := []string{"c.kind in ('agent_session','conversation')", liveDefaultItemPredicate}
 	params := []any{}
 	where, params = appendSessionFilters(where, params, filters)
 	params = append(params, limit)
 	sqlText := `select s.kind, coalesce(s.name,''), c.id, c.external_id, c.name, c.kind, count(i.id), coalesce(min(i.created_at),'') as first_seen, coalesce(max(i.created_at),'') as last_seen,
-coalesce((select ii.id from items ii where ii.collection_id = c.id order by coalesce(ii.created_at,'') desc, ii.id desc limit 1),''),
-coalesce((select ii.raw_path from items ii where ii.collection_id = c.id and coalesce(ii.raw_path,'') != '' order by coalesce(ii.created_at,'') desc, ii.id desc limit 1),''),
-coalesce((select ii.raw_ordinal from items ii where ii.collection_id = c.id and ii.raw_ordinal is not null order by coalesce(ii.created_at,'') desc, ii.id desc limit 1),0)
+coalesce((select ii.id from items ii where ii.collection_id = c.id and (` + liveII + `) order by coalesce(ii.created_at,'') desc, ii.id desc limit 1),''),
+coalesce((select ii.raw_path from items ii where ii.collection_id = c.id and (` + liveII + `) and coalesce(ii.raw_path,'') != '' order by coalesce(ii.created_at,'') desc, ii.id desc limit 1),''),
+coalesce((select ii.raw_ordinal from items ii where ii.collection_id = c.id and (` + liveII + `) and ii.raw_ordinal is not null order by coalesce(ii.created_at,'') desc, ii.id desc limit 1),0)
 from collections c
 join sources s on s.id = c.source_id
 join items i on i.collection_id = c.id
@@ -237,6 +242,7 @@ func sessionPreview(db *sql.DB, collectionID string) string {
 from items i
 left join actors a on a.id = i.actor_id
 where i.collection_id = ?
+  and (`+liveDefaultItemPredicate+`)
 order by (case when a.type = 'human' then 0 else 1 end), coalesce(i.created_at,''), i.id
 limit 1`, collectionID).Scan(&text)
 	if err != nil {
@@ -261,6 +267,7 @@ join collections c on c.id = i.collection_id
 join sources s on s.id = i.source_id
 left join actors a on a.id = i.actor_id
 where c.external_id = ? and s.kind = ?
+  and (`+liveDefaultItemPredicate+`)
 order by coalesce(i.created_at,''), i.id
 limit ?`, externalID, sourceKind, limit)
 	if err != nil {
@@ -285,7 +292,7 @@ func searchSessions(db *sql.DB, query string, filters SessionFilters, limit int)
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
-	where := []string{"item_fts match ?", "c.kind in ('agent_session','conversation')", "i.tombstoned_at is null"}
+	where := []string{"item_fts match ?", "c.kind in ('agent_session','conversation')", liveDefaultItemPredicate}
 	params := []any{ftsQuery(query)}
 	where, params = appendSessionFilters(where, params, filters)
 	params = append(params, limit*10)
@@ -360,7 +367,10 @@ limit ?`
 }
 
 func sessionStats(db *sql.DB, collectionID string) (count int, first, last string, err error) {
-	err = db.QueryRow(`select count(id), coalesce(min(created_at),''), coalesce(max(created_at),'') from items where collection_id = ?`, collectionID).Scan(&count, &first, &last)
+	err = db.QueryRow(`select count(i.id), coalesce(min(i.created_at),''), coalesce(max(i.created_at),'')
+from items i
+where i.collection_id = ?
+  and (`+liveDefaultItemPredicate+`)`, collectionID).Scan(&count, &first, &last)
 	return count, first, last, err
 }
 

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -564,6 +564,9 @@ func upsertRecord(tx *sql.Tx, rec adapter.Record, sourcePath string, ordinal int
 		if err := reconcileKnownItem(tx, rec, itemID, sourceID, collectionID, actorID, contentHash, rawHash, rawPath, rawOrdinal, raw, body, now); err != nil {
 			return false, err
 		}
+		if err := softTombstoneSupersededVersions(tx, sourceID, collectionID, rec.Item.ExternalID, itemID, now); err != nil {
+			return false, err
+		}
 		return false, nil
 	} else if err != sql.ErrNoRows {
 		return false, err
@@ -610,6 +613,9 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, null
 		if err := reconcileKnownItem(tx, rec, itemID, sourceID, collectionID, actorID, contentHash, rawHash, rawPath, rawOrdinal, raw, body, now); err != nil {
 			return false, err
 		}
+		if err := softTombstoneSupersededVersions(tx, sourceID, collectionID, rec.Item.ExternalID, itemID, now); err != nil {
+			return false, err
+		}
 		return false, nil
 	}
 	eventID := stableID("event", itemID, createdAt, rec.Item.Kind)
@@ -617,7 +623,57 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, null
 	if err := replaceItemSideTables(tx, rec, itemID, sourceID, collectionID, capturedAt, raw, body, now, false); err != nil {
 		return false, err
 	}
+	if err := softTombstoneSupersededVersions(tx, sourceID, collectionID, rec.Item.ExternalID, itemID, now); err != nil {
+		return false, err
+	}
 	return true, nil
+}
+
+// softTombstoneSupersededVersions keeps one default-live content version per
+// (source, collection, external_id). Older non-tombstoned rows are soft-
+// tombstoned and removed from FTS so their unique text cannot surface in
+// default search. Inbound relation targets pointing at superseded ids are
+// cleared for later re-resolution onto the live winner. The kept id is
+// revived when a previously superseded content-hash is re-imported.
+func softTombstoneSupersededVersions(tx *sql.Tx, sourceID, collectionID, externalID, keepItemID, now string) error {
+	if externalID == "" || keepItemID == "" {
+		return nil
+	}
+	if _, err := tx.Exec(`update items set tombstoned_at = null where id = ?`, keepItemID); err != nil {
+		return err
+	}
+	rows, err := tx.Query(`
+select id from items
+where source_id = ? and collection_id = ? and external_id = ?
+  and tombstoned_at is null and id != ?`, sourceID, collectionID, externalID, keepItemID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	var superseded []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+		superseded = append(superseded, id)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, id := range superseded {
+		if _, err := tx.Exec(`update items set tombstoned_at = ? where id = ? and tombstoned_at is null`, now, id); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`delete from item_fts where item_id = ?`, id); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`update relations set target_item_id = null
+where target_item_id = ? and source_item_id != ?`, id, id); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func nextIngestSeq(tx *sql.Tx) (int64, error) {

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -188,6 +188,13 @@ func CompleteMemoryScan(db *sql.DB, scanID string, observed []ObservedCard, rece
 	}
 	receipt.Removed = removed
 
+	// Soft-tombstone superseded content-hash versions left live by earlier
+	// imports so completed scans leave exactly one default-live row per
+	// (source, collection, external_id) and remove their FTS bodies.
+	if _, err := softTombstoneSupersededMemoryVersions(tx, namespace, now); err != nil {
+		return err
+	}
+
 	live, err := liveMemoryExternalIDs(tx, namespace)
 	if err != nil {
 		return err
@@ -339,6 +346,57 @@ where target_item_id = ? and source_item_id != ?`, r.id, r.id); err != nil {
 		removedIDs[r.externalID] = true
 	}
 	return len(removedIDs), nil
+}
+
+// softTombstoneSupersededMemoryVersions soft-tombstones every non-latest
+// non-tombstoned memory_card row in a namespace and deletes their FTS rows.
+func softTombstoneSupersededMemoryVersions(tx *sql.Tx, namespace, now string) (int, error) {
+	rows, err := tx.Query(`
+select i.id
+from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ?
+  and i.kind = 'memory_card'
+  and i.tombstoned_at is null
+  and c.external_id = ?
+  and i.id != (
+    select i2.id from items i2
+    where i2.source_id = i.source_id
+      and i2.collection_id = i.collection_id
+      and i2.external_id = i.external_id
+      and i2.tombstoned_at is null
+    order by i2.ingest_seq desc, i2.id desc
+    limit 1
+  )`, MemorySourceKind, namespace)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var superseded []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return 0, err
+		}
+		superseded = append(superseded, id)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	for _, id := range superseded {
+		if _, err := tx.Exec(`update items set tombstoned_at = ? where id = ? and tombstoned_at is null`, now, id); err != nil {
+			return 0, err
+		}
+		if _, err := tx.Exec(`delete from item_fts where item_id = ?`, id); err != nil {
+			return 0, err
+		}
+		if _, err := tx.Exec(`update relations set target_item_id = null
+where target_item_id = ? and source_item_id != ?`, id, id); err != nil {
+			return 0, err
+		}
+	}
+	return len(superseded), nil
 }
 
 func liveMemoryExternalIDs(tx *sql.Tx, namespace string) (map[string]string, error) {


### PR DESCRIPTION
## Summary

Engine-only E2 for #843 (post-E1 #850, rebased through #851 provenance/schema v4). Shared latest-live/tombstone predicate on generic read paths: search/show/doctor, Markdown export, session list/metadata/preview/transcript/search/stats, and evidence related-item expansion. Latest-live filtering runs inside the bounded FTS candidate CTE; Markdown export stages and reconciles managed files when reusing `--out`. No Brigade facade, card mutation, memory-specific renderer, or storage migration.

## Contract mapping

| Criterion | How met |
| --- | --- |
| One live version per `(source, collection, external_id)` | Soft-tombstone superseded content-hash rows + delete FTS on import (including known-item revive) and completed memory scan cleanup; search/evidence filter tombstones and non-latest |
| Old unique text leaves FTS/default search | FTS rows deleted for superseded/removal tombstones; regressions assert absence |
| FTS candidate pool cannot hide live hits | `liveDefaultItemPredicate` applied inside the materialized FTS CTE before the 1,000-row `LIMIT`; regression seeds >1000 stale non-tombstoned FTS hits |
| Doctor excludes intentional tombstones | `archive_items_missing_fts` counts only `tombstoned_at is null` |
| `show --json` qualified relations + live state | Emits `target_source_kind`, `target_collection_external_id`, `target_external_id`, nullable `target_item_id`, plus `live`/`tombstoned`/`tombstoned_at`; preserves #851 `attachShowProvenance` |
| Safe default show for quarantined injection-pending | Omits text/raw unless `--include-untrusted-body` / `include_untrusted_body` |
| Markdown export | Shared latest-live predicate; stages under `.miseledger-export-stage`, tracks managed basenames in `.miseledger-export-files`, reconciles obsolete managed `*.md` when reusing `--out` |
| Session list/metadata/preview/transcript/search/stats | Uses shared latest-live predicate (not tombstone-only), covering pre-E2 duplicate live rows |
| Evidence related-item expansion | Filters superseded/tombstoned neighbors out of `--include-related` |
| Focused regressions | `e2_readpath_test.go` covers search/show/doctor, over-cap FTS, export reuse, sessions, related |
| Preserve E1 + #851 | Namespace/rebuild/reconciliation unchanged; provenance projections/events/schema v4 retained |

## Out of scope

Facade/#844, care/scheduler, semantic retrieval, #498 redaction, canonical Markdown mutation, memory-specific renderer/adapter CLI, storage migration, unrelated Python/release/run-budget work.

## Verification

```console
$ brigade work verify run --target engines/evidence-ledger \
    --command "go vet ./..." --command "go test ./..." --no-reuse
status: completed
run_id: 20260811-020732-work-verify-4c15be

$ brigade work verify run --target /workspace \
    --argv-json '["/tmp/e2-verify-full.sh"]' --capture brigade-work --no-reuse
status: completed
run_id: 20260811-020749-work-verify-0521e7
outcome capture: brigade-work signal=+1
```

Handoff lint: `.claude/memory-handoffs/2026-08-11-evidence-ledger-e2-fts-export-reconcile.md` valid (create-card).

Closes #843