### PR TITLE
fix(research): repair bounded R3 characterization

### DIFF
--- a/docs/measurements/issue-846-work-store-r3.json
+++ b/docs/measurements/issue-846-work-store-r3.json
@@ -1,0 +1,2202 @@
+{
+  "anonymous_metrics": "disabled_in_harness",
+  "capability_notes": {
+    "dolt_cli_per_command": {
+      "branch_diff_merge": "native_candidate",
+      "concurrent_cross_machine_claim": "not_by_cli_alone",
+      "concurrent_same_store_claim": "unmeasured_r3",
+      "dolt_commit_policy": "candidate mapping: claim CAS / graph apply / release / reassign would need an explicit CALL DOLT_COMMIT after SQL commit; readiness queries would not create Dolt commits",
+      "portable_sync": "clone_push_pull_candidate",
+      "row_locks": "unsupported_select_for_update",
+      "runtime_dependency": "forbidden_unless_later_issue_approves",
+      "sql_tx_vs_claim_cas": "SQL transaction success is not Brigade claim-CAS proof; cell-level merge can allow lost updates vs row-lock DBs"
+    },
+    "dolt_sql_server": {
+      "branch_diff_merge": "native_candidate",
+      "concurrent_cross_machine_claim": "possible_but_not_current_need",
+      "eligibility_gate": "eligible only if a later concurrent-claim requirement cannot meet measured correctness through file or replica candidates",
+      "extra_ops": "users_grants_backup_version_lifecycle_listener",
+      "listener_policy": "loopback_only_with_approval_or_no_listener",
+      "portable_sync": "central_service_candidate",
+      "row_locks": "unsupported_select_for_update",
+      "runtime_dependency": "forbidden_unless_later_issue_approves",
+      "status": "blocked_no_listener_in_r3"
+    },
+    "embedded_dolt": {
+      "branch_diff_merge": "native_candidate",
+      "concurrent_cross_machine_claim": "not_by_embed_alone",
+      "portable_sync": "local_replica_candidate",
+      "row_locks": "unsupported_select_for_update",
+      "runtime_dependency": "forbidden_unless_later_issue_approves",
+      "server_lifecycle": "none",
+      "status": "blocked_no_boundary_in_repo"
+    },
+    "json_ledger": {
+      "branch_diff_merge": "absent",
+      "concurrent_cross_machine_claim": "not_supported",
+      "concurrent_same_store_claim": "supported_via_dir_lock",
+      "dolt_commit_policy": "n/a",
+      "portable_sync": "absent_first_class",
+      "row_locks": "n/a_file_cas"
+    },
+    "sources": [
+      "https://www.dolthub.com/docs/sql-reference/sql-support/supported-statements/",
+      "https://www.dolthub.com/blog/2026-02-17-dolt-concurrency/",
+      "https://www.dolthub.com/docs/introduction/installation/application-server/",
+      "https://www.dolthub.com/docs/sql-reference/server/backups/",
+      "https://www.dolthub.com/docs/other/versioning/"
+    ],
+    "sqlite_wal": {
+      "branch_diff_merge": "absent",
+      "concurrent_cross_machine_claim": "not_safe_on_shared_network_fs",
+      "concurrent_same_store_claim": "supported_via_begin_immediate",
+      "dolt_commit_policy": "n/a",
+      "portable_sync": "file_copy_only",
+      "row_locks": "sqlite_transaction_locks",
+      "runtime_dependency": "forbidden_for_brigade_runtime"
+    }
+  },
+  "datasets": [
+    "chain_50",
+    "diamond_200",
+    "wide_500_1000"
+  ],
+  "decision": {
+    "backend_adoption": false,
+    "beads": "excluded_under_770",
+    "brigade_workstore_v1": false,
+    "concurrent_cross_machine_claims": "not_current_requirement",
+    "current_need": "sequential_portable_sync_plus_reviewable_branch_merge_proposals",
+    "dolt": "characterization_candidate_not_banned_not_selected",
+    "portable_sync": "adopt_as_follow_up_requirement_not_implemented_in_r3",
+    "shared_service_eligibility": "only_if_later_concurrent_claim_requirement_fails_file_or_replica_candidates",
+    "shared_store_conformance_fixture": "not_approved",
+    "sqlite": "optional_local_characterization_only_not_runtime_dependency",
+    "store_decision": "keep_machine_local_json_ledger"
+  },
+  "environment": {
+    "directory_fsync_supported": true,
+    "dolt_on_path": false,
+    "filesystem_type": "ext4",
+    "platform": "Linux-6.18.35-x86_64-with-glibc2.39",
+    "python_version": "3.14.4 (main, May  1 2026, 05:51:55) [GCC 13.3.0]",
+    "sqlite_version": "3.45.1"
+  },
+  "fixtures": {
+    "chain_50": {
+      "blocks_edges": 49,
+      "contains_hostnames": false,
+      "digest_sha256": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+      "edge_count": 49,
+      "expected": {
+        "blocks_edges": 49,
+        "edge_count": 49,
+        "parent_child_edges": 0,
+        "provenance_edges": 0,
+        "ready_count": 1,
+        "task_count": 50
+      },
+      "machine_neutral": true,
+      "name": "chain_50",
+      "parent_child_edges": 0,
+      "provenance_edges": 0,
+      "ready_count": 1,
+      "task_count": 50
+    },
+    "diamond_200": {
+      "blocks_edges": 396,
+      "contains_hostnames": false,
+      "digest_sha256": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+      "edge_count": 396,
+      "expected": {
+        "blocks_edges": 396,
+        "edge_count": 396,
+        "parent_child_edges": 0,
+        "provenance_edges": 0,
+        "ready_count": 1,
+        "task_count": 200
+      },
+      "machine_neutral": true,
+      "name": "diamond_200",
+      "parent_child_edges": 0,
+      "provenance_edges": 0,
+      "ready_count": 1,
+      "task_count": 200
+    },
+    "wide_500_1000": {
+      "blocks_edges": 0,
+      "contains_hostnames": false,
+      "digest_sha256": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+      "edge_count": 1000,
+      "expected": {
+        "blocks_edges": 0,
+        "edge_count": 1000,
+        "parent_child_edges": 0,
+        "provenance_edges": 1000,
+        "ready_count": 500,
+        "task_count": 500
+      },
+      "machine_neutral": true,
+      "name": "wide_500_1000",
+      "parent_child_edges": 0,
+      "provenance_edges": 1000,
+      "ready_count": 500,
+      "task_count": 500
+    }
+  },
+  "issue": 846,
+  "kind": "work-store-characterization",
+  "normative_anchors": {
+    "issue_737": "graph ready-set, chains, diamonds, cycles, provenance-only edges",
+    "issue_738": "claim CAS with one winner and exit 13 on lost race",
+    "issue_770": "BUILD native; Beads excluded"
+  },
+  "protocol_version": 3,
+  "results": [
+    {
+      "backup_restore": {
+        "backup_time_ns": 541489,
+        "branch_heads": {
+          "detail": "shape has no first-class branch heads",
+          "digest_sha256": null,
+          "status": "unsupported"
+        },
+        "claim_digest_after": "9d6532577ab4038767feac51dd6ce7e04c051a63e592217077d735873c4bdfc7",
+        "claim_digest_before": "9d6532577ab4038767feac51dd6ce7e04c051a63e592217077d735873c4bdfc7",
+        "config_digest_after": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "config_digest_before": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "pass": true,
+        "status": "measured",
+        "task_edge_digest_after": "36b99abd2b135a378185d8848ab2377d31cd185789c1098c9a50de8cc6843988",
+        "task_edge_digest_before": "36b99abd2b135a378185d8848ab2377d31cd185789c1098c9a50de8cc6843988"
+      },
+      "branch_diff_merge": {
+        "detail": "JSON ledger has no first-class branch/diff/merge path",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "status": "measured",
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "cold_start": {
+        "cold": true,
+        "cold_start_ns": 503811631,
+        "cold_start_timing_scope": "parent_subprocess_wall",
+        "inner_operation_ns": 856249,
+        "inner_operation_timing_scope": "probe_read_after_import",
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured",
+        "task_count": 50
+      },
+      "crash_consistency": {
+        "mode": "before_replace",
+        "original_intact": true,
+        "pass": true,
+        "status": "measured"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "digest_after": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "digest_before": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "pass": true,
+        "status": "measured"
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 49,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "guard_and_empty_filter": {
+        "empty_filter": {
+          "exit_code": 2,
+          "pass": true,
+          "reason": "empty_filter"
+        },
+        "if_actor_mismatch": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "if_status_match": {
+          "exit_code": 0,
+          "pass": true,
+          "released": true
+        },
+        "if_status_mismatch": {
+          "exit_code": 13,
+          "expected": "pending",
+          "guard": "if_status",
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "pass": true,
+        "status": "measured",
+        "still_held_after_rejects": true
+      },
+      "install_footprint": {
+        "note": "JSON ledger is in-tree; no extra runtime dependency install",
+        "pass": true,
+        "runtime_dependency_bytes": 0,
+        "status": "measured",
+        "tasks_json_bytes": 24699,
+        "work_tree_bytes": 24699
+      },
+      "metrics_state": {
+        "anonymous_metrics_config": "disabled",
+        "brigade_anonymous_metrics_env": "0",
+        "claim_exit_code": 0,
+        "disable_telemetry_env": "1",
+        "metrics_artifacts": [],
+        "pass": true,
+        "status": "measured"
+      },
+      "mutation_latency": {
+        "max_ns": 17872818,
+        "min_ns": 4024282,
+        "p50_ns": 4872079,
+        "p95_ns": 10212118,
+        "samples": 100
+      },
+      "offline_divergence": {
+        "detail": "No portable sync primitive in current JSON ledger",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 1.0,
+        "p95_vs_json": 1.0
+      },
+      "resource_measurements": {
+        "claim_exit_code": 0,
+        "disk_bytes_after": 24939,
+        "disk_bytes_before": 24699,
+        "disk_growth_bytes": 240,
+        "pass": true,
+        "peak_rss_kib": 51324,
+        "peak_rss_mib": 50.12,
+        "rss_protocol": "popen_sample_child",
+        "rss_sampling": "measured",
+        "rss_scope": "subprocess_child",
+        "status": "measured",
+        "stdout_bytes": 280
+      },
+      "restart_recovery": {
+        "assignee": "lane-restart",
+        "claim_id": "claim-restart",
+        "claim_persisted": true,
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured"
+      },
+      "same_actor_and_retry": {
+        "idempotent_retry": {
+          "created_first": true,
+          "created_retry": false,
+          "idempotent": true
+        },
+        "pass": true,
+        "same_actor_rejection": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "already_claimed"
+        },
+        "status": "measured"
+      },
+      "schema_version_policy": {
+        "downgrade_coerced_on_read": true,
+        "downgrade_rejected": false,
+        "downgrade_version_after_read": 2,
+        "downgrade_version_written": 1,
+        "expected_version": 2,
+        "future_version_after_read": 2,
+        "future_version_coerced_on_read": true,
+        "future_version_rejected": false,
+        "future_version_written": 102,
+        "observed_policy": "ensure_ledger_edges_coerces_version_to_current",
+        "pass": true,
+        "status": "measured"
+      },
+      "secret_history_handling": {
+        "git_history": {
+          "ignore_path": ".brigade/work/",
+          "ignored_path_secret_absent_from_git": true,
+          "pass": true,
+          "status": "measured",
+          "synthetic_tracked_history": {
+            "deleted_secret_retained_in_history": true,
+            "pass": true,
+            "status": "measured",
+            "tracked_path": "synth/tracked-secret.txt"
+          },
+          "work_path_ignored": true
+        },
+        "live_and_backup_pass": true,
+        "live_retains_deleted_path": false,
+        "live_retains_deleted_secret": false,
+        "pass": true,
+        "post_delete_backup_retains_secret": false,
+        "pre_delete_backup_retains_secret": true,
+        "status": "measured",
+        "synthetic_secret_marker": "synth-secret-846-r3-TOKEN-not-a-real-credential"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "json_ledger",
+      "status": "measured"
+    },
+    {
+      "backup_restore": {
+        "backup_time_ns": 484708,
+        "branch_heads": {
+          "detail": "shape has no first-class branch heads",
+          "digest_sha256": null,
+          "status": "unsupported"
+        },
+        "claim_digest_after": "9d6532577ab4038767feac51dd6ce7e04c051a63e592217077d735873c4bdfc7",
+        "claim_digest_before": "9d6532577ab4038767feac51dd6ce7e04c051a63e592217077d735873c4bdfc7",
+        "config_digest_after": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "config_digest_before": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "pass": true,
+        "status": "measured",
+        "task_edge_digest_after": "50b78b56f8eec9a9008ee333eb847c60a7726d4f27d14e51f4330115fd480ce4",
+        "task_edge_digest_before": "50b78b56f8eec9a9008ee333eb847c60a7726d4f27d14e51f4330115fd480ce4"
+      },
+      "branch_diff_merge": {
+        "detail": "SQLite WAL adapter has no branch/diff/merge",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "status": "measured",
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "cold_start": {
+        "cold": true,
+        "cold_start_ns": 519258714,
+        "cold_start_timing_scope": "parent_subprocess_wall",
+        "inner_operation_ns": 2334941,
+        "inner_operation_timing_scope": "probe_export_after_import",
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured",
+        "task_count": 50
+      },
+      "crash_consistency": {
+        "mode": "before_commit",
+        "original_intact": true,
+        "pass": true,
+        "status": "measured"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "digest_after": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "digest_before": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "pass": true,
+        "status": "measured"
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 49,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "guard_and_empty_filter": {
+        "claim_cleanup": {
+          "item_revision": 2,
+          "pass": true
+        },
+        "empty_filter": {
+          "exit_code": 2,
+          "pass": true,
+          "reason": "empty_filter"
+        },
+        "if_actor_mismatch": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "if_status_match": {
+          "exit_code": 0,
+          "pass": true,
+          "released": true
+        },
+        "if_status_mismatch": {
+          "exit_code": 13,
+          "guard": "if_status",
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "pass": true,
+        "status": "measured"
+      },
+      "install_footprint": {
+        "db_bytes": 57344,
+        "note": "stdlib sqlite3 only; not a Brigade runtime dependency",
+        "pass": true,
+        "runtime_dependency_bytes": 0,
+        "status": "measured"
+      },
+      "metrics_state": {
+        "anonymous_metrics_config": "disabled",
+        "brigade_anonymous_metrics_env": "0",
+        "claim_exit_code": 0,
+        "disable_telemetry_env": "1",
+        "metrics_artifacts": [],
+        "pass": true,
+        "scanned_store_path": "ws-sqlite-metrics-store-29fu5wy2",
+        "status": "measured"
+      },
+      "mutation_latency": {
+        "max_ns": 22230736,
+        "min_ns": 3972103,
+        "p50_ns": 4555931,
+        "p95_ns": 11411668,
+        "samples": 100
+      },
+      "note": "stdlib sqlite3 characterization only; not a Brigade runtime dependency",
+      "offline_divergence": {
+        "detail": "File copy only; no merge protocol in this adapter",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 0.9351102475965599,
+        "p95_vs_json": 1.1174633900626687
+      },
+      "resource_measurements": {
+        "claim_exit_code": 0,
+        "disk_bytes_after": 61440,
+        "disk_bytes_before": 57344,
+        "disk_growth_bytes": 4096,
+        "pass": true,
+        "peak_rss_kib": 39852,
+        "peak_rss_mib": 38.92,
+        "rss_protocol": "popen_sample_child",
+        "rss_sampling": "measured",
+        "rss_scope": "subprocess_child",
+        "status": "measured"
+      },
+      "restart_recovery": {
+        "assignee": "lane-restart",
+        "claim_id": "claim-restart",
+        "claim_persisted": true,
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured"
+      },
+      "same_actor_and_retry": {
+        "idempotent_retry": {
+          "created_first": true,
+          "created_retry": false,
+          "reason": "idempotent_retry"
+        },
+        "pass": true,
+        "same_actor_rejection": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "already_claimed"
+        },
+        "status": "measured"
+      },
+      "schema_version_policy": {
+        "downgrade_coerced_on_export": true,
+        "downgrade_rejected": false,
+        "downgrade_version_after_export": 2,
+        "downgrade_version_written": 1,
+        "expected_version": 2,
+        "future_version_after_export": 2,
+        "future_version_coerced_on_export": true,
+        "future_version_rejected": false,
+        "future_version_written": 102,
+        "observed_policy": "adapter_meta_preserves_written_version_export_coerces_via_ensure_ledger_edges",
+        "pass": true,
+        "status": "measured"
+      },
+      "secret_history_handling": {
+        "git_history": {
+          "pass": null,
+          "reason": "sqlite characterization adapter has no native VCS; JSON ledger measures synthetic git/ignore-path history",
+          "status": "unavailable"
+        },
+        "live_and_backup_pass": true,
+        "live_retains_deleted_secret": false,
+        "pass": true,
+        "post_delete_backup_retains_secret": false,
+        "pre_delete_backup_retains_secret": true,
+        "status": "measured",
+        "synthetic_secret_marker": "synth-secret-846-r3-TOKEN-not-a-real-credential"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "sqlite_wal",
+      "status": "measured"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "dolt binary not available on PATH; optional temporary CLI not supplied (--dolt-bin). Cell left unmeasured rather than fabricated",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "dolt_cli_per_command",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "No embedded Dolt boundary is checked into this repo; R3 does not build or persist a Go/Dolt dependency",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "embedded_dolt",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "R3 policy: harness must not start a network listener; operator-owned server characterization requires separate approval",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "dolt_sql_server",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "backup_time_ns": 401021,
+        "branch_heads": {
+          "detail": "shape has no first-class branch heads",
+          "digest_sha256": null,
+          "status": "unsupported"
+        },
+        "claim_digest_after": "3248cf250f8c175e371bdb4e8852985a7642d4ea386c3c03f1f7ed48dfad4bae",
+        "claim_digest_before": "3248cf250f8c175e371bdb4e8852985a7642d4ea386c3c03f1f7ed48dfad4bae",
+        "config_digest_after": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "config_digest_before": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "pass": true,
+        "status": "measured",
+        "task_edge_digest_after": "2f06d09a748e89cb4aa4245ead29d28872d727454dadf8751aea4f8f5c5bcd44",
+        "task_edge_digest_before": "2f06d09a748e89cb4aa4245ead29d28872d727454dadf8751aea4f8f5c5bcd44"
+      },
+      "branch_diff_merge": {
+        "detail": "JSON ledger has no first-class branch/diff/merge path",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "status": "measured",
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "cold_start": {
+        "cold": true,
+        "cold_start_ns": 456334012,
+        "cold_start_timing_scope": "parent_subprocess_wall",
+        "inner_operation_ns": 4586172,
+        "inner_operation_timing_scope": "probe_read_after_import",
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured",
+        "task_count": 200
+      },
+      "crash_consistency": {
+        "mode": "before_replace",
+        "original_intact": true,
+        "pass": true,
+        "status": "measured"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "digest_after": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "digest_before": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "pass": true,
+        "status": "measured"
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 199,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "guard_and_empty_filter": {
+        "empty_filter": {
+          "exit_code": 2,
+          "pass": true,
+          "reason": "empty_filter"
+        },
+        "if_actor_mismatch": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "if_status_match": {
+          "exit_code": 0,
+          "pass": true,
+          "released": true
+        },
+        "if_status_mismatch": {
+          "exit_code": 13,
+          "expected": "pending",
+          "guard": "if_status",
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "pass": true,
+        "status": "measured",
+        "still_held_after_rejects": true
+      },
+      "install_footprint": {
+        "note": "JSON ledger is in-tree; no extra runtime dependency install",
+        "pass": true,
+        "runtime_dependency_bytes": 0,
+        "status": "measured",
+        "tasks_json_bytes": 140737,
+        "work_tree_bytes": 140737
+      },
+      "metrics_state": {
+        "anonymous_metrics_config": "disabled",
+        "brigade_anonymous_metrics_env": "0",
+        "claim_exit_code": 0,
+        "disable_telemetry_env": "1",
+        "metrics_artifacts": [],
+        "pass": true,
+        "status": "measured"
+      },
+      "mutation_latency": {
+        "max_ns": 672487749,
+        "min_ns": 10122122,
+        "p50_ns": 11572495,
+        "p95_ns": 21166162,
+        "samples": 100
+      },
+      "offline_divergence": {
+        "detail": "No portable sync primitive in current JSON ledger",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 1.0,
+        "p95_vs_json": 1.0
+      },
+      "resource_measurements": {
+        "claim_exit_code": 0,
+        "disk_bytes_after": 140977,
+        "disk_bytes_before": 140737,
+        "disk_growth_bytes": 240,
+        "pass": true,
+        "peak_rss_kib": 52040,
+        "peak_rss_mib": 50.82,
+        "rss_protocol": "popen_sample_child",
+        "rss_sampling": "measured",
+        "rss_scope": "subprocess_child",
+        "status": "measured",
+        "stdout_bytes": 282
+      },
+      "restart_recovery": {
+        "assignee": "lane-restart",
+        "claim_id": "claim-restart",
+        "claim_persisted": true,
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured"
+      },
+      "same_actor_and_retry": {
+        "idempotent_retry": {
+          "created_first": true,
+          "created_retry": false,
+          "idempotent": true
+        },
+        "pass": true,
+        "same_actor_rejection": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "already_claimed"
+        },
+        "status": "measured"
+      },
+      "schema_version_policy": {
+        "downgrade_coerced_on_read": true,
+        "downgrade_rejected": false,
+        "downgrade_version_after_read": 2,
+        "downgrade_version_written": 1,
+        "expected_version": 2,
+        "future_version_after_read": 2,
+        "future_version_coerced_on_read": true,
+        "future_version_rejected": false,
+        "future_version_written": 102,
+        "observed_policy": "ensure_ledger_edges_coerces_version_to_current",
+        "pass": true,
+        "status": "measured"
+      },
+      "secret_history_handling": {
+        "git_history": {
+          "ignore_path": ".brigade/work/",
+          "ignored_path_secret_absent_from_git": true,
+          "pass": true,
+          "status": "measured",
+          "synthetic_tracked_history": {
+            "deleted_secret_retained_in_history": true,
+            "pass": true,
+            "status": "measured",
+            "tracked_path": "synth/tracked-secret.txt"
+          },
+          "work_path_ignored": true
+        },
+        "live_and_backup_pass": true,
+        "live_retains_deleted_path": false,
+        "live_retains_deleted_secret": false,
+        "pass": true,
+        "post_delete_backup_retains_secret": false,
+        "pre_delete_backup_retains_secret": true,
+        "status": "measured",
+        "synthetic_secret_marker": "synth-secret-846-r3-TOKEN-not-a-real-credential"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "json_ledger",
+      "status": "measured"
+    },
+    {
+      "backup_restore": {
+        "backup_time_ns": 799620,
+        "branch_heads": {
+          "detail": "shape has no first-class branch heads",
+          "digest_sha256": null,
+          "status": "unsupported"
+        },
+        "claim_digest_after": "3248cf250f8c175e371bdb4e8852985a7642d4ea386c3c03f1f7ed48dfad4bae",
+        "claim_digest_before": "3248cf250f8c175e371bdb4e8852985a7642d4ea386c3c03f1f7ed48dfad4bae",
+        "config_digest_after": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "config_digest_before": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "pass": true,
+        "status": "measured",
+        "task_edge_digest_after": "6390c7e86c78db8202867a46b02435951b7c67563966c224b1bd72e51d1f6765",
+        "task_edge_digest_before": "6390c7e86c78db8202867a46b02435951b7c67563966c224b1bd72e51d1f6765"
+      },
+      "branch_diff_merge": {
+        "detail": "SQLite WAL adapter has no branch/diff/merge",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "status": "measured",
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "cold_start": {
+        "cold": true,
+        "cold_start_ns": 488552600,
+        "cold_start_timing_scope": "parent_subprocess_wall",
+        "inner_operation_ns": 11879047,
+        "inner_operation_timing_scope": "probe_export_after_import",
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured",
+        "task_count": 200
+      },
+      "crash_consistency": {
+        "mode": "before_commit",
+        "original_intact": true,
+        "pass": true,
+        "status": "measured"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "digest_after": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "digest_before": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "pass": true,
+        "status": "measured"
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 199,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "guard_and_empty_filter": {
+        "claim_cleanup": {
+          "item_revision": 2,
+          "pass": true
+        },
+        "empty_filter": {
+          "exit_code": 2,
+          "pass": true,
+          "reason": "empty_filter"
+        },
+        "if_actor_mismatch": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "if_status_match": {
+          "exit_code": 0,
+          "pass": true,
+          "released": true
+        },
+        "if_status_mismatch": {
+          "exit_code": 13,
+          "guard": "if_status",
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "pass": true,
+        "status": "measured"
+      },
+      "install_footprint": {
+        "db_bytes": 208896,
+        "note": "stdlib sqlite3 only; not a Brigade runtime dependency",
+        "pass": true,
+        "runtime_dependency_bytes": 0,
+        "status": "measured"
+      },
+      "metrics_state": {
+        "anonymous_metrics_config": "disabled",
+        "brigade_anonymous_metrics_env": "0",
+        "claim_exit_code": 0,
+        "disable_telemetry_env": "1",
+        "metrics_artifacts": [],
+        "pass": true,
+        "scanned_store_path": "ws-sqlite-metrics-store-es6hnf0m",
+        "status": "measured"
+      },
+      "mutation_latency": {
+        "max_ns": 72114209,
+        "min_ns": 4382316,
+        "p50_ns": 5524940,
+        "p95_ns": 18054008,
+        "samples": 100
+      },
+      "note": "stdlib sqlite3 characterization only; not a Brigade runtime dependency",
+      "offline_divergence": {
+        "detail": "File copy only; no merge protocol in this adapter",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 0.4774199513588038,
+        "p95_vs_json": 0.8529655966915495
+      },
+      "resource_measurements": {
+        "claim_exit_code": 0,
+        "disk_bytes_after": 212992,
+        "disk_bytes_before": 208896,
+        "disk_growth_bytes": 4096,
+        "pass": true,
+        "peak_rss_kib": 39956,
+        "peak_rss_mib": 39.02,
+        "rss_protocol": "popen_sample_child",
+        "rss_sampling": "measured",
+        "rss_scope": "subprocess_child",
+        "status": "measured"
+      },
+      "restart_recovery": {
+        "assignee": "lane-restart",
+        "claim_id": "claim-restart",
+        "claim_persisted": true,
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured"
+      },
+      "same_actor_and_retry": {
+        "idempotent_retry": {
+          "created_first": true,
+          "created_retry": false,
+          "reason": "idempotent_retry"
+        },
+        "pass": true,
+        "same_actor_rejection": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "already_claimed"
+        },
+        "status": "measured"
+      },
+      "schema_version_policy": {
+        "downgrade_coerced_on_export": true,
+        "downgrade_rejected": false,
+        "downgrade_version_after_export": 2,
+        "downgrade_version_written": 1,
+        "expected_version": 2,
+        "future_version_after_export": 2,
+        "future_version_coerced_on_export": true,
+        "future_version_rejected": false,
+        "future_version_written": 102,
+        "observed_policy": "adapter_meta_preserves_written_version_export_coerces_via_ensure_ledger_edges",
+        "pass": true,
+        "status": "measured"
+      },
+      "secret_history_handling": {
+        "git_history": {
+          "pass": null,
+          "reason": "sqlite characterization adapter has no native VCS; JSON ledger measures synthetic git/ignore-path history",
+          "status": "unavailable"
+        },
+        "live_and_backup_pass": true,
+        "live_retains_deleted_secret": false,
+        "pass": true,
+        "post_delete_backup_retains_secret": false,
+        "pre_delete_backup_retains_secret": true,
+        "status": "measured",
+        "synthetic_secret_marker": "synth-secret-846-r3-TOKEN-not-a-real-credential"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "sqlite_wal",
+      "status": "measured"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "dolt binary not available on PATH; optional temporary CLI not supplied (--dolt-bin). Cell left unmeasured rather than fabricated",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "dolt_cli_per_command",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "No embedded Dolt boundary is checked into this repo; R3 does not build or persist a Go/Dolt dependency",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "embedded_dolt",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "R3 policy: harness must not start a network listener; operator-owned server characterization requires separate approval",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "dolt_sql_server",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "backup_time_ns": 948207,
+        "branch_heads": {
+          "detail": "shape has no first-class branch heads",
+          "digest_sha256": null,
+          "status": "unsupported"
+        },
+        "claim_digest_after": "dc738a64bd5c2ef993301fb027b239355207d06c9b20dfeb79ef5b28689f5644",
+        "claim_digest_before": "dc738a64bd5c2ef993301fb027b239355207d06c9b20dfeb79ef5b28689f5644",
+        "config_digest_after": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "config_digest_before": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "pass": true,
+        "status": "measured",
+        "task_edge_digest_after": "0a87f63fd2879b12a02580af0c6e33a4883c8030f078148ffa9d7e39d5aa831d",
+        "task_edge_digest_before": "0a87f63fd2879b12a02580af0c6e33a4883c8030f078148ffa9d7e39d5aa831d"
+      },
+      "branch_diff_merge": {
+        "detail": "JSON ledger has no first-class branch/diff/merge path",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "status": "measured",
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "cold_start": {
+        "cold": true,
+        "cold_start_ns": 461399046,
+        "cold_start_timing_scope": "parent_subprocess_wall",
+        "inner_operation_ns": 12126627,
+        "inner_operation_timing_scope": "probe_read_after_import",
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured",
+        "task_count": 500
+      },
+      "crash_consistency": {
+        "mode": "before_replace",
+        "original_intact": true,
+        "pass": true,
+        "status": "measured"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "digest_after": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "digest_before": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "pass": true,
+        "status": "measured"
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 0,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 500
+      },
+      "guard_and_empty_filter": {
+        "empty_filter": {
+          "exit_code": 2,
+          "pass": true,
+          "reason": "empty_filter"
+        },
+        "if_actor_mismatch": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "if_status_match": {
+          "exit_code": 0,
+          "pass": true,
+          "released": true
+        },
+        "if_status_mismatch": {
+          "exit_code": 13,
+          "expected": "pending",
+          "guard": "if_status",
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "pass": true,
+        "status": "measured",
+        "still_held_after_rejects": true
+      },
+      "install_footprint": {
+        "note": "JSON ledger is in-tree; no extra runtime dependency install",
+        "pass": true,
+        "runtime_dependency_bytes": 0,
+        "status": "measured",
+        "tasks_json_bytes": 353443,
+        "work_tree_bytes": 353443
+      },
+      "metrics_state": {
+        "anonymous_metrics_config": "disabled",
+        "brigade_anonymous_metrics_env": "0",
+        "claim_exit_code": 0,
+        "disable_telemetry_env": "1",
+        "metrics_artifacts": [],
+        "pass": true,
+        "status": "measured"
+      },
+      "mutation_latency": {
+        "max_ns": 805433481,
+        "min_ns": 18667255,
+        "p50_ns": 20766292,
+        "p95_ns": 36429784,
+        "samples": 100
+      },
+      "offline_divergence": {
+        "detail": "No portable sync primitive in current JSON ledger",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 1.0,
+        "p95_vs_json": 1.0
+      },
+      "resource_measurements": {
+        "claim_exit_code": 0,
+        "disk_bytes_after": 353683,
+        "disk_bytes_before": 353443,
+        "disk_growth_bytes": 240,
+        "pass": true,
+        "peak_rss_kib": 53384,
+        "peak_rss_mib": 52.13,
+        "rss_protocol": "popen_sample_child",
+        "rss_sampling": "measured",
+        "rss_scope": "subprocess_child",
+        "status": "measured",
+        "stdout_bytes": 279
+      },
+      "restart_recovery": {
+        "assignee": "lane-restart",
+        "claim_id": "claim-restart",
+        "claim_persisted": true,
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured"
+      },
+      "same_actor_and_retry": {
+        "idempotent_retry": {
+          "created_first": true,
+          "created_retry": false,
+          "idempotent": true
+        },
+        "pass": true,
+        "same_actor_rejection": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "already_claimed"
+        },
+        "status": "measured"
+      },
+      "schema_version_policy": {
+        "downgrade_coerced_on_read": true,
+        "downgrade_rejected": false,
+        "downgrade_version_after_read": 2,
+        "downgrade_version_written": 1,
+        "expected_version": 2,
+        "future_version_after_read": 2,
+        "future_version_coerced_on_read": true,
+        "future_version_rejected": false,
+        "future_version_written": 102,
+        "observed_policy": "ensure_ledger_edges_coerces_version_to_current",
+        "pass": true,
+        "status": "measured"
+      },
+      "secret_history_handling": {
+        "git_history": {
+          "ignore_path": ".brigade/work/",
+          "ignored_path_secret_absent_from_git": true,
+          "pass": true,
+          "status": "measured",
+          "synthetic_tracked_history": {
+            "deleted_secret_retained_in_history": true,
+            "pass": true,
+            "status": "measured",
+            "tracked_path": "synth/tracked-secret.txt"
+          },
+          "work_path_ignored": true
+        },
+        "live_and_backup_pass": true,
+        "live_retains_deleted_path": false,
+        "live_retains_deleted_secret": false,
+        "pass": true,
+        "post_delete_backup_retains_secret": false,
+        "pre_delete_backup_retains_secret": true,
+        "status": "measured",
+        "synthetic_secret_marker": "synth-secret-846-r3-TOKEN-not-a-real-credential"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "json_ledger",
+      "status": "measured"
+    },
+    {
+      "backup_restore": {
+        "backup_time_ns": 735948,
+        "branch_heads": {
+          "detail": "shape has no first-class branch heads",
+          "digest_sha256": null,
+          "status": "unsupported"
+        },
+        "claim_digest_after": "dc738a64bd5c2ef993301fb027b239355207d06c9b20dfeb79ef5b28689f5644",
+        "claim_digest_before": "dc738a64bd5c2ef993301fb027b239355207d06c9b20dfeb79ef5b28689f5644",
+        "config_digest_after": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "config_digest_before": "24e831dd06f47b03d6a3a8b558fdb5b822442d8d1f969b2e88146375448a01d9",
+        "pass": true,
+        "status": "measured",
+        "task_edge_digest_after": "c3bb2700b837962f29b679adc793a23f04b4cc5a1636599bbe38533ba0eb4a58",
+        "task_edge_digest_before": "c3bb2700b837962f29b679adc793a23f04b4cc5a1636599bbe38533ba0eb4a58"
+      },
+      "branch_diff_merge": {
+        "detail": "SQLite WAL adapter has no branch/diff/merge",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-a",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "status": "measured",
+        "winner_actor": "lane-a",
+        "winner_count": 1
+      },
+      "cold_start": {
+        "cold": true,
+        "cold_start_ns": 491832997,
+        "cold_start_timing_scope": "parent_subprocess_wall",
+        "inner_operation_ns": 22051989,
+        "inner_operation_timing_scope": "probe_export_after_import",
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured",
+        "task_count": 500
+      },
+      "crash_consistency": {
+        "mode": "before_commit",
+        "original_intact": true,
+        "pass": true,
+        "status": "measured"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "digest_after": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "digest_before": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "pass": true,
+        "status": "measured"
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 0,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 500
+      },
+      "guard_and_empty_filter": {
+        "claim_cleanup": {
+          "item_revision": 2,
+          "pass": true
+        },
+        "empty_filter": {
+          "exit_code": 2,
+          "pass": true,
+          "reason": "empty_filter"
+        },
+        "if_actor_mismatch": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "if_status_match": {
+          "exit_code": 0,
+          "pass": true,
+          "released": true
+        },
+        "if_status_mismatch": {
+          "exit_code": 13,
+          "guard": "if_status",
+          "pass": true,
+          "reason": "guard_mismatch"
+        },
+        "pass": true,
+        "status": "measured"
+      },
+      "install_footprint": {
+        "db_bytes": 458752,
+        "note": "stdlib sqlite3 only; not a Brigade runtime dependency",
+        "pass": true,
+        "runtime_dependency_bytes": 0,
+        "status": "measured"
+      },
+      "metrics_state": {
+        "anonymous_metrics_config": "disabled",
+        "brigade_anonymous_metrics_env": "0",
+        "claim_exit_code": 0,
+        "disable_telemetry_env": "1",
+        "metrics_artifacts": [],
+        "pass": true,
+        "scanned_store_path": "ws-sqlite-metrics-store-6j7vrshh",
+        "status": "measured"
+      },
+      "mutation_latency": {
+        "max_ns": 34203339,
+        "min_ns": 3158316,
+        "p50_ns": 3842630,
+        "p95_ns": 9657140,
+        "samples": 100
+      },
+      "note": "stdlib sqlite3 characterization only; not a Brigade runtime dependency",
+      "offline_divergence": {
+        "detail": "File copy only; no merge protocol in this adapter",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 0.18504170123390348,
+        "p95_vs_json": 0.2650891369545315
+      },
+      "resource_measurements": {
+        "claim_exit_code": 0,
+        "disk_bytes_after": 458752,
+        "disk_bytes_before": 458752,
+        "disk_growth_bytes": 0,
+        "pass": true,
+        "peak_rss_kib": 39848,
+        "peak_rss_mib": 38.91,
+        "rss_protocol": "popen_sample_child",
+        "rss_sampling": "measured",
+        "rss_scope": "subprocess_child",
+        "status": "measured"
+      },
+      "restart_recovery": {
+        "assignee": "lane-restart",
+        "claim_id": "claim-restart",
+        "claim_persisted": true,
+        "pass": true,
+        "process_boundary": "subprocess",
+        "status": "measured"
+      },
+      "same_actor_and_retry": {
+        "idempotent_retry": {
+          "created_first": true,
+          "created_retry": false,
+          "reason": "idempotent_retry"
+        },
+        "pass": true,
+        "same_actor_rejection": {
+          "exit_code": 13,
+          "pass": true,
+          "reason": "already_claimed"
+        },
+        "status": "measured"
+      },
+      "schema_version_policy": {
+        "downgrade_coerced_on_export": true,
+        "downgrade_rejected": false,
+        "downgrade_version_after_export": 2,
+        "downgrade_version_written": 1,
+        "expected_version": 2,
+        "future_version_after_export": 2,
+        "future_version_coerced_on_export": true,
+        "future_version_rejected": false,
+        "future_version_written": 102,
+        "observed_policy": "adapter_meta_preserves_written_version_export_coerces_via_ensure_ledger_edges",
+        "pass": true,
+        "status": "measured"
+      },
+      "secret_history_handling": {
+        "git_history": {
+          "pass": null,
+          "reason": "sqlite characterization adapter has no native VCS; JSON ledger measures synthetic git/ignore-path history",
+          "status": "unavailable"
+        },
+        "live_and_backup_pass": true,
+        "live_retains_deleted_secret": false,
+        "pass": true,
+        "post_delete_backup_retains_secret": false,
+        "pre_delete_backup_retains_secret": true,
+        "status": "measured",
+        "synthetic_secret_marker": "synth-secret-846-r3-TOKEN-not-a-real-credential"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "sqlite_wal",
+      "status": "measured"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "dolt binary not available on PATH; optional temporary CLI not supplied (--dolt-bin). Cell left unmeasured rather than fabricated",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "dolt_cli_per_command",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "No embedded Dolt boundary is checked into this repo; R3 does not build or persist a Go/Dolt dependency",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "embedded_dolt",
+      "status": "blocked"
+    },
+    {
+      "backup_restore": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "branch_diff_merge": {
+        "status": "blocked"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "cold_start": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "guard_and_empty_filter": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "install_footprint": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "metrics_state": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "blocked"
+      },
+      "pass": null,
+      "reason": "R3 policy: harness must not start a network listener; operator-owned server characterization requires separate approval",
+      "relative_to_json": null,
+      "resource_measurements": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "restart_recovery": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "same_actor_and_retry": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "schema_version_policy": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "secret_history_handling": {
+        "pass": null,
+        "status": "blocked"
+      },
+      "server_auth_tls_permissions": {
+        "pass": null,
+        "reason": "requires network listener; pending separate operator approval",
+        "status": "blocked"
+      },
+      "shape": "dolt_sql_server",
+      "status": "blocked"
+    }
+  ],
+  "shapes": [
+    "json_ledger",
+    "sqlite_wal",
+    "dolt_cli_per_command",
+    "embedded_dolt",
+    "dolt_sql_server"
+  ],
+  "slice": "R3",
+  "timebox": "R3 bounded repair: correct the SQLite release characterization while retaining the accepted no-listener scope and residual cells. Dolt shapes stay optional characterization candidates and must not enter Brigade runtime dependencies. Server listeners, TLS, and permission cells that need a listener remain blocked pending separate operator approval and are never started here.",
+  "trials": 100,
+  "warmups": 10
+}

--- a/docs/research/issue-846-work-store-characterization-r3.md
+++ b/docs/research/issue-846-work-store-characterization-r3.md
@@ -1,0 +1,32 @@
+# Issue #846 R3 - bounded SQLite release characterization repair
+
+Refs #846. R3 repairs only the research SQLite adapter and its characterization artifacts. It does not select or adopt a backend, modify the production store, add a dependency, start a listener, or migrate the source of truth.
+
+## Provenance and scope
+
+- Baseline: `3532f07cb125bfb6ad5c06a3fab0eb97ee555aeb` on the current `main` lineage.
+- Inputs: the accepted R1 and R2 harness artifacts plus the bounded R3 correction request.
+- Harness: `scripts/measure_work_store.py`, standard-library SQLite, 10 warmups and 100 measured trials per dataset.
+- Output: `docs/measurements/issue-846-work-store-r3.json`.
+- GraphTrail was invoked through `brigade code doctor --target .` and `brigade code impact _sqlite_release --target .`; both reported `error: graphtrail is not installed; run \`brigade setup\``. No graph result is claimed.
+
+The accepted R2 JSON and report remain byte-for-byte unchanged. R3 uses only synthetic, machine-neutral data; the measurement output records platform class and contains no private workspace path.
+
+## Corrected behavior
+
+The SQLite adapter now performs release under `BEGIN IMMEDIATE` and delegates task mutation semantics to the canonical claim helpers:
+
+1. Releasing a pending, unclaimed task returns exit `1` with reason `not_claimed`; the transaction rolls back and the exported ledger is byte-for-byte unchanged.
+2. A successful claim creates the canonical nested claim record and increments top-level `item_revision`.
+3. A successful release increments `item_revision` again, returns the released claim record, and removes `assignee`, `claim`, `claim_id`, and `claimed_at` while returning status to `pending`.
+4. `if_actor` mismatch, `if_status` mismatch, matching guards, and an empty actor filter execute against the SQLite transaction path. Mismatches and empty filters roll back.
+
+The R3 measurement reports the SQLite guard/release cell as measured rather than unavailable. All JSON-ledger behavior and the no-listener/Dolt-blocked boundaries remain characterization-only.
+
+## Decision record
+
+The decision remains to keep the machine-local JSON ledger. SQLite remains a standard-library, local characterization adapter only. Dolt remains neither selected nor banned, and all listener-dependent cells remain blocked.
+
+## Verification protocol
+
+Focused checks are run through Brigade work verification with the measurement regression and the #737/#738 anchors. The repository completion gate is `./scripts/verify`. Measurement values are observations from this checkout and are not service-level commitments.

--- a/scripts/measure_work_store.py
+++ b/scripts/measure_work_store.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Issue #846 work-store characterization harness (R1 baseline + R2 residuals).
+"""Issue #846 work-store characterization harness (R1/R2 baseline + R3 repair).
 
 Measures candidate store *shapes* against synthetic, machine-neutral graph
 fixtures. This script is research-only: it does not edit production work-store
@@ -16,7 +16,7 @@ Shapes:
 Protocol defaults match the #846 scoping comment: 10 warmups and 100 measured
 trials, nearest-rank p50/p95, two-claimer barrier race requiring one success
 and one exit 13, and pass/fail gates for #737/#738 anchors where exercised.
-R2 adds residual no-listener cells: same-actor rejection, guards/empty-filter,
+R3 retains the residual no-listener cells: same-actor rejection, guards/empty-filter,
 restart recovery, schema coercion observation, branch/config backup restore,
 install footprint, cold-start/backup timing, resource samples, and observed
 metrics-state plus deleted-secret/history checks. Latency remains descriptive
@@ -57,18 +57,19 @@ from brigade.work_cmd import helpers as work_helpers
 from brigade.work_cmd import ledger as ledger_mod
 
 ISSUE = 846
-SLICE = "R2"
+SLICE = "R3"
 KIND = "work-store-characterization"
-PROTOCOL_VERSION = 2
+PROTOCOL_VERSION = 3
 TIMEBOX_NOTE = (
-    "R2 residual timebox: extend the R1 JSON/SQLite harness with no-listener "
-    "residual cells only. Dolt shapes stay optional characterization candidates "
+    "R3 bounded repair: correct the SQLite release characterization while "
+    "retaining the accepted no-listener scope and residual cells. Dolt shapes "
+    "stay optional characterization candidates "
     "and must not enter Brigade runtime dependencies. Server listeners, TLS, "
     "and permission cells that need a listener remain blocked pending separate "
     "operator approval and are never started here."
 )
-SYNTHETIC_SECRET = "synth-secret-846-r2-TOKEN-not-a-real-credential"
-SYNTHETIC_SECRET_PATH = "synth/paths/issue-846-r2/private-token.example"
+SYNTHETIC_SECRET = "synth-secret-846-r3-TOKEN-not-a-real-credential"
+SYNTHETIC_SECRET_PATH = "synth/paths/issue-846-r3/private-token.example"
 METRICS_SCAN_NAMES = (
     "telemetry",
     "metrics.json",
@@ -292,7 +293,7 @@ def _write_synthetic_backup_config(target: Path) -> Path:
     config_path.write_text(
         "# synthetic characterization only\n"
         "[destinations.nas]\n"
-        'label = "synth-nas-846-r2"\n'
+        'label = "synth-nas-846-r3"\n'
         'summary_path = ".brigade/backups/nas-summary.json"\n',
         encoding="utf-8",
     )
@@ -1564,12 +1565,13 @@ def _sqlite_claim(path: Path, task_id: str, *, actor: str, claim_id: str) -> tup
         if row is None:
             conn.execute("ROLLBACK")
             return 2, {"reason": claim_mod.REASON_UNKNOWN_TASK}
-        status, assignee, existing_claim, revision, payload_raw = row
+        status, assignee, existing_claim, _revision, payload_raw = row
         task = json.loads(payload_raw)
-        if existing_claim == claim_id and status == "in_progress" and assignee == actor:
+        existing = claim_mod.claim_record(task)
+        if existing is not None and existing["claim_id"] == claim_id and status == "in_progress" and assignee == actor:
             conn.execute("COMMIT")
             return 0, {"created": False, "reason": "idempotent_retry"}
-        if status == "in_progress" or existing_claim:
+        if status == "in_progress" or existing_claim or existing is not None:
             holder = assignee or "unknown"
             conn.execute("ROLLBACK")
             return EXIT_CLAIM_BUSY, {
@@ -1584,28 +1586,75 @@ def _sqlite_claim(path: Path, task_id: str, *, actor: str, claim_id: str) -> tup
                 "exit_code": EXIT_CLAIM_BUSY,
             }
         claimed_at = _FIXED_CREATED_AT
-        task["status"] = "in_progress"
-        task["assignee"] = actor
-        task["claim"] = {
-            "claim_id": claim_id,
-            "actor": actor,
-            "claimed_at": claimed_at,
-            "item_revision": int(revision) + 1,
-        }
-        task["updated_at"] = claimed_at
+        record = claim_mod._set_claim(task, actor=actor, claim_id=claim_id, claimed_at=claimed_at)
         conn.execute(
             "UPDATE tasks SET status=?, assignee=?, claim_id=?, item_revision=?, payload=? WHERE id=?",
             (
                 "in_progress",
                 actor,
                 claim_id,
-                int(revision) + 1,
+                record["item_revision"],
                 json.dumps(task, sort_keys=True),
                 task_id,
             ),
         )
         conn.execute("COMMIT")
         return 0, {"created": True, "holder": actor, "claim_id": claim_id}
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+        raise
+    finally:
+        conn.close()
+
+
+def _sqlite_release(
+    path: Path,
+    task_id: str,
+    *,
+    actor: str | None = None,
+    if_actor: str | None = None,
+    if_status: str | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Release a SQLite claim atomically with Brigade's canonical semantics."""
+    conn = _sqlite_connect(path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute("SELECT payload FROM tasks WHERE id=?", (task_id,)).fetchone()
+        if row is None:
+            conn.execute("ROLLBACK")
+            return 2, {"reason": claim_mod.REASON_UNKNOWN_TASK, "task_id": task_id}
+        task = json.loads(row[0])
+        try:
+            result = claim_mod.apply_release_to_task(
+                {"tasks": [task], "edges": []},
+                task,
+                actor=actor,
+                if_actor=if_actor,
+                if_status=if_status,
+            )
+        except claim_mod.ClaimError as exc:
+            conn.execute("ROLLBACK")
+            return int(exc.exit_code), exc.as_dict()
+        record = result["released"]
+        conn.execute(
+            "UPDATE tasks SET status=?, assignee=NULL, claim_id=NULL, item_revision=?, payload=? WHERE id=?",
+            (
+                task["status"],
+                task["item_revision"],
+                json.dumps(task, sort_keys=True),
+                task_id,
+            ),
+        )
+        conn.execute("COMMIT")
+        return 0, {
+            "task_id": task_id,
+            "status": task["status"],
+            "released": record,
+            "item_revision": task["item_revision"],
+        }
     except Exception:
         try:
             conn.execute("ROLLBACK")
@@ -1743,6 +1792,51 @@ def _sqlite_same_actor_and_retry(root: Path, ledger: dict[str, Any]) -> dict[str
                 "pass": same_ok,
             },
             "pass": ok,
+        }
+    finally:
+        for suffix in ("", "-wal", "-shm"):
+            Path(str(db_path) + suffix).unlink(missing_ok=True)
+
+
+def _sqlite_guard_and_empty_filter(root: Path, ledger: dict[str, Any]) -> dict[str, Any]:
+    db_path = Path(tempfile.mkstemp(prefix="ws-sqlite-guards-", suffix=".db", dir=root)[1])
+    try:
+        _sqlite_load(db_path, ledger)
+        task_id = _claim_target_id(ledger)
+        claim_code, _claimed = _sqlite_claim(db_path, task_id, actor="lane-a", claim_id="guard-claim")
+        actor_code, actor_payload = _sqlite_release(db_path, task_id, if_actor="other-lane")
+        status_code, status_payload = _sqlite_release(db_path, task_id, if_status="pending")
+        empty_code, empty_payload = _sqlite_release(db_path, task_id, actor="")
+        release_code, released = _sqlite_release(
+            db_path,
+            task_id,
+            if_actor="lane-a",
+            if_status="in_progress",
+        )
+        exported = _sqlite_export_ledger(db_path)
+        stored = next(task for task in exported["tasks"] if task["id"] == task_id)
+        cleanup_ok = (
+            stored.get("status") == "pending"
+            and stored.get("item_revision") == 2
+            and not any(key in stored for key in ("assignee", "claim", "claim_id", "claimed_at"))
+        )
+        actor_ok = actor_code == EXIT_CLAIM_BUSY and actor_payload.get("reason") == claim_mod.REASON_GUARD_MISMATCH
+        status_ok = status_code == EXIT_CLAIM_BUSY and status_payload.get("reason") == claim_mod.REASON_GUARD_MISMATCH
+        empty_ok = empty_code == 2 and empty_payload.get("reason") == claim_mod.REASON_EMPTY_FILTER
+        success_ok = release_code == 0 and released.get("item_revision") == 2 and cleanup_ok
+        return {
+            "status": "measured",
+            "if_actor_mismatch": {"exit_code": actor_code, "reason": actor_payload.get("reason"), "pass": actor_ok},
+            "if_status_mismatch": {
+                "exit_code": status_code,
+                "reason": status_payload.get("reason"),
+                "guard": status_payload.get("guard"),
+                "pass": status_ok,
+            },
+            "empty_filter": {"exit_code": empty_code, "reason": empty_payload.get("reason"), "pass": empty_ok},
+            "if_status_match": {"exit_code": release_code, "released": success_ok, "pass": success_ok},
+            "claim_cleanup": {"item_revision": stored.get("item_revision"), "pass": cleanup_ok},
+            "pass": claim_code == 0 and actor_ok and status_ok and empty_ok and success_ok,
         }
     finally:
         for suffix in ("", "-wal", "-shm"):
@@ -2085,10 +2179,7 @@ def measure_sqlite_wal(
     mutation = _sqlite_measure_mutation(root, ledger, warmups=warmups, trials=trials)
     claim_race = _sqlite_claim_race(root, ledger)
     same_actor = _sqlite_same_actor_and_retry(root, ledger)
-    guards = _cell_unavailable(
-        "sqlite characterization adapter does not implement Brigade release "
-        "guards or empty-filter semantics; measured on json_ledger"
-    )
+    guards = _sqlite_guard_and_empty_filter(root, ledger)
     restart = _sqlite_restart_recovery(root, ledger)
     schema = _sqlite_schema_version_policy(root, ledger)
     # Graph readiness still evaluated by Brigade resolver on exported form.
@@ -2114,7 +2205,7 @@ def measure_sqlite_wal(
     metrics_state = _sqlite_metrics_state(root, ledger)
     secret_history = _sqlite_secret_history(root, ledger)
     baseline_stats = None if json_baseline is None else json_baseline.get("mutation_latency")
-    claim_738 = bool(claim_race.get("pass")) and bool(same_actor.get("pass"))
+    claim_738 = bool(claim_race.get("pass")) and bool(same_actor.get("pass")) and bool(guards.get("pass"))
     gates = {
         "issue_737_graph": graph["pass"],
         "issue_738_claim": claim_738,
@@ -2206,14 +2297,14 @@ def measure_dolt_shape(shape: str, dataset: str, *, dolt_bin: str | None) -> dic
         return _dolt_blocked_result(
             shape,
             dataset,
-            "R2 policy: harness must not start a network listener; "
+            "R3 policy: harness must not start a network listener; "
             "operator-owned server characterization requires separate approval",
         )
     if shape == "embedded_dolt":
         return _dolt_blocked_result(
             shape,
             dataset,
-            "No embedded Dolt boundary is checked into this repo; R2 does not build or persist a Go/Dolt dependency",
+            "No embedded Dolt boundary is checked into this repo; R3 does not build or persist a Go/Dolt dependency",
         )
     # dolt_cli_per_command
     resolved = dolt_bin or shutil.which("dolt")
@@ -2224,12 +2315,12 @@ def measure_dolt_shape(shape: str, dataset: str, *, dolt_bin: str | None) -> dic
             "dolt binary not available on PATH; optional temporary CLI not supplied "
             "(--dolt-bin). Cell left unmeasured rather than fabricated",
         )
-    # A binary may be present for future optional runners; R2 still does not
+    # A binary may be present for future optional runners; R3 still does not
     # auto-run Dolt mutations without an explicit enable flag.
     return _dolt_blocked_result(
         shape,
         dataset,
-        f"dolt binary observed at {Path(resolved).name} but R2 timebox keeps "
+        f"dolt binary observed at {Path(resolved).name} but R3 timebox keeps "
         "CLI mutation runner disabled; documentation-only characterization applies",
     )
 
@@ -2360,7 +2451,7 @@ def capability_matrix_notes() -> dict[str, Any]:
         },
         "dolt_cli_per_command": {
             "portable_sync": "clone_push_pull_candidate",
-            "concurrent_same_store_claim": "unmeasured_r2",
+            "concurrent_same_store_claim": "unmeasured_r3",
             "concurrent_cross_machine_claim": "not_by_cli_alone",
             "branch_diff_merge": "native_candidate",
             "row_locks": "unsupported_select_for_update",
@@ -2396,7 +2487,7 @@ def capability_matrix_notes() -> dict[str, Any]:
                 "meet measured correctness through file or replica candidates"
             ),
             "runtime_dependency": "forbidden_unless_later_issue_approves",
-            "status": "blocked_no_listener_in_r2",
+            "status": "blocked_no_listener_in_r3",
         },
         "sources": [
             "https://www.dolthub.com/docs/sql-reference/sql-support/supported-statements/",
@@ -2413,7 +2504,7 @@ def decision_record() -> dict[str, Any]:
         "current_need": "sequential_portable_sync_plus_reviewable_branch_merge_proposals",
         "concurrent_cross_machine_claims": "not_current_requirement",
         "store_decision": "keep_machine_local_json_ledger",
-        "portable_sync": "adopt_as_follow_up_requirement_not_implemented_in_r2",
+        "portable_sync": "adopt_as_follow_up_requirement_not_implemented_in_r3",
         "sqlite": "optional_local_characterization_only_not_runtime_dependency",
         "shared_store_conformance_fixture": "not_approved",
         "shared_service_eligibility": ("only_if_later_concurrent_claim_requirement_fails_file_or_replica_candidates"),

--- a/tests/test_work_store_measurement.py
+++ b/tests/test_work_store_measurement.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/measure_work_store.py (#846 R2 characterization harness)."""
+"""Tests for scripts/measure_work_store.py (#846 R3 characterization harness)."""
 
 from __future__ import annotations
 
@@ -76,8 +76,8 @@ def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
         trials=2,
     )
     assert report["issue"] == 846
-    assert report["slice"] == "R2"
-    assert report["protocol_version"] == 2
+    assert report["slice"] == "R3"
+    assert report["protocol_version"] == 3
     assert report["kind"] == "work-store-characterization"
     assert report["anonymous_metrics"] == "disabled_in_harness"
     assert {"environment", "fixtures", "results", "decision", "capability_notes"} <= set(report)
@@ -147,7 +147,9 @@ def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
     assert git_history["synthetic_tracked_history"]["deleted_secret_retained_in_history"] is True
     assert git_history["pass"] is True
     sqlite_result = next(item for item in report["results"] if item["shape"] == "sqlite_wal")
-    assert sqlite_result["guard_and_empty_filter"]["status"] == "unavailable"
+    assert sqlite_result["guard_and_empty_filter"]["status"] == "measured"
+    assert sqlite_result["guard_and_empty_filter"]["pass"] is True
+    assert sqlite_result["guard_and_empty_filter"]["claim_cleanup"] == {"item_revision": 2, "pass": True}
     assert sqlite_result["restart_recovery"]["process_boundary"] == "subprocess"
     assert sqlite_result["cold_start"]["process_boundary"] == "subprocess"
     assert sqlite_result["cold_start"]["cold"] is True
@@ -238,6 +240,21 @@ def test_json_guard_covers_if_status_match_and_mismatch(tmp_path):
     assert result["if_status_match"]["released"] is True
 
 
+def test_sqlite_release_rejects_unclaimed_pending_without_changing_export(tmp_path):
+    module = _load_module()
+    db_path = tmp_path / "release.db"
+    module._sqlite_load(db_path, module.build_fixture("chain_50"))
+    task_id = module._claim_target_id(module.build_fixture("chain_50"))
+    before = json.dumps(module._sqlite_export_ledger(db_path), sort_keys=True).encode()
+
+    code, payload = module._sqlite_release(db_path, task_id)
+
+    after = json.dumps(module._sqlite_export_ledger(db_path), sort_keys=True).encode()
+    assert code == 1
+    assert payload["reason"] == "not_claimed"
+    assert after == before
+
+
 def test_measure_matrix_marks_dolt_shapes_blocked(tmp_path):
     module = _load_module()
     report = module.measure_matrix(
@@ -308,7 +325,7 @@ def test_cli_writes_measurement_and_fixture_manifest(tmp_path):
     assert proc.returncode == 0, proc.stderr
     payload = json.loads(output.read_text())
     assert payload["issue"] == 846
-    assert payload["slice"] == "R2"
+    assert payload["slice"] == "R3"
     assert len(payload["results"]) == 3
     statuses = {item["shape"]: item["status"] for item in payload["results"]}
     assert statuses["json_ledger"] == "measured"
@@ -317,7 +334,7 @@ def test_cli_writes_measurement_and_fixture_manifest(tmp_path):
     fixture_payload = json.loads(manifest.read_text())
     assert "chain_50" in fixture_payload["fixtures"]
     assert fixture_payload["fixtures"]["chain_50"]["task_count"] == 50
-    assert fixture_payload["slice"] == "R2"
+    assert fixture_payload["slice"] == "R3"
 
 
 def test_measure_matrix_rejects_nonpositive_trials(tmp_path):


### PR DESCRIPTION
## Summary

Repair the bounded R3 SQLite release characterization so release guards and cleanup use the canonical claim semantics, and add the R3 measurement artifacts.

## Verification

- `pytest -q tests/test_work_store_measurement.py`
- `ruff check scripts/measure_work_store.py tests/test_work_store_measurement.py`
- `python -m json.tool docs/measurements/issue-846-work-store-r3.json`
- `brigade guard git --staged`

Fixes #846