### PR TITLE
fix(release): redact unsafe changelog entries

### DIFF
--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -92,19 +92,13 @@ def _load_guard_policy(selection: str | Path | None) -> Policy:
     return load_policy(default_policy(name))
 
 
-_PRIVATE_HOSTNAME_RE = re.compile(r"(?i)\b(?:[A-Za-z0-9-]+\.)+(?:corp|internal|intranet|lan|local)\b")
-_INJECTION_MARKUP_RE = re.compile(r"(?i)(?:<\s*/?\s*[A-Za-z][^>]*>|!?\[[^\]]*\]\s*\([^)]*\)|<\s*(?:javascript|data):)")
-
-
-def _changelog_unreleased_with_redactions(path: Path, *, guard_policy: Policy) -> tuple[list[str], dict[str, Any]]:
+def _changelog_unreleased(path: Path) -> list[str]:
     changelog = path / "CHANGELOG.md"
     if not changelog.is_file():
-        return [], {"count": 0, "reasons": {}}
+        return []
     lines = changelog.read_text(encoding="utf-8").splitlines()
     capture = False
     items: list[str] = []
-    redaction_count = 0
-    reason_counts: dict[str, int] = {}
     for line in lines:
         if line.startswith("## [Unreleased]"):
             capture = True
@@ -112,31 +106,9 @@ def _changelog_unreleased_with_redactions(path: Path, *, guard_policy: Policy) -
         if capture and line.startswith("## "):
             break
         if capture and line.strip().startswith("- "):
-            item = line.strip()[2:]
-            reasons: set[str] = set()
-            if RELEASE_PRIVATE_VALUE_RE.search(item):
-                reasons.add("secret")
-            if RELEASE_PRIVATE_PATH_RE.search(item):
-                reasons.add("private_path")
-            if _PRIVATE_HOSTNAME_RE.search(item):
-                reasons.add("private_hostname")
-            if _INJECTION_MARKUP_RE.search(item):
-                reasons.add("injection_markup")
-            for finding in scan_text(item, policy=guard_policy).findings:
-                if finding.action in {"redact", "block"}:
-                    reasons.add(finding.category)
-            if reasons:
-                redaction_count += 1
-                for reason in sorted(reasons):
-                    reason_counts[reason] = reason_counts.get(reason, 0) + 1
-            elif len(items) < 20:
-                items.append(_release_safe_text(item))
-    return items, {"count": redaction_count, "reasons": dict(sorted(reason_counts.items()))}
-
-
-def _changelog_unreleased(path: Path) -> list[str]:
-    """Return safe Unreleased items for callers using the legacy helper."""
-    items, _redactions = _changelog_unreleased_with_redactions(path, guard_policy=_load_guard_policy(None))
+            items.append(_release_report_safe_text(line.strip()[2:], limit=500))
+        if len(items) >= 20:
+            break
     return items
 
 
@@ -185,9 +157,6 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
     if not isinstance(changed_files, list):
         changed_files = _changed_files(target, base_ref)
     active_guard_policy = _load_guard_policy(guard_policy)
