### PR TITLE
feat(runs): fail-closed scrubbed worker-event export (#592)

### DIFF
--- a/.grok/memory-handoffs/2026-08-11-lifecycle-journal-smuggle-866.md
+++ b/.grok/memory-handoffs/2026-08-11-lifecycle-journal-smuggle-866.md
@@ -1,0 +1,42 @@
+# Memory Handoff
+
+## Type
+
+bugfix
+
+## Title
+
+Lifecycle journal reserved-path worker-envelope smuggling (#866)
+
+## Summary
+
+Maintainer review on PR #866 found that reserved top-level `events/lifecycle.jsonl` was excluded from worker-stream discovery without authenticating its record shape, so a digest-valid archive could smuggle raw JSON-RPC worker notifications as public `role=journal`. Export/validate/import now authenticate `brigade.run_event.v1` journals and reject worker envelopes in that path.
+
+## Durable facts
+
+- Nested worker-stream recursive discovery remains in place
+- `assert_lifecycle_journal_authentic` rejects JSON-RPC worker envelopes in `events/lifecycle.jsonl`
+- Valid empty or `brigade.run_event.v1` lifecycle journals still export/validate/import
+- `_assert_export_privacy_tree` runs checkpoint, worker-stream, and lifecycle gates together
+
+## Evidence
+
+- files changed: `src/brigade/work_run_archive.py`, `tests/test_work_run_archive.py`, `docs/worker-event-streams.md`, `docs/receipt-schemas.md`, `CHANGELOG.md`
+- commands run: `pytest -q tests/test_work_run_archive.py tests/test_worker_events.py`; `brigade work verify run`; `./scripts/verify`
+- error strings: `events/lifecycle.jsonl carries a worker notification envelope; reserved journal path rejects raw JSON-RPC worker streams`
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/ERRORS.md
+
+## Suggested document content
+
+### Lifecycle journal reserved-path smuggle
+
+Excluding `events/lifecycle.jsonl` from worker discovery is not enough. Archive
+export/validate/import must authenticate the lifecycle record shape or reject
+JSON-RPC worker envelopes before granting the public journal classification.

--- a/.grok/memory-handoffs/2026-08-11-nested-worker-event-export-866.md
+++ b/.grok/memory-handoffs/2026-08-11-nested-worker-event-export-866.md
@@ -1,0 +1,43 @@
+# Memory Handoff
+
+## Type
+
+bugfix
+
+## Title
+
+Nested worker-event JSONL export boundary repair (#866 / #592)
+
+## Summary
+
+Terra sendback on PR #866 showed `events/nested/coder.jsonl` bypassed fail-closed export and was classified public support. Discovery is now recursive under `events/`, nested streams scrub to sidecars or refuse export, and validate/import reject nested raw-stream smuggling.
+
+## Durable facts
+
+- `list_worker_event_streams` uses `rglob("*.jsonl")` and excludes only top-level `events/lifecycle.jsonl`
+- `is_raw_worker_event_stream_rel` / `is_scrubbed_worker_event_stream_rel` accept nested `events/**` paths
+- Nested scrubbed sidecars land beside the raw path as `<stem>.scrubbed.json`
+- Validate/import refuse nested public-support smuggling of raw worker JSONL
+- Source-run raw streams remain local/`unclassified` under `policy=local-only`
+
+## Evidence
+
+- files changed: `src/brigade/worker_events.py`, `tests/test_work_run_archive.py`, `docs/worker-event-streams.md`, `docs/receipt-schemas.md`, `CHANGELOG.md`
+- commands run: `brigade code impact list_worker_event_streams`; `brigade work verify run ...`; `pytest -q tests/test_work_run_archive.py tests/test_worker_events.py`
+- error strings: `raw worker stream crossed an export boundary: events/nested/coder.jsonl`; `export refuses raw worker stream events/nested/coder.jsonl`
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/ERRORS.md
+
+## Suggested document content
+
+### Nested worker JSONL export bypass
+
+Worker-like JSONL anywhere under `events/` must be treated as a scrub/export
+candidate. Top-level-only glob left nested streams classified as public
+support; recursive discovery plus validate/import refusal closes that hole.

--- a/.grok/memory-handoffs/2026-08-11-pr-866-rebase-main-landing.md
+++ b/.grok/memory-handoffs/2026-08-11-pr-866-rebase-main-landing.md
@@ -1,0 +1,42 @@
+# Memory Handoff
+
+## Type
+
+workflow
+
+## Title
+
+PR #866 rebase onto main 3532f07c for landing
+
+## Summary
+
+Landing follow-up on PR #866 rebased the reviewed #592 export privacy branch onto exact current main `3532f07cb125bfb6ad5c06a3fab0eb97ee555aeb`. The only main delta was evidence-ledger E2 (#865); CHANGELOG.md and docs/receipt-schemas.md needed no conflict resolution because those files did not overlap with main. Reviewed #592 behavior stayed byte-identical for archive/worker-event sources.
+
+## Durable facts
+
+- Exact main tip for this landing was `3532f07cb125bfb6ad5c06a3fab0eb97ee555aeb`
+- Rebase of the three #592 commits was clean with no semantic conflicts
+- Expected mechanical CHANGELOG.md / docs/receipt-schemas.md overlap did not appear against that main tip
+- Reviewed archive/worker-event source trees matched pre-rebase tip `e48b4af6`
+
+## Evidence
+
+- files changed: rebase only (no #592 source edits)
+- commands run: `git rebase 3532f07cb125bfb6ad5c06a3fab0eb97ee555aeb`; `pytest -q tests/test_work_run_archive.py tests/test_worker_events.py`; `./scripts/verify`
+- error strings: none
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/LEARNINGS.md
+
+## Suggested document content
+
+### PR #866 landing rebase
+
+When rebasing #866 onto main `3532f07c`, expect a clean replay if main only
+carries evidence-ledger E2. Preserve the three #592 commits unchanged; do not
+invent CHANGELOG/receipt-schemas merges unless a real conflict appears.

--- a/.grok/memory-handoffs/2026-08-11-pr-866-rebase-main-landing.md
+++ b/.grok/memory-handoffs/2026-08-11-pr-866-rebase-main-landing.md
@@ -6,23 +6,24 @@ workflow
 
 ## Title
 
-PR #866 rebase onto main 3532f07c for landing
+PR #866 rebase onto main 3e9278f9 for landing
 
 ## Summary
 
-Landing follow-up on PR #866 rebased the reviewed #592 export privacy branch onto exact current main `3532f07cb125bfb6ad5c06a3fab0eb97ee555aeb`. The only main delta was evidence-ledger E2 (#865); CHANGELOG.md and docs/receipt-schemas.md needed no conflict resolution because those files did not overlap with main. Reviewed #592 behavior stayed byte-identical for archive/worker-event sources.
+Landing follow-up on PR #866 rebased the reviewed #592 export privacy branch onto exact current main `3e9278f9f3c968fc95783207d4ed040bc0bfb672` (includes merged #863). Prior tip `3532f07c` was superseded by #863 onboarding/gitignore work. Replay stayed clean: CHANGELOG.md absorbed main's #860/#863 Fixed and Documentation bullets beside the #592 Added entry without a conflict marker, and docs/receipt-schemas.md did not overlap. Reviewed #592 archive/worker-event sources stayed byte-identical.
 
 ## Durable facts
 
-- Exact main tip for this landing was `3532f07cb125bfb6ad5c06a3fab0eb97ee555aeb`
-- Rebase of the three #592 commits was clean with no semantic conflicts
-- Expected mechanical CHANGELOG.md / docs/receipt-schemas.md overlap did not appear against that main tip
-- Reviewed archive/worker-event source trees matched pre-rebase tip `e48b4af6`
+- Exact main tip for this landing is `3e9278f9f3c968fc95783207d4ed040bc0bfb672`
+- Rebase of the #592 commits plus landing handoff was clean with no semantic conflicts
+- CHANGELOG.md carries both main #860/#863 entries and the #592 worker-event privacy bullet
+- docs/receipt-schemas.md needed no conflict resolution against that tip
+- Reviewed archive/worker-event source trees matched pre-rebase tip `f2236f15`
 
 ## Evidence
 
 - files changed: rebase only (no #592 source edits)
-- commands run: `git rebase 3532f07cb125bfb6ad5c06a3fab0eb97ee555aeb`; `pytest -q tests/test_work_run_archive.py tests/test_worker_events.py`; `./scripts/verify`
+- commands run: `git rebase 3e9278f9f3c968fc95783207d4ed040bc0bfb672`; `pytest -q tests/test_work_run_archive.py tests/test_worker_events.py`; `./scripts/verify`
 - error strings: none
 
 ## Recommended memory action
@@ -35,8 +36,9 @@ no-card
 
 ## Suggested document content
 
-### PR #866 landing rebase
+### PR #866 landing rebase onto 3e9278f9
 
-When rebasing #866 onto main `3532f07c`, expect a clean replay if main only
-carries evidence-ledger E2. Preserve the three #592 commits unchanged; do not
-invent CHANGELOG/receipt-schemas merges unless a real conflict appears.
+When rebasing #866 onto main `3e9278f9` (merged #863), expect a clean replay
+that keeps main's gitignore/quickstart CHANGELOG bullets and the #592 Added
+entry together. Preserve the #592 commits unchanged; stop if any semantic
+conflict appears outside mechanical CHANGELOG/docs overlap.

--- a/.grok/memory-handoffs/2026-08-11-worker-event-export-archive-592.md
+++ b/.grok/memory-handoffs/2026-08-11-worker-event-export-archive-592.md
@@ -1,0 +1,43 @@
+# Memory Handoff
+
+## Type
+
+project-context
+
+## Title
+
+Worker-event export/archive fail-closed boundary (#592)
+
+## Summary
+
+Completed the remaining #592 export/archive slice after #823/#862. `brigade runs export` no longer copies raw `events/<worker>.jsonl` as public support data; it emits `events/<worker>.scrubbed.json` via the existing scrubber (distinct media type, artifact role, redacted privacy) or refuses with a bounded export-privacy diagnostic. Source raw streams stay local/unclassified for `policy=local-only`.
+
+## Durable facts
+
+- Export helpers: `worker_events.project_worker_streams_for_export` and `assert_export_tree_has_no_raw_worker_streams`
+- Archive classification: scrubbed sidecar `role=artifact`, `privacy_class=redacted`, `media_type=SCRUBBED_MEDIA_TYPE`, `nested_schema=STREAM_SCHEMA`
+- Raw `events/*.jsonl` (except lifecycle) fail closed in `_classify_path` / `validate_archive`
+- Source run directories are unchanged; resume/audit local-only policy is preserved
+- Legacy backfill of on-disk historical streams remains out of scope
+
+## Evidence
+
+- files changed: `src/brigade/worker_events.py`, `src/brigade/work_run_archive.py`, `tests/test_work_run_archive.py`, `docs/worker-event-streams.md`, `docs/receipt-schemas.md`, `CHANGELOG.md`
+- commands run: `pytest -q tests/test_work_run_archive.py tests/test_worker_events.py`, `./scripts/verify`
+- error strings: `raw worker stream crossed an export boundary`; `export refuses raw worker stream`
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/FEATURE_REQUESTS.md
+
+## Suggested document content
+
+### Export boundary for worker streams
+
+Issue #592 export/archive wiring now fail-closes portable `brigade.work-run`
+archives: scrubbed sidecars only, never raw public support classification.
+Legacy on-disk backfill remains optional follow-up work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `brigade runs export` / `validate-archive` enforce the #592 worker-event
-  privacy boundary: raw `events/<worker>.jsonl` streams stay local-only and are
+  privacy boundary: raw worker-like JSONL anywhere under `events/` (including
+  nested paths such as `events/nested/coder.jsonl`) stays local-only and is
   never classified as public support data. Export writes distinct scrubbed
-  sidecars (`events/<worker>.scrubbed.json` with scrubbed media type,
+  sidecars (`events/**/<worker>.scrubbed.json` with scrubbed media type,
   `role=artifact`, `privacy_class=redacted`) via the existing fail-closed
   scrubber, or refuses the export with a bounded diagnostic when any
   method/field/item is unknown or unsafely classified. Source runs remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--force`. (#860)
 
 ### Added
+- `brigade runs export` / `validate-archive` enforce the #592 worker-event
+  privacy boundary: raw `events/<worker>.jsonl` streams stay local-only and are
+  never classified as public support data. Export writes distinct scrubbed
+  sidecars (`events/<worker>.scrubbed.json` with scrubbed media type,
+  `role=artifact`, `privacy_class=redacted`) via the existing fail-closed
+  scrubber, or refuses the export with a bounded diagnostic when any
+  method/field/item is unknown or unsafely classified. Source runs remain
+  unclassified until scrubbed; audit/replay still require `policy=local-only`
+  for raw salvage.
 - Issue #846 R2 residual work-store characterization: extend the R1 harness
   with observed same-actor/guard/empty-filter, restart, schema coercion,
   backup/restore, install/cold-start/backup timing, resource, metrics-state,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sidecars (`events/**/<worker>.scrubbed.json` with scrubbed media type,
   `role=artifact`, `privacy_class=redacted`) via the existing fail-closed
   scrubber, or refuses the export with a bounded diagnostic when any
-  method/field/item is unknown or unsafely classified. Source runs remain
-  unclassified until scrubbed; audit/replay still require `policy=local-only`
-  for raw salvage.
+  method/field/item is unknown or unsafely classified. The reserved
+  `events/lifecycle.jsonl` journal exemption authenticates
+  `brigade.run_event.v1` records and rejects raw JSON-RPC worker envelopes.
+  Source runs remain unclassified until scrubbed; audit/replay still require
+  `policy=local-only` for raw salvage.
 - Issue #846 R2 residual work-store characterization: extend the R1 harness
   with observed same-actor/guard/empty-filter, restart, schema coercion,
   backup/restore, install/cold-start/backup timing, resource, metrics-state,

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -759,7 +759,8 @@ not infer import acceptance from the artifact filename alone.
     roster.json
     ...
     events/lifecycle.jsonl
-    events/<worker>.scrubbed.json            # scrubbed worker streams only (#592)
+    events/<worker>.scrubbed.json            # scrubbed worker streams (#592)
+    events/**/<worker>.scrubbed.json         # nested worker streams also scrubbed
     events/recovery-checkpoints/<sha256>.json   # artifact references only
 ```
 
@@ -802,7 +803,7 @@ not infer import acceptance from the artifact filename alone.
 | Nested receipt unknown keys | **Ignore** (receipt-family additive evolution) |
 | Symlinks / special files | **Refuse** |
 | Recovery-checkpoint bodies | **Strip** to closed artifact references on export (#636); validate refuses bodies |
-| Raw worker event streams (`events/<worker>.jsonl`) | **Refuse** as portable public support; export replaces with scrubbed sidecars (`events/<worker>.scrubbed.json`, `privacy_class=redacted`) or fails closed (#592) |
+| Raw worker event streams (`events/**/*.jsonl` except lifecycle) | **Refuse** as portable public support; export replaces with scrubbed sidecars (`events/**/<worker>.scrubbed.json`, `privacy_class=redacted`) or fails closed (#592); nested smuggling paths are rejected |
 | Resume after import | **Not supported** in v1 (`resume_supported: false`); import is inspection/audit oriented |
 | Digest mismatch | **Refuse** |
 

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -759,6 +759,7 @@ not infer import acceptance from the artifact filename alone.
     roster.json
     ...
     events/lifecycle.jsonl
+    events/<worker>.scrubbed.json            # scrubbed worker streams only (#592)
     events/recovery-checkpoints/<sha256>.json   # artifact references only
 ```
 
@@ -801,6 +802,7 @@ not infer import acceptance from the artifact filename alone.
 | Nested receipt unknown keys | **Ignore** (receipt-family additive evolution) |
 | Symlinks / special files | **Refuse** |
 | Recovery-checkpoint bodies | **Strip** to closed artifact references on export (#636); validate refuses bodies |
+| Raw worker event streams (`events/<worker>.jsonl`) | **Refuse** as portable public support; export replaces with scrubbed sidecars (`events/<worker>.scrubbed.json`, `privacy_class=redacted`) or fails closed (#592) |
 | Resume after import | **Not supported** in v1 (`resume_supported: false`); import is inspection/audit oriented |
 | Digest mismatch | **Refuse** |
 

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -803,7 +803,8 @@ not infer import acceptance from the artifact filename alone.
 | Nested receipt unknown keys | **Ignore** (receipt-family additive evolution) |
 | Symlinks / special files | **Refuse** |
 | Recovery-checkpoint bodies | **Strip** to closed artifact references on export (#636); validate refuses bodies |
-| Raw worker event streams (`events/**/*.jsonl` except lifecycle) | **Refuse** as portable public support; export replaces with scrubbed sidecars (`events/**/<worker>.scrubbed.json`, `privacy_class=redacted`) or fails closed (#592); nested smuggling paths are rejected |
+| Raw worker event streams (`events/**/*.jsonl` except authenticated lifecycle) | **Refuse** as portable public support; export replaces with scrubbed sidecars (`events/**/<worker>.scrubbed.json`, `privacy_class=redacted`) or fails closed (#592); nested smuggling paths are rejected |
+| Reserved `events/lifecycle.jsonl` | **Authenticate** as `brigade.run_event.v1` chain (or empty); reject raw JSON-RPC worker envelopes disguised as the journal (#592) |
 | Resume after import | **Not supported** in v1 (`resume_supported: false`); import is inspection/audit oriented |
 | Digest mismatch | **Refuse** |
 

--- a/docs/worker-event-streams.md
+++ b/docs/worker-event-streams.md
@@ -1,6 +1,7 @@
 # Worker event streams: field classification and scrubbed projections
 
-Status: implemented for issue #592 (first slice).
+Status: implemented for issue #592 (classification/scrubbing + export/archive
+boundary).
 
 ## Boundary
 
@@ -38,8 +39,30 @@ Legacy on-disk NDJSON remains locally inspectable and is marked
 
 Library entry points live in `brigade.worker_events` (`scrub_event`,
 `scrub_stream_file`, `inspect_stream_file`, `load_stream_for_consumer`,
-`require_consumer_policy`). `brigade.run_audit.reject_raw_worker_stream_evidence`
-is the audit/replay gate.
+`require_consumer_policy`, `project_worker_streams_for_export`,
+`assert_export_tree_has_no_raw_worker_streams`).
+`brigade.run_audit.reject_raw_worker_stream_evidence` is the audit/replay gate.
+`brigade.work_run_archive.export_run` is the portable archive gate.
+
+## Export / archive boundary
+
+`brigade runs export` never copies raw `events/<worker>.jsonl` into a
+`brigade.work-run` archive as public support data. On the export staging tree
+only:
+
+1. each raw worker stream is scrubbed with the fail-closed scrubber
+2. a distinct sidecar `events/<worker>.scrubbed.json` is written
+3. the raw NDJSON is removed from the export copy
+4. the manifest classifies the sidecar as
+   `role=artifact`, `privacy_class=redacted`,
+   `media_type=<scrubbed media type>`,
+   `nested_schema=brigade.worker_event_stream_scrubbed.v1`
+
+If any method, field, or item is unknown or unsafely classified, export refuses
+with a bounded `export-privacy` diagnostic and leaves the source run unchanged.
+`validate-archive` / import also refuse raw worker streams and misclassified
+scrubbed sidecars. Local raw streams remain available under
+`policy=local-only` for resume/salvage; that policy is never implied by export.
 
 ## Raw capture vs scrub matrix
 
@@ -80,52 +103,19 @@ scrub/export matrix for known Codex app-server notification shapes.
 | `item/completed` | same as started, plus `completedAtMs` | same as started |
 | `item/commandExecution/requestApproval#auto-declined` | `threadId`, `turnId`, `itemId`, `availableDecisions` | `command`, `cwd`, `reason`, headers, cookies, env, credentials, prompts, grant roots |
 
-Only the classified approval auto-decline method above is accepted by the
-scrubber. Other `*#auto-declined` bases fail closed. Unknown methods or fields
-likewise fail scrubbing with a bounded diagnostic and stay rejected from
-scrub/export.
+Only the recorded approval auto-decline method above is accepted. Other
+`*#auto-declined` bases fail closed.
 
-### Turn fields
-
-| Field | Class |
-| --- | --- |
-| `id` | public_metadata |
-| `status` | public_metadata |
-| `items` | public_metadata (each element via item-type matrix) |
-| `error` | prohibited |
+Delta methods (`item/*/delta`, …) are never recorded by Brigade and are
+intentionally absent. Unknown methods or fields fail scrubbing with a bounded
+diagnostic.
 
 ### Item types
 
 Every supported item type keeps `id` and `type` as public metadata. Content
-fields are private or prohibited. Closed per-type key set:
-
-| Item type | Public fields | Stripped fields |
-| --- | --- | --- |
-| `userMessage` | `id`, `type`, `clientId` | `content` |
-| `agentMessage` | `id`, `type`, `phase` | `text` |
-| `plan` | `id`, `type` | `text` |
-| `reasoning` | `id`, `type` | `summary`, `content` |
-| `commandExecution` | `id`, `type`, `status`, `exitCode`, `durationMs` | `command`, `cwd`, `commandActions`, `aggregatedOutput` |
-| `fileChange` | `id`, `type`, `status` | `changes` |
-| `mcpToolCall` | `id`, `type`, `server`, `tool`, `status`, `pluginId` | `arguments`, `appContext`, `result`, `error`, `mcpAppResourceUri` |
-| `dynamicToolCall` | `id`, `type`, `tool`, `status`, `success`, `durationMs` | `arguments`, `contentItems` |
-| `collabToolCall` | `id`, `type`, `tool`, `status`, `senderThreadId`, `receiverThreadId`, `newThreadId`, `agentStatus` | `prompt` |
-| `webSearch` | `id`, `type` | `query`, `action` |
-| `imageView` | `id`, `type` | `path` |
-| `enteredReviewMode` | `id`, `type` | `review` |
-| `exitedReviewMode` | `id`, `type` | `review` |
-| `contextCompaction` | `id`, `type` | _(none)_ |
-
-### Global secret keys
-
-These keys are secret wherever they appear under `params` (including nested
-objects that would otherwise be public): `authorization`, `Authorization`,
-`cookie`, `Cookie`, `cookies`, `set-cookie`, `Set-Cookie`, `credentials`,
-`apiKey`, `api_key`, `token`, `accessToken`, `refreshToken`, `password`,
-`secret`, `env`, `environment`, `headers`.
-
-Absolute home paths travel in `cwd` / `path` / `grantRoot` and are classified
-`private_content`. Provider error bodies are `prohibited`.
+fields (`text`, `content`, `command`, `cwd`, `changes`, `arguments`, `result`,
+`query`, `path`, `review`, `prompt`, …) are private or prohibited. See
+`classification_matrix()["item_types"]` for the closed per-type key set.
 
 ## Schemas
 
@@ -135,23 +125,23 @@ Absolute home paths travel in `cwd` / `path` / `grantRoot` and are classified
 Golden adversarial fixtures:
 `src/brigade/fixtures/worker-events-appserver.v1.golden.json`.
 
-## Acceptance mapping (#592 first slice)
+## Acceptance mapping (#592)
 
 | Criterion | Enforcement |
 | --- | --- |
 | Documented scrub matrix covers known Codex app-server methods/item types | this document + `classification_matrix()` |
 | Raw capture is open-ended for non-delta methods; matrix is not a recorder allowlist | docs + recorder-to-matrix contract test |
 | Unknown types/fields fail closed with bounded diagnostics | `WorkerEventError` / `MAX_DIAGNOSTIC_LEN` |
-| Credentials, headers, cookies, env, prompts, private content, home paths, provider error bodies absent | scrub omit + `scrubbed_projection_omits_sensitive_material` + adversarial goldens |
-| Order, stable IDs, safe operation names, schema versions, source digests preserved | scrubbed stream document + golden stream case |
-| Distinct raw/scrubbed media types and artifact classes | `media_types()` / `artifact_classes()` |
+| Credentials, headers, cookies, env, prompts, private content, home paths, provider error bodies absent | scrub omit + `scrubbed_projection_omits_sensitive_material` + adversarial goldens + archive export regressions |
+| Order, stable IDs, safe operation names, schema versions, source digests preserved | scrubbed stream document + golden stream case + export sidecar |
+| Distinct raw/scrubbed media types and artifact classes | `media_types()` / `artifact_classes()` + archive manifest classification |
 | Audit/replay reject raw unless `local-only` | `load_stream_for_consumer`, `run_audit.reject_raw_worker_stream_evidence` |
+| Export never ships raw streams as public support | `project_worker_streams_for_export`, `_classify_path`, `validate_archive` |
 | Adversarial goldens for the supported transport | fixture cases for every matrix item type |
-| Legacy streams inspectable and unclassified until scrubbed | `inspect_stream_file` |
+| Legacy streams inspectable and unclassified until scrubbed | `inspect_stream_file` (source run unchanged by export) |
 
-## Non-goals (first slice)
+## Non-goals
 
-- Legacy backfill of historical streams
-- Export/archive wiring for scrubbed sidecars
+- Legacy backfill of historical streams into scrubbed sidecars on disk
 - Treating redaction as a substitute for access control
 - Replacing the ProvenanceEnvelope trust contract (#498)

--- a/docs/worker-event-streams.md
+++ b/docs/worker-event-streams.md
@@ -46,12 +46,14 @@ Library entry points live in `brigade.worker_events` (`scrub_event`,
 
 ## Export / archive boundary
 
-`brigade runs export` never copies raw `events/<worker>.jsonl` into a
-`brigade.work-run` archive as public support data. On the export staging tree
-only:
+`brigade runs export` never copies raw worker-like JSONL under `events/` into a
+`brigade.work-run` archive as public support data. Discovery is recursive: any
+`events/**/*.jsonl` except the top-level lifecycle journal is a worker-stream
+candidate (including nested paths such as `events/nested/coder.jsonl`). On the
+export staging tree only:
 
 1. each raw worker stream is scrubbed with the fail-closed scrubber
-2. a distinct sidecar `events/<worker>.scrubbed.json` is written
+2. a distinct sidecar `events/**/<worker>.scrubbed.json` is written beside it
 3. the raw NDJSON is removed from the export copy
 4. the manifest classifies the sidecar as
    `role=artifact`, `privacy_class=redacted`,
@@ -60,8 +62,8 @@ only:
 
 If any method, field, or item is unknown or unsafely classified, export refuses
 with a bounded `export-privacy` diagnostic and leaves the source run unchanged.
-`validate-archive` / import also refuse raw worker streams and misclassified
-scrubbed sidecars. Local raw streams remain available under
+`validate-archive` / import also refuse nested raw worker streams and
+misclassified scrubbed sidecars. Local raw streams remain available under
 `policy=local-only` for resume/salvage; that policy is never implied by export.
 
 ## Raw capture vs scrub matrix
@@ -136,7 +138,7 @@ Golden adversarial fixtures:
 | Order, stable IDs, safe operation names, schema versions, source digests preserved | scrubbed stream document + golden stream case + export sidecar |
 | Distinct raw/scrubbed media types and artifact classes | `media_types()` / `artifact_classes()` + archive manifest classification |
 | Audit/replay reject raw unless `local-only` | `load_stream_for_consumer`, `run_audit.reject_raw_worker_stream_evidence` |
-| Export never ships raw streams as public support | `project_worker_streams_for_export`, `_classify_path`, `validate_archive` |
+| Export never ships raw streams as public support | `project_worker_streams_for_export`, recursive `list_worker_event_streams`, `_classify_path`, `validate_archive` / import |
 | Adversarial goldens for the supported transport | fixture cases for every matrix item type |
 | Legacy streams inspectable and unclassified until scrubbed | `inspect_stream_file` (source run unchanged by export) |
 

--- a/docs/worker-event-streams.md
+++ b/docs/worker-event-streams.md
@@ -62,8 +62,10 @@ export staging tree only:
 
 If any method, field, or item is unknown or unsafely classified, export refuses
 with a bounded `export-privacy` diagnostic and leaves the source run unchanged.
-`validate-archive` / import also refuse nested raw worker streams and
-misclassified scrubbed sidecars. Local raw streams remain available under
+`validate-archive` / import also refuse nested raw worker streams,
+misclassified scrubbed sidecars, and reserved `events/lifecycle.jsonl` files
+that carry raw JSON-RPC worker envelopes instead of authenticated
+`brigade.run_event.v1` journal records. Local raw streams remain available under
 `policy=local-only` for resume/salvage; that policy is never implied by export.
 
 ## Raw capture vs scrub matrix

--- a/src/brigade/work_run_archive.py
+++ b/src/brigade/work_run_archive.py
@@ -17,7 +17,7 @@ import stat
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 
-from . import __version__, localio, receipt_schema, run_checkpoint, worker_events
+from . import __version__, localio, receipt_schema, run_checkpoint, run_journal, worker_events
 
 WORK_RUN_ARCHIVE_SCHEMA = "brigade.work-run"
 WORK_RUN_ARCHIVE_SCHEMA_VERSION = 1
@@ -106,6 +106,101 @@ class WorkRunArchiveError(ValueError):
     def __init__(self, message: str, *, category: str = "schema") -> None:
         super().__init__(message)
         self.category = category
+
+
+def _bound_privacy(message: str) -> str:
+    text = str(message)
+    if len(text) <= worker_events.MAX_DIAGNOSTIC_LEN:
+        return text
+    return text[: worker_events.MAX_DIAGNOSTIC_LEN - 3] + "..."
+
+
+def _looks_like_worker_notification_envelope(obj: Mapping[str, Any]) -> bool:
+    """True for JSON-RPC worker envelopes that must not use the lifecycle journal path."""
+    if obj.get("schema") == receipt_schema.RUN_EVENT_SCHEMA:
+        return False
+    method = obj.get("method")
+    if not isinstance(method, str) or not method:
+        return False
+    return "jsonrpc" in obj or isinstance(obj.get("params"), Mapping)
+
+
+def assert_lifecycle_journal_authentic(payload_root: Path) -> None:
+    """Authenticate ``events/lifecycle.jsonl`` before treating it as a public journal.
+
+    The reserved top-level lifecycle filename is excluded from worker-stream
+    discovery. Without shape authentication, a digest-valid archive can smuggle
+    raw JSON-RPC worker notifications (with secrets/prompts) as ``role=journal``.
+    Missing journals are allowed. Present journals must parse as the allowed
+    ``brigade.run_event.v1`` chain (or be empty); worker envelopes fail closed.
+    """
+    path = payload_root / "events" / "lifecycle.jsonl"
+    if not path.exists():
+        return
+    if path.is_symlink() or not path.is_file():
+        raise WorkRunArchiveError(
+            "events/lifecycle.jsonl is not a regular file",
+            category="export-privacy",
+        )
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise WorkRunArchiveError(
+            _bound_privacy(f"events/lifecycle.jsonl is unreadable: {exc}"),
+            category="export-privacy",
+        ) from exc
+
+    for line_no, line in enumerate(raw_text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise WorkRunArchiveError(
+                _bound_privacy(f"events/lifecycle.jsonl line {line_no} is not valid JSON: {exc}"),
+                category="export-privacy",
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise WorkRunArchiveError(
+                _bound_privacy(f"events/lifecycle.jsonl line {line_no} must be a JSON object"),
+                category="export-privacy",
+            )
+        if _looks_like_worker_notification_envelope(parsed):
+            raise WorkRunArchiveError(
+                _bound_privacy(
+                    "events/lifecycle.jsonl carries a worker notification envelope; "
+                    "reserved journal path rejects raw JSON-RPC worker streams"
+                ),
+                category="export-privacy",
+            )
+
+    try:
+        report = run_journal.read_journal_bounded(path)
+    except run_journal.RunJournalError as exc:
+        raise WorkRunArchiveError(
+            _bound_privacy(f"events/lifecycle.jsonl failed lifecycle authentication: {exc}"),
+            category="export-privacy",
+        ) from exc
+    if report.chain_errors:
+        raise WorkRunArchiveError(
+            _bound_privacy("events/lifecycle.jsonl failed lifecycle authentication: " + report.chain_errors[0]),
+            category="export-privacy",
+        )
+    if report.partial_tail:
+        raise WorkRunArchiveError(
+            "events/lifecycle.jsonl has a partial trailing record",
+            category="export-privacy",
+        )
+
+
+def _assert_export_privacy_tree(payload_root: Path) -> None:
+    """Run checkpoint, worker-stream, and lifecycle export-privacy gates."""
+    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(payload_root)
+    try:
+        worker_events.assert_export_tree_has_no_raw_worker_streams(payload_root)
+    except worker_events.WorkerEventError as exc:
+        raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
+    assert_lifecycle_journal_authentic(payload_root)
 
 
 def schema_artifact_relative_path() -> str:
@@ -215,11 +310,7 @@ def validate_archive(archive_dir: Path) -> dict[str, Any]:
     if not payload_root.is_dir() or payload_root.is_symlink():
         raise WorkRunArchiveError(f"missing payload directory: {WORK_RUN_PAYLOAD_DIR}", category="io")
 
-    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(payload_root)
-    try:
-        worker_events.assert_export_tree_has_no_raw_worker_streams(payload_root)
-    except worker_events.WorkerEventError as exc:
-        raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
+    _assert_export_privacy_tree(payload_root)
 
     declared = {entry["path"]: entry for entry in manifest["files"]}
     on_disk = _collect_payload_files(payload_root)
@@ -298,11 +389,7 @@ def build_manifest_for_payload(
     payload_root = payload_root.expanduser().resolve()
     if not payload_root.is_dir():
         raise WorkRunArchiveError(f"payload directory not found: {payload_root}", category="io")
-    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(payload_root)
-    try:
-        worker_events.assert_export_tree_has_no_raw_worker_streams(payload_root)
-    except worker_events.WorkerEventError as exc:
-        raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
+    _assert_export_privacy_tree(payload_root)
 
     files: list[dict[str, Any]] = []
     for rel in _collect_payload_files(payload_root):
@@ -374,11 +461,11 @@ def export_run(
                 if temp_path.is_file() and not temp_path.is_symlink():
                     temp_path.unlink()
         run_checkpoint.strip_checkpoint_bodies_for_export(payload_root)
-        run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(payload_root)
         try:
             worker_events.project_worker_streams_for_export(payload_root)
         except worker_events.WorkerEventError as exc:
             raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
+        _assert_export_privacy_tree(payload_root)
 
         run_id = run_dir.name
         if not _RUN_ID_RE.fullmatch(run_id):
@@ -452,11 +539,7 @@ def import_archive(
         )
     try:
         _copy_run_tree_refuse_special(archive_dir / WORK_RUN_PAYLOAD_DIR, staging)
-        run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(staging)
-        try:
-            worker_events.assert_export_tree_has_no_raw_worker_streams(staging)
-        except worker_events.WorkerEventError as exc:
-            raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
+        _assert_export_privacy_tree(staging)
         # Re-check digests against the validated manifest after the copy.
         for entry in manifest["files"]:
             rel = str(entry["path"])

--- a/src/brigade/work_run_archive.py
+++ b/src/brigade/work_run_archive.py
@@ -17,7 +17,7 @@ import stat
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 
-from . import __version__, localio, receipt_schema, run_checkpoint
+from . import __version__, localio, receipt_schema, run_checkpoint, worker_events
 
 WORK_RUN_ARCHIVE_SCHEMA = "brigade.work-run"
 WORK_RUN_ARCHIVE_SCHEMA_VERSION = 1
@@ -216,6 +216,10 @@ def validate_archive(archive_dir: Path) -> dict[str, Any]:
         raise WorkRunArchiveError(f"missing payload directory: {WORK_RUN_PAYLOAD_DIR}", category="io")
 
     run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(payload_root)
+    try:
+        worker_events.assert_export_tree_has_no_raw_worker_streams(payload_root)
+    except worker_events.WorkerEventError as exc:
+        raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
 
     declared = {entry["path"]: entry for entry in manifest["files"]}
     on_disk = _collect_payload_files(payload_root)
@@ -249,6 +253,32 @@ def validate_archive(archive_dir: Path) -> dict[str, Any]:
                     f"checkpoint body crossed an export boundary: {rel}",
                     category="export-privacy",
                 )
+        if worker_events.is_scrubbed_worker_event_stream_rel(rel):
+            if entry.get("media_type") != worker_events.SCRUBBED_MEDIA_TYPE:
+                raise WorkRunArchiveError(
+                    f"scrubbed worker stream media_type mismatch: {rel}",
+                    category="export-privacy",
+                )
+            if entry.get("privacy_class") != "redacted":
+                raise WorkRunArchiveError(
+                    f"scrubbed worker stream privacy_class must be redacted: {rel}",
+                    category="export-privacy",
+                )
+            if entry.get("role") != "artifact":
+                raise WorkRunArchiveError(
+                    f"scrubbed worker stream role must be artifact: {rel}",
+                    category="export-privacy",
+                )
+            if entry.get("nested_schema") != worker_events.STREAM_SCHEMA:
+                raise WorkRunArchiveError(
+                    f"scrubbed worker stream nested_schema mismatch: {rel}",
+                    category="export-privacy",
+                )
+        if worker_events.is_raw_worker_event_stream_rel(rel):
+            raise WorkRunArchiveError(
+                f"raw worker stream crossed an export boundary: {rel}",
+                category="export-privacy",
+            )
 
     run_json = payload_root / "run.json"
     if not run_json.is_file():
@@ -269,6 +299,10 @@ def build_manifest_for_payload(
     if not payload_root.is_dir():
         raise WorkRunArchiveError(f"payload directory not found: {payload_root}", category="io")
     run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(payload_root)
+    try:
+        worker_events.assert_export_tree_has_no_raw_worker_streams(payload_root)
+    except worker_events.WorkerEventError as exc:
+        raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
 
     files: list[dict[str, Any]] = []
     for rel in _collect_payload_files(payload_root):
@@ -306,7 +340,8 @@ def export_run(
     """Export a run directory into a versioned ``brigade.work-run`` archive.
 
     The source run directory is left unchanged. Private recovery-checkpoint
-    bodies are stripped on the export copy only (#636).
+    bodies are stripped on the export copy only (#636). Raw worker event
+    streams are replaced with scrubbed sidecars or refused (#592).
     """
     run_dir = _normalize_user_path(run_dir)
     dest_input = destination.expanduser()
@@ -340,6 +375,10 @@ def export_run(
                     temp_path.unlink()
         run_checkpoint.strip_checkpoint_bodies_for_export(payload_root)
         run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(payload_root)
+        try:
+            worker_events.project_worker_streams_for_export(payload_root)
+        except worker_events.WorkerEventError as exc:
+            raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
 
         run_id = run_dir.name
         if not _RUN_ID_RE.fullmatch(run_id):
@@ -414,6 +453,10 @@ def import_archive(
     try:
         _copy_run_tree_refuse_special(archive_dir / WORK_RUN_PAYLOAD_DIR, staging)
         run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(staging)
+        try:
+            worker_events.assert_export_tree_has_no_raw_worker_streams(staging)
+        except worker_events.WorkerEventError as exc:
+            raise WorkRunArchiveError(str(exc), category="export-privacy") from exc
         # Re-check digests against the validated manifest after the copy.
         for entry in manifest["files"]:
             rel = str(entry["path"])
@@ -582,6 +625,15 @@ def _classify_path(rel: str, raw: bytes) -> tuple[str, str, str]:
         return "receipt", _MEDIA_JSON, "public"
     if rel == "events/lifecycle.jsonl":
         return "journal", _MEDIA_JSONL, "public"
+    if worker_events.is_raw_worker_event_stream_rel(rel):
+        # Raw streams are local-only. Export must project them first; classify
+        # never treats them as public support data.
+        raise WorkRunArchiveError(
+            f"raw worker stream crossed an export boundary: {rel}",
+            category="export-privacy",
+        )
+    if worker_events.is_scrubbed_worker_event_stream_rel(rel):
+        return "artifact", worker_events.SCRUBBED_MEDIA_TYPE, "redacted"
     if rel.startswith(f"events/{run_checkpoint.CHECKPOINT_DIR_NAME}/") and rel.endswith(".json"):
         privacy = "private"
         try:
@@ -618,6 +670,22 @@ def _nested_schema_for(rel: str, raw: bytes) -> tuple[str | None, int | None]:
             if type(version) is int and version >= 1:
                 schema_version = version
         return schema_name, schema_version
+    if worker_events.is_scrubbed_worker_event_stream_rel(rel):
+        try:
+            parsed = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return worker_events.STREAM_SCHEMA, worker_events.STREAM_SCHEMA_VERSION
+        if isinstance(parsed, dict):
+            nested = parsed.get("schema")
+            version = parsed.get("schema_version")
+            nested_schema = worker_events.STREAM_SCHEMA
+            nested_version = worker_events.STREAM_SCHEMA_VERSION
+            if isinstance(nested, str) and nested:
+                nested_schema = nested
+            if type(version) is int and version >= 1:
+                nested_version = version
+            return nested_schema, nested_version
+        return worker_events.STREAM_SCHEMA, worker_events.STREAM_SCHEMA_VERSION
     if rel.endswith(".json"):
         try:
             parsed = json.loads(raw.decode("utf-8"))
@@ -626,9 +694,9 @@ def _nested_schema_for(rel: str, raw: bytes) -> tuple[str | None, int | None]:
         if isinstance(parsed, dict):
             nested = parsed.get("schema")
             version = parsed.get("schema_version")
-            nested_schema = nested if isinstance(nested, str) and nested else None
-            nested_version = version if type(version) is int and version >= 1 else None
-            return nested_schema, nested_version
+            json_schema = nested if isinstance(nested, str) and nested else None
+            json_version = version if type(version) is int and version >= 1 else None
+            return json_schema, json_version
     if rel == "events/lifecycle.jsonl":
         return receipt_schema.RUN_EVENT_SCHEMA, receipt_schema.RUN_EVENT_SCHEMA_VERSION
     return None, None
@@ -763,6 +831,9 @@ def export_cli(
         print(f"error: {exc.category}: {exc}", file=sys.stderr)
         return 2 if exc.category in {"io", "compatibility"} else 1
     except run_checkpoint.CheckpointError as exc:
+        print(f"error: export-privacy: {exc}", file=sys.stderr)
+        return 1
+    except worker_events.WorkerEventError as exc:
         print(f"error: export-privacy: {exc}", file=sys.stderr)
         return 1
     if json_output:

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -1,12 +1,15 @@
 """Worker event stream field classification and fail-closed scrubbed projections.
 
 Implements the privacy boundary for Codex app-server worker streams recorded
-under ``events/<worker>.jsonl`` (issue #592, first slice).
+under ``events/<worker>.jsonl`` (issue #592).
 
 Raw streams stay local. Scrubbed projections keep only public metadata, stable
 IDs, safe operation names, schema versions, and source digests. Unknown event
 types or fields fail closed with bounded diagnostics. Legacy raw streams remain
 inspectable locally but are marked unclassified until successfully scrubbed.
+Portable ``brigade.work-run`` export replaces raw streams with scrubbed
+sidecars (or refuses the export) rather than classifying raw NDJSON as public
+support data.
 
 Standard library only. Brigade is zero-runtime-dependency.
 """
@@ -15,6 +18,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -1005,6 +1009,120 @@ def list_worker_event_streams(events_dir: Path) -> list[Path]:
     return out
 
 
+def is_raw_worker_event_stream_rel(rel: str) -> bool:
+    """True for ``events/<worker>.jsonl`` excluding the lifecycle journal."""
+    pure = Path(rel)
+    if len(pure.parts) != 2 or pure.parts[0] != "events":
+        return False
+    name = pure.parts[1]
+    return name.endswith(".jsonl") and name != "lifecycle.jsonl"
+
+
+def is_scrubbed_worker_event_stream_rel(rel: str) -> bool:
+    """True for ``events/<worker>.scrubbed.json`` export/sidecar projections."""
+    pure = Path(rel)
+    if len(pure.parts) != 2 or pure.parts[0] != "events":
+        return False
+    return pure.parts[1].endswith(".scrubbed.json")
+
+
+def scrubbed_sidecar_path_for_raw(raw_path: Path) -> Path:
+    """Map ``events/<worker>.jsonl`` to ``events/<worker>.scrubbed.json``."""
+    raw_path = Path(raw_path)
+    if raw_path.suffix != ".jsonl":
+        raise WorkerEventError(
+            _bound(f"raw worker stream path must end with .jsonl: {raw_path.name}"),
+            category="export-privacy",
+        )
+    return raw_path.with_name(f"{raw_path.stem}.scrubbed.json")
+
+
+def project_worker_streams_for_export(run_dir: Path) -> list[Path]:
+    """Replace raw worker streams with scrubbed projections on an export copy.
+
+    Call only on a staging/export tree. The local source run keeps raw NDJSON
+    unclassified for ``policy=local-only`` salvage. Unknown methods/fields or
+    unsafely classified content fail closed with a bounded diagnostic.
+    """
+    run_dir = Path(run_dir)
+    events_dir = run_dir / "events"
+    written: list[Path] = []
+    for raw_path in list_worker_event_streams(events_dir):
+        if raw_path.is_symlink() or not raw_path.is_file():
+            raise WorkerEventError(
+                _bound(f"raw worker stream is not a regular file: {raw_path.name}"),
+                category="export-privacy",
+            )
+        try:
+            doc = scrub_stream_file(raw_path)
+        except WorkerEventError as exc:
+            raise WorkerEventError(
+                _bound(f"export refuses raw worker stream {raw_path.name}: {exc.diagnostic}"),
+                category="export-privacy",
+            ) from exc
+        validation_errors = _scrubbed_stream_document_validation_errors(doc)
+        if validation_errors:
+            raise WorkerEventError(
+                _bound(f"export scrubbed projection invalid for {raw_path.name}: {validation_errors[0]}"),
+                category="export-privacy",
+            )
+        for index, event in enumerate(doc.get("events") or []):
+            if not isinstance(event, Mapping):
+                raise WorkerEventError(
+                    _bound(f"export scrubbed event {index} is not an object"),
+                    category="export-privacy",
+                )
+            leaks = scrubbed_projection_omits_sensitive_material(event)
+            if leaks:
+                raise WorkerEventError(
+                    _bound(f"export scrubbed projection retains sensitive material: {leaks[0]}"),
+                    category="export-privacy",
+                )
+        sidecar = scrubbed_sidecar_path_for_raw(raw_path)
+        if sidecar.exists() and (sidecar.is_symlink() or not sidecar.is_file()):
+            raise WorkerEventError(
+                _bound(f"scrubbed sidecar path is not a replaceable file: {sidecar.name}"),
+                category="export-privacy",
+            )
+        sidecar.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.chmod(sidecar, 0o600)
+        raw_path.unlink()
+        written.append(sidecar)
+    assert_export_tree_has_no_raw_worker_streams(run_dir)
+    return written
+
+
+def assert_export_tree_has_no_raw_worker_streams(root: Path) -> None:
+    """Fail closed if a raw/unclassified worker stream remains under an export tree."""
+    root = Path(root)
+    events_dir = root / "events"
+    for path in list_worker_event_streams(events_dir):
+        raise WorkerEventError(
+            _bound(
+                f"raw worker stream crossed an export boundary: {path.name} "
+                f"(artifact_class={UNCLASSIFIED_ARTIFACT_CLASS}; policy={POLICY_LOCAL_ONLY} only)"
+            ),
+            category="export-privacy",
+        )
+    if not events_dir.is_dir():
+        return
+    for path in sorted(events_dir.glob("*.scrubbed.json")):
+        if path.is_symlink() or not path.is_file():
+            raise WorkerEventError(
+                _bound(f"scrubbed worker stream is not a regular file: {path.name}"),
+                category="export-privacy",
+            )
+        info = inspect_stream_file(path)
+        if info.status != STATUS_SCRUBBED or info.artifact_class != SCRUBBED_ARTIFACT_CLASS:
+            detail = info.diagnostic or f"status={info.status}"
+            raise WorkerEventError(
+                _bound(f"export scrubbed sidecar is not admissible: {path.name}: {detail}"),
+                category="export-privacy",
+            )
+        # Portable consumers must accept the sidecar under scrubbed-only policy.
+        load_stream_for_consumer(path, consumer="export", policy=POLICY_SCRUBBED_ONLY)
+
+
 def assert_audit_rejects_raw_streams(
     events_dir: Path,
     *,
@@ -1134,19 +1252,24 @@ __all__ = [
     "WorkerEventError",
     "WorkerEventPolicyError",
     "assert_audit_rejects_raw_streams",
+    "assert_export_tree_has_no_raw_worker_streams",
     "artifact_classes",
     "canonical_event_bytes",
     "classification_matrix",
     "inspect_stream_file",
+    "is_raw_worker_event_stream_rel",
+    "is_scrubbed_worker_event_stream_rel",
     "list_worker_event_streams",
     "load_stream_for_consumer",
     "media_types",
+    "project_worker_streams_for_export",
     "require_consumer_policy",
     "scrub_event",
     "scrub_stream_file",
     "scrub_stream_lines",
     "scrub_stream_text",
     "scrubbed_projection_omits_sensitive_material",
+    "scrubbed_sidecar_path_for_raw",
     "source_digest_for_event",
     "source_digest_for_stream_bytes",
     "validate_scrubbed_event",

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -21,7 +21,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Iterator, Mapping
 
 TRANSPORT = "codex-app-server"
@@ -997,37 +997,59 @@ def _file_is_scrubbed_document(path: Path) -> bool:
 
 
 def list_worker_event_streams(events_dir: Path) -> list[Path]:
-    """Return worker event JSONL paths under an events directory (excludes lifecycle)."""
+    """Return worker event JSONL paths under an events directory (excludes lifecycle).
+
+    Discovery is recursive: any ``*.jsonl`` beneath ``events/`` is a worker-stream
+    candidate except the top-level lifecycle journal ``events/lifecycle.jsonl``.
+    Nested paths such as ``events/nested/coder.jsonl`` must not fall through to
+    public support classification on export.
+    """
     events_dir = Path(events_dir)
     if not events_dir.is_dir():
         return []
     out: list[Path] = []
-    for path in sorted(events_dir.glob("*.jsonl")):
-        if path.name == "lifecycle.jsonl":
+    for path in sorted(events_dir.rglob("*.jsonl")):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            rel = path.relative_to(events_dir).as_posix()
+        except ValueError:
+            continue
+        if rel == "lifecycle.jsonl":
             continue
         out.append(path)
     return out
 
 
+def _events_relative_posix(rel: str) -> PurePosixPath | None:
+    pure = PurePosixPath(rel)
+    if not pure.parts or pure.parts[0] != "events":
+        return None
+    if pure.is_absolute() or ".." in pure.parts or "\\" in rel:
+        return None
+    return pure
+
+
 def is_raw_worker_event_stream_rel(rel: str) -> bool:
-    """True for ``events/<worker>.jsonl`` excluding the lifecycle journal."""
-    pure = Path(rel)
-    if len(pure.parts) != 2 or pure.parts[0] != "events":
+    """True for ``events/**/*.jsonl`` excluding the lifecycle journal."""
+    pure = _events_relative_posix(rel)
+    if pure is None:
         return False
-    name = pure.parts[1]
-    return name.endswith(".jsonl") and name != "lifecycle.jsonl"
+    if rel == "events/lifecycle.jsonl":
+        return False
+    return pure.name.endswith(".jsonl")
 
 
 def is_scrubbed_worker_event_stream_rel(rel: str) -> bool:
-    """True for ``events/<worker>.scrubbed.json`` export/sidecar projections."""
-    pure = Path(rel)
-    if len(pure.parts) != 2 or pure.parts[0] != "events":
+    """True for ``events/**/<worker>.scrubbed.json`` export/sidecar projections."""
+    pure = _events_relative_posix(rel)
+    if pure is None:
         return False
-    return pure.parts[1].endswith(".scrubbed.json")
+    return pure.name.endswith(".scrubbed.json")
 
 
 def scrubbed_sidecar_path_for_raw(raw_path: Path) -> Path:
-    """Map ``events/<worker>.jsonl`` to ``events/<worker>.scrubbed.json``."""
+    """Map ``events/**/<worker>.jsonl`` to ``events/**/<worker>.scrubbed.json``."""
     raw_path = Path(raw_path)
     if raw_path.suffix != ".jsonl":
         raise WorkerEventError(
@@ -1037,33 +1059,46 @@ def scrubbed_sidecar_path_for_raw(raw_path: Path) -> Path:
     return raw_path.with_name(f"{raw_path.stem}.scrubbed.json")
 
 
+def _worker_stream_label(run_dir: Path, path: Path) -> str:
+    """Return a bounded relative label for diagnostics (prefer events/...)."""
+    try:
+        return path.relative_to(run_dir).as_posix()
+    except ValueError:
+        try:
+            return path.relative_to(run_dir / "events").as_posix()
+        except ValueError:
+            return path.name
+
+
 def project_worker_streams_for_export(run_dir: Path) -> list[Path]:
     """Replace raw worker streams with scrubbed projections on an export copy.
 
     Call only on a staging/export tree. The local source run keeps raw NDJSON
     unclassified for ``policy=local-only`` salvage. Unknown methods/fields or
     unsafely classified content fail closed with a bounded diagnostic.
+    Nested worker-like JSONL under ``events/`` is included.
     """
     run_dir = Path(run_dir)
     events_dir = run_dir / "events"
     written: list[Path] = []
     for raw_path in list_worker_event_streams(events_dir):
+        label = _worker_stream_label(run_dir, raw_path)
         if raw_path.is_symlink() or not raw_path.is_file():
             raise WorkerEventError(
-                _bound(f"raw worker stream is not a regular file: {raw_path.name}"),
+                _bound(f"raw worker stream is not a regular file: {label}"),
                 category="export-privacy",
             )
         try:
             doc = scrub_stream_file(raw_path)
         except WorkerEventError as exc:
             raise WorkerEventError(
-                _bound(f"export refuses raw worker stream {raw_path.name}: {exc.diagnostic}"),
+                _bound(f"export refuses raw worker stream {label}: {exc.diagnostic}"),
                 category="export-privacy",
             ) from exc
         validation_errors = _scrubbed_stream_document_validation_errors(doc)
         if validation_errors:
             raise WorkerEventError(
-                _bound(f"export scrubbed projection invalid for {raw_path.name}: {validation_errors[0]}"),
+                _bound(f"export scrubbed projection invalid for {label}: {validation_errors[0]}"),
                 category="export-privacy",
             )
         for index, event in enumerate(doc.get("events") or []):
@@ -1097,26 +1132,28 @@ def assert_export_tree_has_no_raw_worker_streams(root: Path) -> None:
     root = Path(root)
     events_dir = root / "events"
     for path in list_worker_event_streams(events_dir):
+        label = _worker_stream_label(root, path)
         raise WorkerEventError(
             _bound(
-                f"raw worker stream crossed an export boundary: {path.name} "
+                f"raw worker stream crossed an export boundary: {label} "
                 f"(artifact_class={UNCLASSIFIED_ARTIFACT_CLASS}; policy={POLICY_LOCAL_ONLY} only)"
             ),
             category="export-privacy",
         )
     if not events_dir.is_dir():
         return
-    for path in sorted(events_dir.glob("*.scrubbed.json")):
+    for path in sorted(events_dir.rglob("*.scrubbed.json")):
+        label = _worker_stream_label(root, path)
         if path.is_symlink() or not path.is_file():
             raise WorkerEventError(
-                _bound(f"scrubbed worker stream is not a regular file: {path.name}"),
+                _bound(f"scrubbed worker stream is not a regular file: {label}"),
                 category="export-privacy",
             )
         info = inspect_stream_file(path)
         if info.status != STATUS_SCRUBBED or info.artifact_class != SCRUBBED_ARTIFACT_CLASS:
             detail = info.diagnostic or f"status={info.status}"
             raise WorkerEventError(
-                _bound(f"export scrubbed sidecar is not admissible: {path.name}: {detail}"),
+                _bound(f"export scrubbed sidecar is not admissible: {label}: {detail}"),
                 category="export-privacy",
             )
         # Portable consumers must accept the sidecar under scrubbed-only policy.

--- a/tests/test_work_run_archive.py
+++ b/tests/test_work_run_archive.py
@@ -1,4 +1,4 @@
-"""Tests for the versioned brigade.work-run archive schema (#487)."""
+"""Tests for the versioned brigade.work-run archive schema (#487, #592)."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, run_checkpoint, work_run_archive
+from brigade import cli, run_checkpoint, worker_events, work_run_archive
 from brigade.work_run_archive import (
     WORK_RUN_ARCHIVE_SCHEMA,
     WORK_RUN_ARCHIVE_SCHEMA_VERSION,
@@ -299,3 +299,250 @@ def test_import_refuses_dangling_destination_run_symlink(tmp_path: Path):
     (runs_dir / RUN_ID).symlink_to(tmp_path / "missing-target")
     with pytest.raises(WorkRunArchiveError, match="symlink"):
         work_run_archive.import_archive(archive, runs_dir=runs_dir)
+
+
+# -- Issue #592: worker-event export/archive boundary -------------------------
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "src" / "brigade" / "fixtures"
+_GOLDEN = json.loads((_FIXTURES / "worker-events-appserver.v1.golden.json").read_text(encoding="utf-8"))
+
+
+def _golden_case(name: str) -> dict:
+    for case in _GOLDEN["cases"]:
+        if case["name"] == name:
+            return case
+    raise KeyError(name)
+
+
+def _write_worker_stream(run_dir: Path, worker: str, events: list[dict]) -> Path:
+    events_dir = run_dir / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    path = events_dir / f"{worker}.jsonl"
+    path.write_text("".join(json.dumps(event, sort_keys=True) + "\n" for event in events), encoding="utf-8")
+    return path
+
+
+def test_export_projects_worker_stream_to_scrubbed_sidecar_not_public_support(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    raw_events = list(_GOLDEN["stream"]["raw_events"])
+    raw_path = _write_worker_stream(run_dir, "coder", raw_events)
+    raw_text = raw_path.read_text(encoding="utf-8")
+    assert "SECRET" in raw_text or "sk-" in raw_text or "/home/" in raw_text or "Bearer" in raw_text
+
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+
+    # Source remains local-only raw / unclassified.
+    assert raw_path.is_file()
+    info = worker_events.inspect_stream_file(raw_path)
+    assert info.status == worker_events.STATUS_UNCLASSIFIED
+    assert info.artifact_class == worker_events.UNCLASSIFIED_ARTIFACT_CLASS
+    local = worker_events.load_stream_for_consumer(
+        raw_path,
+        consumer="run_resume",
+        policy=worker_events.POLICY_LOCAL_ONLY,
+    )
+    assert isinstance(local, list) and len(local) == len(raw_events)
+
+    # Archive must not ship the raw NDJSON as public support data.
+    assert not (archive / "payload" / "events" / "coder.jsonl").exists()
+    scrubbed_path = archive / "payload" / "events" / "coder.scrubbed.json"
+    assert scrubbed_path.is_file()
+    scrubbed = json.loads(scrubbed_path.read_text(encoding="utf-8"))
+    assert scrubbed["schema"] == worker_events.STREAM_SCHEMA
+    assert scrubbed["media_type"] == worker_events.SCRUBBED_MEDIA_TYPE
+    assert scrubbed["artifact_class"] == worker_events.SCRUBBED_ARTIFACT_CLASS
+    assert scrubbed["event_count"] == len(raw_events)
+    assert [event["method"] for event in scrubbed["events"]] == [event["method"] for event in raw_events]
+    for raw, projected in zip(raw_events, scrubbed["events"], strict=True):
+        assert projected["source_digest"] == worker_events.source_digest_for_event(raw)
+        assert projected["schema"] == worker_events.SCHEMA
+        assert not worker_events.scrubbed_projection_omits_sensitive_material(projected)
+
+    blob = scrubbed_path.read_text(encoding="utf-8")
+    assert "sk-" not in blob
+    assert "Bearer " not in blob
+    assert "/home/" not in blob
+    assert "SECRET" not in blob
+
+    entry = next(
+        item
+        for item in json.loads((archive / "work-run.json").read_text(encoding="utf-8"))["files"]
+        if item["path"] == "events/coder.scrubbed.json"
+    )
+    assert entry["role"] == "artifact"
+    assert entry["media_type"] == worker_events.SCRUBBED_MEDIA_TYPE
+    assert entry["privacy_class"] == "redacted"
+    assert entry["nested_schema"] == worker_events.STREAM_SCHEMA
+    assert entry["nested_schema_version"] == worker_events.STREAM_SCHEMA_VERSION
+    assert entry["sha256"] == hashlib.sha256(scrubbed_path.read_bytes()).hexdigest()
+
+    with pytest.raises(WorkRunArchiveError, match="raw worker stream"):
+        work_run_archive._classify_path("events/coder.jsonl", b"{}\n")
+
+
+def test_export_refuses_unknown_method_with_bounded_diagnostic(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    _write_worker_stream(
+        run_dir,
+        "coder",
+        [
+            _golden_case("turn_started_public")["raw"],
+            {
+                "jsonrpc": "2.0",
+                "method": "provider/undocumentedHook",
+                "params": {"threadId": "thread-x", "secret": "sk-export-must-refuse-01234567"},
+            },
+        ],
+    )
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.export_run(run_dir, tmp_path / "archive")
+    assert excinfo.value.category == "export-privacy"
+    assert len(str(excinfo.value)) <= worker_events.MAX_DIAGNOSTIC_LEN
+    assert "provider/undocumentedHook" in str(excinfo.value) or "unknown" in str(excinfo.value).lower()
+    assert not (tmp_path / "archive").exists()
+    # Source untouched.
+    assert (run_dir / "events" / "coder.jsonl").is_file()
+
+
+@pytest.mark.parametrize(
+    "case_name,forbidden_snippets",
+    [
+        (
+            "auto_declined_with_secrets",
+            [
+                "sk-live-EXAMPLESECRETVALUE99",
+                "Bearer ",
+                "Cookie",
+                "OPENAI_API_KEY",
+                "/home/example-user",
+                "raw user prompt",
+            ],
+        ),
+        (
+            "turn_completed_with_provider_error",
+            ["provider dump", "sk-live-EXAMPLESECRETVALUE99", "Bearer "],
+        ),
+        (
+            "item_completed_agent_message_private",
+            ["sk-live-EXAMPLESECRETVALUE99", "Secret plan", "exfiltrate"],
+        ),
+        (
+            "item_completed_commandExecution_adversarial",
+            [
+                "/home/example-user",
+                "sk-live-EXAMPLESECRETVALUE99",
+                "Bearer ",
+            ],
+        ),
+    ],
+)
+def test_export_adversarial_cases_omit_private_tokens_paths_and_errors(
+    tmp_path: Path,
+    case_name: str,
+    forbidden_snippets: list[str],
+):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    case = _golden_case(case_name)
+    _write_worker_stream(run_dir, "worker-a", [case["raw"]])
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+    scrubbed_path = archive / "payload" / "events" / "worker-a.scrubbed.json"
+    blob = scrubbed_path.read_text(encoding="utf-8")
+    for snippet in forbidden_snippets:
+        assert snippet not in blob, snippet
+    scrubbed = json.loads(blob)
+    assert scrubbed["events"][0]["source_digest"] == case["source_digest"]
+    assert scrubbed["events"][0]["method"] == case["raw"]["method"]
+
+
+def test_export_refuses_unknown_field_and_cross_method_contamination(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    started = deepcopy(_golden_case("turn_started_public")["raw"])
+    started["params"]["undocumentedLeak"] = "sk-must-not-export-aaaaaaaa"
+    other = {
+        "jsonrpc": "2.0",
+        "method": "item/fileChange/requestApproval#auto-declined",
+        "params": {
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "itemId": "file-1",
+            "availableDecisions": ["accept"],
+            "command": "cat /home/demo/.ssh/id_rsa",
+        },
+    }
+    _write_worker_stream(run_dir, "coder", [started, other])
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.export_run(run_dir, tmp_path / "archive")
+    assert excinfo.value.category == "export-privacy"
+    assert len(str(excinfo.value)) <= worker_events.MAX_DIAGNOSTIC_LEN
+    assert not (tmp_path / "archive").exists()
+
+
+def test_validate_archive_refuses_raw_worker_stream_smuggled_as_public_support(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+
+    smuggled = archive / "payload" / "events" / "coder.jsonl"
+    smuggled.parent.mkdir(parents=True, exist_ok=True)
+    smuggled.write_text(
+        json.dumps(_golden_case("auto_declined_with_secrets")["raw"], sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    # Rebuild manifest as a naive exporter that classifies *.jsonl as public support.
+    raw = smuggled.read_bytes()
+    manifest = json.loads((archive / "work-run.json").read_text(encoding="utf-8"))
+    manifest["files"].append(
+        {
+            "path": "events/coder.jsonl",
+            "sha256": hashlib.sha256(raw).hexdigest(),
+            "byte_size": len(raw),
+            "role": "support",
+            "media_type": "application/x-ndjson",
+            "privacy_class": "public",
+        }
+    )
+    manifest["files"].sort(key=lambda row: row["path"])
+    (archive / "work-run.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.validate_archive(archive)
+    assert excinfo.value.category == "export-privacy"
+    assert "raw worker stream" in str(excinfo.value)
+
+
+def test_validate_archive_refuses_misclassified_scrubbed_sidecar(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    _write_worker_stream(run_dir, "coder", [_golden_case("turn_started_public")["raw"]])
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+
+    manifest = json.loads((archive / "work-run.json").read_text(encoding="utf-8"))
+    for entry in manifest["files"]:
+        if entry["path"] == "events/coder.scrubbed.json":
+            entry["privacy_class"] = "public"
+            entry["role"] = "support"
+            entry["media_type"] = "application/json"
+    (archive / "work-run.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.validate_archive(archive)
+    assert excinfo.value.category == "export-privacy"
+
+
+def test_imported_scrubbed_sidecar_is_admissible_scrubbed_only(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    _write_worker_stream(run_dir, "coder", list(_GOLDEN["stream"]["raw_events"]))
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+    imported = work_run_archive.import_archive(archive, runs_dir=tmp_path / "imported-runs")
+    scrubbed = Path(imported["run_dir"]) / "events" / "coder.scrubbed.json"
+    loaded = worker_events.load_stream_for_consumer(scrubbed, consumer="run_audit")
+    assert loaded["artifact_class"] == worker_events.SCRUBBED_ARTIFACT_CLASS
+    assert loaded["event_count"] == len(_GOLDEN["stream"]["raw_events"])
+    with pytest.raises(worker_events.WorkerEventPolicyError):
+        worker_events.load_stream_for_consumer(
+            run_dir / "events" / "coder.jsonl",
+            consumer="run_audit",
+        )

--- a/tests/test_work_run_archive.py
+++ b/tests/test_work_run_archive.py
@@ -681,3 +681,135 @@ def test_list_worker_event_streams_is_recursive_under_events(tmp_path: Path):
     assert worker_events.is_raw_worker_event_stream_rel("events/nested/deep/helper.jsonl")
     assert worker_events.is_scrubbed_worker_event_stream_rel("events/nested/deep/helper.scrubbed.json")
     assert not worker_events.is_raw_worker_event_stream_rel("events/lifecycle.jsonl")
+
+
+def _valid_lifecycle_line(*, run_id: str = RUN_ID) -> bytes:
+    from brigade import run_events
+
+    envelope = run_events.build_event(
+        run_id=run_id,
+        sequence=1,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="create-1",
+        recorded_at="2026-08-09T12:00:00.000000Z",
+        previous_digest=None,
+    )
+    return run_events.canonical_bytes(envelope) + b"\n"
+
+
+def _smuggle_lifecycle_worker_envelope(archive: Path) -> bytes:
+    smuggle = {
+        "jsonrpc": "2.0",
+        "method": "turn/started",
+        "params": {
+            "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+            "prompt": "private lifecycle smuggle",
+            "cwd": "/home/example-user/project",
+        },
+    }
+    life = archive / "payload" / "events" / "lifecycle.jsonl"
+    life.parent.mkdir(parents=True, exist_ok=True)
+    raw = (json.dumps(smuggle, sort_keys=True) + "\n").encode("utf-8")
+    life.write_bytes(raw)
+    manifest = json.loads((archive / "work-run.json").read_text(encoding="utf-8"))
+    manifest["files"] = [entry for entry in manifest["files"] if entry["path"] != "events/lifecycle.jsonl"]
+    manifest["files"].append(
+        {
+            "path": "events/lifecycle.jsonl",
+            "sha256": hashlib.sha256(raw).hexdigest(),
+            "byte_size": len(raw),
+            "role": "journal",
+            "media_type": "application/x-ndjson",
+            "privacy_class": "public",
+            "nested_schema": "brigade.run_event.v1",
+            "nested_schema_version": 1,
+        }
+    )
+    manifest["files"].sort(key=lambda row: row["path"])
+    (archive / "work-run.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return raw
+
+
+def test_validate_archive_refuses_lifecycle_jsonl_worker_envelope_smuggling(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+    raw = _smuggle_lifecycle_worker_envelope(archive)
+    assert b"Bearer sk-live-EXAMPLESECRETVALUE99" in raw
+    assert b"private lifecycle smuggle" in raw
+
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.validate_archive(archive)
+    assert excinfo.value.category == "export-privacy"
+    message = str(excinfo.value)
+    assert "lifecycle.jsonl" in message
+    assert "worker" in message.lower() or "json-rpc" in message.lower() or "notification" in message.lower()
+    assert len(message) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_import_archive_refuses_lifecycle_jsonl_worker_envelope_smuggling(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+    _smuggle_lifecycle_worker_envelope(archive)
+
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.import_archive(archive, runs_dir=tmp_path / "imported-runs")
+    assert excinfo.value.category == "export-privacy"
+    assert "lifecycle.jsonl" in str(excinfo.value)
+    assert not (tmp_path / "imported-runs" / RUN_ID).exists()
+
+
+def test_validate_and_import_accept_authentic_lifecycle_journal(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    life = run_dir / "events" / "lifecycle.jsonl"
+    life.parent.mkdir(parents=True, exist_ok=True)
+    life.write_bytes(_valid_lifecycle_line())
+
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+    entry = next(
+        item
+        for item in json.loads((archive / "work-run.json").read_text(encoding="utf-8"))["files"]
+        if item["path"] == "events/lifecycle.jsonl"
+    )
+    assert entry["role"] == "journal"
+    assert entry["privacy_class"] == "public"
+    assert entry["nested_schema"] == "brigade.run_event.v1"
+
+    manifest = work_run_archive.validate_archive(archive)
+    assert any(item["path"] == "events/lifecycle.jsonl" for item in manifest["files"])
+
+    imported = work_run_archive.import_archive(archive, runs_dir=tmp_path / "imported-runs")
+    imported_life = Path(imported["run_dir"]) / "events" / "lifecycle.jsonl"
+    assert imported_life.is_file()
+    assert b'"schema":"brigade.run_event.v1"' in imported_life.read_bytes()
+    assert b"Bearer " not in imported_life.read_bytes()
+
+
+def test_export_refuses_source_lifecycle_worker_envelope(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    life = run_dir / "events" / "lifecycle.jsonl"
+    life.parent.mkdir(parents=True, exist_ok=True)
+    life.write_text(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "item/completed",
+                "params": {
+                    "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+                    "prompt": "source lifecycle smuggle",
+                },
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.export_run(run_dir, tmp_path / "archive")
+    assert excinfo.value.category == "export-privacy"
+    assert "lifecycle.jsonl" in str(excinfo.value)
+    assert not (tmp_path / "archive").exists()
+    assert life.is_file()

--- a/tests/test_work_run_archive.py
+++ b/tests/test_work_run_archive.py
@@ -314,8 +314,16 @@ def _golden_case(name: str) -> dict:
     raise KeyError(name)
 
 
-def _write_worker_stream(run_dir: Path, worker: str, events: list[dict]) -> Path:
+def _write_worker_stream(
+    run_dir: Path,
+    worker: str,
+    events: list[dict],
+    *,
+    nested_under: str | None = None,
+) -> Path:
     events_dir = run_dir / "events"
+    if nested_under is not None:
+        events_dir = events_dir / nested_under
     events_dir.mkdir(parents=True, exist_ok=True)
     path = events_dir / f"{worker}.jsonl"
     path.write_text("".join(json.dumps(event, sort_keys=True) + "\n" for event in events), encoding="utf-8")
@@ -546,3 +554,130 @@ def test_imported_scrubbed_sidecar_is_admissible_scrubbed_only(tmp_path: Path):
             run_dir / "events" / "coder.jsonl",
             consumer="run_audit",
         )
+
+
+def test_export_discovers_nested_worker_stream_and_writes_scrubbed_sidecar(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    case = _golden_case("auto_declined_with_secrets")
+    raw_path = _write_worker_stream(run_dir, "coder", [case["raw"]], nested_under="nested")
+    raw_text = raw_path.read_text(encoding="utf-8")
+    assert "Bearer " in raw_text
+    assert "/home/example-user" in raw_text
+
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+
+    # Source nested raw remains local-only / unclassified.
+    assert raw_path.is_file()
+    assert worker_events.inspect_stream_file(raw_path).status == worker_events.STATUS_UNCLASSIFIED
+
+    assert not (archive / "payload" / "events" / "nested" / "coder.jsonl").exists()
+    scrubbed_path = archive / "payload" / "events" / "nested" / "coder.scrubbed.json"
+    assert scrubbed_path.is_file()
+    blob = scrubbed_path.read_text(encoding="utf-8")
+    for snippet in (
+        "Bearer ",
+        "sk-live-EXAMPLESECRETVALUE99",
+        "/home/example-user",
+        "OPENAI_API_KEY",
+        "raw user prompt",
+    ):
+        assert snippet not in blob, snippet
+    scrubbed = json.loads(blob)
+    assert scrubbed["events"][0]["source_digest"] == case["source_digest"]
+    assert scrubbed["events"][0]["method"] == case["raw"]["method"]
+
+    entry = next(
+        item
+        for item in json.loads((archive / "work-run.json").read_text(encoding="utf-8"))["files"]
+        if item["path"] == "events/nested/coder.scrubbed.json"
+    )
+    assert entry["role"] == "artifact"
+    assert entry["media_type"] == worker_events.SCRUBBED_MEDIA_TYPE
+    assert entry["privacy_class"] == "redacted"
+    assert entry["nested_schema"] == worker_events.STREAM_SCHEMA
+
+
+def test_export_refuses_nested_unknown_method_with_secret_marker(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    _write_worker_stream(
+        run_dir,
+        "coder",
+        [
+            {
+                "jsonrpc": "2.0",
+                "method": "provider/undocumentedHook",
+                "params": {
+                    "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+                    "cwd": "/home/example-user/project",
+                },
+            }
+        ],
+        nested_under="nested",
+    )
+    with pytest.raises(WorkRunArchiveError) as excinfo:
+        work_run_archive.export_run(run_dir, tmp_path / "archive")
+    assert excinfo.value.category == "export-privacy"
+    message = str(excinfo.value)
+    assert len(message) <= worker_events.MAX_DIAGNOSTIC_LEN
+    assert "events/nested/coder.jsonl" in message or "nested/coder.jsonl" in message
+    assert "unknown" in message.lower() or "provider/undocumentedHook" in message
+    assert not (tmp_path / "archive").exists()
+    assert (run_dir / "events" / "nested" / "coder.jsonl").is_file()
+
+
+def test_validate_and_import_refuse_nested_raw_worker_stream_smuggling(tmp_path: Path):
+    run_dir = _seed_run(tmp_path / "runs" / RUN_ID)
+    archive = tmp_path / "archive"
+    work_run_archive.export_run(run_dir, archive)
+
+    smuggled = archive / "payload" / "events" / "nested" / "coder.jsonl"
+    smuggled.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "provider/undocumentedHook",
+        "params": {
+            "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+            "cwd": "/home/example-user/project",
+            "prompt": "private nested content",
+        },
+    }
+    smuggled.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    raw = smuggled.read_bytes()
+    manifest = json.loads((archive / "work-run.json").read_text(encoding="utf-8"))
+    manifest["files"].append(
+        {
+            "path": "events/nested/coder.jsonl",
+            "sha256": hashlib.sha256(raw).hexdigest(),
+            "byte_size": len(raw),
+            "role": "support",
+            "media_type": "application/x-ndjson",
+            "privacy_class": "public",
+        }
+    )
+    manifest["files"].sort(key=lambda row: row["path"])
+    (archive / "work-run.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(WorkRunArchiveError) as validate_exc:
+        work_run_archive.validate_archive(archive)
+    assert validate_exc.value.category == "export-privacy"
+    assert "raw worker stream" in str(validate_exc.value)
+    assert "nested" in str(validate_exc.value)
+
+    with pytest.raises(WorkRunArchiveError) as import_exc:
+        work_run_archive.import_archive(archive, runs_dir=tmp_path / "imported-runs")
+    assert import_exc.value.category == "export-privacy"
+    assert "raw worker stream" in str(import_exc.value)
+
+
+def test_list_worker_event_streams_is_recursive_under_events(tmp_path: Path):
+    events = tmp_path / "events"
+    (events / "nested" / "deep").mkdir(parents=True)
+    (events / "lifecycle.jsonl").write_text("{}\n", encoding="utf-8")
+    (events / "coder.jsonl").write_text("{}\n", encoding="utf-8")
+    (events / "nested" / "deep" / "helper.jsonl").write_text("{}\n", encoding="utf-8")
+    found = [path.relative_to(events).as_posix() for path in worker_events.list_worker_event_streams(events)]
+    assert found == ["coder.jsonl", "nested/deep/helper.jsonl"]
+    assert worker_events.is_raw_worker_event_stream_rel("events/nested/deep/helper.jsonl")
+    assert worker_events.is_scrubbed_worker_event_stream_rel("events/nested/deep/helper.scrubbed.json")
+    assert not worker_events.is_raw_worker_event_stream_rel("events/lifecycle.jsonl")


### PR DESCRIPTION
## What and why

Issue #592 remained open after #823 and #862 because `brigade runs export` could still copy raw worker streams and classify them as public support data. This change closes that boundary for top-level and nested `events/**` paths. It also authenticates the reserved `events/lifecycle.jsonl` journal so raw JSON-RPC worker envelopes cannot pass as lifecycle records.

Closes #592

## Behavior

- Raw worker JSONL stays local and unclassified in the source run.
- Export replaces discovered streams with scrubbed sidecars.
- Nested event paths receive the same classification and privacy checks as top-level streams.
- `events/lifecycle.jsonl` must be empty or a valid `brigade.run_event.v1` hash chain.
- Unknown methods, malformed projections, unclassifiable nested streams, and lifecycle worker-envelope smuggling fail closed.
- Archive validation and import repeat the privacy checks before accepting copied data.
- The source run remains unchanged.

## Verification

- Focused archive and worker-event suite: 56 passed
- Exact-head Luna review: ready
- Exact-head Terra review: ready
- GitHub Actions on `8ebce963`: 23 successful checks, no failures or pending checks
- Rebased on current main `3e9278f9`, including #863

## Out of scope

- Historical stream backfill
- Protected #750 publish work
- Memory projection work

## Checklist

- [x] Added direct and nested export, validate, and import regressions
- [x] Added malicious and valid lifecycle-journal cases
- [x] Updated `CHANGELOG.md` and receipt documentation
- [x] No new runtime dependencies
- [x] Existing commits retain their Cursor co-author trailer