### PR TITLE
fix(outcome): keep linked-worktree artifacts repository-bounded

### DIFF
--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -15,9 +15,11 @@ import io
 import json
 import os
 import platform as platform_mod
+import re
 import secrets
 import sys
 import time
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +27,9 @@ from . import localio, outcome as core, receipt_schema, scorecard as scorecard_m
 
 _LOCK_WAIT_SECONDS = 30.0
 _LOCK_SENTINEL_BYTE = b"\0"
+# Align with Brigade public/slug identifiers (no arbitrary length cap).
+_SAFE_SKILL_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+_WARNING_LABEL_LIMIT = 80
 
 # Generic fallback when no exercised skill/card is known. Prefer a real artifact
 # id at capture time so distinct skills do not collapse into one rank bucket.
@@ -97,16 +102,130 @@ def load_status(target: Path) -> dict[str, dict]:
     return artifacts if isinstance(artifacts, dict) else {}
 
 
-def _known_skill_names(target: Path) -> list[str]:
-    """Skill ids the target actually has: wired into a harness or in the registry."""
+def _artifact_id_has_controls(artifact_id: str) -> bool:
+    """True when artifact_id contains Unicode control (Cc) or format (Cf) characters."""
+    return any(unicodedata.category(ch) in {"Cc", "Cf"} for ch in artifact_id)
+
+
+def _safe_path_component(artifact_id: str) -> str | None:
+    """Return artifact_id only when it is a single safe on-disk path component."""
+    if not artifact_id or artifact_id in {".", ".."}:
+        return None
+    if any(sep in artifact_id for sep in ("/", "\\")):
+        return None
+    if artifact_id.startswith("~") or ":" in artifact_id:
+        return None
+    if any(ch in artifact_id for ch in "*?[]"):
+        return None
+    if _artifact_id_has_controls(artifact_id):
+        return None
+    return artifact_id
+
+
+def _safe_skill_id_component(skill_id: str) -> str | None:
+    """Return skill_id only when it is a single safe slug path component."""
+    safe = _safe_path_component(skill_id)
+    if safe is None:
+        return None
+    if _SAFE_SKILL_ID_RE.fullmatch(safe) is None:
+        return None
+    return safe
+
+
+def _safe_card_id_component(card_id: str) -> str | None:
+    """Return card_id when it is a single safe path component (Unicode/spaces ok)."""
+    return _safe_path_component(card_id)
+
+
+def _resolve_root(root: Path) -> Path | None:
+    try:
+        return root.expanduser().resolve()
+    except OSError:
+        return None
+
+
+def _contained_under(root_resolved: Path, candidate: Path) -> Path | None:
+    """Return candidate when it resolves to a real file inside root."""
+    try:
+        if not candidate.is_file():
+            return None
+        resolved = candidate.resolve()
+    except OSError:
+        return None
+    if not resolved.is_relative_to(root_resolved):
+        return None
+    return candidate
+
+
+def _contained_card_file(target: Path, candidate: Path) -> Path | None:
+    """Return candidate when it resolves under the selected cards root inside target.
+
+    Blocks both an escaping ``memory`` / ``memory/cards`` directory symlink
+    (cards resolve outside the target) and a per-file symlink that lands
+    outside ``memory/cards`` even when still inside the target tree.
+    """
+    target_resolved = _resolve_root(target)
+    if target_resolved is None:
+        return None
+    cards_resolved = _resolve_root(target / "memory" / "cards")
+    if cards_resolved is None or not cards_resolved.is_relative_to(target_resolved):
+        return None
+    return _contained_under(cards_resolved, candidate)
+
+
+def _skill_names_at(root: Path) -> set[str]:
+    """Skill ids present under one checkout: harness installs or registry dirs."""
     names: set[str] = set()
-    for skill_md in target.glob(".*/skills/*/SKILL.md"):
-        names.add(skill_md.parent.name)
-    registry = target / ".brigade" / "skills" / "registry"
+    root_resolved = _resolve_root(root)
+    if root_resolved is None:
+        return names
+    for skill_md in root.glob(".*/skills/*/SKILL.md"):
+        skill_id = _safe_skill_id_component(skill_md.parent.name)
+        if skill_id is None:
+            continue
+        if _contained_under(root_resolved, skill_md) is None:
+            continue
+        names.add(skill_id)
+    registry = root / ".brigade" / "skills" / "registry"
     if registry.is_dir():
         for child in registry.iterdir():