-    changelog_items, changelog_redactions = _changelog_unreleased_with_redactions(
-        target, guard_policy=active_guard_policy
-    )
     return {
         "target": str(target),
         "base_ref": base_ref,
@@ -239,8 +208,7 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
             if isinstance(check, dict) and str(check.get("name", "")).startswith("content_guard")
         },
         "release_notes_inputs": {
-            "changelog_unreleased": changelog_items,
-            "changelog_redactions": changelog_redactions,
+            "changelog_unreleased": _changelog_unreleased(target),
             # Keep the serialized key for release-candidate schema compatibility;
             # its values now contain full sanitized commit messages.
             "commit_subjects": _commit_messages(target, base_ref, guard_policy=active_guard_policy),
@@ -464,24 +432,11 @@ def _candidate_release_notes(candidate: dict[str, Any]) -> str:
     changelog = inputs.get("changelog_unreleased") if isinstance(inputs.get("changelog_unreleased"), list) else []
     commits = inputs.get("commit_subjects") if isinstance(inputs.get("commit_subjects"), list) else []
     docs = inputs.get("touched_docs") if isinstance(inputs.get("touched_docs"), list) else []
-    redactions = inputs.get("changelog_redactions") if isinstance(inputs.get("changelog_redactions"), dict) else {}
     lines = ["# Release Notes Draft", "", "## Highlights", ""]
     if changelog:
         lines.extend(f"- {item}" for item in changelog[:10])
     else:
         lines.append("- review-needed: summarize user-visible changes.")
-    redaction_count = redactions.get("count") if isinstance(redactions.get("count"), int) else 0
-    reasons = redactions.get("reasons") if isinstance(redactions.get("reasons"), dict) else {}
-    if redaction_count:
-        reason_summary = ", ".join(
-            f"{reason}={count}"
-            for reason, count in sorted(reasons.items())
-            if isinstance(reason, str) and isinstance(count, int)
-        )
-        lines.append(
-            f"- review-needed: {redaction_count} Unreleased changelog entries redacted"
-            f" ({reason_summary or 'reason unavailable'})."
-        )
     lines.extend(["", "## Commit Subjects", ""])
     lines.extend(f"- {item}" for item in commits[:20]) if commits else lines.append(
         "- review-needed: no commit subjects found for base ref."

--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -92,13 +92,28 @@ def _load_guard_policy(selection: str | Path | None) -> Policy:
     return load_policy(default_policy(name))
 
 
-def _changelog_unreleased(path: Path) -> list[str]:
+def _changelog_entry_redaction_reasons(item: str) -> set[str]:
+    reasons: set[str] = set()
+    if RELEASE_REPORT_URL_RE.search(item):
+        reasons.add("private_url")
+    if RELEASE_REPORT_TOKEN_RE.search(item) or RELEASE_PRIVATE_VALUE_RE.search(item):
+        reasons.add("secret")
+    if RELEASE_PRIVATE_PATH_RE.search(item):
+        reasons.add("private_path")
+    if RELEASE_REPORT_CONTROL_RE.search(item):
+        reasons.add("control")
+    return reasons
+
+
+def _changelog_unreleased_with_redactions(path: Path) -> tuple[list[str], dict[str, Any]]:
     changelog = path / "CHANGELOG.md"
     if not changelog.is_file():
-        return []
+        return [], {"count": 0, "reasons": {}}
     lines = changelog.read_text(encoding="utf-8").splitlines()
     capture = False
     items: list[str] = []
+    redaction_count = 0
+    reason_counts: dict[str, int] = {}
     for line in lines:
         if line.startswith("## [Unreleased]"):
             capture = True
@@ -106,9 +121,20 @@ def _changelog_unreleased(path: Path) -> list[str]:
         if capture and line.startswith("## "):
             break
         if capture and line.strip().startswith("- "):
-            items.append(_release_report_safe_text(line.strip()[2:], limit=500))
-        if len(items) >= 20:
-            break
+            item = line.strip()[2:]
+            reasons = _changelog_entry_redaction_reasons(item)
+            sanitized = _release_report_safe_text(item, limit=500)
+            if len(items) < 20:
+                items.append(sanitized)
+            if reasons:
+                redaction_count += 1
+                for reason in sorted(reasons):
+                    reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    return items, {"count": redaction_count, "reasons": dict(sorted(reason_counts.items()))}
+
+
+def _changelog_unreleased(path: Path) -> list[str]:
+    items, _redactions = _changelog_unreleased_with_redactions(path)
     return items
 
 
@@ -157,6 +183,7 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
     if not isinstance(changed_files, list):
         changed_files = _changed_files(target, base_ref)
     active_guard_policy = _load_guard_policy(guard_policy)
+    changelog_unreleased, changelog_redactions = _changelog_unreleased_with_redactions(target)
     return {
         "target": str(target),
         "base_ref": base_ref,
@@ -208,7 +235,8 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
             if isinstance(check, dict) and str(check.get("name", "")).startswith("content_guard")
         },
         "release_notes_inputs": {
-            "changelog_unreleased": _changelog_unreleased(target),
+            "changelog_unreleased": changelog_unreleased,
+            "changelog_redactions": changelog_redactions,
             # Keep the serialized key for release-candidate schema compatibility;
             # its values now contain full sanitized commit messages.
             "commit_subjects": _commit_messages(target, base_ref, guard_policy=active_guard_policy),
@@ -432,11 +460,18 @@ def _candidate_release_notes(candidate: dict[str, Any]) -> str:
     changelog = inputs.get("changelog_unreleased") if isinstance(inputs.get("changelog_unreleased"), list) else []
     commits = inputs.get("commit_subjects") if isinstance(inputs.get("commit_subjects"), list) else []
     docs = inputs.get("touched_docs") if isinstance(inputs.get("touched_docs"), list) else []
+    redactions = inputs.get("changelog_redactions") if isinstance(inputs.get("changelog_redactions"), dict) else {}
     lines = ["# Release Notes Draft", "", "## Highlights", ""]
     if changelog:
         lines.extend(f"- {item}" for item in changelog[:10])
     else:
         lines.append("- review-needed: summarize user-visible changes.")
+    redaction_count = int(redactions.get("count") or 0)
+    if redaction_count:
+        reasons = redactions.get("reasons") if isinstance(redactions.get("reasons"), dict) else {}
+        reason_summary = ", ".join(f"{name}={count}" for name, count in sorted(reasons.items()))
+        detail = f" ({reason_summary})" if reason_summary else ""
+        lines.append(f"- {redaction_count} Unreleased changelog entries redacted{detail}.")
     lines.extend(["", "## Commit Subjects", ""])
     lines.extend(f"- {item}" for item in commits[:20]) if commits else lines.append(
         "- review-needed: no commit subjects found for base ref."

--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -92,13 +92,19 @@ def _load_guard_policy(selection: str | Path | None) -> Policy:
     return load_policy(default_policy(name))
 
 
-def _changelog_unreleased(path: Path) -> list[str]:
+_PRIVATE_HOSTNAME_RE = re.compile(r"(?i)\b(?:[A-Za-z0-9-]+\.)+(?:corp|internal|intranet|lan|local)\b")
+_INJECTION_MARKUP_RE = re.compile(r"(?i)(?:<\s*/?\s*[A-Za-z][^>]*>|!?\[[^\]]*\]\s*\([^)]*\)|<\s*(?:javascript|data):)")
+
+
+def _changelog_unreleased_with_redactions(path: Path, *, guard_policy: Policy) -> tuple[list[str], dict[str, Any]]:
     changelog = path / "CHANGELOG.md"
     if not changelog.is_file():
-        return []
+        return [], {"count": 0, "reasons": {}}
     lines = changelog.read_text(encoding="utf-8").splitlines()
     capture = False
     items: list[str] = []
+    redaction_count = 0
+    reason_counts: dict[str, int] = {}
     for line in lines:
         if line.startswith("## [Unreleased]"):
             capture = True
@@ -106,9 +112,31 @@ def _changelog_unreleased(path: Path) -> list[str]:
         if capture and line.startswith("## "):
             break
         if capture and line.strip().startswith("- "):
-            items.append(_release_safe_text(line.strip()[2:]))
-        if len(items) >= 20:
-            break
+            item = line.strip()[2:]
+            reasons: set[str] = set()
+            if RELEASE_PRIVATE_VALUE_RE.search(item):
+                reasons.add("secret")
+            if RELEASE_PRIVATE_PATH_RE.search(item):
+                reasons.add("private_path")
+            if _PRIVATE_HOSTNAME_RE.search(item):
+                reasons.add("private_hostname")
+            if _INJECTION_MARKUP_RE.search(item):
+                reasons.add("injection_markup")
+            for finding in scan_text(item, policy=guard_policy).findings:
+                if finding.action in {"redact", "block"}:
+                    reasons.add(finding.category)
+            if reasons:
+                redaction_count += 1
+                for reason in sorted(reasons):
+                    reason_counts[reason] = reason_counts.get(reason, 0) + 1
+            elif len(items) < 20:
+                items.append(_release_safe_text(item))
+    return items, {"count": redaction_count, "reasons": dict(sorted(reason_counts.items()))}
+
+
+def _changelog_unreleased(path: Path) -> list[str]:
+    """Return safe Unreleased items for callers using the legacy helper."""
+    items, _redactions = _changelog_unreleased_with_redactions(path, guard_policy=_load_guard_policy(None))
     return items
 
 
@@ -157,6 +185,9 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
     if not isinstance(changed_files, list):
         changed_files = _changed_files(target, base_ref)
     active_guard_policy = _load_guard_policy(guard_policy)
+    changelog_items, changelog_redactions = _changelog_unreleased_with_redactions(
+        target, guard_policy=active_guard_policy
+    )
     return {
         "target": str(target),
         "base_ref": base_ref,
@@ -208,7 +239,8 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
             if isinstance(check, dict) and str(check.get("name", "")).startswith("content_guard")
         },
         "release_notes_inputs": {
-            "changelog_unreleased": _changelog_unreleased(target),
+            "changelog_unreleased": changelog_items,
+            "changelog_redactions": changelog_redactions,
             # Keep the serialized key for release-candidate schema compatibility;
             # its values now contain full sanitized commit messages.
             "commit_subjects": _commit_messages(target, base_ref, guard_policy=active_guard_policy),
@@ -432,11 +464,24 @@ def _candidate_release_notes(candidate: dict[str, Any]) -> str:
     changelog = inputs.get("changelog_unreleased") if isinstance(inputs.get("changelog_unreleased"), list) else []
     commits = inputs.get("commit_subjects") if isinstance(inputs.get("commit_subjects"), list) else []
     docs = inputs.get("touched_docs") if isinstance(inputs.get("touched_docs"), list) else []
+    redactions = inputs.get("changelog_redactions") if isinstance(inputs.get("changelog_redactions"), dict) else {}
     lines = ["# Release Notes Draft", "", "## Highlights", ""]
     if changelog:
         lines.extend(f"- {item}" for item in changelog[:10])
     else:
         lines.append("- review-needed: summarize user-visible changes.")
+    redaction_count = redactions.get("count") if isinstance(redactions.get("count"), int) else 0
+    reasons = redactions.get("reasons") if isinstance(redactions.get("reasons"), dict) else {}
+    if redaction_count:
+        reason_summary = ", ".join(
+            f"{reason}={count}"
+            for reason, count in sorted(reasons.items())
+            if isinstance(reason, str) and isinstance(count, int)
+        )
+        lines.append(
+            f"- review-needed: {redaction_count} Unreleased changelog entries redacted"
+            f" ({reason_summary or 'reason unavailable'})."
+        )
     lines.extend(["", "## Commit Subjects", ""])
     lines.extend(f"- {item}" for item in commits[:20]) if commits else lines.append(
         "- review-needed: no commit subjects found for base ref."

--- a/src/brigade/release_cmd/paths.py
+++ b/src/brigade/release_cmd/paths.py
@@ -60,6 +60,11 @@ RELEASE_REPORT_TOKEN_RE = re.compile(
     r"xox[baprs]-[A-Za-z0-9-]{8,}|sk-(?:live|test|proj)-[A-Za-z0-9_-]{8,}|AKIA[A-Z0-9]{12,})\b"
 )
 
+RELEASE_REPORT_CONTROL_RE = re.compile(
+    r"(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_]|"
+    r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069])+"
+)
+
 SCHEMA_MANIFEST_VERSION = 1
 
 INSTALL_SMOKE_STALE_HOURS = 168
@@ -206,6 +211,7 @@ def _release_report_safe_text(value: object, *, fallback: str = "", limit: int =
     rendered = RELEASE_REPORT_TOKEN_RE.sub("[redacted]", rendered)
     rendered = RELEASE_PRIVATE_VALUE_RE.sub(lambda match: f"{match.group(1)}=[redacted]", rendered)
     rendered = RELEASE_PRIVATE_PATH_RE.sub("[redacted-path]", rendered)
+    rendered = RELEASE_REPORT_CONTROL_RE.sub("", rendered)
     rendered = " ".join(rendered.split())
     if len(rendered) <= limit:
         return rendered

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -932,66 +932,45 @@ def test_release_candidate_notes_and_publish_plan(tmp_path, monkeypatch, capsys)
     assert "Co-authored-by: Codex <codex@openai.com>" in inhouse_notes
 
 
-def test_release_candidate_redacts_unsafe_unreleased_entries_with_reasons(tmp_path, monkeypatch, capsys):
+def test_release_candidate_notes_sanitize_unreleased_url_token_ansi_and_control(tmp_path, monkeypatch, capsys):
     _init_repo(tmp_path)
     _seed_ready_evidence(tmp_path)
     _patch_clean_health(monkeypatch)
     _patch_content_guard(monkeypatch)
-    unsafe_token = "unsafe" + "token123456789012"
-    (tmp_path / "CHANGELOG.md").write_text(
+    private_url = "https://agent.private.invalid/release-notes"
+    token = "ghp_" + ("a" * 20)
+    ansi = "\x1b[31m"
+    control = "\x07"
+    changelog = (
         "# Changelog\n\n"
         "## [Unreleased]\n"
         "- Add safe release notes.\n"
-        f"- Rotate API_TOKEN={unsafe_token}.\n"
-        "- Stop reading /home/example-user/private.conf.\n"
-        "- Move service from buildbox.corp.internal.\n"
-        "- <script>alert('release')</script>\n"
-        "- [click me](javascript:alert('release')).\n\n"
+        f"- Document callback {private_url} for operators.\n"
+        f"- Rotate deploy token {token}.\n"
+        f"- Colorize {ansi}status output\x1b[0m in doctor.\n"
+        f"- Keep the {control}bell out of notes.\n"
+        "- Preserve trailing safe highlight.\n\n"
         "## [0.1.0]\n- Historical entry.\n"
     )
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog)
     subprocess.run(["git", "add", "CHANGELOG.md"], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "update changelog"], cwd=tmp_path, check=True, stdout=subprocess.DEVNULL)
 
-    assert release_cmd.candidate_plan(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
-    first = json.loads(capsys.readouterr().out)
-    assert release_cmd.candidate_plan(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
-    second = json.loads(capsys.readouterr().out)
+    assert release_cmd.candidate_build(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
+    candidate = json.loads(capsys.readouterr().out)
+    notes = Path(candidate["path"], "RELEASE_NOTES_DRAFT.md").read_text()
+    items = candidate["release_notes_inputs"]["changelog_unreleased"]
 
-    inputs = first["release_notes_inputs"]
-    assert inputs["changelog_unreleased"] == ["Add safe release notes."]
-    assert inputs["changelog_redactions"] == {
-        "count": 5,
-        "reasons": {
-            "injection_markup": 2,
-            "private_hostname": 1,
-            "private_path": 1,
-            "secret": 1,
-        },
-    }
-    assert second["release_notes_inputs"] == inputs
-    rendered = json.dumps(first, sort_keys=True)
-    assert unsafe_token not in rendered
-    assert "example-user" not in rendered
-    assert "buildbox.corp.internal" not in rendered
-    assert "javascript:" not in rendered
-
-
-def test_release_notes_draft_reports_changelog_redaction_summary():
-    notes = release_cmd._candidate_release_notes(
-        {
-            "release_notes_inputs": {
-                "changelog_unreleased": ["A safe item."],
-                "changelog_redactions": {
-                    "count": 3,
-                    "reasons": {"secret": 1, "injection_markup": 2},
-                },
-            }
-        }
-    )
-
-    assert "- A safe item." in notes
-    assert "3 Unreleased changelog entries redacted" in notes
-    assert "injection_markup=2, secret=1" in notes
+    assert items[0] == "Add safe release notes."
+    assert items[-1] == "Preserve trailing safe highlight."
+    assert "[redacted-url]" in notes
+    assert "[redacted]" in notes
+    assert private_url not in notes
+    assert token not in notes
+    assert "\x1b" not in notes
+    assert control not in notes
+    assert changelog_path.read_text() == changelog
 
 
 def test_release_candidate_health_warnings(tmp_path, monkeypatch, capsys):

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -932,6 +932,68 @@ def test_release_candidate_notes_and_publish_plan(tmp_path, monkeypatch, capsys)
     assert "Co-authored-by: Codex <codex@openai.com>" in inhouse_notes
 
 
+def test_release_candidate_redacts_unsafe_unreleased_entries_with_reasons(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    unsafe_token = "unsafe" + "token123456789012"
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n"
+        "- Add safe release notes.\n"
+        f"- Rotate API_TOKEN={unsafe_token}.\n"
+        "- Stop reading /home/example-user/private.conf.\n"
+        "- Move service from buildbox.corp.internal.\n"
+        "- <script>alert('release')</script>\n"
+        "- [click me](javascript:alert('release')).\n\n"
+        "## [0.1.0]\n- Historical entry.\n"
+    )
+    subprocess.run(["git", "add", "CHANGELOG.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "update changelog"], cwd=tmp_path, check=True, stdout=subprocess.DEVNULL)
+
+    assert release_cmd.candidate_plan(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
+    first = json.loads(capsys.readouterr().out)
+    assert release_cmd.candidate_plan(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
+    second = json.loads(capsys.readouterr().out)
+
+    inputs = first["release_notes_inputs"]
+    assert inputs["changelog_unreleased"] == ["Add safe release notes."]
+    assert inputs["changelog_redactions"] == {
+        "count": 5,
+        "reasons": {
+            "injection_markup": 2,
+            "private_hostname": 1,
+            "private_path": 1,
+            "secret": 1,
+        },
+    }
+    assert second["release_notes_inputs"] == inputs
+    rendered = json.dumps(first, sort_keys=True)
+    assert unsafe_token not in rendered
+    assert "example-user" not in rendered
+    assert "buildbox.corp.internal" not in rendered
+    assert "javascript:" not in rendered
+
+
+def test_release_notes_draft_reports_changelog_redaction_summary():
+    notes = release_cmd._candidate_release_notes(
+        {
+            "release_notes_inputs": {
+                "changelog_unreleased": ["A safe item."],
+                "changelog_redactions": {
+                    "count": 3,
+                    "reasons": {"secret": 1, "injection_markup": 2},
+                },
+            }
+        }
+    )
+
+    assert "- A safe item." in notes
+    assert "3 Unreleased changelog entries redacted" in notes
+    assert "injection_markup=2, secret=1" in notes
+
+
 def test_release_candidate_health_warnings(tmp_path, monkeypatch, capsys):
     _init_repo(tmp_path)
     _seed_ready_evidence(tmp_path)

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -940,7 +940,8 @@ def test_release_candidate_notes_sanitize_unreleased_url_token_ansi_and_control(
     private_url = "https://agent.private.invalid/release-notes"
     token = "ghp_" + ("a" * 20)
     ansi = "\x1b[31m"
-    control = "\x07"
+    c0 = "\x07"
+    c1 = "\x9b"
     changelog = (
         "# Changelog\n\n"
         "## [Unreleased]\n"
@@ -948,7 +949,8 @@ def test_release_candidate_notes_sanitize_unreleased_url_token_ansi_and_control(
         f"- Document callback {private_url} for operators.\n"
         f"- Rotate deploy token {token}.\n"
         f"- Colorize {ansi}status output\x1b[0m in doctor.\n"
-        f"- Keep the {control}bell out of notes.\n"
+        f"- Keep the {c0}bell out of notes.\n"
+        f"- Strip C1 {c1}bytes from notes.\n"
         "- Preserve trailing safe highlight.\n\n"
         "## [0.1.0]\n- Historical entry.\n"
     )
@@ -960,7 +962,9 @@ def test_release_candidate_notes_sanitize_unreleased_url_token_ansi_and_control(
     assert release_cmd.candidate_build(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
     candidate = json.loads(capsys.readouterr().out)
     notes = Path(candidate["path"], "RELEASE_NOTES_DRAFT.md").read_text()
-    items = candidate["release_notes_inputs"]["changelog_unreleased"]
+    inputs = candidate["release_notes_inputs"]
+    items = inputs["changelog_unreleased"]
+    redactions = inputs["changelog_redactions"]
 
     assert items[0] == "Add safe release notes."
     assert items[-1] == "Preserve trailing safe highlight."
@@ -969,8 +973,35 @@ def test_release_candidate_notes_sanitize_unreleased_url_token_ansi_and_control(
     assert private_url not in notes
     assert token not in notes
     assert "\x1b" not in notes
-    assert control not in notes
+    assert c0 not in notes
+    assert c1 not in notes
+    assert "\x1b" not in "".join(items)
+    assert c0 not in "".join(items)
+    assert c1 not in "".join(items)
+    assert redactions["count"] == 5
+    assert redactions["reasons"]["private_url"] == 1
+    assert redactions["reasons"]["secret"] == 1
+    assert redactions["reasons"]["control"] >= 3
+    assert "5 Unreleased changelog entries redacted" in notes
     assert changelog_path.read_text() == changelog
+
+
+def test_release_notes_draft_reports_changelog_redaction_summary():
+    notes = release_cmd._candidate_release_notes(
+        {
+            "release_notes_inputs": {
+                "changelog_unreleased": ["A safe item."],
+                "changelog_redactions": {
+                    "count": 3,
+                    "reasons": {"secret": 1, "control": 2},
+                },
+            }
+        }
+    )
+
+    assert "- A safe item." in notes
+    assert "3 Unreleased changelog entries redacted" in notes
+    assert "control=2, secret=1" in notes
 
 
 def test_release_candidate_health_warnings(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Exclude unsafe Unreleased changelog entries from release-candidate output and report a counted redaction summary for review.

## Verification

- `pytest -q tests/test_release_cmd.py`
- `ruff check src/brigade/release_cmd/candidate.py tests/test_release_cmd.py`

Fixes #674