### PR TITLE
feat(templates): slim profile selection and render-hash snapshot (#494)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,8 @@ jobs:
         run: python scripts/version_sync.py --check
       - name: Managed snapshot
         run: python scripts/managed_snapshot.py --check
+      - name: Template profile snapshot
+        run: python scripts/template_profile_snapshot.py --check
 
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ Thumbs.db
 !/scripts/windows-native-acceptance.ps1
 !/scripts/published-artifact-acceptance.py
 !/scripts/generate_component_manifest.py
+!/scripts/template_profile_snapshot.py
 !/scripts/verify_version_check_endpoint.py
 !/scripts/hyper-v-native-acceptance.ps1
 !/scripts/measure_work_store.py

--- a/.grok/memory-handoffs/2026-08-11-494-slim-template-profile-snapshot.md
+++ b/.grok/memory-handoffs/2026-08-11-494-slim-template-profile-snapshot.md
@@ -1,0 +1,33 @@
+# Memory Handoff
+
+## Type
+decision
+
+## Title
+#494 slim template-profile snapshot (no public registry)
+
+## Summary
+Operator closed #847 for inventing `brigade.template_registry.v1`, `brigade://template-profiles/*`, `supported_harness_versions` with synthetic `0.0.0`, and an unwired `check_harness_version`. The approved replacement keeps bundled profile selection, `brigade init --profile`, and deterministic render-hash snapshot/check, sourcing compatibility truth from existing `harness-contract.v1` `tested_version` / provenance / evidence fields only.
+
+## Durable facts
+- Module is `template_profiles` with snapshot schema `brigade.template_profile_snapshot.v1` (managed-snapshot style), not a public registry.
+- Built-in profiles: `repo-claude`, `workspace-claude-codex`, `repo-claude-full`. `init --profile` is mutually exclusive with `--depth` / `--harnesses`; profile-less init is unchanged.
+- Render digests use the shared `install.build_render_context` + `resolve_manifests` + `render()` path; `scripts/template_profile_snapshot.py --check` is wired into `./scripts/verify` and CI lint.
+- Per-harness compatibility is projected from `docs/research/fixtures/harness-contract.v1` via `HARNESS_CONTRACT_FIXTURES` (e.g. `claude` → `claude-code`). Unmapped harnesses refuse invented claims; no min/tested `0.0.0` and no install-time version gate.
+- Runtime `resolve_profile` loads the bundled snapshot with `verify_contracts=False` so package installs do not need the docs fixtures; `--check` verifies contracts against live fixtures in-repo.
+- Protected #750 surfaces (`publish.yml`, `verify_version_check_endpoint.py`, `test_publish_workflow.py`) were not touched.
+
+## Evidence
+- files changed: `src/brigade/template_profiles.py`, `src/brigade/templates/template-profile-snapshot.json`, `src/brigade/install.py`, `src/brigade/cli/init.py`, `scripts/template_profile_snapshot.py`, `scripts/verify`, `.github/workflows/ci.yml`, `.gitignore`, `tests/test_template_profiles.py`, `CHANGELOG.md`, `.grok/memory-handoffs/2026-08-11-494-slim-template-profile-snapshot.md`
+- commands run: GraphTrail sync + `impact install_selection` / `resolve_manifests`; focused pytest `20260811-044801-work-verify-4dc1ce` (exit 0); install+profile pytest `20260811-044831-work-verify-ef336b` (59 passed); full `./scripts/verify` `20260811-044839-work-verify-98986a` (6749 passed, 5 skipped, coverage 83.11%); final-tree gates `20260811-061232-work-verify-4ed846` (ruff/mypy/version/managed/template-profile snapshot all exit 0); focused+run_cli rerun `20260811-061157-work-verify-12870d` (template/install/surface + previously flaky run_cli cancel tests exit 0; shell `&&` gate argv rejected by design)
+- error strings: ruff format wanted single-line `tested_version` assignment; CI wiring assert must match `scripts/template_profile_snapshot.py --check` substring inside `"$PY/python" ...`; second full verify `20260811-053018-work-verify-a4d22f` failed 5 unrelated `test_run_cli` SIGINT cancel races with `TimeoutExpired` after 3s under suite load (reproduced green in isolation)
+
+## Recommended memory action
+no-card
+
+## Target document
+.learnings/LEARNINGS.md
+
+## Suggested document content
+### #494 template-profile snapshot contract
+Keep bundled `init --profile` and render-hash snapshot/check. Project harness compatibility from `harness-contract.v1` fixtures only. Do not reintroduce `brigade.template_registry.v1`, `brigade://template-profiles/*`, `supported_harness_versions`, synthetic `0.0.0` claims, or an unwired `check_harness_version`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--force`. (#860)
 
 ### Added
+- Bundled template-profile selection and render-hash snapshot for #494: named
+  presets (`repo-claude`, `workspace-claude-codex`, `repo-claude-full`) via
+  `brigade init --profile`, deterministic rendered-file digests checked by
+  `scripts/template_profile_snapshot.py`, and harness compatibility projected
+  from existing `harness-contract.v1` `tested_version` / provenance / evidence
+  fields. No public registry schema, profile URIs, `supported_harness_versions`,
+  or install-time version gate. Profile-less `--depth` / `--harnesses` init is
+  unchanged.
 - `brigade runs export` / `validate-archive` enforce the #592 worker-event
   privacy boundary: raw worker-like JSONL anywhere under `events/` (including
   nested paths such as `events/nested/coder.jsonl`) stays local-only and is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `brigade init --profile` now merges repeatable `--include` values into the
+  profile includes with first-seen de-duplication before `--full` appends
+  `repo-extras`. Refs #494.
 - Issue #846 R2 harness sendback (comment 5247390894): JSON secret-history
   proves synthetic Git/ignore-path; SQLite marks Git history unavailable;
   cold-start uses parent `subprocess.run` wall with distinct inner timing;

--- a/scripts/template_profile_snapshot.py
+++ b/scripts/template_profile_snapshot.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate or validate Brigade's bundled template-profile render snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from brigade import localio, template_profiles  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="write the bundled template-profile snapshot")
+    mode.add_argument("--check", action="store_true", help="validate the committed template-profile snapshot")
+    args = parser.parse_args()
+
+    path = template_profiles.snapshot_path()
+    if args.write:
+        payload = template_profiles.build_snapshot()
+        localio.write_text_atomic(path, template_profiles.render_snapshot(payload))
+        print(f"template profile snapshot: wrote {path} ({len(payload['profiles'])} profiles)")
+        return 0
+
+    try:
+        payload = template_profiles.load_snapshot(path, verify_contracts=True)
+    except ValueError as exc:
+        print(f"template profile snapshot: {exc}", file=sys.stderr)
+        return 1
+    expected = template_profiles.render_snapshot(payload)
+    actual = path.read_text(encoding="utf-8")
+    if actual != expected:
+        # Rebuild from builtins so check catches missing profiles / stale renders.
+        rebuilt = template_profiles.render_snapshot(template_profiles.build_snapshot())
+        if actual != rebuilt:
+            print(f"template profile snapshot: drift at {path}; run with --write", file=sys.stderr)
+            return 1
+        print(f"template profile snapshot: non-canonical JSON at {path}", file=sys.stderr)
+        return 1
+    rebuilt = template_profiles.build_snapshot()
+    if rebuilt["profiles"] != payload["profiles"] or rebuilt["renders"] != payload["renders"]:
+        print(f"template profile snapshot: drift at {path}; run with --write", file=sys.stderr)
+        return 1
+    if rebuilt["brigade_version"] != payload["brigade_version"]:
+        print(
+            f"template profile snapshot: brigade_version drift "
+            f"({payload['brigade_version']!r} != {rebuilt['brigade_version']!r})",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"template profile snapshot: ok ({len(payload['profiles'])} profiles)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify
+++ b/scripts/verify
@@ -13,4 +13,5 @@ PY=${PY:-.venv/bin}
 # Run `python scripts/version_sync.py --write` to fix drift in one shot.
 "$PY/python" scripts/version_sync.py --check
 "$PY/python" scripts/managed_snapshot.py --check
+"$PY/python" scripts/template_profile_snapshot.py --check
 "$PY/pytest" -q --cov=brigade --cov-report=term --cov-fail-under=78

--- a/src/brigade/cli/init.py
+++ b/src/brigade/cli/init.py
@@ -40,6 +40,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_init.add_argument("--dry-run", action="store_true", help="Show what would happen.")
     p_init.add_argument(
+        "--profile",
+        default=None,
+        help="Named bundled template profile (e.g. repo-claude). Mutually exclusive with --depth and --harnesses.",
+    )
+    p_init.add_argument(
         "--depth",
         choices=["repo", "workspace"],
         default=None,
@@ -73,8 +78,59 @@ def register(sub: argparse._SubParsersAction) -> None:
 
 
 def dispatch(args) -> int:
+    profile = getattr(args, "profile", None)
+    depth_arg = getattr(args, "depth", None)
+    harnesses_arg = getattr(args, "harnesses", None)
+    if profile is not None:
+        if depth_arg is not None or harnesses_arg is not None:
+            print(
+                "error: --profile cannot be combined with --depth or --harnesses",
+                file=sys.stderr,
+            )
+            return 2
+        from ..template_profiles import UnknownTemplateProfile, resolve_profile
+        from ..install import install_selection
+        from ..selection import Selection, resolve_owner
+
+        try:
+            sel = resolve_profile(profile)
+        except UnknownTemplateProfile as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        except ValueError as exc:
+            print(f"error: template profile snapshot invalid: {exc}", file=sys.stderr)
+            return 2
+        includes = list(sel.includes)
+        if getattr(args, "full", False) and sel.depth == "repo" and "repo-extras" not in includes:
+            includes.append("repo-extras")
+        if args.owner is not None:
+            try:
+                owner = resolve_owner(sel.harnesses, override=args.owner)
+            except ValueError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+        else:
+            owner = sel.owner
+        sel = Selection(
+            depth=sel.depth,
+            harnesses=list(sel.harnesses),
+            owner=owner,
+            includes=includes,
+            surfaces=list(sel.surfaces),
+        )
+        return install_selection(
+            target=args.target,
+            selection=sel,
+            force=getattr(args, "force", False),
+            dry_run=getattr(args, "dry_run", False),
+            allow_home=getattr(args, "allow_home", False),
+            use_git_exclude=getattr(args, "git_exclude", False),
+            update_gitignore=getattr(args, "update_gitignore", True),
+            wire_skills=getattr(args, "wire_skills", True),
+        )
+
     # New v0.3.0 path: --depth/--harnesses build a Selection directly.
-    if getattr(args, "depth", None) is not None or getattr(args, "harnesses", None) is not None:
+    if depth_arg is not None or harnesses_arg is not None:
         from ..selection import Selection, KNOWN_HARNESSES, resolve_owner
         from ..install import install_selection
 

--- a/src/brigade/cli/init.py
+++ b/src/brigade/cli/init.py
@@ -100,7 +100,10 @@ def dispatch(args) -> int:
         except ValueError as exc:
             print(f"error: template profile snapshot invalid: {exc}", file=sys.stderr)
             return 2
-        includes = list(sel.includes)
+        includes: list[str] = []
+        for include in list(sel.includes) + list(args.includes):
+            if include not in includes:
+                includes.append(include)
         if getattr(args, "full", False) and sel.depth == "repo" and "repo-extras" not in includes:
             includes.append("repo-extras")
         if args.owner is not None:

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -256,6 +256,24 @@ def _replace_managed_gitignore_blocks(
     return "".join(output), True
 
 
+def build_render_context(selection: Selection) -> dict[str, str]:
+    """Build the placeholder context used when rendering text templates."""
+    owner_label = harness_memory_owner(selection.owner, selection.owner)
+    writer_inboxes = [WRITER_INBOXES[h] for h in selection.harnesses if h in WRITER_INBOXES]
+    owner_inbox = WRITER_INBOXES.get(selection.owner)
+    if owner_inbox:
+        writer_inboxes = [owner_inbox] + [p for p in writer_inboxes if p != owner_inbox]
+    if not writer_inboxes:
+        writer_inboxes = [WRITER_INBOXES["claude"]]
+    return {
+        "memory_owner": selection.owner,
+        "memory_owner_name": owner_label,
+        "harness": selection.owner,
+        "handoff_inbox": f"{writer_inboxes[0]}/",
+        "handoff_inboxes": ", ".join(f"`{p}/`" for p in writer_inboxes),
+    }
+
+
 def resolve_manifests(selection: Selection) -> Tuple[List[dict], List[str], List[str]]:
     """Return (files, dirs, post_install_notes) for a Selection.
 
@@ -374,20 +392,7 @@ def install_selection(
     for d in dirs:
         (target / d).mkdir(parents=True, exist_ok=True)
 
-    owner_label = harness_memory_owner(selection.owner, selection.owner)
-    writer_inboxes = [WRITER_INBOXES[h] for h in selection.harnesses if h in WRITER_INBOXES]
-    owner_inbox = WRITER_INBOXES.get(selection.owner)
-    if owner_inbox:
-        writer_inboxes = [owner_inbox] + [p for p in writer_inboxes if p != owner_inbox]
-    if not writer_inboxes:
-        writer_inboxes = [WRITER_INBOXES["claude"]]
-    context = {
-        "memory_owner": selection.owner,
-        "memory_owner_name": owner_label,
-        "harness": selection.owner,
-        "handoff_inbox": f"{writer_inboxes[0]}/",
-        "handoff_inboxes": ", ".join(f"`{p}/`" for p in writer_inboxes),
-    }
+    context = build_render_context(selection)
 
     root = template_root()
     kept_files: list[Path] = []
@@ -464,7 +469,7 @@ def install_selection(
     print(
         f"brigade: installed depth={selection.depth} harnesses={','.join(selection.harnesses) or '(none)'} -> {target}"
     )
-    print(f"brigade: memory owner -> {owner_label}")
+    print(f"brigade: memory owner -> {context['memory_owner_name']}")
     if kept_files:
         print(
             f"brigade: kept {len(kept_files)} existing file(s); re-run init only if you intend "

--- a/src/brigade/template_profiles.py
+++ b/src/brigade/template_profiles.py
@@ -1,0 +1,396 @@
+"""Bundled template-profile selection presets and rendered-file hash snapshot.
+
+Compatibility / version truth for selected harnesses is sourced from the
+existing ``harness-contract.v1`` fixtures (``tested_version``, ``provenance``,
+``evidence``). This module does not publish a public registry schema, profile
+URIs, or install-time harness version enforcement.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+from .install import build_render_context, resolve_manifests
+from .selection import Selection
+from .templates import is_text, render, template_root
+
+SCHEMA = "brigade.template_profile_snapshot.v1"
+HARNESS_CONTRACT_SCHEMA = "harness-contract.v1"
+
+# Selection harness id -> primary harness-contract.v1 fixture stem.
+HARNESS_CONTRACT_FIXTURES: dict[str, str] = {
+    "claude": "claude-code",
+    "codex": "codex-cli",
+    "opencode": "opencode",
+    "antigravity": "antigravity",
+    "pi": "pi",
+    "cursor": "cursor-cli",
+    "grok": "grok-cli",
+    "openclaw": "openclaw",
+    "hermes": "hermes",
+}
+
+BUILTIN_PROFILES: dict[str, dict[str, Any]] = {
+    "repo-claude": {
+        "description": "Minimal repo install with Claude Code bridge.",
+        "selection": {
+            "depth": "repo",
+            "harnesses": ["claude"],
+            "owner": "claude",
+            "includes": [],
+        },
+    },
+    "workspace-claude-codex": {
+        "description": "Full workspace with Claude and Codex bridges.",
+        "selection": {
+            "depth": "workspace",
+            "harnesses": ["claude", "codex"],
+            "owner": "claude",
+            "includes": [],
+        },
+    },
+    "repo-claude-full": {
+        "description": "Repo depth with Claude and the full kit (repo-extras).",
+        "selection": {
+            "depth": "repo",
+            "harnesses": ["claude"],
+            "owner": "claude",
+            "includes": ["repo-extras"],
+        },
+    },
+}
+
+
+class UnknownTemplateProfile(ValueError):
+    """A named template profile is not in the bundled snapshot."""
+
+    def __init__(self, profile_name: str) -> None:
+        self.profile_name = profile_name
+        super().__init__(f"unknown template profile: {profile_name!r}")
+
+
+def snapshot_path() -> Path:
+    return template_root() / "template-profile-snapshot.json"
+
+
+def harness_contract_fixtures_dir() -> Path:
+    """Repo-relative harness-contract.v1 fixture directory."""
+    return Path(__file__).resolve().parents[2] / "docs" / "research" / "fixtures" / "harness-contract.v1"
+
+
+def _selection_from_mapping(raw: Mapping[str, Any]) -> Selection:
+    depth = raw.get("depth")
+    harnesses = raw.get("harnesses")
+    owner = raw.get("owner", "this-repo")
+    includes = raw.get("includes", [])
+    if not isinstance(depth, str):
+        raise ValueError("profile selection.depth must be a string")
+    if not isinstance(harnesses, list) or not all(isinstance(item, str) for item in harnesses):
+        raise ValueError("profile selection.harnesses must be a string list")
+    if not isinstance(owner, str):
+        raise ValueError("profile selection.owner must be a string")
+    if not isinstance(includes, list) or not all(isinstance(item, str) for item in includes):
+        raise ValueError("profile selection.includes must be a string list")
+    selection = Selection(
+        depth=depth,
+        harnesses=list(harnesses),
+        owner=owner,
+        includes=list(includes),
+    )
+    selection.validate()
+    return selection
+
+
+def _capability_truth(capability: Mapping[str, Any]) -> dict[str, Any]:
+    cap_id = capability.get("id")
+    tested_version = capability.get("tested_version")
+    provenance = capability.get("provenance")
+    evidence = capability.get("evidence")
+    if not isinstance(cap_id, str) or not cap_id:
+        raise ValueError("harness-contract capability.id must be a non-empty string")
+    if tested_version is not None and not isinstance(tested_version, str):
+        raise ValueError(f"harness-contract capability {cap_id!r} tested_version must be a string or null")
+    if not isinstance(provenance, str) or not provenance:
+        raise ValueError(f"harness-contract capability {cap_id!r} provenance must be a non-empty string")
+    if not isinstance(evidence, list) or not evidence:
+        raise ValueError(f"harness-contract capability {cap_id!r} evidence must be a non-empty list")
+    normalized_evidence: list[dict[str, str]] = []
+    for item in evidence:
+        if not isinstance(item, dict):
+            raise ValueError(f"harness-contract capability {cap_id!r} evidence entries must be objects")
+        kind = item.get("kind")
+        reference = item.get("reference")
+        if not isinstance(kind, str) or not kind:
+            raise ValueError(f"harness-contract capability {cap_id!r} evidence.kind must be a non-empty string")
+        if not isinstance(reference, str) or not reference:
+            raise ValueError(f"harness-contract capability {cap_id!r} evidence.reference must be a non-empty string")
+        normalized_evidence.append({"kind": kind, "reference": reference})
+    return {
+        "id": cap_id,
+        "tested_version": tested_version,
+        "provenance": provenance,
+        "evidence": normalized_evidence,
+    }
+
+
+def load_harness_contract_fixture(contract_id: str, *, fixtures_dir: Path | None = None) -> dict[str, Any]:
+    directory = fixtures_dir or harness_contract_fixtures_dir()
+    path = directory / f"{contract_id}.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"harness-contract fixture could not be loaded: {path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema") != HARNESS_CONTRACT_SCHEMA:
+        raise ValueError(f"harness-contract fixture schema must be {HARNESS_CONTRACT_SCHEMA}: {path}")
+    harness = payload.get("harness")
+    if not isinstance(harness, dict) or harness.get("id") != contract_id:
+        raise ValueError(f"harness-contract fixture harness.id must be {contract_id!r}: {path}")
+    capabilities = payload.get("capabilities")
+    if not isinstance(capabilities, list) or not capabilities:
+        raise ValueError(f"harness-contract fixture capabilities must be a non-empty list: {path}")
+    return payload
+
+
+def harness_compatibility_from_contracts(
+    harnesses: Sequence[str],
+    *,
+    fixtures_dir: Path | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Project harness-contract.v1 truth for each selected harness id."""
+    compatibility: dict[str, dict[str, Any]] = {}
+    for harness_id in harnesses:
+        contract_id = HARNESS_CONTRACT_FIXTURES.get(harness_id)
+        if contract_id is None:
+            raise ValueError(
+                f"no harness-contract.v1 fixture mapping for harness {harness_id!r}; "
+                "refusing to invent compatibility claims"
+            )
+        fixture = load_harness_contract_fixture(contract_id, fixtures_dir=fixtures_dir)
+        capabilities = [_capability_truth(item) for item in fixture["capabilities"]]
+        capabilities.sort(key=lambda item: item["id"])
+        compatibility[harness_id] = {
+            "contract_id": contract_id,
+            "surface": fixture["harness"]["surface"],
+            "capabilities": capabilities,
+        }
+    return compatibility
+
+
+def _profile_record(
+    name: str,
+    raw: Mapping[str, Any],
+    *,
+    fixtures_dir: Path | None = None,
+    compatibility: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    description = raw.get("description")
+    selection_raw = raw.get("selection")
+    if not isinstance(description, str) or not description:
+        raise ValueError(f"profile {name!r} needs a non-empty description")
+    if not isinstance(selection_raw, dict):
+        raise ValueError(f"profile {name!r} selection must be an object")
+    selection = _selection_from_mapping(selection_raw)
+    if compatibility is None:
+        harness_compatibility = harness_compatibility_from_contracts(
+            selection.harnesses,
+            fixtures_dir=fixtures_dir,
+        )
+    else:
+        if not isinstance(compatibility, dict):
+            raise ValueError(f"profile {name!r} harness_compatibility must be an object")
+        expected = harness_compatibility_from_contracts(selection.harnesses, fixtures_dir=fixtures_dir)
+        if compatibility != expected:
+            raise ValueError(f"profile {name!r} harness_compatibility does not match harness-contract.v1 fixtures")
+        harness_compatibility = deepcopy(compatibility)
+    return {
+        "description": description,
+        "selection": {
+            "depth": selection.depth,
+            "harnesses": selection.harnesses,
+            "owner": selection.owner,
+            "includes": selection.includes,
+        },
+        "harness_compatibility": harness_compatibility,
+    }
+
+
+def compute_profile_renders(selection: Selection) -> list[dict[str, Any]]:
+    """Return deterministic rendered-file hashes for a selection."""
+    files, _, _ = resolve_manifests(selection)
+    context = build_render_context(selection)
+    root = template_root()
+    renders: list[dict[str, Any]] = []
+    for entry in sorted(files, key=lambda item: item["dst"]):
+        src = root / entry["src"]
+        if not src.is_file():
+            raise FileNotFoundError(f"template missing for render hash: {src}")
+        if is_text(entry["src"]):
+            content = render(src.read_text(encoding="utf-8"), context).encode("utf-8")
+            rendered = True
+        else:
+            content = src.read_bytes()
+            rendered = False
+        renders.append(
+            {
+                "dst": entry["dst"],
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "byte_size": len(content),
+                "rendered": rendered,
+            }
+        )
+    return renders
+
+
+def build_snapshot(
+    profile_names: Sequence[str] | None = None,
+    *,
+    fixtures_dir: Path | None = None,
+) -> dict[str, Any]:
+    names = sorted(profile_names or BUILTIN_PROFILES)
+    profiles: dict[str, dict[str, Any]] = {}
+    renders: dict[str, list[dict[str, Any]]] = {}
+    for name in names:
+        raw = BUILTIN_PROFILES.get(name)
+        if raw is None:
+            raise ValueError(f"unknown built-in profile: {name!r}")
+        profile = _profile_record(name, raw, fixtures_dir=fixtures_dir)
+        profiles[name] = profile
+        selection = _selection_from_mapping(profile["selection"])
+        renders[name] = compute_profile_renders(selection)
+    return {
+        "schema": SCHEMA,
+        "brigade_version": __version__,
+        "profiles": profiles,
+        "renders": renders,
+    }
+
+
+def render_snapshot(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _validate_render_records(records: Any) -> list[dict[str, Any]]:
+    if not isinstance(records, list):
+        raise ValueError("render records must be a list")
+    seen: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("render record must be an object")
+        dst = record.get("dst")
+        sha256 = record.get("sha256")
+        byte_size = record.get("byte_size")
+        rendered = record.get("rendered")
+        if not isinstance(dst, str) or not dst or dst in seen:
+            raise ValueError(f"invalid or duplicate render dst: {dst!r}")
+        if not isinstance(sha256, str) or len(sha256) != 64:
+            raise ValueError(f"render dst {dst!r} needs a sha256 digest")
+        if not isinstance(byte_size, int) or byte_size < 0:
+            raise ValueError(f"render dst {dst!r} needs a non-negative byte_size")
+        if not isinstance(rendered, bool):
+            raise ValueError(f"render dst {dst!r} needs a rendered boolean")
+        seen.add(dst)
+        normalized.append(
+            {
+                "dst": dst,
+                "sha256": sha256,
+                "byte_size": byte_size,
+                "rendered": rendered,
+            }
+        )
+    return normalized
+
+
+def load_snapshot(
+    path: Path | None = None,
+    *,
+    fixtures_dir: Path | None = None,
+    verify_contracts: bool = True,
+) -> dict[str, Any]:
+    source_path = path or snapshot_path()
+    try:
+        payload = json.loads(source_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"template profile snapshot could not be loaded: {source_path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA:
+        raise ValueError(f"template profile snapshot schema must be {SCHEMA}")
+    brigade_version = payload.get("brigade_version")
+    if not isinstance(brigade_version, str) or not brigade_version:
+        raise ValueError("template profile snapshot brigade_version must be a non-empty string")
+    profiles_raw = payload.get("profiles")
+    renders_raw = payload.get("renders")
+    if not isinstance(profiles_raw, dict):
+        raise ValueError("template profile snapshot profiles must be an object")
+    if not isinstance(renders_raw, dict):
+        raise ValueError("template profile snapshot renders must be an object")
+    profiles: dict[str, dict[str, Any]] = {}
+    renders: dict[str, list[dict[str, Any]]] = {}
+    for name in sorted(profiles_raw):
+        raw = profiles_raw[name]
+        if not isinstance(raw, dict):
+            raise ValueError(f"profile {name!r} must be an object")
+        compatibility = raw.get("harness_compatibility")
+        if verify_contracts:
+            profile = _profile_record(name, raw, fixtures_dir=fixtures_dir, compatibility=compatibility)
+        else:
+            description = raw.get("description")
+            selection_raw = raw.get("selection")
+            if not isinstance(description, str) or not description:
+                raise ValueError(f"profile {name!r} needs a non-empty description")
+            if not isinstance(selection_raw, dict):
+                raise ValueError(f"profile {name!r} selection must be an object")
+            selection = _selection_from_mapping(selection_raw)
+            if not isinstance(compatibility, dict):
+                raise ValueError(f"profile {name!r} harness_compatibility must be an object")
+            profile = {
+                "description": description,
+                "selection": {
+                    "depth": selection.depth,
+                    "harnesses": selection.harnesses,
+                    "owner": selection.owner,
+                    "includes": selection.includes,
+                },
+                "harness_compatibility": deepcopy(compatibility),
+            }
+        profiles[name] = profile
+        expected_renders = compute_profile_renders(_selection_from_mapping(profile["selection"]))
+        actual_renders = _validate_render_records(renders_raw.get(name))
+        if actual_renders != expected_renders:
+            raise ValueError(f"template profile snapshot render digest mismatch for profile {name!r}")
+        renders[name] = actual_renders
+    extra_renders = set(renders_raw) - set(profiles)
+    if extra_renders:
+        raise ValueError(f"template profile snapshot renders has unknown profiles: {sorted(extra_renders)}")
+    return {
+        "schema": SCHEMA,
+        "brigade_version": brigade_version,
+        "profiles": profiles,
+        "renders": renders,
+    }
+
+
+def list_profile_names(path: Path | None = None) -> list[str]:
+    return sorted(load_snapshot(path, verify_contracts=False)["profiles"])
+
+
+def resolve_profile(profile_name: str, path: Path | None = None) -> Selection:
+    """Resolve a named bundled profile to a validated Selection."""
+    snapshot = load_snapshot(path, verify_contracts=False)
+    profile = snapshot["profiles"].get(profile_name)
+    if profile is None:
+        raise UnknownTemplateProfile(profile_name)
+    return _selection_from_mapping(profile["selection"])
+
+
+def profile_metadata(profile_name: str, *, path: Path | None = None) -> dict[str, Any]:
+    snapshot = load_snapshot(path, verify_contracts=False)
+    profile = snapshot["profiles"].get(profile_name)
+    if profile is None:
+        raise UnknownTemplateProfile(profile_name)
+    return deepcopy(profile)

--- a/src/brigade/templates/template-profile-snapshot.json
+++ b/src/brigade/templates/template-profile-snapshot.json
@@ -1,0 +1,882 @@
+{
+  "brigade_version": "0.26.1",
+  "profiles": {
+    "repo-claude": {
+      "description": "Minimal repo install with Claude Code bridge.",
+      "harness_compatibility": {
+        "claude": {
+          "capabilities": [
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "handoff",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/hooks"
+                }
+              ],
+              "id": "hooks",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/memory"
+                }
+              ],
+              "id": "instructions",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/mcp"
+                }
+              ],
+              "id": "mcp",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "local_probe",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "platform",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "reload",
+              "provenance": "unknown",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "session",
+              "provenance": "unknown",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/skills"
+                }
+              ],
+              "id": "skills",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/monitoring-usage"
+                }
+              ],
+              "id": "telemetry",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "verification",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/memory"
+                }
+              ],
+              "id": "workspace",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            }
+          ],
+          "contract_id": "claude-code",
+          "surface": "cli"
+        }
+      },
+      "selection": {
+        "depth": "repo",
+        "harnesses": [
+          "claude"
+        ],
+        "includes": [],
+        "owner": "claude"
+      }
+    },
+    "repo-claude-full": {
+      "description": "Repo depth with Claude and the full kit (repo-extras).",
+      "harness_compatibility": {
+        "claude": {
+          "capabilities": [
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "handoff",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/hooks"
+                }
+              ],
+              "id": "hooks",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/memory"
+                }
+              ],
+              "id": "instructions",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/mcp"
+                }
+              ],
+              "id": "mcp",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "local_probe",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "platform",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "reload",
+              "provenance": "unknown",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "session",
+              "provenance": "unknown",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/skills"
+                }
+              ],
+              "id": "skills",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/monitoring-usage"
+                }
+              ],
+              "id": "telemetry",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "verification",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/memory"
+                }
+              ],
+              "id": "workspace",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            }
+          ],
+          "contract_id": "claude-code",
+          "surface": "cli"
+        }
+      },
+      "selection": {
+        "depth": "repo",
+        "harnesses": [
+          "claude"
+        ],
+        "includes": [
+          "repo-extras"
+        ],
+        "owner": "claude"
+      }
+    },
+    "workspace-claude-codex": {
+      "description": "Full workspace with Claude and Codex bridges.",
+      "harness_compatibility": {
+        "claude": {
+          "capabilities": [
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "handoff",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/hooks"
+                }
+              ],
+              "id": "hooks",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/memory"
+                }
+              ],
+              "id": "instructions",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/mcp"
+                }
+              ],
+              "id": "mcp",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "local_probe",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "platform",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "reload",
+              "provenance": "unknown",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "session",
+              "provenance": "unknown",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/skills"
+                }
+              ],
+              "id": "skills",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/monitoring-usage"
+                }
+              ],
+              "id": "telemetry",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_claude/.brigade/work/verify-runs/20260718-044953-work-verify-8f1b1a/receipt.json"
+                }
+              ],
+              "id": "verification",
+              "provenance": "observed",
+              "tested_version": "2.1.211"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://code.claude.com/docs/en/memory"
+                }
+              ],
+              "id": "workspace",
+              "provenance": "documented",
+              "tested_version": "2.1.211"
+            }
+          ],
+          "contract_id": "claude-code",
+          "surface": "cli"
+        },
+        "codex": {
+          "capabilities": [
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_codex/.brigade/work/verify-runs/20260718-044953-work-verify-28cebe/receipt.json"
+                }
+              ],
+              "id": "handoff",
+              "provenance": "inferred",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://learn.chatgpt.com/docs/hooks"
+                }
+              ],
+              "id": "hooks",
+              "provenance": "documented",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://learn.chatgpt.com/docs/agent-configuration/agents-md"
+                }
+              ],
+              "id": "instructions",
+              "provenance": "documented",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://learn.chatgpt.com/docs/extend/mcp"
+                }
+              ],
+              "id": "mcp",
+              "provenance": "documented",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://learn.chatgpt.com/docs/codex/cli"
+                }
+              ],
+              "id": "platform",
+              "provenance": "documented",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_codex/.brigade/runs/20260718-044429-114cf3b9"
+                }
+              ],
+              "id": "reload",
+              "provenance": "unknown",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://learn.chatgpt.com/docs/codex/cli"
+                }
+              ],
+              "id": "session",
+              "provenance": "documented",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://learn.chatgpt.com/docs/skills"
+                }
+              ],
+              "id": "skills",
+              "provenance": "documented",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_codex/.brigade/runs/20260718-044429-114cf3b9"
+                }
+              ],
+              "id": "telemetry",
+              "provenance": "unknown",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "probe_receipt",
+                  "reference": "probe_codex/.brigade/work/verify-runs/20260718-044953-work-verify-28cebe/receipt.json"
+                }
+              ],
+              "id": "verification",
+              "provenance": "inferred",
+              "tested_version": "0.144.5"
+            },
+            {
+              "evidence": [
+                {
+                  "kind": "vendor_documentation",
+                  "reference": "https://learn.chatgpt.com/docs/config-file/config-reference"
+                }
+              ],
+              "id": "workspace",
+              "provenance": "documented",
+              "tested_version": "0.144.5"
+            }
+          ],
+          "contract_id": "codex-cli",
+          "surface": "cli"
+        }
+      },
+      "selection": {
+        "depth": "workspace",
+        "harnesses": [
+          "claude",
+          "codex"
+        ],
+        "includes": [],
+        "owner": "claude"
+      }
+    }
+  },
+  "renders": {
+    "repo-claude": [
+      {
+        "byte_size": 1108,
+        "dst": ".brigade/handoff-sources.example.json",
+        "rendered": false,
+        "sha256": "4d32bfa7dfa7816841aadf1c2efa6a049198c1face8bf721e6203c0333701a58"
+      },
+      {
+        "byte_size": 872,
+        "dst": ".brigade/policies/personal.json",
+        "rendered": false,
+        "sha256": "bb4e59151a0d8822ea7eeb4d11e9f77154d7748b9f87a15c714e9ebbe080b436"
+      },
+      {
+        "byte_size": 754,
+        "dst": ".brigade/policies/public-repo.json",
+        "rendered": false,
+        "sha256": "c54518f4cff1f04817f2b497e7d6bc1870699b60caf181185045541ff0af8c92"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".claude/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 4847,
+        "dst": "AGENTS.md",
+        "rendered": true,
+        "sha256": "0f23a2bd6467ed7b29711d438ad3fc0042d62a9aa34c9c42a3b6fd4eac58631c"
+      },
+      {
+        "byte_size": 2216,
+        "dst": "CLAUDE.md",
+        "rendered": true,
+        "sha256": "e33b63334b7ca776b5a41b47f7d4be16303a27147dd10e61053260a4e1efe8ff"
+      },
+      {
+        "byte_size": 6331,
+        "dst": "SAFETY_RULES.md",
+        "rendered": true,
+        "sha256": "d133ba8fdb2a580d44b896aaaf744c9d1516ce8b2019fbc1aab8a3a351000bcc"
+      }
+    ],
+    "repo-claude-full": [
+      {
+        "byte_size": 1108,
+        "dst": ".brigade/handoff-sources.example.json",
+        "rendered": false,
+        "sha256": "4d32bfa7dfa7816841aadf1c2efa6a049198c1face8bf721e6203c0333701a58"
+      },
+      {
+        "byte_size": 872,
+        "dst": ".brigade/policies/personal.json",
+        "rendered": false,
+        "sha256": "bb4e59151a0d8822ea7eeb4d11e9f77154d7748b9f87a15c714e9ebbe080b436"
+      },
+      {
+        "byte_size": 754,
+        "dst": ".brigade/policies/public-repo.json",
+        "rendered": false,
+        "sha256": "c54518f4cff1f04817f2b497e7d6bc1870699b60caf181185045541ff0af8c92"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".claude/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 4847,
+        "dst": "AGENTS.md",
+        "rendered": true,
+        "sha256": "0f23a2bd6467ed7b29711d438ad3fc0042d62a9aa34c9c42a3b6fd4eac58631c"
+      },
+      {
+        "byte_size": 2216,
+        "dst": "CLAUDE.md",
+        "rendered": true,
+        "sha256": "e33b63334b7ca776b5a41b47f7d4be16303a27147dd10e61053260a4e1efe8ff"
+      },
+      {
+        "byte_size": 2210,
+        "dst": "INSTALL_FOR_AGENTS.md",
+        "rendered": true,
+        "sha256": "92630c7db302eeea5993187d9a9772972f2d569284a66e1ef98ea46449f3756b"
+      },
+      {
+        "byte_size": 6331,
+        "dst": "SAFETY_RULES.md",
+        "rendered": true,
+        "sha256": "d133ba8fdb2a580d44b896aaaf744c9d1516ce8b2019fbc1aab8a3a351000bcc"
+      },
+      {
+        "byte_size": 8148,
+        "dst": "hooks/pre-push",
+        "rendered": false,
+        "sha256": "556efbc045adef273a9ff3c03bc703e35a326f95a6d90157bc6173437924bd99"
+      },
+      {
+        "byte_size": 1121,
+        "dst": "rules/acceptance-driven-work.md",
+        "rendered": true,
+        "sha256": "531a3b30619029b01ea7ffefb118638eea2fcc858ae9cfbd634e34723e9f2b9e"
+      },
+      {
+        "byte_size": 1194,
+        "dst": "rules/issue-tdd-loop.md",
+        "rendered": true,
+        "sha256": "79bb1c9ed0b14c235614193fb26e2e15aaef971a0d9c9ff89b37e7ea3d09ba8b"
+      }
+    ],
+    "workspace-claude-codex": [
+      {
+        "byte_size": 3414,
+        "dst": ".brigade/chat-memory-sweep.example.json",
+        "rendered": false,
+        "sha256": "5d29c607824c03e156eb522491903ab2aa5874f6138804d86ec20f9831b74c79"
+      },
+      {
+        "byte_size": 1108,
+        "dst": ".brigade/handoff-sources.example.json",
+        "rendered": false,
+        "sha256": "4d32bfa7dfa7816841aadf1c2efa6a049198c1face8bf721e6203c0333701a58"
+      },
+      {
+        "byte_size": 511,
+        "dst": ".brigade/memory-care.example.json",
+        "rendered": false,
+        "sha256": "bdfb973a6225b16ddf26d0e6d66947723cf3039052c36644dc9380ec501d42e7"
+      },
+      {
+        "byte_size": 872,
+        "dst": ".brigade/policies/personal.json",
+        "rendered": false,
+        "sha256": "bb4e59151a0d8822ea7eeb4d11e9f77154d7748b9f87a15c714e9ebbe080b436"
+      },
+      {
+        "byte_size": 754,
+        "dst": ".brigade/policies/public-repo.json",
+        "rendered": false,
+        "sha256": "c54518f4cff1f04817f2b497e7d6bc1870699b60caf181185045541ff0af8c92"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".claude/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".codex/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 11823,
+        "dst": "AGENTS.md",
+        "rendered": true,
+        "sha256": "87dd1344f69c9c78075fcac94c62b9f032b98ecef3c79c44d28fb2985c106253"
+      },
+      {
+        "byte_size": 3226,
+        "dst": "CLAUDE.md",
+        "rendered": true,
+        "sha256": "2ab6e4d9a8dcd24d5c063eac56439f61c29bffedbe6102f2057cde66e3b0664a"
+      },
+      {
+        "byte_size": 1578,
+        "dst": "HEARTBEAT.md",
+        "rendered": true,
+        "sha256": "3a3ff123f454c9d9eed6591d162a026b744fb555524acccf5a161599243b5833"
+      },
+      {
+        "byte_size": 735,
+        "dst": "IDENTITY.md",
+        "rendered": true,
+        "sha256": "f9d92ede54fd60564cb2b39dc776491111498f2b2f45ebbb0c5de759c6f8bd02"
+      },
+      {
+        "byte_size": 4431,
+        "dst": "INSTALL_FOR_AGENTS.md",
+        "rendered": true,
+        "sha256": "3a7e9a3aa2677f0c2d5bcff46a3e7b65414deaa3fffb397b41dd5cb015bc6d0d"
+      },
+      {
+        "byte_size": 4873,
+        "dst": "MEMORY.md",
+        "rendered": true,
+        "sha256": "d08485c9c00bb4e6d3811e71d49871a76372a8c4b960d89492cab2e2b814c2db"
+      },
+      {
+        "byte_size": 6331,
+        "dst": "SAFETY_RULES.md",
+        "rendered": true,
+        "sha256": "d133ba8fdb2a580d44b896aaaf744c9d1516ce8b2019fbc1aab8a3a351000bcc"
+      },
+      {
+        "byte_size": 5122,
+        "dst": "SOUL.md",
+        "rendered": true,
+        "sha256": "3f4509bc1f269eccfe4303ecc41204ff78cf670d480d451fa1ec0f4003c19279"
+      },
+      {
+        "byte_size": 4749,
+        "dst": "TOOLS.md",
+        "rendered": true,
+        "sha256": "53fe19ed20ad8fe8cc754f135d588ad489af559a59990b3b6b5b32d080bc7d20"
+      },
+      {
+        "byte_size": 2062,
+        "dst": "USER.md",
+        "rendered": true,
+        "sha256": "76d5b8da982a7907d78967456ce2ad6c86069e8e55578c861ed3d7aab8d1a9ae"
+      },
+      {
+        "byte_size": 8148,
+        "dst": "hooks/pre-push",
+        "rendered": false,
+        "sha256": "556efbc045adef273a9ff3c03bc703e35a326f95a6d90157bc6173437924bd99"
+      },
+      {
+        "byte_size": 5259,
+        "dst": "memory/cards/backup-restic.md",
+        "rendered": true,
+        "sha256": "0eda477da2526d337c5589f1b143c2cbe60be63ad70dfaca4194f64956c0d136"
+      },
+      {
+        "byte_size": 6264,
+        "dst": "memory/cards/chat-surface-crawlers.md",
+        "rendered": true,
+        "sha256": "6f5d6e8eda5c8d6537b05283838c21250ebb0063be239db96d36e9b1609eaec0"
+      },
+      {
+        "byte_size": 1967,
+        "dst": "memory/cards/content-safety.md",
+        "rendered": true,
+        "sha256": "094d37f8e9f9e3abf8883fbc412e18bfa4de6fdff5528a2afb5d9bfbddcecafa"
+      },
+      {
+        "byte_size": 3258,
+        "dst": "memory/cards/handoff-flow.md",
+        "rendered": true,
+        "sha256": "996140feb4a54265732c01c0b8f37e14479d4df14ecf938122b0a9901fae5ca1"
+      },
+      {
+        "byte_size": 2080,
+        "dst": "memory/cards/memory-architecture.md",
+        "rendered": true,
+        "sha256": "0fb656c0b51505fff201b47260e69aac4ce6165be9ab4c480ea5fe44f2e52908"
+      },
+      {
+        "byte_size": 3009,
+        "dst": "memory/cards/memory-care-staleness.md",
+        "rendered": true,
+        "sha256": "b9e91694892da5fe81597ac9ae19bb28467a0186d7251de7bd71d64befb31988"
+      },
+      {
+        "byte_size": 6537,
+        "dst": "memory/cards/memory-scanner.md",
+        "rendered": true,
+        "sha256": "b35f4904693402364a24831e24d0f3286180410dc5b5249ca427883a26125137"
+      },
+      {
+        "byte_size": 2772,
+        "dst": "memory/cards/multi-workspace-handoff-admin.md",
+        "rendered": true,
+        "sha256": "a0d3afbd184bacb4aeba1ba436f8382c838a407ae07b4a044cce7d715f827f29"
+      },
+      {
+        "byte_size": 3834,
+        "dst": "memory/cards/obsidian-notes.md",
+        "rendered": true,
+        "sha256": "ba1e8ce25bdfea76d981673165c7a901799bc30b5d054af47545ad0579278b3b"
+      },
+      {
+        "byte_size": 3906,
+        "dst": "memory/cards/pipeline-standups.md",
+        "rendered": true,
+        "sha256": "67ba2c28b119cd32cc24cd836248dd10be3b5d9b2f369bdfd5b3a51ba5809c61"
+      },
+      {
+        "byte_size": 4080,
+        "dst": "memory/cards/token-glace-output-compaction.md",
+        "rendered": true,
+        "sha256": "5f8898d45696a8186ab2cf756553e9d3d655ce1da46d633c5fd5c6844883a43c"
+      },
+      {
+        "byte_size": 1121,
+        "dst": "rules/acceptance-driven-work.md",
+        "rendered": true,
+        "sha256": "531a3b30619029b01ea7ffefb118638eea2fcc858ae9cfbd634e34723e9f2b9e"
+      },
+      {
+        "byte_size": 1194,
+        "dst": "rules/issue-tdd-loop.md",
+        "rendered": true,
+        "sha256": "79bb1c9ed0b14c235614193fb26e2e15aaef971a0d9c9ff89b37e7ea3d09ba8b"
+      },
+      {
+        "byte_size": 5238,
+        "dst": "scripts/backup-restic.sh",
+        "rendered": false,
+        "sha256": "b2cf1874706813d40114192884450c374589b2b26fdb819f44aedd5008166970"
+      },
+      {
+        "byte_size": 7094,
+        "dst": "skills/brigade-work/SKILL.md",
+        "rendered": true,
+        "sha256": "822ce10efce89c14964cacba6627728104f167bae0f065465bf5ff49af018261"
+      },
+      {
+        "byte_size": 5347,
+        "dst": "skills/note/SKILL.md",
+        "rendered": true,
+        "sha256": "457078ef56f4143910ba68729198285e204645d66ababc557e17b80496fe4cb1"
+      },
+      {
+        "byte_size": 2376,
+        "dst": "skills/ultra-work-scout/SKILL.md",
+        "rendered": true,
+        "sha256": "dcac8b8a66195a861cb62d563b8f18a5b868b9d070d288e75f53d026d81445b5"
+      }
+    ]
+  },
+  "schema": "brigade.template_profile_snapshot.v1"
+}

--- a/tests/test_template_profiles.py
+++ b/tests/test_template_profiles.py
@@ -131,6 +131,105 @@ def test_init_profile_conflicts_with_depth(tmp_path, capsys):
     assert "--profile cannot be combined" in capsys.readouterr().err
 
 
+def test_init_profile_conflicts_with_harnesses(tmp_path, capsys):
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--profile",
+            "repo-claude",
+            "--harnesses",
+            "claude",
+        ]
+    )
+    assert rc == 2
+    assert "--profile cannot be combined" in capsys.readouterr().err
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_init_profile_merges_includes_with_first_seen_dedupe(tmp_path):
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--profile",
+            "repo-claude-full",
+            "--include",
+            "publisher",
+            "--include",
+            "repo-extras",
+            "--include",
+            "publisher",
+            "--no-wire",
+        ]
+    )
+    assert rc == 0
+    config = json.loads((tmp_path / ".brigade" / "config.json").read_text(encoding="utf-8"))
+    assert config["includes"] == ["repo-extras", "publisher"]
+    assert (tmp_path / "INSTALL_FOR_AGENTS.md").is_file()
+
+
+def test_init_profile_owner_override_propagates(tmp_path):
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--profile",
+            "workspace-claude-codex",
+            "--owner",
+            "codex",
+            "--no-wire",
+        ]
+    )
+    assert rc == 0
+    config = json.loads((tmp_path / ".brigade" / "config.json").read_text(encoding="utf-8"))
+    assert config["owner"] == "codex"
+    assert config["harnesses"] == ["claude", "codex"]
+
+
+def test_init_profile_full_appends_repo_extras_after_include_merge(tmp_path):
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--profile",
+            "repo-claude",
+            "--include",
+            "publisher",
+            "--full",
+            "--no-wire",
+        ]
+    )
+    assert rc == 0
+    config = json.loads((tmp_path / ".brigade" / "config.json").read_text(encoding="utf-8"))
+    assert config["includes"] == ["publisher", "repo-extras"]
+    assert (tmp_path / "INSTALL_FOR_AGENTS.md").is_file()
+
+
+def test_init_profile_dry_run_leaves_no_files(tmp_path, capsys):
+    before = list(tmp_path.iterdir())
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--profile",
+            "repo-claude",
+            "--dry-run",
+            "--no-wire",
+        ]
+    )
+    assert rc == 0
+    assert list(tmp_path.iterdir()) == before
+    out = capsys.readouterr().out
+    assert "[dry-run]" in out
+    assert "repo" in out
+
+
 def test_init_legacy_default_without_profile_unchanged(tmp_path):
     """Profile-less installs keep the existing depth/harness default path."""
     rc = cli.main(

--- a/tests/test_template_profiles.py
+++ b/tests/test_template_profiles.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, template_profiles
+from brigade.install import build_render_context, install_selection, resolve_manifests
+from brigade.selection import Selection
+
+FIXTURES = Path(__file__).parents[1] / "docs" / "research" / "fixtures" / "harness-contract.v1"
+
+
+def test_bundled_snapshot_schema_renders_and_harness_contracts():
+    payload = template_profiles.load_snapshot(verify_contracts=True)
+    assert payload["schema"] == template_profiles.SCHEMA
+    assert set(payload["profiles"]) == set(template_profiles.BUILTIN_PROFILES)
+    for name, profile in payload["profiles"].items():
+        assert "identity" not in profile
+        assert "supported_harness_versions" not in profile
+        selection = Selection(**profile["selection"])
+        selection.validate()
+        assert payload["renders"][name] == template_profiles.compute_profile_renders(selection)
+        expected = template_profiles.harness_compatibility_from_contracts(selection.harnesses)
+        assert profile["harness_compatibility"] == expected
+        for harness_id, compat in profile["harness_compatibility"].items():
+            assert compat["contract_id"] == template_profiles.HARNESS_CONTRACT_FIXTURES[harness_id]
+            for capability in compat["capabilities"]:
+                assert set(capability) == {"id", "tested_version", "provenance", "evidence"}
+                assert capability["evidence"]
+
+
+def test_build_snapshot_matches_committed_snapshot():
+    built = template_profiles.build_snapshot()
+    committed = template_profiles.load_snapshot(verify_contracts=True)
+    assert built["profiles"] == committed["profiles"]
+    assert built["renders"] == committed["renders"]
+    assert built["brigade_version"] == committed["brigade_version"]
+
+
+def test_resolve_profile_returns_valid_selection():
+    selection = template_profiles.resolve_profile("repo-claude")
+    assert selection.depth == "repo"
+    assert selection.harnesses == ["claude"]
+    assert selection.owner == "claude"
+    assert selection.includes == []
+
+
+def test_unknown_profile_raises():
+    with pytest.raises(template_profiles.UnknownTemplateProfile, match="missing-profile"):
+        template_profiles.resolve_profile("missing-profile")
+
+
+def test_harness_compatibility_refuses_unmapped_harness():
+    with pytest.raises(ValueError, match="no harness-contract.v1 fixture mapping"):
+        template_profiles.harness_compatibility_from_contracts(["aider"])
+
+
+def test_harness_compatibility_tracks_fixture_tested_version_provenance_evidence():
+    fixture = json.loads((FIXTURES / "claude-code.json").read_text(encoding="utf-8"))
+    projected = template_profiles.harness_compatibility_from_contracts(["claude"])["claude"]
+    by_id = {item["id"]: item for item in projected["capabilities"]}
+    for capability in fixture["capabilities"]:
+        projected_cap = by_id[capability["id"]]
+        assert projected_cap["tested_version"] == capability["tested_version"]
+        assert projected_cap["provenance"] == capability["provenance"]
+        assert projected_cap["evidence"] == [
+            {"kind": item["kind"], "reference": item["reference"]} for item in capability["evidence"]
+        ]
+
+
+def test_render_hashes_are_deterministic_for_same_selection():
+    selection = template_profiles.resolve_profile("workspace-claude-codex")
+    first = template_profiles.compute_profile_renders(selection)
+    second = template_profiles.compute_profile_renders(selection)
+    assert first == second
+    assert first
+    assert all(len(item["sha256"]) == 64 for item in first)
+
+
+def test_render_hash_matches_installed_bytes(tmp_path):
+    selection = template_profiles.resolve_profile("repo-claude")
+    renders = {item["dst"]: item for item in template_profiles.compute_profile_renders(selection)}
+    assert install_selection(tmp_path, selection) == 0
+    for dst, record in renders.items():
+        content = (tmp_path / dst).read_bytes()
+        assert hashlib.sha256(content).hexdigest() == record["sha256"]
+        assert len(content) == record["byte_size"]
+
+
+def test_build_render_context_uses_owner_inbox_first():
+    selection = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex"],
+        owner="codex",
+        includes=[],
+    )
+    context = build_render_context(selection)
+    assert context["handoff_inbox"] == ".codex/memory-handoffs/"
+
+
+def test_init_profile_installs_named_selection(tmp_path, capsys):
+    rc = cli.main(["init", "--target", str(tmp_path), "--profile", "repo-claude", "--no-wire"])
+    assert rc == 0
+    assert (tmp_path / "CLAUDE.md").is_file()
+    capsys.readouterr()
+
+
+def test_init_profile_unknown_returns_error(tmp_path, capsys):
+    rc = cli.main(["init", "--target", str(tmp_path), "--profile", "missing-profile"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown template profile" in err
+
+
+def test_init_profile_conflicts_with_depth(tmp_path, capsys):
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--profile",
+            "repo-claude",
+            "--depth",
+            "repo",
+        ]
+    )
+    assert rc == 2
+    assert "--profile cannot be combined" in capsys.readouterr().err
+
+
+def test_init_legacy_default_without_profile_unchanged(tmp_path):
+    """Profile-less installs keep the existing depth/harness default path."""
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--depth",
+            "repo",
+            "--harnesses",
+            "claude",
+            "--no-wire",
+        ]
+    )
+    assert rc == 0
+    files, _, _ = resolve_manifests(Selection(depth="repo", harnesses=["claude"], owner="claude"))
+    for entry in files:
+        assert (tmp_path / entry["dst"]).is_file()
+
+
+def test_snapshot_rejects_stale_render_digest(tmp_path):
+    payload = template_profiles.build_snapshot(["repo-claude"])
+    payload["renders"]["repo-claude"][0]["sha256"] = "0" * 64
+    path = tmp_path / "template-profile-snapshot.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="render digest mismatch"):
+        template_profiles.load_snapshot(path, verify_contracts=True)
+
+
+def test_snapshot_rejects_stale_harness_compatibility(tmp_path):
+    payload = template_profiles.build_snapshot(["repo-claude"])
+    payload["profiles"]["repo-claude"]["harness_compatibility"]["claude"]["capabilities"][0]["tested_version"] = "9.9.9"
+    path = tmp_path / "template-profile-snapshot.json"
+    path.write_text(template_profiles.render_snapshot(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="harness_compatibility does not match"):
+        template_profiles.load_snapshot(path, verify_contracts=True)
+
+
+def test_no_public_registry_vocabulary_in_module_surface():
+    assert not hasattr(template_profiles, "check_harness_version")
+    assert not hasattr(template_profiles, "UnsupportedHarnessVersion")
+    assert "template_registry" not in template_profiles.SCHEMA
+    assert "brigade://" not in template_profiles.render_snapshot(template_profiles.build_snapshot(["repo-claude"]))
+
+
+def test_ci_and_verify_check_template_profile_snapshot():
+    root = Path(__file__).resolve().parents[1]
+    verify = (root / "scripts" / "verify").read_text(encoding="utf-8")
+    ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "scripts/template_profile_snapshot.py --check" in verify
+    assert "python scripts/template_profile_snapshot.py --check" in ci


### PR DESCRIPTION
## Summary

Implements the operator-approved slim replacement for #494 and supersedes closed PR #847.

- Adds bundled template profiles: `repo-claude`, `workspace-claude-codex`, and `repo-claude-full`.
- Adds `brigade init --profile <name>`, mutually exclusive with `--depth` and `--harnesses`.
- Merges repeatable `--include` values into profile includes in first-seen order, then applies the existing `--full` extras.
- Preserves owner overrides, dry-run behavior, and profile-less initialization.
- Adds a deterministic rendered-template hash snapshot and checks it in `scripts/verify` and CI.
- Projects compatibility from existing `harness-contract.v1` fields: `tested_version`, `provenance`, and `evidence`.

Closes #494

## Explicit non-goals

This change does not add a public template registry, `brigade://` profile URIs, `supported_harness_versions`, synthetic `0.0.0` compatibility claims, or install-time version enforcement. It does not touch protected #750, release workflows, or evidence-ledger code.

## Verification

- Template-profile snapshot check: passed, Brigade receipt `20260811-065056-work-verify-e3700f`
- Focused profile suite: passed, receipt `20260811-064755-work-verify-0dacf8`
- Combined profile/init/install/selection suite: passed, receipt `20260811-064809-work-verify-9c84cc`
- Exact-head Luna review: ready
- Exact-head Terra review: ready
- Exact evidence-ledger suite passes locally; the current GitHub failure is an unrelated concurrent SQLite lock in unchanged engine code

## Checklist

- [x] Include merge and de-duplication tests
- [x] Owner, full, dry-run, harness-conflict, and profile-less regressions
- [x] Rejected registry vocabulary remains absent
- [x] No new runtime dependencies
- [x] Existing commits retain their Cursor co-author trailer