-            if child.is_dir():
-                names.add(child.name)
+            skill_id = _safe_skill_id_component(child.name)
+            if skill_id is None:
+                continue
+            skill_md = child / "SKILL.md"
+            if _contained_under(root_resolved, skill_md) is None:
+                continue
+            names.add(skill_id)
+    return names
+
+
+def _linked_worktree_skill_roots(target: Path) -> list[Path]:
+    """Target first, then linked-worktree parent. Never global home skill dirs."""
+    roots = [target]
+    from . import roster
+
+    parent = roster._linked_worktree_parent(target)
+    if parent is None:
+        return roots
+    try:
+        if parent.resolve() == target.expanduser().resolve():
+            return roots
+    except OSError:
+        return roots
+    roots.append(parent)
+    return roots
+
+
+def _known_skill_names(target: Path) -> list[str]:
+    """Skill ids the target actually has: wired into a harness or in the registry.
+
+    Linked git worktrees inherit the parent clone's harness/registry skills after
+    the target-local set, matching roster resolution. Global home skill dirs are
+    intentionally out of scope so capture attribution stays repo-bounded.
+    """
+    names: set[str] = set()
+    for root in _linked_worktree_skill_roots(target):
+        names |= _skill_names_at(root)
     return sorted(names)
 
 
@@ -114,7 +233,15 @@ def _known_card_names(target: Path) -> list[str]:
     cards = target / "memory" / "cards"
     if not cards.is_dir():
         return []
-    return sorted(p.stem for p in cards.glob("*.md"))
+    names: list[str] = []
+    for path in cards.glob("*.md"):
+        card_id = _safe_card_id_component(path.stem)
+        if card_id is None:
+            continue
+        if _contained_card_file(target, path) is None:
+            continue
+        names.append(card_id)
+    return sorted(names)
 
 
 def _artifact_known(target: Path, artifact_id: str, kind: str) -> bool:
@@ -123,27 +250,145 @@ def _artifact_known(target: Path, artifact_id: str, kind: str) -> bool:
     return artifact_id in _known_skill_names(target)
 
 
+def _artifact_content_path_at(root: Path, artifact_id: str) -> Path | None:
+    """Harness-installed copy first, then registry master, under one root."""
+    skill_id = _safe_skill_id_component(artifact_id)
+    if skill_id is None:
+        return None
+    root_resolved = _resolve_root(root)
+    if root_resolved is None:
+        return None
+    # Enumerate harness skill roots without interpolating the untrusted id into glob.
+    for skills_root in sorted(path for path in root.glob(".*/skills") if path.is_dir()):
+        candidate = skills_root / skill_id / "SKILL.md"
+        contained = _contained_under(root_resolved, candidate)
+        if contained is not None:
+            return contained
+    registry_md = root / ".brigade" / "skills" / "registry" / skill_id / "SKILL.md"
+    return _contained_under(root_resolved, registry_md)
+
+
 def _artifact_content_path(target: Path, artifact_id: str, kind: str) -> Path | None:
     """Locate the artifact text a fingerprint should pin.
 
     Harness-installed copy first: a verified run exercises the installed skill,
     not the registry master, so when the two drift the installed text is what
     the signal is evidence about. The registry copy is the fallback for skills
-    known but not yet installed. capture and rank/explain both resolve through
-    here, so "current cohort" always means the text that actually runs.
+    known but not yet installed. On a linked worktree, target-local copies win
+    over the parent clone. capture and rank/explain both resolve through here,
+    so "current cohort" always means the text that actually runs.
     """
     if kind == "card":
