### PR TITLE
fix(evidence): use covering index for status counts

### DIFF
--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -193,6 +193,10 @@ type Status struct {
 	Capability     map[string]any         `json:"capability,omitempty"`
 }
 
+// statusSourceCountSQL counts joined non-null items.source_id so SQLite can
+// satisfy the LEFT JOIN with COVERING INDEX idx_items_source_external.
+const statusSourceCountSQL = `select s.kind, count(i.source_id) from sources s left join items i on i.source_id = s.id group by s.kind order by s.kind`
+
 func collectStatus(db *sql.DB, paths Paths) (Status, error) {
 	version, err := archive.UserVersion(db)
 	if err != nil {
@@ -207,7 +211,7 @@ func collectStatus(db *sql.DB, paths Paths) (Status, error) {
 	if last.Valid {
 		st.LastImport = &last.String
 	}
-	rows, err := db.Query(`select s.kind, count(i.id) from sources s left join items i on i.source_id = s.id group by s.kind order by s.kind`)
+	rows, err := db.Query(statusSourceCountSQL)
 	if err == nil {
 		defer rows.Close()
 		for rows.Next() {

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -2099,6 +2099,50 @@ func TestSearchMultiTermAndPrefix(t *testing.T) {
 	}
 }
 
+func TestCollectStatusSourceCountsUseCoveringIndex(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	db, paths, err := openMigrated()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	now := "2026-07-02T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, created_at, updated_at) values
+('src-codex','codex','Codex',?,?),
+('src-claude','claude','Claude',?,?)`, now, now, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name) values('col-codex','src-codex','collection:codex','agent_session','Codex')`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("item-codex-%d", i)
+		if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, text, content_hash, raw_json)
+values(?,?,?,?,?,?,?,?,?)`, id, "src-codex", "col-codex", id, "message", now, "body", "hash-"+id, "{}"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	status, err := collectStatus(db, paths)
+	if err != nil {
+		t.Fatalf("collectStatus: %v", err)
+	}
+	if got, want := status.SourceCounts["codex"], int64(3); got != want {
+		t.Fatalf("populated source count = %d, want %d", got, want)
+	}
+	if got, want := status.SourceCounts["claude"], int64(0); got != want {
+		t.Fatalf("zero-item source count = %d, want %d", got, want)
+	}
+
+	plan := explainPlan(t, db, statusSourceCountSQL)
+	wantCovering := "USING COVERING INDEX idx_items_source_external"
+	if !strings.Contains(plan, wantCovering) {
+		t.Fatalf("status source-count plan missing %q:\n%s", wantCovering, plan)
+	}
+}
+
 func TestSearchPlanBoundsFTSCandidatesBeforeJoins(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")


### PR DESCRIPTION
## Summary

- Count joined item `source_id` values instead of `id` values in the evidence status aggregate.
- Add regression coverage for the covering-index plan and zero-item source counts.

## Why

`brigade evidence status` requests per-source item totals from the evidence engine. The existing query joined on `items.source_id` but counted `items.id`, forcing table-row reads after SQLite found matches through `idx_items_source_external`. Since `items.source_id` is non-null, counting it returns the same totals and lets SQLite answer the join from the covering index.

## Verification

- `go -C engines/evidence-ledger test ./internal/app -run TestCollectStatusSourceCountsUseCoveringIndex -count=1`
- `go -C engines/evidence-ledger vet ./...`
- `go -C engines/evidence-ledger test ./...`
- `./scripts/verify`

On the live archive, direct SQL completed the source-count aggregate in 3.49 seconds. The other status aggregates completed in 0.04, 0.29, and 0.06 seconds.

Two 30-second CLI probes timed out before status collection because the current `main` engine first ran the schema 1-to-4 migration and provenance backfill. The direct SQL timings isolate the status queries from that migration cost.

## Risk

Low. This changes no schema and preserves zero-item rows from the `LEFT JOIN`. The regression test checks both populated and empty sources and pins the current covering-index plan.
