### PR TITLE
feat(evidence): memory projection crawl facade (#844 F1)

### DIFF
--- a/src/brigade/cli/evidence.py
+++ b/src/brigade/cli/evidence.py
@@ -57,6 +57,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_export_plan.add_argument("--write", action="store_true", help="Write plan under .brigade/evidence/plans/.")
     p_export_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
+    # Inert F2 hook: projection-only rebuild + identity audit register later.
+    from .. import evidence_runtime
+
+    evidence_runtime.register_memory_facade_extensions(evidence_sub)
+
     p_evidence.set_defaults(func=dispatch)
 
 

--- a/src/brigade/evidence_cmd.py
+++ b/src/brigade/evidence_cmd.py
@@ -69,9 +69,10 @@ def _write_last_run(
     started_at: str,
     finished_at: str,
     detail: str,
+    extra: dict[str, Any] | None = None,
 ) -> None:
     _last_run_dir(target).mkdir(parents=True, exist_ok=True)
-    payload = {
+    payload: dict[str, Any] = {
         "status": status,
         "exit_code": exit_code,
         "crawler_version": crawler_version,
@@ -80,6 +81,14 @@ def _write_last_run(
         "finished_at": finished_at,
         "detail": detail,
     }
+    if extra:
+        for key, value in extra.items():
+            if key == "status":
+                # Engine scan status is recorded separately; last-run status stays
+                # the Brigade classification (ok|partial|fail).
+                payload["scan_status"] = value
+                continue
+            payload[key] = value
     _last_run_path(target, source).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
@@ -87,6 +96,7 @@ _HEALTH_RANK = {
     "ok": 0,
     "warn": 1,
     "incomplete": 2,
+    "partial": 2,
     "unwired": 3,
     "timeout": 4,
     "missing": 5,
@@ -153,6 +163,117 @@ def _enrich_crawler_health(payload: dict[str, Any], target: Path) -> dict[str, A
             payload["health"] = worst_health
             if worst_health == "fail":
                 payload["summary"] = f"crawler unhealthy; {payload['summary']}"
+    return _enrich_memory_projection_health(payload, target)
+
+
+def _memory_health_from_engine_payloads(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull body-free memory health from embedded status/doctor JSON."""
+
+    for section in ("doctor", "status"):
+        block = payload.get(section) or {}
+        if not isinstance(block, dict):
+            continue
+        stdout = block.get("stdout_json")
+        if not isinstance(stdout, dict):
+            continue
+        for key in ("memory_health", "memory"):
+            health = evidence_runtime.body_free_memory_health(
+                stdout.get(key) if isinstance(stdout.get(key), dict) else None
+            )
+            if health:
+                return health
+        # Capability advertisement without a prior scan.
+        capability_block = stdout.get("capability")
+        if isinstance(capability_block, dict) and isinstance(capability_block.get("memory"), str):
+            return evidence_runtime.body_free_memory_health(
+                {
+                    "capability": capability_block.get("memory"),
+                    "engine_version": capability_block.get("engine_version") or stdout.get("engine_version"),
+                    "status": "absent",
+                }
+            )
+    return None
+
+
+def _enrich_memory_projection_health(payload: dict[str, Any], target: Path) -> dict[str, Any]:
+    """Surface body-free memory projection health for doctor/status."""
+
+    last_run = _read_last_run(target, evidence_runtime.MEMORY_SOURCE)
+    engine_health = _memory_health_from_engine_payloads(payload)
+    # Prefer last-run receipt fields when present so a partial crawl cannot be
+    # masked by a stale healthy engine snapshot.
+    merged: dict[str, Any] = {}
+    if engine_health:
+        merged.update(engine_health)
+    if isinstance(last_run, dict):
+        for key in evidence_runtime.MEMORY_HEALTH_SAFE_KEYS:
+            if key in last_run and last_run[key] is not None:
+                merged[key] = last_run[key]
+        if isinstance(last_run.get("scan_status"), str):
+            merged["status"] = last_run["scan_status"]
+        if "failed" in last_run:
+            merged["failed"] = last_run.get("failed")
+        if last_run.get("scan_id"):
+            merged["last_scan_id"] = last_run.get("scan_id")
+        merged["latest_run_status"] = last_run.get("status")
+
+    if not merged and last_run is None:
+        return payload
+
+    capability = merged.get("capability")
+    if not isinstance(capability, str):
+        capability = None
+    status = merged.get("status") if isinstance(merged.get("status"), str) else None
+    stale = merged.get("stale") if isinstance(merged.get("stale"), bool) else None
+    partial = merged.get("partial") if isinstance(merged.get("partial"), bool) else None
+    failed_raw = merged.get("failed")
+    failed = int(failed_raw) if isinstance(failed_raw, int) else None
+    latest = last_run.get("status") if isinstance(last_run, dict) else None
+    engine_ok = payload.get("health") not in ("missing", "fail", "timeout", "incomplete", "unwired")
+    if latest in ("fail", "partial"):
+        engine_ok = False
+    healthy = evidence_runtime.memory_projection_is_healthy(
+        capability=capability,
+        status=status,
+        stale=stale,
+        partial=partial,
+        failed=failed if failed is not None else (0 if status == "completed" and latest == "ok" else None),
+        engine_ok=engine_ok and latest != "fail",
+    )
+    # A failed/partial last-run or missing required capability is never healthy.
+    if latest in ("fail", "partial"):
+        healthy = False
+    if capability and capability != evidence_runtime.MEMORY_PROJECTION_CAPABILITY:
+        healthy = False
+
+    block = {
+        "capability": capability,
+        "engine_version": merged.get("engine_version"),
+        "last_completed_scan_id": merged.get("last_completed_scan_id"),
+        "canonical_count": merged.get("canonical_count"),
+        "live_count": merged.get("live_count"),
+        "hash_divergence": merged.get("hash_divergence"),
+        "unresolved_relations": merged.get("unresolved_relations"),
+        "malformed_skipped": merged.get("malformed_skipped"),
+        "stale": stale,
+        "partial": partial,
+        "status": status,
+        "failed": failed,
+        "healthy": healthy,
+        "latest_run": last_run,
+    }
+    payload["memory_projection"] = block
+
+    # Absent (never crawled) is informational only. Failed/partial last-runs and
+    # non-absent unhealthy engine health must surface on the station health.
+    should_affect_overall = last_run is not None or (status is not None and status != "absent")
+    if not healthy and merged and should_affect_overall:
+        projected = "fail" if latest == "fail" or (isinstance(failed, int) and failed > 0) else "incomplete"
+        if latest == "partial":
+            projected = "incomplete"
+        if _health_rank(projected) > _health_rank(payload.get("health")):
+            payload["health"] = projected
+            payload["summary"] = f"memory projection unhealthy; {payload.get('summary')}"
     return payload
 
 
@@ -208,6 +329,144 @@ def _run_miseledger(verb: str, arguments: list[str], *, env: dict[str, str] | No
     return result.code
 
 
+def _run_memory_crawl(
+    arguments: list[str],
+    *,
+    env: dict[str, str],
+    started_at: str,
+) -> int:
+    """Preflight MiseLedger memory projection, then delegate crawl storage."""
+
+    if len(arguments) < 2:
+        print(
+            "error: usage: brigade evidence crawl memory <workspace> [--json] [--dry-run] [--limit N]",
+            file=sys.stderr,
+        )
+        return 2
+
+    workspace = Path(arguments[1]).expanduser().resolve()
+    rest = list(arguments[2:])
+    target = workspace
+    binary = evidence_brief._miseledger_bin()
+    probe = evidence_runtime.probe_memory_projection(binary, env=env)
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+    if compat.state == "fail":
+        detail = compat.detail
+        print(f"error: evidence crawl refused for memory: {detail}", file=sys.stderr)
+        _write_last_run(
+            target=target,
+            source=evidence_runtime.MEMORY_SOURCE,
+            status="fail",
+            exit_code=1,
+            crawler_version=compat.version,
+            database=compat.database,
+            started_at=started_at,
+            finished_at=_now(),
+            detail=detail,
+            extra={
+                "capability": probe.capability,
+                "engine_version": probe.engine_version or probe.version,
+                "required_capability": evidence_runtime.MEMORY_PROJECTION_CAPABILITY,
+                "preflight": "refused",
+            },
+        )
+        return 1
+
+    # Ensure JSON receipt for pass-through counts; still honor caller --json.
+    want_json = "--json" in rest
+    crawl_args = ["memory", str(workspace), *rest]
+    if not want_json:
+        crawl_args.append("--json")
+
+    result = _run_miseledger_result("crawl", crawl_args, env=env)
+    receipt: dict[str, Any] | None = None
+    parsed = result.json()
+    if isinstance(parsed, dict):
+        receipt = parsed
+    counts = (
+        evidence_runtime.extract_memory_crawl_counts(receipt)
+        if receipt
+        else {
+            "scan_id": None,
+            "created": 0,
+            "updated": 0,
+            "unchanged": 0,
+            "removed": 0,
+            "skipped": 0,
+            "failed": 0,
+        }
+    )
+    run_status = evidence_runtime.classify_memory_crawl_status(exit_code=result.code, receipt=receipt)
+    health = evidence_runtime.body_free_memory_health(
+        receipt.get("memory_health") if isinstance(receipt, dict) else None
+    )
+    extra: dict[str, Any] = {
+        "capability": (receipt or {}).get("capability") or probe.capability,
+        "engine_version": (receipt or {}).get("engine_version") or probe.engine_version or probe.version,
+        "required_capability": evidence_runtime.MEMORY_PROJECTION_CAPABILITY,
+        "workspace": str(workspace),
+        "preflight": "ok",
+        **counts,
+    }
+    if isinstance(receipt, dict):
+        for key in (
+            "status",
+            "stale",
+            "partial",
+            "canonical_count",
+            "live_count",
+            "hash_divergence",
+            "unresolved_relations",
+            "malformed_skipped",
+            "memory_namespace",
+        ):
+            if key in receipt:
+                extra[key] = receipt[key]
+        if health:
+            if not extra.get("last_completed_scan_id") and health.get("last_completed_scan_id"):
+                extra["last_completed_scan_id"] = health.get("last_completed_scan_id")
+            # Prefer receipt scan as last completed when healthy/completed.
+            if receipt.get("status") == "completed" and counts.get("scan_id"):
+                extra["last_completed_scan_id"] = counts["scan_id"]
+    _write_last_run(
+        target=target,
+        source=evidence_runtime.MEMORY_SOURCE,
+        status=run_status,
+        exit_code=result.code if result.code != 0 else (0 if run_status == "ok" else 1),
+        crawler_version=extra.get("engine_version"),
+        database=compat.database,
+        started_at=started_at,
+        finished_at=_now(),
+        detail=(result.stderr or "").strip()[:500] or (f"memory crawl {run_status}; scan_id={counts.get('scan_id')}"),
+        extra=extra,
+    )
+
+    if want_json and result.stdout:
+        print(result.stdout, end="")
+    elif receipt is not None:
+        print(
+            "scan={scan_id} created={created} updated={updated} unchanged={unchanged} "
+            "removed={removed} skipped={skipped} failed={failed} status={status}".format(
+                scan_id=counts.get("scan_id"),
+                created=counts["created"],
+                updated=counts["updated"],
+                unchanged=counts["unchanged"],
+                removed=counts["removed"],
+                skipped=counts["skipped"],
+                failed=counts["failed"],
+                status=run_status,
+            )
+        )
+    elif result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+
+    if result.code != 0:
+        return result.code
+    return 0 if run_status == "ok" else 1
+
+
 def _run_crawl(arguments: list[str]) -> int:
     """Resolve and health-check the crawler before delegating to MiseLedger.
 
@@ -227,6 +486,9 @@ def _run_crawl(arguments: list[str]) -> int:
 
     if source is None:
         return _run_miseledger("crawl", arguments)
+
+    if source == evidence_runtime.MEMORY_SOURCE:
+        return _run_memory_crawl(arguments, env=env, started_at=started_at)
 
     runtime = evidence_runtime.resolve_crawler(source, env=env)
     if runtime is None:
@@ -552,6 +814,23 @@ def status(*, target: Path, json_output: bool = False) -> int:
         for source, block in crawlers.items():
             compat = block.get("compatibility") or {}
             print(f"crawler/{source}: {compat.get('state')} - {compat.get('detail')}")
+    memory_projection = payload.get("memory_projection")
+    if isinstance(memory_projection, dict):
+        print(
+            "memory_projection: "
+            f"healthy={memory_projection.get('healthy')} "
+            f"capability={memory_projection.get('capability')} "
+            f"engine_version={memory_projection.get('engine_version')} "
+            f"last_completed={memory_projection.get('last_completed_scan_id')} "
+            f"canonical={memory_projection.get('canonical_count')} "
+            f"live={memory_projection.get('live_count')} "
+            f"hash_divergence={memory_projection.get('hash_divergence')} "
+            f"unresolved={memory_projection.get('unresolved_relations')} "
+            f"malformed_skipped={memory_projection.get('malformed_skipped')} "
+            f"stale={memory_projection.get('stale')} "
+            f"partial={memory_projection.get('partial')} "
+            f"failed={memory_projection.get('failed')}"
+        )
     doctor_data = (payload.get("doctor") or {}).get("stdout_json") or {}
     if isinstance(doctor_data, dict) and doctor_data.get("checks"):
         print("checks:")
@@ -579,6 +858,23 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
     else:
         print(f"evidence doctor: {payload['summary']}")
         print(f"health: {payload.get('health') or 'unknown'}")
+        memory_projection = payload.get("memory_projection")
+        if isinstance(memory_projection, dict):
+            print(
+                "memory_projection: "
+                f"healthy={memory_projection.get('healthy')} "
+                f"capability={memory_projection.get('capability')} "
+                f"engine_version={memory_projection.get('engine_version')} "
+                f"last_completed={memory_projection.get('last_completed_scan_id')} "
+                f"canonical={memory_projection.get('canonical_count')} "
+                f"live={memory_projection.get('live_count')} "
+                f"hash_divergence={memory_projection.get('hash_divergence')} "
+                f"unresolved={memory_projection.get('unresolved_relations')} "
+                f"malformed_skipped={memory_projection.get('malformed_skipped')} "
+                f"stale={memory_projection.get('stale')} "
+                f"partial={memory_projection.get('partial')} "
+                f"failed={memory_projection.get('failed')}"
+            )
         doctor_data = (payload.get("doctor") or {}).get("stdout_json") or {}
         if isinstance(doctor_data, dict) and doctor_data.get("checks"):
             print("checks:")
@@ -608,6 +904,7 @@ def crawl_plan_payload(*, target: Path) -> dict[str, Any]:
         "commands": [
             [miseledger_cmd, "init"],
             [miseledger_cmd, "crawl", "sessions"],
+            [miseledger_cmd, "crawl", "memory", str(target)],
             [miseledger_cmd, "crawl", "files", "--root", str(target)],
             [miseledger_cmd, "crawl", "gitlog", "--repo", str(target)],
             [miseledger_cmd, "status", "--json"],

--- a/src/brigade/evidence_cmd.py
+++ b/src/brigade/evidence_cmd.py
@@ -97,6 +97,7 @@ _HEALTH_RANK = {
     "warn": 1,
     "incomplete": 2,
     "partial": 2,
+    "dry_run": 2,
     "unwired": 3,
     "timeout": 4,
     "missing": 5,
@@ -240,8 +241,8 @@ def _enrich_memory_projection_health(payload: dict[str, Any], target: Path) -> d
         failed=failed if failed is not None else (0 if status == "completed" and latest == "ok" else None),
         engine_ok=engine_ok and latest != "fail",
     )
-    # A failed/partial last-run or missing required capability is never healthy.
-    if latest in ("fail", "partial"):
+    # A failed/partial/dry-run last-run or missing required capability is never healthy.
+    if latest in ("fail", "partial", "dry_run"):
         healthy = False
     if capability and capability != evidence_runtime.MEMORY_PROJECTION_CAPABILITY:
         healthy = False
@@ -260,16 +261,18 @@ def _enrich_memory_projection_health(payload: dict[str, Any], target: Path) -> d
         "status": status,
         "failed": failed,
         "healthy": healthy,
-        "latest_run": last_run,
+        "latest_run": evidence_runtime.public_memory_latest_run(last_run),
     }
     payload["memory_projection"] = block
 
     # Absent (never crawled) is informational only. Failed/partial last-runs and
     # non-absent unhealthy engine health must surface on the station health.
     should_affect_overall = last_run is not None or (status is not None and status != "absent")
+    if latest in ("fail", "partial", "dry_run"):
+        should_affect_overall = True
     if not healthy and merged and should_affect_overall:
         projected = "fail" if latest == "fail" or (isinstance(failed, int) and failed > 0) else "incomplete"
-        if latest == "partial":
+        if latest in ("partial", "dry_run"):
             projected = "incomplete"
         if _health_rank(projected) > _health_rank(payload.get("health")):
             payload["health"] = projected
@@ -286,8 +289,13 @@ def _run_miseledger_result(
     arguments: list[str],
     *,
     env: dict[str, str] | None = None,
+    binary: str | None = None,
 ) -> proc.Result:
-    """Run MiseLedger and return the raw result without printing."""
+    """Run MiseLedger and return the raw result without printing.
+
+    When ``binary`` is provided it is used verbatim (the preflight-resolved
+    path). Otherwise fall back to the configured MiseLedger resolver.
+    """
 
     timeout_env = _CRAWL_TIMEOUT_ENV if verb == "crawl" else _SHORT_OPERATION_TIMEOUT_ENV
     timeout_default = _CRAWL_TIMEOUT_SECONDS if verb == "crawl" else _SHORT_OPERATION_TIMEOUT_SECONDS
@@ -297,14 +305,14 @@ def _run_miseledger_result(
         return proc.Result(2, "", "")
     timeout = configured_timeout
 
-    binary = evidence_brief._miseledger_bin()
-    if binary is None:
+    resolved = binary if binary is not None else evidence_brief._miseledger_bin()
+    if resolved is None:
         print("error: the evidence engine (miseledger) is not installed; run `brigade setup`", file=sys.stderr)
         return proc.Result(127, "", "the evidence engine (miseledger) is not installed; run `brigade setup`")
     run_kwargs: dict[str, Any] = {}
     if env is not None:
         run_kwargs["env"] = env
-    return proc.run([binary, verb, *arguments], timeout=timeout, **run_kwargs)
+    return proc.run([resolved, verb, *arguments], timeout=timeout, **run_kwargs)
 
 
 def _run_miseledger(verb: str, arguments: list[str], *, env: dict[str, str] | None = None) -> int:
@@ -347,6 +355,26 @@ def _run_memory_crawl(
     workspace = Path(arguments[1]).expanduser().resolve()
     rest = list(arguments[2:])
     target = workspace
+    option_error, want_json, dry_run, passthrough = evidence_runtime.parse_memory_crawl_options(rest)
+    if option_error is not None:
+        print(f"error: evidence crawl refused for memory: {option_error}", file=sys.stderr)
+        _write_last_run(
+            target=target,
+            source=evidence_runtime.MEMORY_SOURCE,
+            status="fail",
+            exit_code=2,
+            crawler_version=None,
+            database=None,
+            started_at=started_at,
+            finished_at=_now(),
+            detail=option_error,
+            extra={
+                "required_capability": evidence_runtime.MEMORY_PROJECTION_CAPABILITY,
+                "preflight": "refused",
+            },
+        )
+        return 2
+
     binary = evidence_brief._miseledger_bin()
     probe = evidence_runtime.probe_memory_projection(binary, env=env)
     compat = evidence_runtime.check_memory_projection_preflight(probe)
@@ -372,78 +400,85 @@ def _run_memory_crawl(
         )
         return 1
 
-    # Ensure JSON receipt for pass-through counts; still honor caller --json.
-    want_json = "--json" in rest
-    crawl_args = ["memory", str(workspace), *rest]
-    if not want_json:
+    if compat.resolved_path is None:
+        print("error: evidence crawl refused for memory: no executable resolved", file=sys.stderr)
+        return 1
+
+    # Invoke the exact binary that passed capability/version preflight.
+    crawl_args = ["memory", str(workspace), *passthrough]
+    if dry_run:
+        crawl_args.append("--dry-run")
+    # Always request JSON for fail-closed receipt parsing; still honor caller --json for stdout.
+    if "--json" not in crawl_args:
         crawl_args.append("--json")
 
-    result = _run_miseledger_result("crawl", crawl_args, env=env)
+    result = _run_miseledger_result("crawl", crawl_args, env=env, binary=compat.resolved_path)
     receipt: dict[str, Any] | None = None
     parsed = result.json()
     if isinstance(parsed, dict):
         receipt = parsed
-    counts = (
-        evidence_runtime.extract_memory_crawl_counts(receipt)
-        if receipt
-        else {
-            "scan_id": None,
-            "created": 0,
-            "updated": 0,
-            "unchanged": 0,
-            "removed": 0,
-            "skipped": 0,
-            "failed": 0,
-        }
-    )
-    run_status = evidence_runtime.classify_memory_crawl_status(exit_code=result.code, receipt=receipt)
-    health = evidence_runtime.body_free_memory_health(
-        receipt.get("memory_health") if isinstance(receipt, dict) else None
-    )
+
+    if result.code != 0:
+        run_status = "fail"
+        counts = None
+        receipt_detail = (result.stderr or "").strip()[:500] or "memory crawl engine exit nonzero"
+    else:
+        run_status, counts, parsed_detail = evidence_runtime.parse_memory_crawl_receipt(receipt, dry_run=dry_run)
+        receipt_detail = parsed_detail or (f"memory crawl {run_status}; scan_id={(counts or {}).get('scan_id')}")
+
     extra: dict[str, Any] = {
         "capability": (receipt or {}).get("capability") or probe.capability,
         "engine_version": (receipt or {}).get("engine_version") or probe.engine_version or probe.version,
         "required_capability": evidence_runtime.MEMORY_PROJECTION_CAPABILITY,
-        "workspace": str(workspace),
         "preflight": "ok",
-        **counts,
+        "resolved_path": compat.resolved_path,
     }
-    if isinstance(receipt, dict):
-        for key in (
-            "status",
-            "stale",
-            "partial",
-            "canonical_count",
-            "live_count",
-            "hash_divergence",
-            "unresolved_relations",
-            "malformed_skipped",
-            "memory_namespace",
-        ):
-            if key in receipt:
-                extra[key] = receipt[key]
-        if health:
-            if not extra.get("last_completed_scan_id") and health.get("last_completed_scan_id"):
-                extra["last_completed_scan_id"] = health.get("last_completed_scan_id")
-            # Prefer receipt scan as last completed when healthy/completed.
+    if dry_run or (isinstance(receipt, dict) and receipt.get("dry_run") is True):
+        extra["dry_run"] = True
+    # Persist typed counts only when the receipt validated; never fabricate zeros.
+    if counts is not None:
+        extra.update(counts)
+        if isinstance(receipt, dict):
+            for key in (
+                "status",
+                "stale",
+                "partial",
+                "canonical_count",
+                "live_count",
+                "hash_divergence",
+                "unresolved_relations",
+                "malformed_skipped",
+                "memory_namespace",
+            ):
+                if key in receipt:
+                    extra[key] = receipt[key]
             if receipt.get("status") == "completed" and counts.get("scan_id"):
                 extra["last_completed_scan_id"] = counts["scan_id"]
+    elif isinstance(receipt, dict) and run_status == "dry_run":
+        # Dry-run may expose capability/version/namespace without inventing counts.
+        for key in ("capability", "engine_version", "memory_namespace", "canonical_count"):
+            if key in receipt and key not in extra:
+                extra[key] = receipt[key]
+
+    exit_code = result.code if result.code != 0 else (0 if run_status == "ok" else 1)
     _write_last_run(
         target=target,
         source=evidence_runtime.MEMORY_SOURCE,
         status=run_status,
-        exit_code=result.code if result.code != 0 else (0 if run_status == "ok" else 1),
+        exit_code=exit_code,
         crawler_version=extra.get("engine_version"),
         database=compat.database,
         started_at=started_at,
         finished_at=_now(),
-        detail=(result.stderr or "").strip()[:500] or (f"memory crawl {run_status}; scan_id={counts.get('scan_id')}"),
+        detail=receipt_detail,
         extra=extra,
     )
 
     if want_json and result.stdout:
         print(result.stdout, end="")
-    elif receipt is not None:
+    elif run_status == "dry_run":
+        print(f"memory crawl dry-run: non-current; status={run_status}")
+    elif counts is not None:
         print(
             "scan={scan_id} created={created} updated={updated} unchanged={unchanged} "
             "removed={removed} skipped={skipped} failed={failed} status={status}".format(
@@ -457,8 +492,10 @@ def _run_memory_crawl(
                 status=run_status,
             )
         )
-    elif result.stdout:
+    elif result.stdout and want_json:
         print(result.stdout, end="")
+    else:
+        print(f"memory crawl {run_status}: {receipt_detail}", file=sys.stderr)
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
 

--- a/src/brigade/evidence_runtime.py
+++ b/src/brigade/evidence_runtime.py
@@ -5,6 +5,10 @@ an explicit override), checks that the resolved binary is compatible, and only
 then asks MiseLedger to crawl.  All destructive or archive-mutating crawler
 subcommands are driven by MiseLedger; this module only runs the read-only
 ``version`` and ``doctor --json`` probes.
+
+Memory projection (#844 F1) probes the configured MiseLedger engine itself for
+the authoritative ``memory-projection.v1`` capability before any crawl
+delegation. Discord/Discrawl keeps the external-crawler contract below.
 """
 
 from __future__ import annotations
@@ -16,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import proc
+from . import component_bins, proc
 
 
 @dataclass(frozen=True)
@@ -56,6 +60,21 @@ class CompatResult:
     detail: str
 
 
+@dataclass(frozen=True)
+class MemoryProjectionProbe:
+    """Read-only MiseLedger probe for the memory projection capability gate."""
+
+    resolved_path: str | None
+    version: str | None
+    capability: str | None
+    engine_version: str | None
+    archive_ok: bool
+    probe_exit_code: int | None
+    missing_capabilities: list[str]
+    detail: str
+    error: str | None = None
+
+
 # Source contracts encoded in code.  Optional .brigade/evidence.toml parsing may
 # be added later, but defaults must work with no config.
 _CRAWLER_DEFAULTS: dict[str, CrawlerDefaults] = {
@@ -65,6 +84,33 @@ _CRAWLER_DEFAULTS: dict[str, CrawlerDefaults] = {
         required_capabilities=["export"],
     ),
 }
+
+# Native engine source (not an external crawler). Kept out of _CRAWLER_DEFAULTS
+# so Discord PATH/--help probing stays unchanged.
+MEMORY_SOURCE = "memory"
+MEMORY_PROJECTION_CAPABILITY = "memory-projection.v1"
+# Documented diagnostic floor: in-tree engine Version and current managed pin
+# are 0.6.0. Capability memory-projection.v1 is authoritative; a version floor
+# alone cannot distinguish the published pre-feature 0.6.0 release. Do not
+# invent a newer release pin here — that decision is a separate package.
+MISELEDGER_VERSION_FLOOR = "0.6.0"
+
+MEMORY_HEALTH_SAFE_KEYS = (
+    "capability",
+    "engine_version",
+    "memory_namespace",
+    "last_completed_scan_id",
+    "last_completed_at",
+    "canonical_count",
+    "live_count",
+    "hash_divergence",
+    "unresolved_relations",
+    "malformed_skipped",
+    "stale",
+    "partial",
+    "status",
+    "failed",
+)
 
 _CAPABILITY_CANDIDATES = ("version", "doctor", "export", "crawl")
 _READ_ONLY_TIMEOUT = 30.0
@@ -300,3 +346,323 @@ def check_compatibility(runtime: CrawlerRuntime, env: dict[str, str] | None = No
         missing_capabilities=missing_capabilities,
         detail="; ".join(detail_parts) if detail_parts else "crawler compatible",
     )
+
+
+def register_memory_facade_extensions(_evidence_sub: Any = None) -> None:
+    """Inert F2 registration point for rebuild routing and identity audit.
+
+    F1 leaves this as a no-op so F2 can attach projection-only rebuild and
+    read-only identity-audit commands without reshaping the crawl gate.
+    """
+
+    return None
+
+
+def resolve_miseledger(env: dict[str, str] | None = None) -> str | None:
+    """Resolve the configured MiseLedger engine binary, or None when missing."""
+
+    return component_bins.resolve("miseledger", env=env)
+
+
+def _normalize_miseledger_version(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if text.lower().startswith("miseledger "):
+        text = text.split(None, 1)[1].strip()
+    return text or None
+
+
+def _probe_miseledger_version(binary_path: str, env: dict[str, str]) -> str | None:
+    result = proc.run([binary_path, "version"], env=env, timeout=_READ_ONLY_TIMEOUT)
+    if result.code != 0:
+        return None
+    first = (result.stdout or "").strip().splitlines()
+    return _normalize_miseledger_version(first[0] if first else None)
+
+
+def _extract_memory_capability(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return (capability, engine_version) from doctor/status JSON."""
+
+    capability_block = payload.get("capability")
+    if not isinstance(capability_block, dict):
+        return None, None
+    raw_cap = capability_block.get("memory")
+    capability = raw_cap if isinstance(raw_cap, str) else None
+    raw_version = capability_block.get("engine_version")
+    engine_version = raw_version if isinstance(raw_version, str) else None
+    top_version = payload.get("engine_version")
+    if engine_version is None and isinstance(top_version, str):
+        engine_version = top_version
+    return capability, engine_version
+
+
+def _archive_readable_from_doctor(payload: dict[str, Any], exit_code: int) -> tuple[bool, str | None]:
+    """Interpret MiseLedger doctor JSON for archive readability.
+
+    Preflight accepts a readable archive even when memory health is unhealthy
+    (so a stale projection can be re-crawled). A failed database check or a
+    non-JSON probe is refused before delegation.
+    """
+
+    checks = payload.get("checks")
+    if isinstance(checks, list):
+        for row in checks:
+            if not isinstance(row, dict):
+                continue
+            if row.get("name") == "database" and row.get("ok") is False:
+                return False, str(row.get("detail") or "database check failed")
+            if row.get("name") == "paths" and row.get("ok") is False:
+                return False, str(row.get("detail") or "paths check failed")
+    if exit_code not in (0, 1):
+        return False, f"doctor exit {exit_code}"
+    # exit 1 with structured checks is allowed when the archive opened (memory
+    # projection health may fail while capability is still readable).
+    return True, None
+
+
+def probe_memory_projection(
+    binary_path: str | None,
+    env: dict[str, str] | None = None,
+) -> MemoryProjectionProbe:
+    """Read-only probe of MiseLedger for ``memory-projection.v1``.
+
+    Invokes only ``version`` and ``doctor --json``. Never runs crawl/import.
+    """
+
+    if env is None:
+        env = dict(os.environ)
+
+    if not binary_path:
+        return MemoryProjectionProbe(
+            resolved_path=None,
+            version=None,
+            capability=None,
+            engine_version=None,
+            archive_ok=False,
+            probe_exit_code=None,
+            missing_capabilities=[MEMORY_PROJECTION_CAPABILITY],
+            detail="miseledger binary not found; run `brigade setup`",
+            error="missing binary",
+        )
+
+    version = _probe_miseledger_version(binary_path, env)
+    result = proc.run([binary_path, "doctor", "--json"], env=env, timeout=_READ_ONLY_TIMEOUT)
+    data = result.json()
+    if not isinstance(data, dict):
+        return MemoryProjectionProbe(
+            resolved_path=binary_path,
+            version=version,
+            capability=None,
+            engine_version=None,
+            archive_ok=False,
+            probe_exit_code=result.code,
+            missing_capabilities=[MEMORY_PROJECTION_CAPABILITY],
+            detail=(
+                f"malformed miseledger doctor probe: expected JSON object, exit_code={result.code}, version={version!r}"
+            ),
+            error="malformed probe",
+        )
+
+    capability, engine_version = _extract_memory_capability(data)
+    if engine_version is None:
+        engine_version = version
+    archive_ok, archive_detail = _archive_readable_from_doctor(data, result.code)
+    missing: list[str] = []
+    if capability != MEMORY_PROJECTION_CAPABILITY:
+        missing.append(MEMORY_PROJECTION_CAPABILITY)
+
+    detail_parts: list[str] = []
+    if not archive_ok:
+        detail_parts.append(f"archive unreadable: {archive_detail or 'doctor probe failed'}")
+    if capability is None:
+        detail_parts.append(
+            f"absent capability: expected {MEMORY_PROJECTION_CAPABILITY}, observed capability.memory=None"
+        )
+    elif capability != MEMORY_PROJECTION_CAPABILITY:
+        detail_parts.append(
+            f"incompatible capability: expected {MEMORY_PROJECTION_CAPABILITY}, observed {capability!r}"
+        )
+    if not detail_parts:
+        detail_parts.append(f"memory projection probe ok: capability={capability}, engine_version={engine_version}")
+
+    return MemoryProjectionProbe(
+        resolved_path=binary_path,
+        version=version,
+        capability=capability,
+        engine_version=engine_version,
+        archive_ok=archive_ok,
+        probe_exit_code=result.code,
+        missing_capabilities=missing,
+        detail="; ".join(detail_parts),
+        error=None if archive_ok and not missing else "incompatible",
+    )
+
+
+def check_memory_projection_preflight(probe: MemoryProjectionProbe) -> CompatResult:
+    """Gate crawl/import mutation on the memory projection probe.
+
+    Failures (missing binary, failed/malformed probe, absent/old/future
+    capability, below-floor version, unreadable archive) must refuse
+    delegation. Version floor is the documented ``MISELEDGER_VERSION_FLOOR``;
+    capability match remains authoritative.
+    """
+
+    base = CompatResult(
+        state="fail",
+        resolved_path=probe.resolved_path,
+        version=probe.engine_version or probe.version,
+        database="ok" if probe.archive_ok else "unreadable",
+        config_path=None,
+        missing_capabilities=list(probe.missing_capabilities),
+        detail=probe.detail,
+    )
+    if probe.resolved_path is None:
+        return CompatResult(
+            state="fail",
+            resolved_path=None,
+            version=None,
+            database=None,
+            config_path=None,
+            missing_capabilities=[MEMORY_PROJECTION_CAPABILITY],
+            detail=probe.detail or "miseledger binary not found",
+        )
+    if probe.error == "malformed probe" or (probe.probe_exit_code not in (0, 1) and not probe.archive_ok):
+        return base
+    if not probe.archive_ok:
+        return base
+    if probe.missing_capabilities or probe.capability != MEMORY_PROJECTION_CAPABILITY:
+        return base
+
+    observed_raw = probe.engine_version or probe.version
+    observed = _parse_version(observed_raw)
+    required = _parse_version(MISELEDGER_VERSION_FLOOR)
+    detail_parts: list[str] = []
+    state = "ok"
+    if observed_raw is None or observed is None:
+        return CompatResult(
+            state="fail",
+            resolved_path=probe.resolved_path,
+            version=observed_raw,
+            database="ok",
+            config_path=None,
+            missing_capabilities=[],
+            detail=(f"version not parseable: expected >= {MISELEDGER_VERSION_FLOOR}, observed {observed_raw!r}"),
+        )
+    if required is not None and observed < required:
+        return CompatResult(
+            state="fail",
+            resolved_path=probe.resolved_path,
+            version=observed_raw,
+            database="ok",
+            config_path=None,
+            missing_capabilities=[],
+            detail=(f"version below floor: expected >= {MISELEDGER_VERSION_FLOOR}, observed {observed_raw}"),
+        )
+    if observed_raw != MISELEDGER_VERSION_FLOOR:
+        state = "warn"
+        detail_parts.append(
+            f"version drift: expected {MISELEDGER_VERSION_FLOOR}, observed {observed_raw}; "
+            f"capability={MEMORY_PROJECTION_CAPABILITY}"
+        )
+    else:
+        detail_parts.append(
+            f"memory projection compatible: capability={MEMORY_PROJECTION_CAPABILITY}, engine_version={observed_raw}"
+        )
+    return CompatResult(
+        state=state,
+        resolved_path=probe.resolved_path,
+        version=observed_raw,
+        database="ok",
+        config_path=None,
+        missing_capabilities=[],
+        detail="; ".join(detail_parts),
+    )
+
+
+def body_free_memory_health(raw: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return doctor/status memory health fields without card bodies/raw records."""
+
+    if not isinstance(raw, dict):
+        return None
+    out: dict[str, Any] = {}
+    for key in MEMORY_HEALTH_SAFE_KEYS:
+        if key in raw:
+            out[key] = raw[key]
+    return out or None
+
+
+def memory_projection_is_healthy(
+    *,
+    capability: str | None,
+    status: str | None,
+    stale: bool | None,
+    partial: bool | None,
+    failed: int | None,
+    engine_ok: bool,
+) -> bool:
+    """Healthy requires completed + not stale/partial + failed=0 + capability + engine ok."""
+
+    if not engine_ok:
+        return False
+    if capability != MEMORY_PROJECTION_CAPABILITY:
+        return False
+    if status != "completed":
+        return False
+    if stale is not False:
+        return False
+    if partial is not False:
+        return False
+    if failed != 0:
+        return False
+    return True
+
+
+def classify_memory_crawl_status(
+    *,
+    exit_code: int,
+    receipt: dict[str, Any] | None,
+) -> str:
+    """Map engine crawl outcome to last-run status: ok | partial | fail."""
+
+    if exit_code != 0:
+        return "fail"
+    if not isinstance(receipt, dict):
+        return "fail"
+    capability = receipt.get("capability")
+    status = receipt.get("status")
+    stale = bool(receipt.get("stale"))
+    partial = bool(receipt.get("partial"))
+    failed = int(receipt.get("failed") or 0)
+    if memory_projection_is_healthy(
+        capability=capability if isinstance(capability, str) else None,
+        status=status if isinstance(status, str) else None,
+        stale=stale,
+        partial=partial,
+        failed=failed,
+        engine_ok=True,
+    ):
+        return "ok"
+    if status == "completed" and (failed > 0 or partial or stale):
+        return "partial"
+    return "fail"
+
+
+def extract_memory_crawl_counts(receipt: dict[str, Any]) -> dict[str, Any]:
+    """Pass through scan_id and the six result counts from an engine receipt."""
+
+    def _int(key: str) -> int:
+        value = receipt.get(key)
+        return int(value) if isinstance(value, int) else 0
+
+    return {
+        "scan_id": receipt.get("scan_id") if isinstance(receipt.get("scan_id"), str) else None,
+        "created": _int("created"),
+        "updated": _int("updated"),
+        "unchanged": _int("unchanged"),
+        "removed": _int("removed"),
+        "skipped": _int("skipped"),
+        "failed": _int("failed"),
+    }

--- a/src/brigade/evidence_runtime.py
+++ b/src/brigade/evidence_runtime.py
@@ -440,23 +440,52 @@ def _archive_readable_from_doctor(payload: dict[str, Any], exit_code: int) -> tu
     """Interpret MiseLedger doctor JSON for archive readability.
 
     Preflight accepts a readable archive even when memory health is unhealthy
-    (so a stale projection can be re-crawled). A failed database check or a
-    non-JSON probe is refused before delegation.
+    (so a stale projection can be re-crawled). Exit 0/1 alone is not enough:
+    absent or malformed ``checks`` and explicit archive failures refuse
+    delegation. Positive structured evidence is required (``database``,
+    ``schema``, or ``fts`` with ``ok=true``), matching the engine's success
+    path which emits schema/fts after a successful open rather than a
+    ``database: ok`` row.
     """
 
-    checks = payload.get("checks")
-    if isinstance(checks, list):
-        for row in checks:
-            if not isinstance(row, dict):
-                continue
-            if row.get("name") == "database" and row.get("ok") is False:
-                return False, str(row.get("detail") or "database check failed")
-            if row.get("name") == "paths" and row.get("ok") is False:
-                return False, str(row.get("detail") or "paths check failed")
     if exit_code not in (0, 1):
         return False, f"doctor exit {exit_code}"
-    # exit 1 with structured checks is allowed when the archive opened (memory
-    # projection health may fail while capability is still readable).
+
+    checks = payload.get("checks")
+    if "checks" not in payload:
+        return False, "absent checks: doctor JSON missing structured checks"
+    if not isinstance(checks, list):
+        return False, f"malformed checks: expected list, observed {type(checks).__name__}"
+    if not checks:
+        return False, "absent checks: doctor checks list is empty"
+
+    well_formed = 0
+    positive_archive = False
+    for row in checks:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        ok = row.get("ok")
+        if not isinstance(ok, bool):
+            continue
+        well_formed += 1
+        if name in {"database", "paths"} and ok is False:
+            return False, str(row.get("detail") or f"{name} check failed")
+        if name in {"database", "schema", "fts"} and ok is True:
+            positive_archive = True
+
+    if well_formed == 0:
+        return False, "malformed checks: no well-formed doctor check rows"
+    if not positive_archive:
+        return (
+            False,
+            "absent archive-readability evidence: need database|schema|fts ok=true",
+        )
+    # exit 1 with structured positive archive evidence is allowed when another
+    # check fails (for example memory_projection unhealthy while the archive
+    # remains readable).
     return True, None
 
 

--- a/src/brigade/evidence_runtime.py
+++ b/src/brigade/evidence_runtime.py
@@ -112,6 +112,43 @@ MEMORY_HEALTH_SAFE_KEYS = (
     "failed",
 )
 
+# Public doctor/status latest-run whitelist: body-free and path-safe (no
+# absolute workspace, detail/stderr, or arbitrary text/raw payloads).
+MEMORY_LATEST_RUN_PUBLIC_KEYS = (
+    "status",
+    "exit_code",
+    "crawler_version",
+    "database",
+    "started_at",
+    "finished_at",
+    "capability",
+    "engine_version",
+    "required_capability",
+    "preflight",
+    "scan_id",
+    "scan_status",
+    "created",
+    "updated",
+    "unchanged",
+    "removed",
+    "skipped",
+    "failed",
+    "stale",
+    "partial",
+    "canonical_count",
+    "live_count",
+    "hash_divergence",
+    "unresolved_relations",
+    "malformed_skipped",
+    "memory_namespace",
+    "last_completed_scan_id",
+    "dry_run",
+)
+
+MEMORY_COUNT_KEYS = ("created", "updated", "unchanged", "removed", "skipped", "failed")
+MEMORY_F2_REJECTED_FLAGS = frozenset({"--rebuild", "--full"})
+MEMORY_ALLOWED_FLAGS = frozenset({"--json", "--dry-run", "--limit"})
+
 _CAPABILITY_CANDIDATES = ("version", "doctor", "export", "crawl")
 _READ_ONLY_TIMEOUT = 30.0
 
@@ -594,6 +631,78 @@ def body_free_memory_health(raw: dict[str, Any] | None) -> dict[str, Any] | None
     return out or None
 
 
+def public_memory_latest_run(raw: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Whitelist body-free, path-safe fields from a memory last-run record."""
+
+    if not isinstance(raw, dict):
+        return None
+    out: dict[str, Any] = {}
+    for key in MEMORY_LATEST_RUN_PUBLIC_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if key == "database" and isinstance(value, str) and value not in {"ok", "unreadable"}:
+            # Avoid leaking absolute archive paths via database.
+            continue
+        out[key] = value
+    return out or None
+
+
+def parse_memory_crawl_options(rest: list[str]) -> tuple[str | None, bool, bool, list[str]]:
+    """Parse F1 crawl trailing options.
+
+    Returns ``(error, want_json, dry_run, passthrough)``. Rejects F2
+    ``--rebuild``/``--full``. Unknown options are refused rather than forwarded.
+    """
+
+    want_json = False
+    dry_run = False
+    passthrough: list[str] = []
+    i = 0
+    while i < len(rest):
+        arg = rest[i]
+        if arg in MEMORY_F2_REJECTED_FLAGS:
+            return (
+                f"option {arg} is out of scope for evidence crawl memory F1 (projection rebuild belongs to F2)",
+                False,
+                False,
+                [],
+            )
+        if arg == "--json":
+            want_json = True
+            i += 1
+            continue
+        if arg == "--dry-run":
+            dry_run = True
+            i += 1
+            continue
+        if arg == "--limit":
+            if i + 1 >= len(rest):
+                return "option --limit requires a positive integer value", False, False, []
+            value = rest[i + 1]
+            if not value.isdigit() or int(value) < 1:
+                return f"option --limit requires a positive integer, observed {value!r}", False, False, []
+            passthrough.extend(["--limit", value])
+            i += 2
+            continue
+        if arg.startswith("--limit="):
+            value = arg.split("=", 1)[1]
+            if not value.isdigit() or int(value) < 1:
+                return f"option --limit requires a positive integer, observed {value!r}", False, False, []
+            passthrough.append(arg)
+            i += 1
+            continue
+        if arg.startswith("-"):
+            return (
+                f"unsupported evidence crawl memory option {arg!r}; allowed: {', '.join(sorted(MEMORY_ALLOWED_FLAGS))}",
+                False,
+                False,
+                [],
+            )
+        return f"unexpected positional argument after workspace: {arg!r}", False, False, []
+    return None, want_json, dry_run, passthrough
+
+
 def memory_projection_is_healthy(
     *,
     capability: str | None,
@@ -620,49 +729,110 @@ def memory_projection_is_healthy(
     return True
 
 
-def classify_memory_crawl_status(
-    *,
-    exit_code: int,
-    receipt: dict[str, Any] | None,
-) -> str:
-    """Map engine crawl outcome to last-run status: ok | partial | fail."""
+def _typed_nonneg_int(value: object) -> int | None:
+    """Accept only real ints (reject bool, str, float, missing)."""
 
-    if exit_code != 0:
-        return "fail"
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def parse_memory_crawl_receipt(
+    receipt: dict[str, Any] | None,
+    *,
+    dry_run: bool = False,
+) -> tuple[str, dict[str, Any] | None, str | None]:
+    """Validate an engine memory crawl receipt fail-closed.
+
+    Returns ``(status, counts_or_none, detail)``. Status is one of
+    ``ok | partial | fail | dry_run``. Missing/malformed fields never fabricate
+    zero counts; ``counts_or_none`` is None when the receipt is incomplete.
+    """
+
     if not isinstance(receipt, dict):
-        return "fail"
+        return "fail", None, "malformed memory crawl receipt: expected JSON object"
+
+    if dry_run or receipt.get("dry_run") is True:
+        # Dry-run is non-mutating and never current/healthy.
+        return "dry_run", None, "memory crawl dry-run is non-current; no scan receipt recorded as healthy"
+
     capability = receipt.get("capability")
+    if capability != MEMORY_PROJECTION_CAPABILITY:
+        return (
+            "fail",
+            None,
+            f"incomplete memory crawl receipt: capability must be {MEMORY_PROJECTION_CAPABILITY}, "
+            f"observed {capability!r}",
+        )
+
+    scan_id = receipt.get("scan_id")
+    if not isinstance(scan_id, str) or not scan_id.strip():
+        return "fail", None, "incomplete memory crawl receipt: missing or empty scan_id"
+
     status = receipt.get("status")
-    stale = bool(receipt.get("stale"))
-    partial = bool(receipt.get("partial"))
-    failed = int(receipt.get("failed") or 0)
+    if status != "completed":
+        return (
+            "fail",
+            None,
+            f"incomplete memory crawl receipt: status must be 'completed', observed {status!r}",
+        )
+
+    if not isinstance(receipt.get("stale"), bool):
+        return "fail", None, "incomplete memory crawl receipt: stale must be an explicit boolean"
+    if not isinstance(receipt.get("partial"), bool):
+        return "fail", None, "incomplete memory crawl receipt: partial must be an explicit boolean"
+
+    counts: dict[str, Any] = {"scan_id": scan_id.strip()}
+    for key in MEMORY_COUNT_KEYS:
+        parsed = _typed_nonneg_int(receipt.get(key))
+        if parsed is None:
+            return (
+                "fail",
+                None,
+                f"incomplete memory crawl receipt: {key} must be a non-negative int, observed {receipt.get(key)!r}",
+            )
+        counts[key] = parsed
+
+    stale = receipt["stale"]
+    partial = receipt["partial"]
+    failed = counts["failed"]
     if memory_projection_is_healthy(
-        capability=capability if isinstance(capability, str) else None,
-        status=status if isinstance(status, str) else None,
+        capability=MEMORY_PROJECTION_CAPABILITY,
+        status="completed",
         stale=stale,
         partial=partial,
         failed=failed,
         engine_ok=True,
     ):
-        return "ok"
-    if status == "completed" and (failed > 0 or partial or stale):
-        return "partial"
-    return "fail"
+        return "ok", counts, None
+    if failed > 0 or partial or stale:
+        return "partial", counts, "memory crawl completed with partial/stale/failed state"
+    return "fail", counts, "memory crawl receipt did not meet healthy contract"
 
 
-def extract_memory_crawl_counts(receipt: dict[str, Any]) -> dict[str, Any]:
-    """Pass through scan_id and the six result counts from an engine receipt."""
+def classify_memory_crawl_status(
+    *,
+    exit_code: int,
+    receipt: dict[str, Any] | None,
+    dry_run: bool = False,
+) -> str:
+    """Map engine crawl outcome to last-run status: ok | partial | fail | dry_run."""
 
-    def _int(key: str) -> int:
-        value = receipt.get(key)
-        return int(value) if isinstance(value, int) else 0
+    if exit_code != 0:
+        return "fail"
+    status, _counts, _detail = parse_memory_crawl_receipt(receipt, dry_run=dry_run)
+    return status
 
-    return {
-        "scan_id": receipt.get("scan_id") if isinstance(receipt.get("scan_id"), str) else None,
-        "created": _int("created"),
-        "updated": _int("updated"),
-        "unchanged": _int("unchanged"),
-        "removed": _int("removed"),
-        "skipped": _int("skipped"),
-        "failed": _int("failed"),
-    }
+
+def extract_memory_crawl_counts(receipt: dict[str, Any]) -> dict[str, Any] | None:
+    """Return scan_id and the six typed counts, or None when incomplete.
+
+    Unlike a soft coerce-to-zero helper, missing or mistyped fields fail closed.
+    """
+
+    status, counts, _detail = parse_memory_crawl_receipt(receipt, dry_run=False)
+    if status == "dry_run":
+        return None
+    return counts

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -654,8 +654,10 @@ def test_memory_status_body_free(monkeypatch, tmp_path, capsys):
             "hash_divergence": 0,
             "unresolved_relations": 0,
             "malformed_skipped": 0,
+            "workspace": str(workspace),
             "text": "SHOULD_NOT_PRINT_CARD_BODY",
             "raw": {"body": "nope"},
+            "resolved_path": "/abs/secret/miseledger",
         },
     )
     miseledger = _write_fake_bin(tmp_path, "miseledger", _miseledger_memory_capable_script())
@@ -672,6 +674,167 @@ def test_memory_status_body_free(monkeypatch, tmp_path, capsys):
     payload = evidence_cmd.status_payload(workspace)
     assert "text" not in (payload.get("memory_projection") or {})
     assert payload["memory_projection"]["healthy"] is True
+    latest = payload["memory_projection"]["latest_run"]
+    assert isinstance(latest, dict)
+    assert "workspace" not in latest
+    assert "detail" not in latest
+    assert "text" not in latest
+    assert "raw" not in latest
+    assert "resolved_path" not in latest
+    assert latest.get("scan_id") == "scan-abc"
+
+
+def test_memory_status_json_whitelists_latest_run(monkeypatch, tmp_path, capsys):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    evidence_cmd._write_last_run(
+        target=workspace,
+        source="memory",
+        status="ok",
+        exit_code=0,
+        crawler_version="0.6.0",
+        database="ok",
+        started_at="2026-01-01T00:00:00Z",
+        finished_at="2026-01-01T00:01:00Z",
+        detail="stderr should stay private",
+        extra={
+            "capability": "memory-projection.v1",
+            "engine_version": "0.6.0",
+            "scan_status": "completed",
+            "stale": False,
+            "partial": False,
+            "failed": 0,
+            "created": 1,
+            "updated": 0,
+            "unchanged": 0,
+            "removed": 0,
+            "skipped": 0,
+            "scan_id": "scan-json",
+            "workspace": str(workspace / "secret"),
+            "text": "BODY",
+            "raw": {"body": "RAW"},
+        },
+    )
+    miseledger = _write_fake_bin(tmp_path, "miseledger", _miseledger_memory_capable_script())
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.status(target=workspace, json_output=True)
+    printed = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    latest = printed["memory_projection"]["latest_run"]
+    assert latest["scan_id"] == "scan-json"
+    assert "workspace" not in latest
+    assert "detail" not in latest
+    assert "text" not in latest
+    assert "raw" not in latest
+    dumped = json.dumps(printed)
+    assert "BODY" not in dumped
+    assert "stderr should stay private" not in dumped
+    assert str(workspace / "secret") not in dumped
+
+
+def test_memory_crawl_rejects_rebuild_and_full(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "invoked.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(marker=marker),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    assert evidence_cmd.run_engine("crawl", ["memory", str(workspace), "--rebuild"]) == 2
+    assert evidence_cmd.run_engine("crawl", ["memory", str(workspace), "--full"]) == 2
+    assert not marker.exists()
+
+
+def test_memory_crawl_dry_run_is_non_current(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    dry_receipt = (
+        '{"source_kind":"brigade-memory","capability":"memory-projection.v1",'
+        '"engine_version":"0.6.0","dry_run":true,"skipped":0,"failed":0,"canonical_count":2}'
+    )
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(crawl_receipt=dry_receipt),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace), "--dry-run"])
+
+    assert rc == 1
+    last_run = evidence_cmd._read_last_run(workspace, "memory")
+    assert last_run["status"] == "dry_run"
+    assert last_run.get("dry_run") is True
+    assert "created" not in last_run
+    assert "failed" not in last_run or last_run.get("scan_id") is None
+    payload = evidence_cmd.status_payload(workspace)
+    assert payload["memory_projection"]["healthy"] is False
+
+
+def test_memory_crawl_malformed_receipt_fail_closed_no_fabricated_zeros(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    # Successful exit but missing counts / scan_id — must not invent zeros or report ok.
+    malformed = (
+        '{"capability":"memory-projection.v1","engine_version":"0.6.0",'
+        '"status":"completed","stale":false,"partial":false}'
+    )
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(crawl_receipt=malformed),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    last_run = evidence_cmd._read_last_run(workspace, "memory")
+    assert last_run["status"] == "fail"
+    assert "created" not in last_run
+    assert "updated" not in last_run
+    assert "unchanged" not in last_run
+    assert "removed" not in last_run
+    assert "skipped" not in last_run
+    assert "failed" not in last_run
+    assert last_run.get("scan_id") is None
+
+
+def test_memory_crawl_uses_preflight_resolved_path(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    good_marker = tmp_path / "good.txt"
+    bad_marker = tmp_path / "bad.txt"
+    good = _write_fake_bin(
+        tmp_path,
+        "miseledger-good",
+        _miseledger_memory_capable_script(marker=good_marker),
+    )
+    bad = _write_fake_bin(
+        tmp_path,
+        "miseledger-bad",
+        (f'if [ "$1" = "crawl" ]; then echo bad > "{bad_marker}"; echo \'{{"scan_id":"bad"}}\'; exit 0; fi\nexit 1\n'),
+    )
+    state = {"n": 0}
+
+    def resolver() -> str:
+        state["n"] += 1
+        return str(good) if state["n"] == 1 else str(bad)
+
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", resolver)
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 0
+    assert good_marker.exists()
+    assert not bad_marker.exists()
+    # Preflight resolved once; crawl must reuse compat.resolved_path (no second resolve).
+    assert state["n"] == 1
 
 
 def test_memory_file_backed_search_works_without_engine(monkeypatch, tmp_path):

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -594,6 +594,34 @@ def test_memory_crawl_refuses_unreadable_archive(monkeypatch, tmp_path):
     assert not marker.exists()
 
 
+def test_memory_crawl_refuses_exit1_doctor_without_checks(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "invoked.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        (
+            'if [ "$1" = "version" ]; then echo "miseledger 0.6.0"; exit 0; fi\n'
+            'if [ "$1" = "doctor" ] && [ "$2" = "--json" ]; then '
+            'echo \'{"ok":false,"capability":{"engine_version":"0.6.0","memory":"memory-projection.v1"}}\'; '
+            "exit 1; fi\n"
+            f'if [ "$1" = "crawl" ]; then echo invoked > "{marker}"; exit 0; fi\n'
+            "exit 1\n"
+        ),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    assert not marker.exists()
+    last_run = evidence_cmd._read_last_run(workspace, "memory")
+    assert last_run is not None
+    assert last_run["status"] == "fail"
+    assert last_run.get("preflight") == "refused"
+
+
 def test_memory_crawl_partial_failed_not_healthy(monkeypatch, tmp_path):
     workspace = tmp_path / "ws"
     workspace.mkdir()

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -424,3 +424,302 @@ def test_stale_cleanup_queue_after_producer_failure(monkeypatch, tmp_path):
 
     assert payload["health"] == "fail"
     assert payload["crawlers"]["discord"]["latest_run"]["status"] == "fail"
+
+
+# ---- memory projection crawl (#844 F1) -------------------------------------
+
+
+def _miseledger_memory_capable_script(
+    *,
+    version: str = "0.6.0",
+    capability: str | None = "memory-projection.v1",
+    crawl_receipt: str | None = None,
+    crawl_exit: int = 0,
+    marker: Path | None = None,
+    database_ok: bool = True,
+) -> str:
+    cap_json = "null" if capability is None else f'"{capability}"'
+    db_ok = "true" if database_ok else "false"
+    receipt = crawl_receipt or (
+        '{"scan_id":"scan-abc","capability":"memory-projection.v1","engine_version":"%s",'
+        '"status":"completed","stale":false,"partial":false,'
+        '"created":1,"updated":2,"unchanged":3,"removed":4,"skipped":5,"failed":0,'
+        '"canonical_count":10,"live_count":9,"hash_divergence":0,'
+        '"unresolved_relations":1,"malformed_skipped":5,'
+        '"memory_health":{"capability":"memory-projection.v1","engine_version":"%s",'
+        '"status":"completed","stale":false,"partial":false,'
+        '"last_completed_scan_id":"scan-abc","canonical_count":10,"live_count":9,'
+        '"hash_divergence":0,"unresolved_relations":1,"malformed_skipped":5}}' % (version, version)
+    )
+    mark = f'echo invoked > "{marker}"\n' if marker is not None else ""
+    return f'''
+if [ "$1" = "version" ]; then echo "miseledger {version}"; exit 0; fi
+if [ "$1" = "doctor" ] && [ "$2" = "--json" ]; then
+  echo '{{"ok":{db_ok},"engine_version":"{version}","capability":{{"engine_version":"{version}","memory":{cap_json}}},"checks":[{{"name":"database","ok":{db_ok},"detail":"db"}}],"fail_count":0,"warn_count":0}}'
+  exit 0
+fi
+if [ "$1" = "status" ] && [ "$2" = "--json" ]; then
+  echo '{{"items":0,"capability":{{"engine_version":"{version}","memory":{cap_json}}},"engine_version":"{version}"}}'
+  exit 0
+fi
+if [ "$1" = "crawl" ] && [ "$2" = "memory" ]; then
+  {mark}echo '{receipt}'
+  exit {crawl_exit}
+fi
+if [ "$1" = "show" ]; then
+  echo '{{"id":"item-1","source":{{"kind":"brigade-memory"}},"collection":{{"external_id":"memory-11111111-1111-4111-8111-111111111111"}},"content_hash":"sha256:abc","raw_hash":"sha256:def","trust_label":"local","injection":"none","live":true,"tombstoned":false,"relations":[{{"type":"derived_from","target_source_kind":"brigade","target_collection_external_id":"brigade:receipts","target_external_id":"receipt:1","target_item_id":null}}]}}'
+  exit 0
+fi
+exit 1
+'''
+
+
+def test_memory_crawl_delegates_when_capable(monkeypatch, tmp_path, capsys):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "invoked.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(marker=marker),
+    )
+    monkeypatch.setenv("PATH", _path_with_bin(tmp_path))
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 0
+    assert marker.exists()
+    out = capsys.readouterr().out
+    assert "scan=scan-abc" in out
+    assert "created=1" in out
+    assert "updated=2" in out
+    assert "unchanged=3" in out
+    assert "removed=4" in out
+    assert "skipped=5" in out
+    assert "failed=0" in out
+    last_run = evidence_cmd._read_last_run(workspace, "memory")
+    assert last_run is not None
+    assert last_run["status"] == "ok"
+    assert last_run["scan_id"] == "scan-abc"
+    assert last_run["created"] == 1
+    assert last_run["updated"] == 2
+    assert last_run["unchanged"] == 3
+    assert last_run["removed"] == 4
+    assert last_run["skipped"] == 5
+    assert last_run["failed"] == 0
+    assert last_run["capability"] == "memory-projection.v1"
+
+
+def test_memory_crawl_refuses_missing_binary(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: None)
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    last_run = evidence_cmd._read_last_run(workspace, "memory")
+    assert last_run is not None
+    assert last_run["status"] == "fail"
+    assert last_run.get("preflight") == "refused"
+
+
+def test_memory_crawl_refuses_absent_capability(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "invoked.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(capability=None, marker=marker),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    assert not marker.exists()
+    assert evidence_cmd._read_last_run(workspace, "memory")["status"] == "fail"
+
+
+def test_memory_crawl_refuses_future_capability(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "invoked.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(capability="memory-projection.v99", marker=marker),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    assert not marker.exists()
+
+
+def test_memory_crawl_refuses_old_version(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "invoked.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(version="0.5.9", marker=marker),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    assert not marker.exists()
+
+
+def test_memory_crawl_refuses_unreadable_archive(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "invoked.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(database_ok=False, marker=marker),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    assert not marker.exists()
+
+
+def test_memory_crawl_partial_failed_not_healthy(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    receipt = (
+        '{"scan_id":"scan-partial","capability":"memory-projection.v1","engine_version":"0.6.0",'
+        '"status":"completed","stale":false,"partial":false,'
+        '"created":0,"updated":0,"unchanged":0,"removed":0,"skipped":1,"failed":2,'
+        '"canonical_count":1,"live_count":0,"hash_divergence":0,'
+        '"unresolved_relations":0,"malformed_skipped":3,'
+        '"memory_health":{"capability":"memory-projection.v1","engine_version":"0.6.0",'
+        '"status":"completed","stale":false,"partial":false,"failed":2,'
+        '"last_completed_scan_id":"scan-partial","canonical_count":1,"live_count":0,'
+        '"hash_divergence":0,"unresolved_relations":0,"malformed_skipped":3}}'
+    )
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(crawl_receipt=receipt),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["memory", str(workspace)])
+
+    assert rc == 1
+    last_run = evidence_cmd._read_last_run(workspace, "memory")
+    assert last_run["status"] == "partial"
+    assert last_run["failed"] == 2
+
+    payload = evidence_cmd.status_payload(workspace)
+    assert payload["memory_projection"]["healthy"] is False
+    assert payload["health"] in {"fail", "incomplete"}
+
+
+def test_memory_status_body_free(monkeypatch, tmp_path, capsys):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    evidence_cmd._write_last_run(
+        target=workspace,
+        source="memory",
+        status="ok",
+        exit_code=0,
+        crawler_version="0.6.0",
+        database="ok",
+        started_at="2026-01-01T00:00:00Z",
+        finished_at="2026-01-01T00:01:00Z",
+        detail="ok",
+        extra={
+            "capability": "memory-projection.v1",
+            "engine_version": "0.6.0",
+            "status": "completed",
+            "stale": False,
+            "partial": False,
+            "failed": 0,
+            "scan_id": "scan-abc",
+            "last_completed_scan_id": "scan-abc",
+            "canonical_count": 4,
+            "live_count": 4,
+            "hash_divergence": 0,
+            "unresolved_relations": 0,
+            "malformed_skipped": 0,
+            "text": "SHOULD_NOT_PRINT_CARD_BODY",
+            "raw": {"body": "nope"},
+        },
+    )
+    miseledger = _write_fake_bin(tmp_path, "miseledger", _miseledger_memory_capable_script())
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.status(target=workspace, json_output=False)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "memory_projection:" in out
+    assert "capability=memory-projection.v1" in out
+    assert "SHOULD_NOT_PRINT_CARD_BODY" not in out
+    assert "nope" not in out
+    payload = evidence_cmd.status_payload(workspace)
+    assert "text" not in (payload.get("memory_projection") or {})
+    assert payload["memory_projection"]["healthy"] is True
+
+
+def test_memory_file_backed_search_works_without_engine(monkeypatch, tmp_path):
+    from brigade import memory_cmd
+
+    cards = tmp_path / "memory" / "cards"
+    cards.mkdir(parents=True)
+    (cards / "alpha.md").write_text(
+        "---\ntopic: alpha-topic\nconfidence: high\nevidence: [README.md]\n---\n\n# Alpha\n\nalpha body keyword zebra\n"
+    )
+    (tmp_path / "MEMORY.md").write_text("- [alpha-topic](memory/cards/alpha.md)\n")
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: None)
+
+    payload = memory_cmd.search_cards_payload(tmp_path, "zebra", limit=5)
+
+    assert payload["matches"]
+    assert any("alpha" in str(row).lower() for row in payload["matches"])
+
+
+def test_generic_show_has_no_memory_renderer(monkeypatch, tmp_path, capsys):
+    miseledger = _write_fake_bin(tmp_path, "miseledger", _miseledger_memory_capable_script())
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("show", ["item-1", "--json"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    data = json.loads(out)
+    assert data["id"] == "item-1"
+    assert data["live"] is True
+    assert data["relations"][0]["target_source_kind"] == "brigade"
+    assert not hasattr(evidence_cmd, "render_memory_show")
+    assert not hasattr(evidence_cmd, "explain_memory")
+
+
+def test_discord_crawl_still_works_alongside_memory(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _write_fake_bin(tmp_path, "discrawl", _discrawl_script())
+    args_file = tmp_path / "args.txt"
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        (f'echo "$*" > "{args_file}"\nif [ "$1" = "crawl" ]; then echo crawled; exit 0; fi\nexit 1\n'),
+    )
+    monkeypatch.setenv("PATH", _path_with_bin(tmp_path))
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    rc = evidence_cmd.run_engine("crawl", ["discord"])
+
+    assert rc == 0
+    assert args_file.read_text().strip() == "crawl discord"

--- a/tests/test_evidence_runtime.py
+++ b/tests/test_evidence_runtime.py
@@ -322,6 +322,123 @@ def test_memory_probe_unreadable_archive(monkeypatch, tmp_path):
     assert "archive unreadable" in compat.detail
 
 
+def test_archive_readable_rejects_exit1_absent_checks():
+    # Fail-open blocker: exit 1 + capability without checks must not pass.
+    ok, detail = evidence_runtime._archive_readable_from_doctor(
+        {"ok": False, "capability": {"memory": "memory-projection.v1"}},
+        1,
+    )
+    assert ok is False
+    assert detail is not None
+    assert "absent checks" in detail
+
+
+def test_archive_readable_rejects_exit1_malformed_checks():
+    ok, detail = evidence_runtime._archive_readable_from_doctor(
+        {"ok": False, "checks": "not-a-list", "capability": {"memory": "memory-projection.v1"}},
+        1,
+    )
+    assert ok is False
+    assert detail is not None
+    assert "malformed checks" in detail
+
+    ok, detail = evidence_runtime._archive_readable_from_doctor(
+        {"ok": False, "checks": [None, "x", {"name": "database"}], "capability": {"memory": "memory-projection.v1"}},
+        1,
+    )
+    assert ok is False
+    assert detail is not None
+    assert "malformed checks" in detail or "absent archive-readability" in detail
+
+
+def test_archive_readable_rejects_explicit_failing_archive_check():
+    ok, detail = evidence_runtime._archive_readable_from_doctor(
+        {
+            "ok": False,
+            "checks": [
+                {"name": "paths", "ok": True, "detail": "/tmp/db"},
+                {"name": "database", "ok": False, "detail": "open failed"},
+            ],
+        },
+        1,
+    )
+    assert ok is False
+    assert detail is not None
+    assert "open failed" in detail or "database" in detail
+
+
+def test_archive_readable_accepts_degraded_but_readable_exit1():
+    # Legitimate degraded: archive opened (schema/fts ok) but memory_projection fails.
+    ok, detail = evidence_runtime._archive_readable_from_doctor(
+        {
+            "ok": False,
+            "capability": {"engine_version": "0.6.0", "memory": "memory-projection.v1"},
+            "checks": [
+                {"name": "paths", "ok": True, "detail": "/tmp/db"},
+                {"name": "schema", "ok": True, "detail": "version 4"},
+                {"name": "fts", "ok": True, "detail": "sqlite fts5"},
+                {
+                    "name": "memory_projection",
+                    "ok": False,
+                    "detail": "status=interrupted stale=true partial=true",
+                },
+            ],
+        },
+        1,
+    )
+    assert ok is True
+    assert detail is None
+
+
+def test_memory_probe_exit1_absent_checks_refuses_preflight(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(
+        bin_dir / "miseledger",
+        (
+            'if [ "$1" = "version" ]; then echo "miseledger 0.6.0"; exit 0; fi\n'
+            'if [ "$1" = "doctor" ] && [ "$2" = "--json" ]; then '
+            'echo \'{"ok":false,"capability":{"engine_version":"0.6.0","memory":"memory-projection.v1"}}\'; '
+            "exit 1; fi\n"
+            "exit 1\n"
+        ),
+    )
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert probe.archive_ok is False
+    assert compat.state == "fail"
+    assert "absent checks" in compat.detail or "archive unreadable" in compat.detail
+
+
+def test_memory_probe_degraded_memory_health_still_preflight_ok(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(
+        bin_dir / "miseledger",
+        (
+            'if [ "$1" = "version" ]; then echo "miseledger 0.6.0"; exit 0; fi\n'
+            'if [ "$1" = "doctor" ] && [ "$2" = "--json" ]; then '
+            'echo \'{"ok":false,"engine_version":"0.6.0",'
+            '"capability":{"engine_version":"0.6.0","memory":"memory-projection.v1"},'
+            '"checks":['
+            '{"name":"paths","ok":true,"detail":"/tmp/db"},'
+            '{"name":"schema","ok":true,"detail":"version 4"},'
+            '{"name":"fts","ok":true,"detail":"sqlite fts5"},'
+            '{"name":"memory_projection","ok":false,"detail":"stale=true"}'
+            "]}'; exit 1; fi\n"
+            "exit 1\n"
+        ),
+    )
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert probe.archive_ok is True
+    assert compat.state in {"ok", "warn"}
+
+
 def test_memory_probe_malformed(monkeypatch, tmp_path):
     bin_dir = _make_bin(tmp_path)
     binary = _write_script(bin_dir / "miseledger", _miseledger_memory_script(malformed=True))

--- a/tests/test_evidence_runtime.py
+++ b/tests/test_evidence_runtime.py
@@ -208,3 +208,206 @@ def test_check_compatibility_override_drift_does_not_downgrade_version_fail(monk
 
     assert compat.state == "fail"
     assert "version below floor" in compat.detail
+
+
+# ---- memory projection (#844 F1) -------------------------------------------
+
+
+def _miseledger_memory_script(
+    *,
+    version: str = "0.6.0",
+    capability: str | None = "memory-projection.v1",
+    doctor_exit: int = 0,
+    database_ok: bool = True,
+    malformed: bool = False,
+    memory_health: str | None = None,
+) -> str:
+    cap_json = "null" if capability is None else f'"{capability}"'
+    db_ok = "true" if database_ok else "false"
+    health = memory_health or (
+        '{"capability":"memory-projection.v1","engine_version":"%s","status":"absent",'
+        '"last_completed_scan_id":"","canonical_count":0,"live_count":0,'
+        '"hash_divergence":0,"unresolved_relations":0,"malformed_skipped":0,'
+        '"stale":false,"partial":false}' % version
+    )
+    if malformed:
+        doctor_body = 'echo "not-json"; exit 0'
+    else:
+        doctor_body = (
+            f'echo \'{{"ok":{db_ok},"engine_version":"{version}",'
+            f'"capability":{{"engine_version":"{version}","memory":{cap_json}}},'
+            f'"memory_health":{health},'
+            f'"checks":[{{"name":"database","ok":{db_ok},"detail":"db"}}]}}\'; '
+            f"exit {doctor_exit}"
+        )
+    return (
+        f'if [ "$1" = "version" ]; then echo "miseledger {version}"; exit 0; fi\n'
+        f'if [ "$1" = "doctor" ] && [ "$2" = "--json" ]; then {doctor_body}; fi\n'
+        "exit 1\n"
+    )
+
+
+def test_memory_probe_ok(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(bin_dir / "miseledger", _miseledger_memory_script())
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert probe.capability == evidence_runtime.MEMORY_PROJECTION_CAPABILITY
+    assert probe.archive_ok is True
+    assert compat.state in {"ok", "warn"}
+
+
+def test_memory_probe_missing_binary():
+    probe = evidence_runtime.probe_memory_projection(None)
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert compat.state == "fail"
+    assert "not found" in compat.detail.lower() or "setup" in compat.detail.lower()
+
+
+def test_memory_probe_absent_capability(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(bin_dir / "miseledger", _miseledger_memory_script(capability=None))
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert compat.state == "fail"
+    assert "absent capability" in compat.detail or evidence_runtime.MEMORY_PROJECTION_CAPABILITY in compat.detail
+
+
+def test_memory_probe_future_capability(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(
+        bin_dir / "miseledger",
+        _miseledger_memory_script(capability="memory-projection.v2"),
+    )
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert compat.state == "fail"
+    assert "incompatible capability" in compat.detail
+
+
+def test_memory_probe_version_below_floor(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(bin_dir / "miseledger", _miseledger_memory_script(version="0.5.0"))
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert compat.state == "fail"
+    assert "version below floor" in compat.detail
+
+
+def test_memory_probe_unreadable_archive(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(
+        bin_dir / "miseledger",
+        _miseledger_memory_script(database_ok=False, doctor_exit=1),
+    )
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert compat.state == "fail"
+    assert "archive unreadable" in compat.detail
+
+
+def test_memory_probe_malformed(monkeypatch, tmp_path):
+    bin_dir = _make_bin(tmp_path)
+    binary = _write_script(bin_dir / "miseledger", _miseledger_memory_script(malformed=True))
+    monkeypatch.setenv("PATH", _path_with(tmp_path, bin_dir))
+
+    probe = evidence_runtime.probe_memory_projection(str(binary))
+    compat = evidence_runtime.check_memory_projection_preflight(probe)
+
+    assert compat.state == "fail"
+    assert "malformed" in compat.detail
+
+
+def test_memory_projection_healthy_requires_failed_zero():
+    assert evidence_runtime.memory_projection_is_healthy(
+        capability="memory-projection.v1",
+        status="completed",
+        stale=False,
+        partial=False,
+        failed=0,
+        engine_ok=True,
+    )
+    assert not evidence_runtime.memory_projection_is_healthy(
+        capability="memory-projection.v1",
+        status="completed",
+        stale=False,
+        partial=False,
+        failed=1,
+        engine_ok=True,
+    )
+    assert not evidence_runtime.memory_projection_is_healthy(
+        capability="memory-projection.v1",
+        status="completed",
+        stale=True,
+        partial=False,
+        failed=0,
+        engine_ok=True,
+    )
+
+
+def test_classify_memory_crawl_status_partial_and_counts():
+    receipt = {
+        "capability": "memory-projection.v1",
+        "status": "completed",
+        "stale": False,
+        "partial": False,
+        "failed": 2,
+        "scan_id": "scan-1",
+        "created": 1,
+        "updated": 2,
+        "unchanged": 3,
+        "removed": 4,
+        "skipped": 5,
+    }
+    assert evidence_runtime.classify_memory_crawl_status(exit_code=0, receipt=receipt) == "partial"
+    counts = evidence_runtime.extract_memory_crawl_counts(receipt)
+    assert counts == {
+        "scan_id": "scan-1",
+        "created": 1,
+        "updated": 2,
+        "unchanged": 3,
+        "removed": 4,
+        "skipped": 5,
+        "failed": 2,
+    }
+
+
+def test_body_free_memory_health_strips_bodies():
+    raw = {
+        "capability": "memory-projection.v1",
+        "engine_version": "0.6.0",
+        "status": "completed",
+        "text": "SECRET CARD BODY",
+        "raw": {"path": "memory/cards/x.md", "body": "nope"},
+        "canonical_count": 3,
+    }
+    cleaned = evidence_runtime.body_free_memory_health(raw)
+    assert cleaned is not None
+    assert "text" not in cleaned
+    assert "raw" not in cleaned
+    assert cleaned["canonical_count"] == 3
+
+
+def test_register_memory_facade_extensions_is_inert():
+    assert evidence_runtime.register_memory_facade_extensions(None) is None
+
+
+def test_known_sources_excludes_memory():
+    assert "memory" not in evidence_runtime.known_sources()
+    assert "discord" in evidence_runtime.known_sources()

--- a/tests/test_evidence_runtime.py
+++ b/tests/test_evidence_runtime.py
@@ -388,6 +388,98 @@ def test_classify_memory_crawl_status_partial_and_counts():
     }
 
 
+def test_parse_memory_receipt_fail_closed_missing_fields():
+    incomplete = {
+        "capability": "memory-projection.v1",
+        "status": "completed",
+        "stale": False,
+        "partial": False,
+        "scan_id": "scan-1",
+        "created": 1,
+        # missing updated/unchanged/removed/skipped/failed
+    }
+    status, counts, detail = evidence_runtime.parse_memory_crawl_receipt(incomplete)
+    assert status == "fail"
+    assert counts is None
+    assert detail is not None
+    assert "updated" in detail
+    assert evidence_runtime.extract_memory_crawl_counts(incomplete) is None
+
+
+def test_parse_memory_receipt_rejects_bool_and_string_counts():
+    receipt = {
+        "capability": "memory-projection.v1",
+        "status": "completed",
+        "stale": False,
+        "partial": False,
+        "scan_id": "scan-1",
+        "created": True,  # bool must not coerce to 1
+        "updated": 0,
+        "unchanged": 0,
+        "removed": 0,
+        "skipped": 0,
+        "failed": 0,
+    }
+    status, counts, detail = evidence_runtime.parse_memory_crawl_receipt(receipt)
+    assert status == "fail"
+    assert counts is None
+    assert detail is not None
+
+    receipt["created"] = "0"
+    status, counts, _detail = evidence_runtime.parse_memory_crawl_receipt(receipt)
+    assert status == "fail"
+    assert counts is None
+
+
+def test_parse_memory_receipt_dry_run_is_non_current():
+    receipt = {
+        "capability": "memory-projection.v1",
+        "dry_run": True,
+        "skipped": 1,
+        "failed": 0,
+    }
+    status, counts, detail = evidence_runtime.parse_memory_crawl_receipt(receipt, dry_run=True)
+    assert status == "dry_run"
+    assert counts is None
+    assert detail is not None
+    assert evidence_runtime.classify_memory_crawl_status(exit_code=0, receipt=receipt, dry_run=True) == "dry_run"
+
+
+def test_parse_memory_options_rejects_rebuild_and_full():
+    err, *_rest = evidence_runtime.parse_memory_crawl_options(["--rebuild"])
+    assert err is not None
+    assert "--rebuild" in err
+    err, *_rest = evidence_runtime.parse_memory_crawl_options(["--full"])
+    assert err is not None
+    assert "--full" in err
+
+
+def test_public_memory_latest_run_whitelist():
+    raw = {
+        "status": "ok",
+        "exit_code": 0,
+        "capability": "memory-projection.v1",
+        "scan_id": "scan-1",
+        "created": 1,
+        "workspace": "/abs/secret/workspace",
+        "detail": "stderr leak",
+        "text": "CARD BODY",
+        "raw": {"body": "nope"},
+        "resolved_path": "/abs/bin/miseledger",
+        "database": "ok",
+    }
+    public = evidence_runtime.public_memory_latest_run(raw)
+    assert public is not None
+    assert public["status"] == "ok"
+    assert public["scan_id"] == "scan-1"
+    assert public["database"] == "ok"
+    assert "workspace" not in public
+    assert "detail" not in public
+    assert "text" not in public
+    assert "raw" not in public
+    assert "resolved_path" not in public
+
+
 def test_body_free_memory_health_strips_bodies():
     raw = {
         "capability": "memory-projection.v1",


### PR DESCRIPTION
## Summary

Implements #844 F1 only: a Brigade-facing memory projection crawl facade.

- Adds `brigade evidence crawl memory <workspace>` with a read-only MiseLedger preflight before crawl or import mutation.
- Requires capability `memory-projection.v1` and uses the exact resolved engine path for both preflight and crawl.
- Rejects F2-only `--rebuild` and `--full` options.
- Treats `--dry-run` as non-current and unhealthy rather than a completed healthy crawl.
- Validates completed receipts and all typed counts before publishing health; malformed success responses do not fabricate zeros.
- Accepts doctor exit 1 only with structured positive archive-readability evidence. Database and path failures block; degraded FTS, permissions, or memory-projection checks remain readable under the engine contract.
- Exposes body-free projection health and a whitelisted, path-safe latest-run summary in status and doctor output.
- Keeps file-backed memory search available when the engine is missing or unhealthy.

Refs #844

## F1 boundary

This PR does not implement F2 rebuild routing, identity audit, staged card IDs, or evidence-ledger engine changes. The registration hook is inert until the later slice.

## Verification

- Focused facade/runtime suite: 73 passed
- Full Brigade verification receipt: `20260811-053030-work-verify-3d4b24`
- Exact-head Luna review verified the original option, receipt, redaction, and resolved-path repairs
- Exact-head Terra review: ready
- Kimi k3 contract tie-break: degraded FTS and memory-projection checks remain readable; database and path failures block
- Rebased on main `6ff6e4c0`

## Checklist

- [x] F1 scope only
- [x] Fail-closed malformed receipt and preflight coverage
- [x] Public latest-run output excludes private paths and raw text
- [x] No new runtime dependencies
- [x] Existing commits retain their Cursor co-author trailer