-        card = target / "memory" / "cards" / f"{artifact_id}.md"
-        return card if card.is_file() else None
-    for skill_md in sorted(target.glob(f".*/skills/{artifact_id}/SKILL.md")):
-        if skill_md.is_file():
-            return skill_md
+        card_id = _safe_card_id_component(artifact_id)
+        if card_id is None:
+            return None
+        candidate = target / "memory" / "cards" / f"{card_id}.md"
+        return _contained_card_file(target, candidate)
+    for root in _linked_worktree_skill_roots(target):
+        path = _artifact_content_path_at(root, artifact_id)
+        if path is not None:
+            return path
+    return None
+
+
+def _strip_warning_controls(value: str) -> str:
+    """Remove terminal, C0/C1, bidi, and other format controls from warning text."""
+    pieces: list[str] = []
+    for character in value:
+        category = unicodedata.category(character)
+        if category in {"Cc", "Cf"}:
+            if character in "\t\n\r":
+                pieces.append(" ")
+            continue
+        pieces.append(character)
+    return "".join(pieces)
+
+
+def _warning_label(value: str) -> str:
+    """Render a bounded, control-stripped label for stderr warnings."""
+    clean = " ".join(_strip_warning_controls(value).split())
+    if len(clean) <= _WARNING_LABEL_LIMIT:
+        return clean
+    return clean[: _WARNING_LABEL_LIMIT - 3] + "..."
+
+
+def _normalize_path_separators(value: str) -> str:
+    return value.replace("\\", "/")
+
+
+def _path_shaped_artifact_id(artifact_id: str) -> bool:
+    normalized = _normalize_path_separators(artifact_id)
+    return (
+        normalized.startswith(("~", "/"))
+        or "/" in normalized
+        or normalized.endswith("SKILL.md")
+        or (len(normalized) >= 2 and normalized[1] == ":")
+    )
+
+
+def _skill_id_from_path_shaped(artifact_id: str) -> str | None:
+    normalized = _normalize_path_separators(artifact_id)
+    try:
+        home = str(Path.home().expanduser().resolve())
+    except OSError:
+        home = ""
+    rendered = normalized
+    if home:
+        rendered = rendered.replace(_normalize_path_separators(home), "~")
+        rendered = rendered.replace(home, "~")
+    path = Path(rendered)
+    name = path.name
+    if name == "SKILL.md":
+        name = path.parent.name
+    if not name or name in {".", ".."}:
+        return None
+    return name
+
+
+def _safe_artifact_id_for_warning(artifact_id: str) -> str:
+    """Keep untrusted path-shaped capture ids out of warning text."""
+    if not artifact_id or artifact_id in {".", ".."}:
+        return _warning_label(artifact_id)
+    if not _path_shaped_artifact_id(artifact_id):
+        return _warning_label(artifact_id)
+    name = _skill_id_from_path_shaped(artifact_id)
+    if name is None:
+        return "[redacted-path]"
+    return _warning_label(name)
+
+
+def _unknown_artifact_remedy(artifact_id: str, artifact_kind: str) -> str | None:
+    """Exact repair command when Brigade can name one without guessing paths."""
+    if artifact_kind != "skill":
+        return None
+    # Path-shaped ids are caller mistakes; point at the directory name only.
+    if _path_shaped_artifact_id(artifact_id):
+        skill_id = _skill_id_from_path_shaped(artifact_id)
+        if skill_id is None:
+            return None
+        safe_id = _warning_label(skill_id)
+        return f"Capture against the skill id `{safe_id}`, not a filesystem path."
     from . import skills_cmd
 
-    registry_md = skills_cmd._skill_md_path(skills_cmd._skill_path(target, artifact_id))
-    if registry_md.is_file():
-        return registry_md
+    if skills_cmd._bundled_skill_exists(artifact_id):
+        safe_id = _warning_label(artifact_id)
+        return f"Install it with: brigade skills install {safe_id}"
     return None
+
+
+def _unknown_artifact_warning(target: Path, artifact_id: str, artifact_kind: str) -> str:
+    known = _known_skill_names(target) if artifact_kind == "skill" else _known_card_names(target)
+    hint = ", ".join(_warning_label(name) for name in known) if known else "none"
+    display_id = _safe_artifact_id_for_warning(artifact_id)
+    message = (
+        f"warning: '{display_id}' is not a known installed {artifact_kind}; recording anyway. "
+        f"Capture against a real {artifact_kind} id to keep ranking trustworthy. "
+        f"known {artifact_kind}s: {hint}"
+    )
+    remedy = _unknown_artifact_remedy(artifact_id, artifact_kind)
+    if remedy:
+        return f"{message} {remedy}"
+    return message
 
 
 # Files inside a skill bundle that are not part of its logic: OS cruft and the
@@ -164,8 +409,18 @@ def _bundle_fingerprint(skill_dir: Path) -> str | None:
     ``sha256(SKILL.md)`` - byte-identical to the pre-bundle fingerprint - so
     existing single-file records are never invalidated. Only a genuinely
     multi-file bundle takes the composite path.
+
+    Symlinks that resolve outside the selected skill directory are excluded so
+    the fingerprint never hashes external dependency bytes.
     """
-    files = sorted(p for p in skill_dir.rglob("*") if p.is_file() and p.name not in _BUNDLE_IGNORED_NAMES)
+    skill_root = _resolve_root(skill_dir)
+    if skill_root is None:
+        return None
+    files = sorted(
+        p
+        for p in skill_dir.rglob("*")
+        if p.name not in _BUNDLE_IGNORED_NAMES and _contained_under(skill_root, p) is not None
+    )
     if not files:
         return None
     skill_md = skill_dir / "SKILL.md"
@@ -202,17 +457,25 @@ def _linked_card_closure(cards_dir: Path, root_id: str) -> list[str]:
     itself. Cycle-safe (a shared visited set), deterministic (sorted output), and
     tolerant of dead links (a ``[[missing]]`` contributes nothing until the card
     exists). Case-insensitive resolution to the actual on-disk stem.
+
+    Only cards whose resolved path stays under the selected cards directory are
+    discoverable, so a symlink escaping that root is treated as a dead link.
     """
     from brigade.memory_doctor.parsing import extract_wiki_links
 
