### PR TITLE
fix(security): sanitize finding output

### DIFF
--- a/src/brigade/security_cmd/commands.py
+++ b/src/brigade/security_cmd/commands.py
@@ -527,6 +527,7 @@ def scan(
         if requested_output_dir is not None:
             print(f"artifacts: {report['artifacts']}")
         for finding in report["findings"]:
+            finding = _sanitize_finding_for_output(finding)
             print(
                 f"- [{finding['severity']}] {finding['category']} "
                 f"{finding['path']}:{finding['line']} {finding['title']}"

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,34 @@ from ..selection import WRITER_INBOXES
 from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
+
+
+def _sanitize_finding_text(value: object) -> str:
+    """Render a finding-controlled value as safe, single-line display text."""
+    text = str(value or "")
+    text = "".join(" " if unicodedata.category(char) in {"Cc", "Cf"} else char for char in text)
+    return " ".join(text.split())
+
+
+def _sanitize_finding_for_output(finding: dict[str, Any]) -> dict[str, Any]:
+    """Copy a finding while sanitizing every string at the output boundary."""
+
+    def sanitize(value: Any) -> Any:
+        if isinstance(value, str):
+            return _sanitize_finding_text(value)
+        if isinstance(value, list):
+            return [sanitize(item) for item in value]
+        if isinstance(value, dict):
+            return {key: sanitize(item) for key, item in value.items()}
+        return value
+
+    return {key: sanitize(value) for key, value in finding.items()}
+
+
+def _escape_finding_markdown(value: object) -> str:
+    """Escape sanitized finding text so it cannot introduce Markdown syntax."""
+    escaped = re.sub(r"([\\`*{}\[\]()<>#+.!_\-|])", r"\\\1", _sanitize_finding_text(value))
+    return escaped.replace(r"\[REDACTED\]", "[REDACTED]")
 
 
 SEVERITY_ORDER = {

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -24,10 +24,34 @@ from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
 
+FINDING_PRIVATE_URL_RE = re.compile(r"(?i)https?://[^\s]+")
+
+FINDING_PRIVATE_TOKEN_RE = re.compile(
+    r"(?i)\b(?:bearer\s+[A-Za-z0-9._~+/=-]{8,}|github_pat_[A-Za-z0-9_]{8,}|ghp_[A-Za-z0-9]{8,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{8,}|sk-(?:live|test|proj)-[A-Za-z0-9_-]{8,}|AKIA[A-Z0-9]{12,})\b"
+)
+
+FINDING_PRIVATE_VALUE_RE = re.compile(
+    r"(?i)\b([A-Za-z0-9_]*(?:api[_-]?key|secret|token|password|passwd|pwd)[A-Za-z0-9_]*)\b\s*[:=]\s*['\"]?([A-Za-z0-9_./+=:-]{8,})"
+)
+
+FINDING_PRIVATE_PATH_RE = re.compile(r"(?<!`)/(?:home|Users|private|mnt|Volumes)/[^\s`)]+")
+
+_FINDING_REDACTION_PLACEHOLDERS = (
+    "[REDACTED-URL]",
+    "[REDACTED-PATH]",
+    "[REDACTED]",
+)
+
+
 def _sanitize_finding_text(value: object) -> str:
     """Render a finding-controlled value as safe, single-line display text."""
     text = str(value or "")
     text = "".join(" " if unicodedata.category(char) in {"Cc", "Cf"} else char for char in text)
+    text = FINDING_PRIVATE_URL_RE.sub("[REDACTED-URL]", text)
+    text = FINDING_PRIVATE_TOKEN_RE.sub("[REDACTED]", text)
+    text = FINDING_PRIVATE_VALUE_RE.sub(lambda match: f"{match.group(1)}=[REDACTED]", text)
+    text = FINDING_PRIVATE_PATH_RE.sub("[REDACTED-PATH]", text)
     return " ".join(text.split())
 
 
@@ -49,7 +73,10 @@ def _sanitize_finding_for_output(finding: dict[str, Any]) -> dict[str, Any]:
 def _escape_finding_markdown(value: object) -> str:
     """Escape sanitized finding text so it cannot introduce Markdown syntax."""
     escaped = re.sub(r"([\\`*{}\[\]()<>#+.!_\-|])", r"\\\1", _sanitize_finding_text(value))
-    return escaped.replace(r"\[REDACTED\]", "[REDACTED]")
+    for placeholder in _FINDING_REDACTION_PLACEHOLDERS:
+        escaped_placeholder = re.sub(r"([\\`*{}\[\]()<>#+.!_\-|])", r"\\\1", placeholder)
+        escaped = escaped.replace(escaped_placeholder, placeholder)
+    return escaped
 
 
 SEVERITY_ORDER = {

--- a/src/brigade/security_cmd/reports.py
+++ b/src/brigade/security_cmd/reports.py
@@ -54,7 +54,7 @@ def _report_findings_for_review(target: Path, report: dict[str, Any]) -> list[di
     for finding in report.get("findings", []):
         if not isinstance(finding, dict):
             continue
-        record = dict(finding)
+        record = _sanitize_finding_for_output(finding)
         record["status"] = (
             "suppressed" if _finding_matches_fingerprints(finding, suppressed, migration_map=migration_map) else "open"
         )
@@ -67,7 +67,7 @@ def _report_findings_for_review(target: Path, report: dict[str, Any]) -> list[di
     for finding in report.get("suppressed_findings", []):
         if not isinstance(finding, dict):
             continue
-        record = dict(finding)
+        record = _sanitize_finding_for_output(finding)
         record["status"] = "suppressed"
         reason = _suppression_reason_for_finding(
             finding, suppressions=suppressed, reasons=reasons, migration_map=migration_map

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -1159,22 +1159,24 @@ def _render_markdown_report(report: dict[str, Any]) -> str:
     if not report["findings"]:
         lines.append("No unsuppressed findings.")
     for finding in report["findings"]:
+        finding = _sanitize_finding_for_output(finding)
+        md = _escape_finding_markdown
         finding_lines = [
-            f"### {finding['id']} - {finding['title']}",
+            f"### {md(finding['id'])} - {md(finding['title'])}",
             "",
-            f"- fingerprint: `{finding['fingerprint']}`",
-            f"- severity: `{finding['severity']}`",
-            f"- category: `{finding['category']}`",
-            f"- path: `{finding['path']}:{finding['line']}`",
-            f"- surface: `{finding['surface']}`",
-            f"- confidence: `{finding['confidence']}`",
-            f"- evidence: `{finding['evidence']}`",
-            f"- suggestion: {finding['suggestion']}",
+            f"- fingerprint: `{md(finding['fingerprint'])}`",
+            f"- severity: `{md(finding['severity'])}`",
+            f"- category: `{md(finding['category'])}`",
+            f"- path: `{md(finding['path'])}:{md(finding['line'])}`",
+            f"- surface: `{md(finding['surface'])}`",
+            f"- confidence: `{md(finding['confidence'])}`",
+            f"- evidence: `{md(finding['evidence'])}`",
+            f"- suggestion: {md(finding['suggestion'])}",
         ]
         response_options = finding.get("response_options") or []
         if response_options:
             finding_lines.append("- response_options:")
-            finding_lines.extend(f"  - {item}" for item in response_options)
+            finding_lines.extend(f"  - {md(item)}" for item in response_options)
         finding_lines.append("")
         lines.extend(finding_lines)
     return "\n".join(lines).rstrip() + "\n"
@@ -1195,6 +1197,7 @@ def _sarif_report(report: dict[str, Any]) -> dict[str, Any]:
     for finding in report.get("findings", []):
         if not isinstance(finding, dict):
             continue
+        finding = _sanitize_finding_for_output(finding)
         rule_id = str(finding.get("rule_id") or finding.get("category") or "brigade.security")
         if rule_id not in rules:
             rules[rule_id] = {

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -2988,6 +2988,102 @@ def test_security_finding_outputs_sanitize_hostile_strings(tmp_path, capsys):
     assert "\u202e" not in plain
 
 
+def test_security_finding_outputs_redact_private_url_token_and_path(tmp_path, capsys):
+    private_url = "https://agent.private.invalid/report?x=1"
+    token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+    abs_path = "/home/privateuser/.openclaw/workspace/secrets.env"
+    fingerprint = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    safe_path = "notes/safe-relative.md"
+    rule_id = "secrets.example"
+    blob = f"hit {private_url} auth={token} path={abs_path}"
+    finding = {
+        "id": "security-leak",
+        "fingerprint": fingerprint,
+        "rule_id": rule_id,
+        "severity": "high",
+        "category": "secrets",
+        "path": safe_path,
+        "line": 3,
+        "surface": "file",
+        "confidence": "high",
+        "title": f"leak title {private_url}",
+        "evidence": blob,
+        "safe_excerpt": blob,
+        "suggestion": f"rotate at {abs_path}",
+        "remediation_hint": f"scrub {token}",
+        "response_options": [f"scrub {token} under {abs_path}"],
+    }
+    report = {
+        "target": str(tmp_path),
+        "generated_at": "2026-01-01T00:00:00Z",
+        "policy": "default",
+        "fail_on": "none",
+        "include_templates": False,
+        "scanned_file_count": 1,
+        "finding_count": 1,
+        "suppressed_count": 0,
+        "severity_counts": {"high": 1},
+        "findings": [finding],
+        "suppressed_findings": [],
+    }
+
+    projected = security_cmd._sanitize_finding_for_output(finding)
+    for surface in (
+        projected["title"],
+        projected["evidence"],
+        projected["suggestion"],
+        projected["remediation_hint"],
+        projected["response_options"][0],
+    ):
+        assert private_url not in surface
+        assert token not in surface
+        assert abs_path not in surface
+        assert "[REDACTED-URL]" in surface or "[REDACTED]" in surface or "[REDACTED-PATH]" in surface
+    assert projected["fingerprint"] == fingerprint
+    assert projected["rule_id"] == rule_id
+    assert projected["path"] == safe_path
+    assert "[REDACTED-URL]" in projected["evidence"]
+    assert "[REDACTED]" in projected["evidence"]
+    assert "[REDACTED-PATH]" in projected["evidence"]
+
+    markdown = security_cmd._render_markdown_report(report)
+    assert private_url not in markdown
+    assert token not in markdown
+    assert abs_path not in markdown
+    assert "agent.private.invalid" not in markdown
+    assert "[REDACTED-URL]" in markdown
+    assert "[REDACTED]" in markdown
+    assert "[REDACTED-PATH]" in markdown
+    assert fingerprint in markdown
+    assert security_cmd._escape_finding_markdown(safe_path) in markdown
+
+    sarif = security_cmd._sarif_report(report)
+    serialized = json.dumps(sarif)
+    assert private_url not in serialized
+    assert token not in serialized
+    assert abs_path not in serialized
+    assert "agent.private.invalid" not in serialized
+    assert "[REDACTED-URL]" in serialized
+    assert "[REDACTED]" in serialized
+    assert "[REDACTED-PATH]" in serialized
+    assert sarif["runs"][0]["results"][0]["ruleId"] == rule_id
+    assert sarif["runs"][0]["results"][0]["partialFingerprints"]["primaryLocationLineHash"] == fingerprint
+    assert sarif["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]["uri"] == safe_path
+
+    output_dir = tmp_path / "bundle"
+    output_dir.mkdir()
+    (output_dir / "security-report.json").write_text(json.dumps(report))
+    assert security_cmd.review(target=tmp_path, output_dir=output_dir) == 0
+    plain = capsys.readouterr().out
+    assert private_url not in plain
+    assert token not in plain
+    assert abs_path not in plain
+    assert "agent.private.invalid" not in plain
+    assert fingerprint in plain
+    assert safe_path in plain
+    assert "[REDACTED-URL]" in plain or "[REDACTED]" in plain or "[REDACTED-PATH]" in plain
+
+
 def test_security_enrich_writes_local_enrichment_bundle(tmp_path, capsys):
     security_cmd.init(target=tmp_path)
     capsys.readouterr()

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -2928,6 +2928,66 @@ def test_security_scan_writes_redacted_evidence_bundle(tmp_path, capsys):
     assert release["evidence"]["security"]["evidence"]["sarif_ready"] is True
 
 
+def test_security_finding_outputs_sanitize_hostile_strings(tmp_path, capsys):
+    hostile = "safe\n## injected\x00\x1b[31m [link](javascript:alert(1)) `code` \u202e"
+    finding = {
+        "id": "security-hostile",
+        "fingerprint": "abc123",
+        "rule_id": "hostile\nrule",
+        "severity": "high\nforged",
+        "category": "category\rforged",
+        "path": "file.md\nFAKE:1",
+        "line": 1,
+        "surface": hostile,
+        "confidence": hostile,
+        "title": hostile,
+        "evidence": hostile,
+        "safe_excerpt": hostile,
+        "suggestion": hostile,
+        "remediation_hint": hostile,
+        "response_options": [hostile],
+    }
+    report = {
+        "target": str(tmp_path),
+        "generated_at": "2026-01-01T00:00:00Z",
+        "policy": "default",
+        "fail_on": "none",
+        "include_templates": False,
+        "scanned_file_count": 1,
+        "finding_count": 1,
+        "suppressed_count": 0,
+        "severity_counts": {"high": 1},
+        "findings": [finding],
+        "suppressed_findings": [],
+    }
+
+    markdown = security_cmd._render_markdown_report(report)
+    assert "\n## injected" not in markdown
+    assert "[link](javascript:alert(1))" not in markdown
+    assert "\\[link\\]\\(javascript:alert\\(1\\)\\)" in markdown
+    assert "\x00" not in markdown
+    assert "\x1b" not in markdown
+    assert "\u202e" not in markdown
+
+    sarif = security_cmd._sarif_report(report)
+    serialized = json.dumps(sarif)
+    assert "\\u0000" not in serialized
+    assert "\\u001b" not in serialized
+    assert "\\u202e" not in serialized
+    assert sarif["runs"][0]["results"][0]["ruleId"] == "hostile rule"
+    assert "\n" not in sarif["runs"][0]["results"][0]["message"]["text"]
+
+    output_dir = tmp_path / "bundle"
+    output_dir.mkdir()
+    (output_dir / "security-report.json").write_text(json.dumps(report))
+    assert security_cmd.review(target=tmp_path, output_dir=output_dir) == 0
+    plain = capsys.readouterr().out
+    assert "\n## injected" not in plain
+    assert "\x00" not in plain
+    assert "\x1b" not in plain
+    assert "\u202e" not in plain
+
+
 def test_security_enrich_writes_local_enrichment_bundle(tmp_path, capsys):
     security_cmd.init(target=tmp_path)
     capsys.readouterr()


### PR DESCRIPTION
## Summary

Sanitize finding-controlled text at the terminal, review, Markdown, and SARIF output boundaries.

## Verification

- `pytest -q tests/test_security_cmd.py`
- `ruff check src/brigade/security_cmd/commands.py src/brigade/security_cmd/models.py src/brigade/security_cmd/reports.py src/brigade/security_cmd/scan_engine.py tests/test_security_cmd.py`

Fixes #673