### PR TITLE
feat(memory): mint stable card IDs

### DIFF
--- a/src/brigade/card_fingerprint.py
+++ b/src/brigade/card_fingerprint.py
@@ -18,6 +18,8 @@ from datetime import date
 from pathlib import Path
 from typing import Any, Callable
 
+from .card_identity import mint_card_id, valid_card_id
+
 # Near-match threshold from issue #724 (~0.9 token Jaccard).
 NEAR_MATCH_THRESHOLD = 0.9
 
@@ -380,6 +382,15 @@ def ensure_fingerprint_frontmatter(content: str) -> str:
         # Keep an existing fingerprint even if stale; backfill owns repairs.
         return content
     return _insert_frontmatter_fields(content, {"fingerprint": fingerprint})
+
+
+def ensure_card_id_frontmatter(content: str, *, preserve_id: str | None = None) -> str:
+    """Insert a stable card ID, preserving a valid canonical identity when set."""
+    meta, has_frontmatter = _parse_frontmatter_lines(content)
+    if not has_frontmatter:
+        return content
+    card_id = valid_card_id(preserve_id) or valid_card_id(meta.get("id")) or valid_card_id(meta.get("card_id"))
+    return _upsert_frontmatter_fields(content, {"id": card_id or mint_card_id()})
 
 
 def reinforce_existing_card(

--- a/src/brigade/card_identity.py
+++ b/src/brigade/card_identity.py
@@ -1,0 +1,80 @@
+"""Stable card identities with legacy aliases for the file-backed memory store."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any
+
+_CARD_ID_RE = re.compile(
+    r"^card-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class CardIdentity:
+    """Primary card identity plus compatibility aliases."""
+
+    card_id: str
+    aliases: tuple[str, ...]
+    explicit: bool
+
+
+def valid_card_id(value: object) -> str | None:
+    """Return a normalized stable ID, or ``None`` when ``value`` is not one."""
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    return candidate if _CARD_ID_RE.fullmatch(candidate) else None
+
+
+def mint_card_id() -> str:
+    """Mint the opaque UUID4 identity used by new canonical cards."""
+    return f"card-{uuid.uuid4()}"
+
+
+def normalized_relative_path(value: str) -> str:
+    """Normalize a workspace-relative card path for legacy fallback reads."""
+    return PurePosixPath(value.replace("\\", "/")).as_posix()
+
+
+def card_identity(frontmatter: dict[str, Any], relative_path: str) -> CardIdentity:
+    """Prefer a valid explicit ID and retain historical keys as aliases."""
+    relative_path = normalized_relative_path(relative_path)
+    explicit = valid_card_id(frontmatter.get("id")) or valid_card_id(frontmatter.get("card_id"))
+    aliases = _legacy_aliases(frontmatter, relative_path)
+    if explicit is not None:
+        return CardIdentity(
+            card_id=explicit, aliases=tuple(alias for alias in aliases if alias != explicit), explicit=True
+        )
+    legacy = _legacy_primary(frontmatter) or PurePosixPath(relative_path).stem
+    return CardIdentity(card_id=legacy, aliases=tuple(alias for alias in aliases if alias != legacy), explicit=False)
+
+
+def _legacy_aliases(frontmatter: dict[str, Any], relative_path: str) -> list[str]:
+    aliases = [relative_path, PurePosixPath(relative_path).stem]
+    for key in ("id", "card_id", "topic"):
+        value = frontmatter.get(key)
+        if isinstance(value, str) and value.strip():
+            aliases.append(value.strip())
+    return list(dict.fromkeys(aliases))
+
+
+def _legacy_primary(frontmatter: dict[str, Any]) -> str | None:
+    for key in ("id", "card_id", "topic"):
+        value = frontmatter.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def identity_collision_aliases(items: list[tuple[str, CardIdentity]]) -> dict[str, tuple[str, ...]]:
+    """Return deterministic aliases claimed by more than one primary identity."""
+    owners: dict[str, set[str]] = {}
+    for path, identity in items:
+        for alias in (identity.card_id, *identity.aliases):
+            owners.setdefault(alias, set()).add(path)
+    return {alias: tuple(sorted(paths)) for alias, paths in sorted(owners.items()) if len(paths) > 1}

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -20,6 +20,7 @@ from typing import Dict, List
 from . import budgets
 from .card_fingerprint import (
     CardMatch,
+    ensure_card_id_frontmatter,
     ensure_fingerprint_frontmatter,
     find_card_match,
     index_cards,
@@ -371,6 +372,16 @@ def _execute(
         assert dest is not None
         content = sections.get("suggested card content", "").strip() + "\n"
         content = ensure_fingerprint_frontmatter(content)
+        if dest.exists():
+            from .card_fingerprint import read_text_nofollow
+            from .card_identity import valid_card_id
+
+            existing, _ = _frontmatter(read_text_nofollow(dest))
+            existing_id = valid_card_id(existing.get("id")) or valid_card_id(existing.get("card_id"))
+            if existing_id is not None:
+                content = ensure_card_id_frontmatter(content, preserve_id=existing_id)
+        else:
+            content = ensure_card_id_frontmatter(content)
         if not content.endswith("\n"):
             content += "\n"
         summary = f"promote → {dest.relative_to(target)}  ({name})"
@@ -426,6 +437,21 @@ def _execute(
         return Action("inboxed", summary)
 
     return Action("skipped", f"skip   {name}  ({outcome.reason})")
+
+
+def _frontmatter(text: str) -> tuple[dict[str, str], bool]:
+    """Small local reader for preservation of a pre-existing stable ID."""
+    if not text.startswith("---"):
+        return {}, False
+    fields: dict[str, str] = {}
+    lines = text.splitlines()
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return fields, True
+        if ":" in line:
+            key, value = line.split(":", 1)
+            fields[key.strip()] = value.strip().strip("'\"")
+    return {}, False
 
 
 def _evidence_pointer(handoff_path: Path, *, sections: Dict[str, str], target: Path) -> str:

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -25,6 +25,7 @@ from .localio import (
     utc_now_iso_z as _utc_iso,
 )
 from .memory_doctor.safety import atomic_write_text
+from .card_identity import CardIdentity, card_identity, identity_collision_aliases
 from .templates import template_root
 
 CONFIG_REL_PATH = ".brigade/memory-care.toml"
@@ -531,6 +532,7 @@ def _issue(
         "path": card_path,
         "card_file": card_path,
         "card_id": card_id,
+        "card_aliases": [card_path, Path(card_path).stem],
         "issue_type": issue_type,
         "refresh_reason": issue_type,
         "reason": issue_type,
@@ -591,15 +593,26 @@ def _scan_payload(target: Path, config: MemoryCareConfig) -> dict[str, Any]:
     issues: list[dict[str, Any]] = []
     card_rows: list[dict[str, Any]] = []
     by_id: dict[str, list[str]] = {}
+    identities: list[tuple[str, CardIdentity]] = []
+    identities_by_path: dict[str, CardIdentity] = {}
     enabled = set(config.enabled_checks)
 
     for path in cards:
         rel = str(path.relative_to(target))
         text = path.read_text(encoding="utf-8", errors="replace")
         meta, has_frontmatter = _parse_frontmatter(text)
-        card_id = str(_frontmatter_value(meta, "id", "card_id", "topic") or Path(rel).stem)
+        identity = card_identity(meta, rel)
+        card_id = identity.card_id
         by_id.setdefault(card_id, []).append(rel)
-        row = {"file": rel, "card_id": card_id, "has_frontmatter": has_frontmatter, "bytes": path.stat().st_size}
+        identities.append((rel, identity))
+        identities_by_path[rel] = identity
+        row = {
+            "file": rel,
+            "card_id": card_id,
+            "card_aliases": list(identity.aliases),
+            "has_frontmatter": has_frontmatter,
+            "bytes": path.stat().st_size,
+        }
         if "missing-frontmatter" in enabled and not has_frontmatter:
             issues.append(
                 _issue(
@@ -773,6 +786,27 @@ def _scan_payload(target: Path, config: MemoryCareConfig) -> dict[str, Any]:
                     )
                 )
 
+        for alias, alias_paths in identity_collision_aliases(identities).items():
+            for rel in alias_paths:
+                identity = identities_by_path[rel]
+                issues.append(
+                    _issue(
+                        target=target,
+                        card_path=rel,
+                        card_id=identity.card_id,
+                        issue_type="contradictory",
+                        severity="medium",
+                        summary=f"Card identity alias {alias!r} appears in multiple cards.",
+                        evidence=list(alias_paths),
+                        action="Resolve the alias collision before applying a reviewed card rewrite.",
+                    )
+                )
+
+    for issue in issues:
+        issue_identity = identities_by_path.get(str(issue.get("card_file") or ""))
+        if issue_identity is not None:
+            issue["card_aliases"] = list(issue_identity.aliases)
+
     counts: dict[str, int] = {}
     for issue in issues:
         issue_type = str(issue["issue_type"])
@@ -812,6 +846,7 @@ def _scan_payload(target: Path, config: MemoryCareConfig) -> dict[str, Any]:
         "refresh_queue_size": len(issues),
         "counts": dict(sorted(counts.items())),
         "metadata": metadata_summary,
+        "identity_collisions": identity_collision_aliases(identities),
         "cards": card_rows,
         "issues": issues,
     }
@@ -1366,6 +1401,11 @@ def _backfill_candidates(target: Path, config: MemoryCareConfig) -> tuple[list[d
             candidate["fields"].append("fingerprint")
             if reviewed is not None and expiry is not None:
                 candidate["source"] = "content-hash"
+        if candidate["fields"] and not card_identity(meta, rel).explicit:
+            from .card_identity import mint_card_id
+
+            candidate["id"] = mint_card_id()
+            candidate["fields"].append("id")
         candidates.append(candidate)
     return candidates, skipped_no_frontmatter
 
@@ -1397,6 +1437,20 @@ def backfill(*, target: Path, apply: bool = False, json_output: bool = False) ->
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
+    identity_collisions = _scan_payload(target, config)["identity_collisions"]
+    if apply and identity_collisions:
+        collision_payload = {
+            "target": str(target),
+            "apply": apply,
+            "written_count": 0,
+            "identity_collisions": identity_collisions,
+            "error": "identity alias collisions must be resolved before reviewed backfill",
+        }
+        if json_output:
+            print(json.dumps(collision_payload, indent=2, sort_keys=True))
+        else:
+            print(f"error: {collision_payload['error']}", file=sys.stderr)
+        return 2
     candidates, skipped_no_frontmatter = _backfill_candidates(target, config)
     written = 0
     receipt_path: Path | None = None
@@ -1413,12 +1467,14 @@ def backfill(*, target: Path, apply: bool = False, json_output: bool = False) ->
         write_json(
             receipt_path,
             {
-                "target": str(target),
                 "generated_at": _utc_iso(),
                 "written_count": written,
                 "skipped_no_frontmatter": skipped_no_frontmatter,
                 "stale_after_days": config.stale_after_days,
-                "candidates": candidates,
+                "identity_mapping": [
+                    {"file": candidate["file"], "card_id": candidate.get("id")}
+                    for candidate in sorted(candidates, key=lambda candidate: str(candidate["file"]))
+                ],
             },
         )
     payload: dict[str, Any] = {
@@ -1551,11 +1607,6 @@ def _normalize_search_query(query: str) -> str:
     return " ".join(str(query or "").lower().split())
 
 
-def _card_id_from_match_path(rel_path: str) -> str:
-    """Stem of the card path; same mapping the retrieval eval harness uses."""
-    return Path(str(rel_path)).stem
-
-
 def _search_log_path(target: Path) -> Path:
     return target.expanduser().resolve() / SEARCH_LOG_REL
 
@@ -1581,12 +1632,29 @@ def _search_log_card_ids(matches: list[dict[str, Any]], *, top_k: int = SEARCH_L
     for match in matches[:top_k]:
         if not isinstance(match, dict):
             continue
-        card_id = _card_id_from_match_path(str(match.get("path") or ""))
+        card_id = str(match.get("card_id") or match.get("path") or "")
         if not card_id or card_id in seen:
             continue
         seen.add(card_id)
         ids.append(card_id)
     return ids
+
+
+def _search_log_aliases(matches: list[dict[str, Any]], *, top_k: int = SEARCH_LOG_TOP_K) -> list[str]:
+    aliases: list[str] = []
+    for match in matches[:top_k]:
+        if not isinstance(match, dict):
+            continue
+        value = match.get("card_aliases")
+        if isinstance(value, list):
+            aliases.extend(str(alias) for alias in value if str(alias))
+    return list(dict.fromkeys(aliases))
+
+
+def _entry_identity_keys(entry: dict[str, Any]) -> set[str]:
+    keys = {str(value) for value in entry.get("card_ids", []) if value}
+    keys.update(str(value) for value in entry.get("card_aliases", []) if value)
+    return keys
 
 
 def _should_log_search(query: str) -> bool:
@@ -1631,8 +1699,8 @@ def followup_rate_from_entries(
         next_ids_value = followup.get("card_ids")
         if not isinstance(next_ids_value, list):
             continue
-        prior_ids = {str(item) for item in card_ids_value if item}
-        next_ids = {str(item) for item in next_ids_value if item}
+        prior_ids = _entry_identity_keys(entry)
+        next_ids = _entry_identity_keys(followup)
         if prior_ids.isdisjoint(next_ids):
             misses += 1
     rate = round(misses / searches, 4) if searches else 0.0
@@ -1675,6 +1743,7 @@ def _record_search_log(
         "ts": ts or _utc_iso(),
         "query": _normalize_search_query(query),
         "card_ids": _search_log_card_ids(matches if isinstance(matches, list) else []),
+        "card_aliases": _search_log_aliases(matches if isinstance(matches, list) else []),
     }
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -1694,10 +1763,13 @@ def _card_search_fields(path: Path, target: Path) -> dict[str, Any]:
     except OSError:
         return {}
     frontmatter, _ = _parse_frontmatter(text)
+    identity = card_identity(frontmatter, str(path.relative_to(target)))
     tags = frontmatter.get("tags")
     tags_list = [str(t) for t in tags] if isinstance(tags, list) else ([str(tags)] if tags else [])
     return {
         "rel": str(path.relative_to(target)),
+        "card_id": identity.card_id,
+        "card_aliases": list(identity.aliases),
         "title": str(frontmatter.get("title") or path.stem),
         "tags": tags_list,
         "summary": str(frontmatter.get("description") or frontmatter.get("summary") or ""),
@@ -1727,6 +1799,8 @@ def search_cards_payload(target: Path, query: str, *, limit: int = 20) -> dict[s
         matches.append(
             {
                 "path": fields["rel"],
+                "card_id": fields["card_id"],
+                "card_aliases": fields["card_aliases"],
                 "title": fields["title"],
                 "tags": fields["tags"],
                 "summary": fields["summary"],

--- a/src/brigade/memory_retrieval_eval/adapters.py
+++ b/src/brigade/memory_retrieval_eval/adapters.py
@@ -31,10 +31,6 @@ def tokenize(text: str) -> list[str]:
     return [t.lower() for t in _TOKEN_RE.findall(text) if t]
 
 
-def _path_to_card_id(rel_path: str) -> str:
-    return Path(rel_path).stem
-
-
 def current_adapter(target: Path) -> AdapterFn:
     """Existing keyword scorer from ``memory_cmd.search_cards_payload``."""
 
@@ -42,7 +38,7 @@ def current_adapter(target: Path) -> AdapterFn:
         payload = search_cards_payload(target, query, limit=limit)
         ranked: list[tuple[str, float]] = []
         for match in payload["matches"]:
-            ranked.append((_path_to_card_id(str(match["path"])), float(match["score"])))
+            ranked.append((str(match.get("card_id") or match["path"]), float(match["score"])))
         return ranked
 
     return search

--- a/src/brigade/memory_retrieval_eval/corpus.py
+++ b/src/brigade/memory_retrieval_eval/corpus.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +20,7 @@ class CardDoc:
     tags: tuple[str, ...]
     summary: str
     body: str
+    aliases: tuple[str, ...] = ()
 
     @property
     def searchable_text(self) -> str:
@@ -67,15 +68,15 @@ def load_cards(target: Path) -> list[CardDoc]:
         fields = _card_search_fields(path, target)
         if not fields:
             continue
-        card_id = path.stem
         cards.append(
             CardDoc(
-                card_id=card_id,
+                card_id=str(fields["card_id"]),
                 path=fields["rel"],
                 title=str(fields["title"]),
                 tags=tuple(str(t) for t in fields["tags"]),
                 summary=str(fields["summary"]),
                 body=str(fields["body"]),
+                aliases=tuple(str(alias) for alias in fields["card_aliases"]),
             )
         )
     cards.sort(key=lambda c: c.card_id)
@@ -115,13 +116,22 @@ def load_queries(queries_path: Path) -> tuple[int, list[QuerySpec]]:
 
 def validate_gold(cards: list[CardDoc], queries: list[QuerySpec]) -> list[str]:
     """Return human-readable problems when gold ids are missing from the corpus."""
-    known = {c.card_id for c in cards}
+    known = {key for card in cards for key in (card.card_id, *card.aliases)}
     problems: list[str] = []
     for q in queries:
         missing = [g for g in q.gold if g not in known]
         if missing:
             problems.append(f"{q.query_id}: missing gold card ids: {', '.join(missing)}")
     return problems
+
+
+def resolve_gold_aliases(cards: list[CardDoc], queries: list[QuerySpec]) -> list[QuerySpec]:
+    """Translate legacy fixture keys to their explicit card IDs for scoring."""
+    aliases: dict[str, str] = {}
+    for card in cards:
+        for key in (card.card_id, *card.aliases):
+            aliases.setdefault(key, card.card_id)
+    return [replace(query, gold=tuple(aliases.get(gold, gold) for gold in query.gold)) for query in queries]
 
 
 def corpus_stats(cards: list[CardDoc], queries: list[QuerySpec]) -> dict[str, Any]:

--- a/src/brigade/memory_retrieval_eval/harness.py
+++ b/src/brigade/memory_retrieval_eval/harness.py
@@ -12,6 +12,7 @@ from .corpus import (
     fixture_root_label,
     load_cards,
     load_queries,
+    resolve_gold_aliases,
     validate_gold,
 )
 from .metrics import aggregate_scores, ceiling_for_queries, score_query
@@ -46,6 +47,7 @@ def run_eval(
     problems = validate_gold(cards, queries)
     if problems:
         raise ValueError("fixture gold validation failed:\n- " + "\n- ".join(problems))
+    queries = resolve_gold_aliases(cards, queries)
 
     wanted = adapters or ["current", "grep", "semantic"]
     unknown = [name for name in wanted if name not in KNOWN_ADAPTERS]

--- a/src/brigade/work_cmd/services.py
+++ b/src/brigade/work_cmd/services.py
@@ -63,6 +63,9 @@ def _memory_refresh_cards(payload: dict[str, Any], *, queue_path: Path) -> tuple
             "reason": reason,
             "queue_path": str(queue_path),
         }
+        aliases = card.get("card_aliases")
+        if isinstance(aliases, list):
+            metadata["card_aliases"] = [str(alias) for alias in aliases if str(alias)]
         for key in (
             "confidence",
             "evidence_references",

--- a/tests/test_card_fingerprint.py
+++ b/tests/test_card_fingerprint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import stat
 from datetime import date
 from pathlib import Path
@@ -194,6 +195,16 @@ def test_reinforce_existing_card_updates_frontmatter(tmp_path: Path):
     assert "reinforcements: 1" in text
     assert "fingerprint:" in text
     assert "handoffs/example.md" in text
+
+
+def test_reinforce_preserves_existing_stable_card_id(tmp_path: Path):
+    path = tmp_path / "card.md"
+    card_id = "card-123e4567-e89b-42d3-a456-426614174000"
+    path.write_text(f"---\nid: {card_id}\ntopic: t\n---\n\nBody.\n")
+
+    reinforce_existing_card(path, today=date(2026, 5, 13), evidence_pointer="handoffs/example.md")
+
+    assert re.search(rf"^id: {re.escape(card_id)}$", path.read_text(), re.MULTILINE)
 
 
 @pytest.mark.skipif(not hasattr(os, "symlink"), reason="platform cannot create symlinks")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import textwrap
 from pathlib import Path
 
@@ -838,6 +839,32 @@ def test_promote_replaces_existing_card_wholesale(tmp_target: Path):
     text = card.read_text()
     assert "new body" in text
     assert "old body" not in text
+
+
+def test_promote_mints_stable_id_for_new_card_and_preserves_it_on_update(tmp_target: Path):
+    inbox = _seed(tmp_target)
+    _write_handoff(
+        inbox,
+        "2026-05-13-1002-new.md",
+        _card_handoff_body("stable.md", "stable", "first body"),
+    )
+    assert ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True) == 0
+    card = tmp_target / "memory" / "cards" / "stable.md"
+    first = card.read_text()
+    match = re.search(
+        r"^id: (card-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$", first, re.MULTILINE
+    )
+    assert match is not None
+
+    _write_handoff(
+        inbox,
+        "2026-05-13-1003-update.md",
+        _card_handoff_body("stable.md", "stable", "replacement body"),
+    )
+    assert ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True) == 0
+    updated = card.read_text()
+    assert f"id: {match.group(1)}" in updated
+    assert "replacement body" in updated
 
 
 def test_create_card_exact_fingerprint_reinforces_existing(tmp_target: Path, capsys):

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shlex
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -681,13 +682,16 @@ def test_memory_care_backfill_apply_writes_metadata_receipt_and_is_idempotent(tm
     assert "last_reviewed: 2026-03-15" in text
     assert "fresh_until: 2026-06-13" in text
     assert "fingerprint:" in text
+    assert re.search(
+        r"^id: card-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", text, re.MULTILINE
+    )
     assert text.endswith("Body.\n")
     assert (cards / "complete.md").read_text() == complete_before
     receipts = list((tmp_path / ".brigade" / "memory-care" / "backfills").glob("*.json"))
     assert len(receipts) == 1
     receipt = json.loads(receipts[0].read_text())
     assert receipt["written_count"] == 1
-    assert receipt["candidates"][0]["source"] == "git-history"
+    assert receipt["identity_mapping"] == [{"file": "memory/cards/bare.md", "card_id": payload["candidates"][0]["id"]}]
 
     assert memory_cmd.backfill(target=tmp_path, json_output=True) == 0
     payload = json.loads(capsys.readouterr().out)
@@ -729,14 +733,29 @@ def test_memory_care_backfill_fingerprint_only_for_dated_cards(tmp_path, capsys)
     payload = json.loads(capsys.readouterr().out)
     assert payload["candidate_count"] == 1
     item = payload["candidates"][0]
-    assert item["fields"] == ["fingerprint"]
+    assert item["fields"] == ["fingerprint", "id"]
     assert item["source"] == "content-hash"
     assert len(item["fingerprint"]) == 64
 
     assert memory_cmd.backfill(target=tmp_path, apply=True, json_output=True) == 0
     text = (cards / "dated.md").read_text()
     assert f"fingerprint: {item['fingerprint']}" in text
+    assert re.search(
+        r"^id: card-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", text, re.MULTILINE
+    )
     assert "last_reviewed: 2026-05-01" in text
+
+
+def test_memory_care_backfill_rejects_alias_collisions_without_writing(tmp_path, capsys):
+    cards = tmp_path / "memory" / "cards"
+    _write_card(cards / "one.md", {"topic": "shared", "confidence": "high", "evidence": ["README.md"]})
+    _write_card(cards / "two.md", {"topic": "shared", "confidence": "high", "evidence": ["README.md"]})
+    before = {path.name: path.read_text() for path in cards.glob("*.md")}
+
+    assert memory_cmd.backfill(target=tmp_path, apply=True, json_output=True) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["identity_collisions"] == {"shared": ["memory/cards/one.md", "memory/cards/two.md"]}
+    assert {path.name: path.read_text() for path in cards.glob("*.md")} == before
 
 
 @pytest.mark.skipif(not hasattr(os, "symlink"), reason="platform cannot create symlinks")

--- a/tests/test_memory_retrieval_eval.py
+++ b/tests/test_memory_retrieval_eval.py
@@ -46,6 +46,21 @@ def test_fixture_corpus_size_and_gold_resolve():
     assert paraphrase > exact  # weighted toward hard cases
 
 
+def test_explicit_card_id_resolves_legacy_fixture_gold_alias(tmp_path: Path):
+    cards = tmp_path / "memory" / "cards"
+    cards.mkdir(parents=True)
+    cards.joinpath("legacy-name.md").write_text(
+        "---\nid: card-123e4567-e89b-42d3-a456-426614174000\ntitle: Stable\n---\nunique retrieval term\n"
+    )
+    (tmp_path / "queries.json").write_text(
+        json.dumps({"k": 1, "queries": [{"id": "q", "query": "unique retrieval", "gold": ["legacy-name"]}]})
+    )
+
+    report = run_eval(fixture_root=tmp_path, adapters=["current", "grep"])
+    assert report["adapters"]["current"]["overall"]["hit_rate"] == 1.0
+    assert report["adapters"]["grep"]["overall"]["hit_rate"] == 1.0
+
+
 def test_paraphrase_slice_is_harder_than_exact_for_baselines():
     report = run_eval(adapters=["current", "grep"])
     for name in ("current", "grep"):

--- a/tests/test_memory_search_mcp.py
+++ b/tests/test_memory_search_mcp.py
@@ -86,6 +86,21 @@ def test_memory_search_writes_local_search_log(tmp_path: Path, capsys):
     assert len(log_path.read_text().splitlines()) == 1
 
 
+def test_search_log_keeps_legacy_alias_for_explicit_card_id(tmp_path: Path, capsys):
+    card_id = "card-123e4567-e89b-42d3-a456-426614174000"
+    cards = tmp_path / "memory" / "cards"
+    cards.mkdir(parents=True)
+    (cards / "renamed.md").write_text(f"---\nid: {card_id}\ntitle: Renamed\n---\nidentity token\n")
+
+    assert memory_cmd.search(target=tmp_path, query="identity", json_output=True) == 0
+    capsys.readouterr()
+    entry = json.loads((tmp_path / ".brigade" / "memory" / "search-log.jsonl").read_text())
+    assert entry["card_ids"] == [card_id]
+    assert entry["card_aliases"] == ["memory/cards/renamed.md", "renamed"]
+    legacy = {"ts": "2026-08-09T12:00:00Z", "query": "before rename", "card_ids": ["renamed"]}
+    assert memory_cmd.followup_rate_from_entries([legacy, entry])["followup_rate"] == 0.0
+
+
 def test_search_log_drops_oldest_beyond_max_entries(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(memory_cmd, "SEARCH_LOG_MAX_ENTRIES", 2)
     _card(tmp_path, "alpha.md", "Alpha", "alpha unique token")

--- a/tests/test_work_cmd_imports.py
+++ b/tests/test_work_cmd_imports.py
@@ -2403,8 +2403,9 @@ def test_work_import_memory_refresh_reads_candidates(tmp_path, monkeypatch, caps
         {
             "refresh_candidates": [
                 {
-                    "id": "tools-card",
+                    "id": "card-123e4567-e89b-42d3-a456-426614174000",
                     "file": "memory/cards/tools.md",
+                    "card_aliases": ["memory/cards/tools.md", "tools-card"],
                     "refresh_reason": "contradictory tool notes",
                     "confidence": "high",
                     "evidence_summary": "Two recent handoffs disagree.",
@@ -2423,7 +2424,8 @@ def test_work_import_memory_refresh_reads_candidates(tmp_path, monkeypatch, caps
     assert item["type"] == "docs"
     assert item["priority"] == "high"
     assert item["template"] == "docs"
-    assert item["metadata"]["card_id"] == "tools-card"
+    assert item["metadata"]["card_id"] == "card-123e4567-e89b-42d3-a456-426614174000"
+    assert item["metadata"]["card_aliases"] == ["memory/cards/tools.md", "tools-card"]
     assert item["metadata"]["card_file"] == "memory/cards/tools.md"
     assert item["metadata"]["refresh_reason"] == "contradictory tool notes"
     assert item["metadata"]["confidence"] == "high"


### PR DESCRIPTION
## Summary

Implements #867.

- Mints `card-<uuid4>` IDs for new canonical cards and reviewed metadata backfills.
- Preserves valid IDs on replacement and reinforcement.
- Carries legacy path, stem, and topic aliases through care queues, search logs, refresh imports, and retrieval evaluation.
- Refuses reviewed backfill when aliases collide, before any canonical write.
- Writes relative-path-only ID mappings in backfill receipts.

## Compatibility

Legacy cards retain their current topic or filename identity. Explicit-ID cards use the stable ID as primary and keep old keys as aliases, so renames preserve their identity.

## Integration note

#844 is limited to the projection crawl facade on current main and does not yet expose its planned read-only identity audit. This PR does not change evidence-projection files or engine contracts.

## Verification

- Focused final-head suite: 220 passed, receipt `20260812-165842-work-verify-2ea08d`.
- Lint, format, mypy, version sync, managed snapshot, template profile snapshot, and coverage passed in full receipt `20260812-164451-work-verify-f5785f`.
- The full suite then reported 7,098 passed, 3 skipped, and two unrelated host failures: `crontab -n` could not create a tempfile under `/var/spool/cron` in `tests/test_care_cmd.py`.
- Memory Handoff lint: receipt `20260812-165818-work-verify-081a59`.

Refs #867