-    stem_by_lower = {p.stem.lower(): p.stem for p in cards_dir.glob("*.md")}
+    cards_root = _resolve_root(cards_dir)
+    if cards_root is None:
+        return []
+    stem_by_lower = {
+        p.stem.lower(): p.stem for p in cards_dir.glob("*.md") if _contained_under(cards_root, p) is not None
+    }
     visited = {root_id.lower()}
     queue = [root_id]
     reached: set[str] = set()
     while queue:
         current = queue.pop()
         card_path = cards_dir / f"{current}.md"
-        if not card_path.is_file():
+        if _contained_under(cards_root, card_path) is None:
             continue
         for raw in extract_wiki_links(card_path.read_text(encoding="utf-8", errors="replace")):
             slug = _link_target_slug(raw).lower()
@@ -236,6 +499,9 @@ def _card_fingerprint(card_path: Path) -> str | None:
     invalidates the referrer the way editing the card itself does.
     """
     cards_dir = card_path.parent
+    cards_root = _resolve_root(cards_dir)
+    if cards_root is None or _contained_under(cards_root, card_path) is None:
+        return None
     try:
         self_bytes = card_path.read_bytes()
         closure = _linked_card_closure(cards_dir, card_path.stem)
@@ -245,9 +511,12 @@ def _card_fingerprint(card_path: Path) -> str | None:
         digest.update(hashlib.sha256(self_bytes).hexdigest().encode("ascii"))
         digest.update(b"\0")
         for stem in closure:
+            linked = cards_dir / f"{stem}.md"
+            if _contained_under(cards_root, linked) is None:
+                continue
             digest.update(stem.encode("utf-8"))
             digest.update(b"\0")
-            digest.update(hashlib.sha256((cards_dir / f"{stem}.md").read_bytes()).hexdigest().encode("ascii"))
+            digest.update(hashlib.sha256(linked.read_bytes()).hexdigest().encode("ascii"))
             digest.update(b"\0")
         return digest.hexdigest()
     except OSError:
@@ -1766,15 +2035,16 @@ def capture(
     if run_id is not None and run_receipt is not None:
         print("error: pass either --run-id or --run-receipt, not both", file=sys.stderr)
         return 1
-    if not _artifact_known(target, artifact_id, artifact_kind):
-        known = _known_skill_names(target) if artifact_kind == "skill" else _known_card_names(target)
-        hint = ", ".join(known) if known else "none"
+    if _artifact_id_has_controls(artifact_id):
+        # Reject before any stdout or ledger write; strip Cc/Cf from the error text.
+        kind_label = "skill" if artifact_kind == "skill" else "card"
         print(
-            f"warning: '{artifact_id}' is not a known installed {artifact_kind}; recording anyway. "
-            f"Capture against a real {artifact_kind} id (or `brigade-work` itself) to keep ranking "
-            f"trustworthy. known {artifact_kind}s: {hint}",
+            f"error: {kind_label} id contains control characters: {_warning_label(artifact_id)}",
             file=sys.stderr,
         )
+        return 1
+    if not _artifact_known(target, artifact_id, artifact_kind):
+        print(_unknown_artifact_warning(target, artifact_id, artifact_kind), file=sys.stderr)
     source = "verify"
     effective_status = ""
     evidence_ref = ""

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -1138,10 +1138,331 @@ def _write_registry_skill(target, skill_id, text="# skill body v1\n"):
     return skill_dir / "SKILL.md"
 
 
+def _write_harness_skill(target, skill_id, text="# harness skill\n", harness=".claude"):
+    skill_md = target / harness / "skills" / skill_id / "SKILL.md"
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    skill_md.write_text(text)
+    return skill_md
+
+
+def _make_linked_worktree(tmp_path):
+    """Lay out a parent clone and a linked git worktree the way git does."""
+    parent = tmp_path / "clone"
+    admin = parent / ".git" / "worktrees" / "wt"
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin}\n")
+    return parent, worktree
+
+
 def _sha256_of(path):
     import hashlib
 
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_capture_resolves_skill_from_linked_worktree_parent(tmp_path, capsys):
+    parent, worktree = _make_linked_worktree(tmp_path)
+    parent_skill = _write_harness_skill(parent, "brigade-work", "# parent brigade-work\n")
+    _write_verify_receipt(worktree)
+
+    assert outcome_cmd.capture(target=worktree, artifact_id="brigade-work", json_output=True) == 0
+    captured = capsys.readouterr()
+    assert "warning:" not in captured.err
+    payload = json.loads(captured.out)
+    assert payload["record"]["content_fingerprint"] == _sha256_of(parent_skill)
+    assert "brigade-work" in outcome_cmd._known_skill_names(worktree)
+
+
+def test_capture_prefers_target_local_skill_over_linked_parent(tmp_path, capsys):
+    parent, worktree = _make_linked_worktree(tmp_path)
+    _write_harness_skill(parent, "skill-x", "# parent copy\n")
+    local_skill = _write_harness_skill(worktree, "skill-x", "# worktree local copy\n")
+    _write_verify_receipt(worktree)
+
+    assert outcome_cmd.capture(target=worktree, artifact_id="skill-x", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["record"]["content_fingerprint"] == _sha256_of(local_skill)
+    assert outcome_cmd.artifact_fingerprint(worktree, "skill-x", "skill") == _sha256_of(local_skill)
+
+
+def test_capture_default_brigade_work_warns_with_install_remedy_not_self_suggestion(tmp_path, capsys):
+    _write_verify_receipt(tmp_path)
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="brigade-work", json_output=True) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert "content_fingerprint" not in payload["record"]
+    assert "warning:" in captured.err
+    assert "brigade-work" in captured.err
+    assert "or `brigade-work` itself" not in captured.err
+    assert "brigade skills install brigade-work" in captured.err
+
+
+def test_capture_unknown_skill_warning_sanitizes_untrusted_paths(tmp_path, capsys, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    _write_verify_receipt(tmp_path)
+    leaked = str(home / ".claude" / "skills" / "secret-skill" / "SKILL.md")
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id=leaked, json_output=True) == 0
+    err = capsys.readouterr().err
+    assert "warning:" in err
+    assert str(home) not in err
+    assert "secret-skill" in err or "[redacted-path]" in err
+    assert "or `brigade-work` itself" not in err
+
+
+def test_capture_does_not_discover_skills_from_home_dirs(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    _write_harness_skill(home, "home-only-skill", "# should stay invisible\n")
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    assert "home-only-skill" not in outcome_cmd._known_skill_names(tmp_path)
+    assert outcome_cmd._artifact_content_path(tmp_path, "home-only-skill", "skill") is None
+    assert outcome_cmd._artifact_known(tmp_path, "home-only-skill", "skill") is False
+
+
+def test_capture_still_resolves_registry_and_local_harness_skills(tmp_path):
+    registry_md = _write_registry_skill(tmp_path, "registry-skill", "# registry\n")
+    local_md = _write_harness_skill(tmp_path, "local-skill", "# local\n")
+
+    assert "registry-skill" in outcome_cmd._known_skill_names(tmp_path)
+    assert "local-skill" in outcome_cmd._known_skill_names(tmp_path)
+    assert outcome_cmd._artifact_content_path(tmp_path, "registry-skill", "skill") == registry_md
+    assert outcome_cmd._artifact_content_path(tmp_path, "local-skill", "skill") == local_md
+    assert outcome_cmd.artifact_fingerprint(tmp_path, "local-skill", "skill") == _sha256_of(local_md)
+
+
+def test_artifact_content_path_rejects_traversal_skill_ids(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside-secret" / "SKILL.md"
+    outside.parent.mkdir()
+    outside.write_text("# should not be fingerprinted\n")
+    _write_harness_skill(repo, "safe-skill", "# inside\n")
+
+    assert outcome_cmd._artifact_content_path(repo, "..", "skill") is None
+    assert outcome_cmd._artifact_content_path(repo, "../outside-secret", "skill") is None
+    assert outcome_cmd._artifact_content_path(repo, "../../outside-secret", "skill") is None
+    assert outcome_cmd.artifact_fingerprint(repo, "../outside-secret", "skill") is None
+
+
+def test_artifact_content_path_rejects_glob_metacharacter_skill_ids(tmp_path):
+    _write_harness_skill(tmp_path, "skill-a", "# a\n")
+    _write_harness_skill(tmp_path, "skill-b", "# b\n")
+
+    assert outcome_cmd._artifact_content_path(tmp_path, "*", "skill") is None
+    assert outcome_cmd._artifact_content_path(tmp_path, "skill-*", "skill") is None
+    assert outcome_cmd._artifact_content_path(tmp_path, "skill-[ab]", "skill") is None
+    assert outcome_cmd.artifact_fingerprint(tmp_path, "*", "skill") is None
+
+
+def test_artifact_content_path_rejects_external_skill_directory_symlink(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside_dir = tmp_path / "external-skill"
+    outside_dir.mkdir()
+    (outside_dir / "SKILL.md").write_text("# external payload\n")
+    skill_link = repo / ".claude" / "skills" / "leaky-skill"
+    skill_link.parent.mkdir(parents=True)
+    skill_link.symlink_to(outside_dir)
+
+    assert "leaky-skill" not in outcome_cmd._known_skill_names(repo)
+    assert outcome_cmd._artifact_content_path(repo, "leaky-skill", "skill") is None
+    assert outcome_cmd.artifact_fingerprint(repo, "leaky-skill", "skill") is None
+
+
+def test_capture_unknown_skill_warning_sanitizes_windows_paths_on_posix(tmp_path, capsys):
+    _write_verify_receipt(tmp_path)
+    leaked = r"C:\Users\victim\.claude\skills\secret-skill\SKILL.md"
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id=leaked, json_output=True) == 0
+    err = capsys.readouterr().err
+    assert "warning:" in err
+    assert r"C:\Users" not in err
+    assert "Users\\victim" not in err
+    assert "secret-skill" in err
+    assert "Capture against the skill id `secret-skill`" in err
+
+
+def test_capture_rejects_skill_ids_with_unicode_controls_before_stdout_or_persist(tmp_path, capsys):
+    """Control-bearing skill ids must not reach stdout/stderr raw or the ledger."""
+    _write_verify_receipt(tmp_path)
+    evil_id = "skill-\x1b[31mRED\x1b[0m\nINJECT"
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id=evil_id, json_output=False) != 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "\x1b" not in captured.err
+    assert "\nINJECT" not in captured.err
+    assert "error:" in captured.err
+    assert "INJECT" in captured.err
+    assert "warning:" not in captured.err
+    assert outcome_cmd.load_records(tmp_path) == []
+
+
+def test_artifact_content_path_rejects_traversal_card_ids(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "memory" / "cards").mkdir(parents=True)
+    outside = tmp_path / "leaked.md"
+    outside.write_text("# should not be fingerprinted\n")
+    _write_card(repo, "safe-card", "# inside\n")
+
+    # From memory/cards, three parents reach tmp_path where leaked.md lives.
+    assert outcome_cmd._artifact_content_path(repo, "..", "card") is None
+    assert outcome_cmd._artifact_content_path(repo, "../../../leaked", "card") is None
+    assert outcome_cmd._artifact_content_path(repo, "../../leaked", "card") is None
+    assert outcome_cmd.artifact_fingerprint(repo, "../../../leaked", "card") is None
+    assert outside.is_file()
+
+
+def test_artifact_content_path_rejects_external_card_symlink(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cards = repo / "memory" / "cards"
+    cards.mkdir(parents=True)
+    outside = tmp_path / "external-card.md"
+    outside.write_text("# external payload\n")
+    card_link = cards / "leaky.md"
+    card_link.symlink_to(outside)
+
+    assert "leaky" not in outcome_cmd._known_card_names(repo)
+    assert outcome_cmd._artifact_content_path(repo, "leaky", "card") is None
+    assert outcome_cmd.artifact_fingerprint(repo, "leaky", "card") is None
+
+
+def test_artifact_content_path_rejects_external_symlinked_memory_root(tmp_path):
+    """A target/memory symlink to an external tree must not trust those cards."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside_memory = tmp_path / "external-memory"
+    outside_cards = outside_memory / "cards"
+    outside_cards.mkdir(parents=True)
+    (outside_cards / "leaky.md").write_text("# external via memory symlink\n")
+    (repo / "memory").symlink_to(outside_memory)
+
+    assert "leaky" not in outcome_cmd._known_card_names(repo)
+    assert outcome_cmd._artifact_content_path(repo, "leaky", "card") is None
+    assert outcome_cmd.artifact_fingerprint(repo, "leaky", "card") is None
+
+
+def test_artifact_content_path_rejects_external_symlinked_memory_cards_root(tmp_path):
+    """A target/memory/cards symlink to an external dir must not trust those cards."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "memory").mkdir()
+    outside_cards = tmp_path / "external-cards"
+    outside_cards.mkdir()
+    (outside_cards / "leaky.md").write_text("# external via cards symlink\n")
+    (repo / "memory" / "cards").symlink_to(outside_cards)
+
+    assert "leaky" not in outcome_cmd._known_card_names(repo)
+    assert outcome_cmd._artifact_content_path(repo, "leaky", "card") is None
+    assert outcome_cmd.artifact_fingerprint(repo, "leaky", "card") is None
+
+
+def test_capture_rejects_card_ids_with_unicode_controls_before_stdout_or_persist(tmp_path, capsys):
+    """Control-bearing card ids must not reach stdout/stderr raw or the ledger."""
+    _write_verify_receipt(tmp_path)
+    evil_id = "card-\x1b[31mRED\x1b[0m\nINJECT"
+
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id=evil_id,
+            artifact_kind="card",
+            json_output=False,
+        )
+        != 0
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "\x1b" not in captured.err
+    assert "\nINJECT" not in captured.err
+    assert "error:" in captured.err
+    assert "INJECT" in captured.err
+    assert "warning:" not in captured.err
+    assert outcome_cmd.load_records(tmp_path) == []
+
+
+def test_capture_discovers_and_fingerprints_unicode_and_space_card_ids(tmp_path, capsys):
+    """Card stems may include Unicode letters and spaces; slug regex must not apply."""
+    card_id = "café notes"
+    card = _write_card(tmp_path, card_id, "# unicode space card\n")
+    _write_verify_receipt(tmp_path)
+
+    assert card_id in outcome_cmd._known_card_names(tmp_path)
+    assert outcome_cmd.artifact_fingerprint(tmp_path, card_id, "card") == _sha256_of(card)
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id=card_id,
+            artifact_kind="card",
+            json_output=True,
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    assert "warning:" not in captured.err
+    payload = json.loads(captured.out)
+    assert payload["record"]["artifact_id"] == card_id
+    assert payload["record"]["content_fingerprint"] == _sha256_of(card)
+
+
+def test_capture_discovers_and_fingerprints_129_char_installed_skill(tmp_path, capsys):
+    """Slug/filesystem skill ids longer than 128 chars must stay discoverable."""
+    skill_id = "a" + ("b" * 128)
+    assert len(skill_id) == 129
+    skill_md = _write_harness_skill(tmp_path, skill_id, "# long skill body\n")
+    _write_verify_receipt(tmp_path)
+
+    assert skill_id in outcome_cmd._known_skill_names(tmp_path)
+    assert outcome_cmd.artifact_fingerprint(tmp_path, skill_id, "skill") == _sha256_of(skill_md)
+    assert outcome_cmd.capture(target=tmp_path, artifact_id=skill_id, json_output=True) == 0
+    captured = capsys.readouterr()
+    assert "warning:" not in captured.err
+    payload = json.loads(captured.out)
+    assert payload["record"]["artifact_id"] == skill_id
+    assert payload["record"]["content_fingerprint"] == _sha256_of(skill_md)
+
+
+def test_unknown_artifact_warning_sanitizes_known_skill_labels(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        outcome_cmd,
+        "_known_skill_names",
+        lambda _target: ["clean-skill", "dirty-\x1b[32mskill\nnext"],
+    )
+    message = outcome_cmd._unknown_artifact_warning(tmp_path, "missing-skill", "skill")
+    assert "\x1b" not in message
+    assert "\nnext" not in message
+    assert "dirty-[32mskill next" in message
+
+
+def test_capture_prefers_target_registry_over_parent_harness(tmp_path):
+    parent, worktree = _make_linked_worktree(tmp_path)
+    _write_harness_skill(parent, "skill-x", "# parent harness copy\n")
+    target_registry = _write_registry_skill(worktree, "skill-x", "# target registry copy\n")
+
+    assert outcome_cmd._artifact_content_path(worktree, "skill-x", "skill") == target_registry
+    assert outcome_cmd.artifact_fingerprint(worktree, "skill-x", "skill") == _sha256_of(target_registry)
+
+
+def test_capture_resolves_parent_registry_only_skill(tmp_path, capsys):
+    parent, worktree = _make_linked_worktree(tmp_path)
+    parent_registry = _write_registry_skill(parent, "parent-reg-skill", "# parent registry only\n")
+    _write_verify_receipt(worktree)
+
+    assert "parent-reg-skill" in outcome_cmd._known_skill_names(worktree)
+    assert outcome_cmd.capture(target=worktree, artifact_id="parent-reg-skill", json_output=True) == 0
+    captured = capsys.readouterr()
+    assert "warning:" not in captured.err
+    payload = json.loads(captured.out)
+    assert payload["record"]["content_fingerprint"] == _sha256_of(parent_registry)
 
 
 def test_capture_stamps_content_fingerprint_of_registry_skill(tmp_path, capsys):
@@ -1584,6 +1905,22 @@ def test_bundle_fingerprint_changes_when_a_file_is_added(tmp_path):
     assert before != after
 
 
+def test_bundle_fingerprint_excludes_helper_symlink_escaping_skill_root(tmp_path):
+    """A helper symlink that resolves outside the skill root must not be hashed."""
+    d = _registry_skill_dir(tmp_path, "skill-x")
+    skill_md = d / "SKILL.md"
+    skill_md.write_text("# body\n")
+    outside = tmp_path / "outside-helper.sh"
+    outside.write_text("echo EXTERNAL_SECRET_v1\n")
+    (d / "helper.sh").symlink_to(outside)
+
+    fp = outcome_cmd.artifact_fingerprint(tmp_path, "skill-x", "skill")
+    # Exclude the escape, or refuse the fingerprint — never fold in external bytes.
+    assert fp is None or fp == _sha256_of(skill_md)
+    outside.write_text("echo EXTERNAL_SECRET_v2\n")
+    assert outcome_cmd.artifact_fingerprint(tmp_path, "skill-x", "skill") == fp
+
+
 def test_editing_a_bundled_helper_makes_prior_records_proven_stale_in_rank(tmp_path, capsys):
     # End to end: a skill's signals were captured against a bundle whose helper has
     # since changed. Rank must drop them from the current score even though SKILL.md
@@ -1708,6 +2045,21 @@ def test_editing_an_unlinked_card_does_not_move_the_fingerprint(tmp_path):
     unrelated.write_text("# z v2\n")
     after = outcome_cmd.artifact_fingerprint(tmp_path, "a", "card")
     assert before == after
+
+
+def test_linked_card_symlink_escaping_cards_root_is_not_discovered_or_fingerprinted(tmp_path):
+    """A [[linked]] card that is a symlink outside memory/cards must be ignored."""
+    a = _write_card(tmp_path, "a", "# a\nsee [[b]]\n")
+    cards = tmp_path / "memory" / "cards"
+    outside = tmp_path / "external-b.md"
+    outside.write_text("# external linked card v1\n")
+    (cards / "b.md").symlink_to(outside)
+
+    assert "b" not in outcome_cmd._known_card_names(tmp_path)
+    # Dead-link behavior: a's fingerprint stays sha256(a), never external bytes.
+    assert outcome_cmd.artifact_fingerprint(tmp_path, "a", "card") == _sha256_of(a)
+    outside.write_text("# external linked card v2\n")
+    assert outcome_cmd.artifact_fingerprint(tmp_path, "a", "card") == _sha256_of(a)
 
 
 def test_editing_a_linked_card_makes_prior_records_stale_in_rank(tmp_path, capsys):

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -5,6 +5,7 @@ import os
 import sys
 import threading
 import time
+import unicodedata
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
@@ -1396,7 +1397,8 @@ def test_capture_discovers_and_fingerprints_unicode_and_space_card_ids(tmp_path,
     card = _write_card(tmp_path, card_id, "# unicode space card\n")
     _write_verify_receipt(tmp_path)
 
-    assert card_id in outcome_cmd._known_card_names(tmp_path)
+    known_card_ids = [unicodedata.normalize("NFC", name) for name in outcome_cmd._known_card_names(tmp_path)]
+    assert unicodedata.normalize("NFC", card_id) in known_card_ids
     assert outcome_cmd.artifact_fingerprint(tmp_path, card_id, "card") == _sha256_of(card)
     assert (
         outcome_cmd.capture(


### PR DESCRIPTION
## Summary

- Resolve outcome skills from the target worktree first, then its linked parent checkout.
- Validate skill and card identifiers before discovery, and require resolved files to stay inside the selected repository roots.
- Fingerprint in-repository skill helpers and linked memory cards while excluding external symlink targets.
- Sanitize unknown-artifact warnings and print a specific install or identifier remedy when one is known.

## Why

`brigade outcome capture brigade-work --run-id latest` could not find a skill installed in the parent checkout of a linked worktree. Capture warned that the skill was unknown and recorded no content fingerprint, which left the verification signal outside a current fingerprint cohort.

Linked-parent discovery also needed strict path handling. Traversal-shaped identifiers, external symlinks, and nested helper or card symlinks must never let discovery or fingerprinting read files outside the selected repository root.

## Verification

- RED: the two nested-symlink regressions failed before the containment fix (`20260811-195257-work-verify-623033`).
- GREEN: both regressions passed in the worker and parent reruns (`20260811-195358-work-verify-678be5`, `20260811-195459-work-verify-6d3068`).
- `pytest -q tests/test_outcome_cmd.py`: 151 passed (`20260811-195503-work-verify-fe0081`).
- `.venv/bin/ruff check src/brigade/outcome_cmd.py tests/test_outcome_cmd.py`: all checks passed (`20260811-195611-work-verify-eded38`).
- `git diff --check`: passed (`20260811-195510-work-verify-46ff51`).
- `./scripts/verify` on committed HEAD: 6,887 passed, 3 skipped, 68 subtests passed, and 83.16% coverage (`20260811-195641-work-verify-665f0f`).
- An earlier `./scripts/verify` run hit one unrelated temp-file race in `test_target_all_preflights_both_profiles_before_any_write[uninstall]`: an `.update-notify.json.*.tmp` file appeared during the file snapshot. The run finished with 1 failed, 6,884 passed, 3 skipped, and 68 subtests passed (`20260811-173341-work-verify-7d1d27`). The isolated test passed on rerun (`20260811-174655-work-verify-665f2f`).

## Risk

Low. This changes outcome attribution and fingerprint cohorting, not skill execution. The main compatibility risk is that path-shaped identifiers and files reached through external symlinks are no longer accepted. Tests retain support for target-over-parent precedence, 129-character skill IDs, and card IDs containing Unicode or spaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for artifact, skill, and card identifiers.
  * Prevented unsafe paths, traversal attempts, and escaping links from being processed.
  * Improved handling of invalid content and control characters during capture.
  * Bundle and card fingerprints now ignore external files, improving consistency.
  * Added clearer warnings with targeted remediation guidance.
  * Improved discovery across linked worktree locations while preserving safe precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->