### PR TITLE
feat(evidence): add memory projection identity audit

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -26,7 +26,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade daily`: 26 command path(s)
 - `brigade doctor`: 1 command path(s)
 - `brigade dogfood` (extras): 1 command path(s)
-- `brigade evidence`: 9 command path(s)
+- `brigade evidence`: 10 command path(s)
 - `brigade extras`: 3 command path(s)
 - `brigade friction` (extras): 3 command path(s)
 - `brigade guard`: 1 command path(s)
@@ -176,6 +176,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade evidence doctor`
 - `brigade evidence explain`
 - `brigade evidence export plan`
+- `brigade evidence memory audit`
 - `brigade evidence search`
 - `brigade evidence show`
 - `brigade evidence stats`

--- a/src/brigade/cli/evidence.py
+++ b/src/brigade/cli/evidence.py
@@ -72,6 +72,11 @@ def dispatch(args) -> int:
         return evidence_cmd.status(target=args.target, json_output=args.json)
     if args.evidence_command == "doctor":
         return evidence_cmd.doctor(target=args.target, json_output=args.json)
+    if args.evidence_command == "memory":
+        if args.evidence_memory_command == "audit":
+            return evidence_cmd.memory_audit(workspaces=args.workspaces, json_output=args.json)
+        args._brigade_parser.error(f"unknown evidence memory command: {args.evidence_memory_command}")
+        return 2
     if args.evidence_command == "crawl":
         if args.engine_args and args.engine_args[0] == "plan":
             plan_args = _crawl_plan_parser().parse_args(args.engine_args[1:])

--- a/src/brigade/evidence_cmd.py
+++ b/src/brigade/evidence_cmd.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from . import evidence_brief, evidence_runtime, proc
+from . import memory_identity_audit
 from .localio import utc_now_iso as _now
 
 
@@ -207,18 +208,39 @@ def _enrich_memory_projection_health(payload: dict[str, Any], target: Path) -> d
     if engine_health:
         merged.update(engine_health)
     if isinstance(last_run, dict):
-        for key in evidence_runtime.MEMORY_HEALTH_SAFE_KEYS:
-            if key in last_run and last_run[key] is not None:
-                merged[key] = last_run[key]
-        if isinstance(last_run.get("scan_status"), str):
-            merged["status"] = last_run["scan_status"]
-        if "failed" in last_run:
-            merged["failed"] = last_run.get("failed")
-        if last_run.get("scan_id"):
-            merged["last_scan_id"] = last_run.get("scan_id")
+        last_health = evidence_runtime.body_free_memory_health(last_run)
+        if last_health:
+            merged.update(last_health)
+        scan_status = evidence_runtime.body_free_memory_health({"status": last_run.get("scan_status")})
+        if scan_status:
+            merged.update(scan_status)
         merged["latest_run_status"] = last_run.get("status")
 
     if not merged and last_run is None:
+        state = (
+            "timed_out"
+            if payload.get("health") == "timeout"
+            else "missing"
+            if payload.get("health") == "missing"
+            else "unknown"
+        )
+        payload["memory_projection"] = {
+            "capability": None,
+            "engine_version": None,
+            "last_completed_scan_id": None,
+            "canonical_count": None,
+            "live_count": None,
+            "hash_divergence": None,
+            "unresolved_relations": None,
+            "malformed_skipped": None,
+            "stale": None,
+            "partial": None,
+            "status": None,
+            "failed": None,
+            "healthy": False,
+            "state": state,
+            "latest_run": None,
+        }
         return payload
 
     capability = merged.get("capability")
@@ -247,6 +269,23 @@ def _enrich_memory_projection_health(payload: dict[str, Any], target: Path) -> d
     if capability and capability != evidence_runtime.MEMORY_PROJECTION_CAPABILITY:
         healthy = False
 
+    if healthy:
+        state = "healthy"
+    elif payload.get("health") == "timeout" or (isinstance(last_run, dict) and last_run.get("exit_code") == 124):
+        state = "timed_out"
+    elif latest == "fail":
+        state = "failed"
+    elif latest in ("partial", "dry_run") or partial is True:
+        state = "partial"
+    elif stale is True:
+        state = "stale"
+    elif status in (None, "absent") and last_run is None:
+        state = "unknown"
+    elif payload.get("health") == "missing":
+        state = "missing"
+    else:
+        state = "unhealthy"
+
     block = {
         "capability": capability,
         "engine_version": merged.get("engine_version"),
@@ -261,6 +300,7 @@ def _enrich_memory_projection_health(payload: dict[str, Any], target: Path) -> d
         "status": status,
         "failed": failed,
         "healthy": healthy,
+        "state": state,
         "latest_run": evidence_runtime.public_memory_latest_run(last_run),
     }
     payload["memory_projection"] = block
@@ -439,19 +479,9 @@ def _run_memory_crawl(
     if counts is not None:
         extra.update(counts)
         if isinstance(receipt, dict):
-            for key in (
-                "status",
-                "stale",
-                "partial",
-                "canonical_count",
-                "live_count",
-                "hash_divergence",
-                "unresolved_relations",
-                "malformed_skipped",
-                "memory_namespace",
-            ):
-                if key in receipt:
-                    extra[key] = receipt[key]
+            safe_health = evidence_runtime.body_free_memory_health(receipt)
+            if safe_health:
+                extra.update(safe_health)
             if receipt.get("status") == "completed" and counts.get("scan_id"):
                 extra["last_completed_scan_id"] = counts["scan_id"]
     elif isinstance(receipt, dict) and run_status == "dry_run":
@@ -588,6 +618,27 @@ def run_engine(verb: str, arguments: list[str]) -> int:
     if verb == "crawl":
         return _run_crawl(arguments)
     return _run_miseledger(verb, arguments)
+
+
+def memory_audit(*, workspaces: list[Path], json_output: bool = False) -> int:
+    """Print the read-only memory identity audit without invoking MiseLedger."""
+
+    payload = memory_identity_audit.audit_workspaces(workspaces)
+    if json_output:
+        _json_print(payload)
+        return 0
+    summary = payload["summary"]
+    print(
+        "memory identity audit: "
+        f"cards={summary['cards']} explicit_ids={summary['explicit_ids']} "
+        f"path_fallbacks={summary['path_fallbacks']} malformed_ids={summary['malformed_ids']} "
+        f"collisions={summary['collisions']}"
+    )
+    readiness = payload["alias_readiness"]
+    print(f"alias_readiness: {'ready' if readiness['ready'] else 'blocked'}")
+    for reason in readiness["blocking_reasons"]:
+        print(f"- {reason}")
+    return 0
 
 
 def _run_json(args: list[str], *, timeout: float = 30.0) -> dict[str, Any]:
@@ -855,6 +906,7 @@ def status(*, target: Path, json_output: bool = False) -> int:
     if isinstance(memory_projection, dict):
         print(
             "memory_projection: "
+            f"state={memory_projection.get('state')} "
             f"healthy={memory_projection.get('healthy')} "
             f"capability={memory_projection.get('capability')} "
             f"engine_version={memory_projection.get('engine_version')} "

--- a/src/brigade/evidence_runtime.py
+++ b/src/brigade/evidence_runtime.py
@@ -146,8 +146,8 @@ MEMORY_LATEST_RUN_PUBLIC_KEYS = (
 )
 
 MEMORY_COUNT_KEYS = ("created", "updated", "unchanged", "removed", "skipped", "failed")
-MEMORY_F2_REJECTED_FLAGS = frozenset({"--rebuild", "--full"})
-MEMORY_ALLOWED_FLAGS = frozenset({"--json", "--dry-run", "--limit"})
+MEMORY_F2_REJECTED_FLAGS = frozenset({"--full"})
+MEMORY_ALLOWED_FLAGS = frozenset({"--json", "--dry-run", "--rebuild", "--limit"})
 
 _CAPABILITY_CANDIDATES = ("version", "doctor", "export", "crawl")
 _READ_ONLY_TIMEOUT = 30.0
@@ -385,14 +385,19 @@ def check_compatibility(runtime: CrawlerRuntime, env: dict[str, str] | None = No
     )
 
 
-def register_memory_facade_extensions(_evidence_sub: Any = None) -> None:
-    """Inert F2 registration point for rebuild routing and identity audit.
+def register_memory_facade_extensions(evidence_sub: Any = None) -> None:
+    """Register the F2 read-only identity audit beneath ``evidence memory``."""
 
-    F1 leaves this as a no-op so F2 can attach projection-only rebuild and
-    read-only identity-audit commands without reshaping the crawl gate.
-    """
+    if evidence_sub is None:
+        return
+    from pathlib import Path
 
-    return None
+    memory = evidence_sub.add_parser("memory", help="Audit canonical memory projection identity without editing cards.")
+    memory_sub = memory.add_subparsers(dest="evidence_memory_command", metavar="<memory-command>")
+    memory_sub.required = True
+    audit = memory_sub.add_parser("audit", help="Read identity coverage and proposed aliases for memory cards.")
+    audit.add_argument("workspaces", nargs="+", type=Path, help="Workspace roots containing memory/cards/.")
+    audit.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
 
 def resolve_miseledger(env: dict[str, str] | None = None) -> str | None:
@@ -655,8 +660,47 @@ def body_free_memory_health(raw: dict[str, Any] | None) -> dict[str, Any] | None
         return None
     out: dict[str, Any] = {}
     for key in MEMORY_HEALTH_SAFE_KEYS:
-        if key in raw:
-            out[key] = raw[key]
+        value = raw.get(key)
+        if key == "capability" and isinstance(value, str) and re.fullmatch(r"memory-projection\.v\d+", value):
+            out[key] = value
+        elif (
+            key == "engine_version"
+            and isinstance(value, str)
+            and re.fullmatch(r"\d+(?:\.\d+){1,3}(?:[-+][A-Za-z0-9.-]+)?", value)
+        ):
+            out[key] = value
+        elif (
+            key == "memory_namespace"
+            and isinstance(value, str)
+            and re.fullmatch(
+                r"memory-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}",
+                value,
+            )
+        ):
+            out[key] = value
+        elif (
+            key == "last_completed_scan_id"
+            and isinstance(value, str)
+            and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}", value)
+        ):
+            out[key] = value
+        elif (
+            key
+            in {
+                "canonical_count",
+                "live_count",
+                "hash_divergence",
+                "unresolved_relations",
+                "malformed_skipped",
+                "failed",
+            }
+            and _typed_nonneg_int(value) is not None
+        ):
+            out[key] = value
+        elif key in {"stale", "partial"} and isinstance(value, bool):
+            out[key] = value
+        elif key == "status" and value in {"absent", "completed", "failed", "interrupted"}:
+            out[key] = value
     return out or None
 
 
@@ -680,8 +724,9 @@ def public_memory_latest_run(raw: dict[str, Any] | None) -> dict[str, Any] | Non
 def parse_memory_crawl_options(rest: list[str]) -> tuple[str | None, bool, bool, list[str]]:
     """Parse F1 crawl trailing options.
 
-    Returns ``(error, want_json, dry_run, passthrough)``. Rejects F2
-    ``--rebuild``/``--full``. Unknown options are refused rather than forwarded.
+    Returns ``(error, want_json, dry_run, passthrough)``. ``--rebuild`` is
+    delegated only after the same preflight as a normal crawl; ``--full`` is
+    intentionally not exposed because it is broader than this projection.
     """
 
     want_json = False
@@ -703,6 +748,10 @@ def parse_memory_crawl_options(rest: list[str]) -> tuple[str | None, bool, bool,
             continue
         if arg == "--dry-run":
             dry_run = True
+            i += 1
+            continue
+        if arg == "--rebuild":
+            passthrough.append(arg)
             i += 1
             continue
         if arg == "--limit":

--- a/src/brigade/memory_identity_audit.py
+++ b/src/brigade/memory_identity_audit.py
@@ -1,0 +1,258 @@
+"""Read-only identity coverage audit for canonical memory cards.
+
+This module intentionally reads only the Markdown authority.  It does not
+call MiseLedger, edit frontmatter, write aliases, or turn legacy identity into
+a validation failure.  Its deterministic proposed aliases are review inputs
+for the later migration slice.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from .memory_cmd import _parse_frontmatter
+
+
+_CARD_ROOT = Path("memory/cards")
+_NAMESPACE_PATH = Path("memory/NAMESPACE")
+_EXPLICIT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _namespace(workspace: Path) -> str | None:
+    try:
+        value = (workspace / _NAMESPACE_PATH).read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    return value or None
+
+
+def _engine_string_field(meta: dict[str, Any], *keys: str) -> str:
+    """Mirror the engine's ``stringField`` coercion for card identity."""
+
+    for key in keys:
+        value = meta.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, bool):
+            return str(value).lower()
+        if isinstance(value, list) and value and all(isinstance(item, str) for item in value):
+            return ", ".join(value)
+    return ""
+
+
+def _identity_warning(identity: str) -> str | None:
+    if _EXPLICIT_ID_PATTERN.fullmatch(identity) and identity.startswith("card-"):
+        return None
+    return "explicit ID does not meet the future card-<uuid> policy"
+
+
+def _proposed_id(namespace: str, path: str) -> str:
+    return "card-" + str(uuid.uuid5(uuid.NAMESPACE_URL, f"brigade://memory/{namespace}/{path}"))
+
+
+def _card_paths(workspace: Path) -> list[Path]:
+    root = workspace / _CARD_ROOT
+    if not root.is_dir():
+        return []
+    return sorted(path for path in root.rglob("*.md") if path.is_file() and not path.is_symlink())
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _persisted_legacy_keys(workspace: Path, namespace: str | None) -> list[dict[str, str]]:
+    """Report known legacy key stores without interpreting their card content."""
+
+    base = {"workspace": workspace.name, "namespace": namespace or ""}
+    keys: list[dict[str, str]] = []
+    search_log = workspace / ".brigade/memory/search-log.jsonl"
+    try:
+        search_lines = search_log.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        search_lines = []
+    for line in search_lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict) or not isinstance(entry.get("card_ids"), list):
+            continue
+        for key in entry["card_ids"]:
+            if isinstance(key, str) and key:
+                keys.append({**base, "consumer": "search", "kind": "search_log_card_id", "key": key})
+
+    care = _read_json(workspace / ".brigade/memory-care/decay/scan-latest.json")
+    if care and isinstance(care.get("cards"), list):
+        for card in care["cards"]:
+            if isinstance(card, dict) and isinstance(card.get("card_id"), str) and card["card_id"]:
+                keys.append({**base, "consumer": "care", "kind": "care_card_id", "key": card["card_id"]})
+
+    evaluation = _read_json(workspace / "evals/memory-retrieval/queries.json")
+    if evaluation and isinstance(evaluation.get("queries"), list):
+        for query in evaluation["queries"]:
+            if not isinstance(query, dict) or not isinstance(query.get("gold"), list):
+                continue
+            for key in query["gold"]:
+                if isinstance(key, str) and key:
+                    keys.append({**base, "consumer": "eval", "kind": "eval_gold_card_id", "key": key})
+    return keys
+
+
+def audit_workspaces(workspaces: list[Path]) -> dict[str, Any]:
+    """Inspect memory identity coverage without modifying the supplied workspaces.
+
+    IDs are unique within the engine's namespace.  Reused explicit IDs across
+    namespaces are not archive collisions, but remain migration collisions
+    because a future alias table cannot safely treat them as globally unique.
+    """
+
+    cards: list[dict[str, Any]] = []
+    malformed_ids: list[dict[str, str]] = []
+    legacy_keys: list[dict[str, str]] = []
+    mappings: list[dict[str, str]] = []
+    namespaces: list[dict[str, str | None]] = []
+    by_namespace: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    explicit_across_namespaces: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+
+    for raw_workspace in workspaces:
+        workspace = raw_workspace.expanduser().resolve()
+        namespace = _namespace(workspace)
+        namespaces.append({"workspace": workspace.name, "namespace": namespace})
+        for path in _card_paths(workspace):
+            relative = path.relative_to(workspace).as_posix()
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                malformed_ids.append(
+                    {
+                        "workspace": workspace.name,
+                        "namespace": namespace or "",
+                        "path": relative,
+                        "detail": "card unreadable",
+                    }
+                )
+                continue
+            meta, _has_frontmatter = _parse_frontmatter(text)
+            explicit_id = _engine_string_field(meta, "id", "card_id")
+            warning = _identity_warning(explicit_id) if explicit_id else None
+            card: dict[str, str] = {
+                "workspace": workspace.name,
+                "namespace": namespace or "",
+                "path": relative,
+                "identity_source": "explicit_id" if explicit_id else "path_fallback",
+                "identity": explicit_id or f"path:{relative}",
+            }
+            if warning:
+                malformed_ids.append(
+                    {"workspace": workspace.name, "namespace": namespace or "", "path": relative, "detail": warning}
+                )
+            cards.append(card)
+
+            legacy_keys.append(
+                {
+                    "workspace": workspace.name,
+                    "namespace": namespace or "",
+                    "path": relative,
+                    "consumer": "search_eval",
+                    "kind": "filename_stem",
+                    "key": path.stem,
+                }
+            )
+            topic = meta.get("topic")
+            if isinstance(topic, str) and topic.strip():
+                legacy_keys.append(
+                    {
+                        "workspace": workspace.name,
+                        "namespace": namespace or "",
+                        "path": relative,
+                        "consumer": "care",
+                        "kind": "topic",
+                        "key": topic.strip(),
+                    }
+                )
+
+            if namespace:
+                by_namespace[namespace][card["identity"]].append(relative)
+                if explicit_id:
+                    explicit_across_namespaces[explicit_id][namespace].append(relative)
+                else:
+                    mappings.append(
+                        {
+                            "namespace": namespace,
+                            "old_id": f"path:{relative}",
+                            "new_id": _proposed_id(namespace, relative),
+                            "path": relative,
+                        }
+                    )
+
+        legacy_keys.extend(_persisted_legacy_keys(workspace, namespace))
+
+    collisions: list[dict[str, Any]] = []
+    within_count = 0
+    for namespace, ids in sorted(by_namespace.items()):
+        for identity, paths in sorted(ids.items()):
+            if len(paths) > 1:
+                within_count += 1
+                collisions.append(
+                    {"scope": "namespace", "namespace": namespace, "id": identity, "paths": sorted(paths)}
+                )
+
+    across_count = 0
+    for identity, namespace_paths in sorted(explicit_across_namespaces.items()):
+        if len(namespace_paths) > 1:
+            across_count += 1
+            collisions.append(
+                {
+                    "scope": "across_namespaces",
+                    "id": identity,
+                    "namespaces": [
+                        {"namespace": namespace, "paths": sorted(paths)}
+                        for namespace, paths in sorted(namespace_paths.items())
+                    ],
+                }
+            )
+
+    explicit_count = sum(card["identity_source"] == "explicit_id" for card in cards)
+    fallback_count = sum(card["identity_source"] == "path_fallback" for card in cards)
+    blocking_reasons: list[str] = []
+    if malformed_ids:
+        blocking_reasons.append("malformed_ids")
+    if within_count:
+        blocking_reasons.append("duplicate_ids_within_namespace")
+    if across_count:
+        blocking_reasons.append("duplicate_ids_across_namespaces")
+    if any(not item["namespace"] for item in namespaces):
+        blocking_reasons.append("missing_namespace")
+
+    summary = {
+        "workspaces": len(workspaces),
+        "cards": len(cards),
+        "explicit_ids": explicit_count,
+        "path_fallbacks": fallback_count,
+        "malformed_ids": len(malformed_ids),
+        "duplicate_ids_within_namespace": within_count,
+        "duplicate_ids_across_namespaces": across_count,
+        "legacy_keys": len(legacy_keys),
+        "collisions": len(collisions),
+    }
+    return {
+        "schema": "brigade.memory-identity-audit.v1",
+        "summary": summary,
+        "namespaces": namespaces,
+        "cards": cards,
+        "malformed_ids": malformed_ids,
+        "collisions": collisions,
+        "legacy_keys": legacy_keys,
+        "mappings": mappings,
+        "alias_readiness": {"ready": not blocking_reasons, "blocking_reasons": blocking_reasons},
+    }

--- a/src/brigade/memory_identity_audit.py
+++ b/src/brigade/memory_identity_audit.py
@@ -9,18 +9,17 @@ for the later migration slice.
 from __future__ import annotations
 
 import json
-import re
 import uuid
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from .card_identity import valid_card_id
 from .memory_cmd import _parse_frontmatter
 
 
 _CARD_ROOT = Path("memory/cards")
 _NAMESPACE_PATH = Path("memory/NAMESPACE")
-_EXPLICIT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 def _namespace(workspace: Path) -> str | None:
@@ -46,7 +45,7 @@ def _engine_string_field(meta: dict[str, Any], *keys: str) -> str:
 
 
 def _identity_warning(identity: str) -> str | None:
-    if _EXPLICIT_ID_PATTERN.fullmatch(identity) and identity.startswith("card-"):
+    if valid_card_id(identity):
         return None
     return "explicit ID does not meet the future card-<uuid> policy"
 

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -168,6 +168,29 @@ def test_export_plan_points_at_receipts_export(tmp_path):
     assert payload["export_cursor_present"] is False
 
 
+def test_memory_crawl_rebuild_delegates_only_after_preflight(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    marker = tmp_path / "called"
+    binary = tmp_path / "miseledger"
+    binary.write_text(
+        """#!/bin/sh
+if [ \"$1\" = \"version\" ]; then echo '0.6.0'; exit 0; fi
+if [ \"$1\" = \"doctor\" ]; then echo '{\"checks\":[{\"name\":\"schema\",\"ok\":true}],\"capability\":{\"memory\":\"memory-projection.v1\",\"engine_version\":\"0.6.0\"}}'; exit 0; fi
+if [ \"$1\" = \"crawl\" ]; then touch '"""
+        + str(marker)
+        + """'; echo '{\"scan_id\":\"scan-rebuild\",\"capability\":\"memory-projection.v1\",\"engine_version\":\"0.6.0\",\"status\":\"completed\",\"stale\":false,\"partial\":false,\"created\":0,\"updated\":0,\"unchanged\":1,\"removed\":0,\"skipped\":0,\"failed\":0}'; exit 0; fi
+exit 1
+"""
+    )
+    binary.chmod(0o755)
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(binary))
+
+    assert evidence_cmd.run_engine("crawl", ["memory", str(workspace), "--rebuild"]) == 0
+
+    assert marker.exists()
+
+
 # ---- crawler runtime and health propagation tests --------------------------
 
 
@@ -653,6 +676,58 @@ def test_memory_crawl_partial_failed_not_healthy(monkeypatch, tmp_path):
     payload = evidence_cmd.status_payload(workspace)
     assert payload["memory_projection"]["healthy"] is False
     assert payload["health"] in {"fail", "incomplete"}
+    assert payload["memory_projection"]["state"] == "partial"
+
+
+def test_memory_projection_state_distinguishes_timeout_stale_missing_and_failed(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    miseledger = _write_fake_bin(tmp_path, "miseledger", _miseledger_memory_capable_script())
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    evidence_cmd._write_last_run(
+        target=workspace,
+        source="memory",
+        status="ok",
+        exit_code=0,
+        crawler_version="0.6.0",
+        database="ok",
+        started_at="2026-01-01T00:00:00Z",
+        finished_at="2026-01-01T00:01:00Z",
+        detail="stale",
+        extra={
+            "capability": "memory-projection.v1",
+            "status": "completed",
+            "stale": True,
+            "partial": False,
+            "failed": 0,
+        },
+    )
+    assert evidence_cmd.status_payload(workspace)["memory_projection"]["state"] == "stale"
+
+    evidence_cmd._write_last_run(
+        target=workspace,
+        source="memory",
+        status="fail",
+        exit_code=124,
+        crawler_version="0.6.0",
+        database="ok",
+        started_at="2026-01-01T00:00:00Z",
+        finished_at="2026-01-01T00:01:00Z",
+        detail="timeout",
+        extra={
+            "capability": "memory-projection.v1",
+            "status": "completed",
+            "stale": False,
+            "partial": False,
+            "failed": 0,
+        },
+    )
+    assert evidence_cmd.status_payload(workspace)["memory_projection"]["state"] == "timed_out"
+
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: None)
+    payload = evidence_cmd.status_payload(tmp_path / "never-crawled")
+    assert payload["memory_projection"]["state"] == "missing"
 
 
 def test_memory_status_body_free(monkeypatch, tmp_path, capsys):
@@ -696,6 +771,7 @@ def test_memory_status_body_free(monkeypatch, tmp_path, capsys):
 
     assert rc == 0
     assert "memory_projection:" in out
+    assert "state=healthy" in out
     assert "capability=memory-projection.v1" in out
     assert "SHOULD_NOT_PRINT_CARD_BODY" not in out
     assert "nope" not in out
@@ -762,6 +838,33 @@ def test_memory_status_json_whitelists_latest_run(monkeypatch, tmp_path, capsys)
     assert str(workspace / "secret") not in dumped
 
 
+def test_memory_status_drops_malformed_optional_health_fields(monkeypatch, tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    receipt = (
+        '{"scan_id":"scan-safe","capability":"memory-projection.v1","engine_version":"0.6.0",'
+        '"status":"completed","stale":false,"partial":false,'
+        '"created":0,"updated":0,"unchanged":1,"removed":0,"skipped":0,"failed":0,'
+        '"canonical_count":"CARD BODY MUST NOT APPEAR","live_count":1,'
+        '"hash_divergence":0,"unresolved_relations":0,"malformed_skipped":0,'
+        '"memory_namespace":"CARD BODY MUST NOT APPEAR"}'
+    )
+    miseledger = _write_fake_bin(
+        tmp_path,
+        "miseledger",
+        _miseledger_memory_capable_script(crawl_receipt=receipt),
+    )
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
+
+    assert evidence_cmd.run_engine("crawl", ["memory", str(workspace)]) == 0
+
+    payload = evidence_cmd.status_payload(workspace)
+    dumped = json.dumps(payload)
+    assert "CARD BODY MUST NOT APPEAR" not in dumped
+    assert payload["memory_projection"]["canonical_count"] is None
+    assert payload["memory_projection"].get("memory_namespace") is None
+
+
 def test_memory_crawl_rejects_rebuild_and_full(monkeypatch, tmp_path):
     workspace = tmp_path / "ws"
     workspace.mkdir()
@@ -773,7 +876,7 @@ def test_memory_crawl_rejects_rebuild_and_full(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: str(miseledger))
 
-    assert evidence_cmd.run_engine("crawl", ["memory", str(workspace), "--rebuild"]) == 2
+    assert evidence_cmd.run_engine("crawl", ["memory", str(workspace), "--full"]) == 2
     assert evidence_cmd.run_engine("crawl", ["memory", str(workspace), "--full"]) == 2
     assert not marker.exists()
 

--- a/tests/test_evidence_runtime.py
+++ b/tests/test_evidence_runtime.py
@@ -563,9 +563,9 @@ def test_parse_memory_receipt_dry_run_is_non_current():
 
 
 def test_parse_memory_options_rejects_rebuild_and_full():
-    err, *_rest = evidence_runtime.parse_memory_crawl_options(["--rebuild"])
-    assert err is not None
-    assert "--rebuild" in err
+    err, _want_json, _dry_run, passthrough = evidence_runtime.parse_memory_crawl_options(["--rebuild"])
+    assert err is None
+    assert passthrough == ["--rebuild"]
     err, *_rest = evidence_runtime.parse_memory_crawl_options(["--full"])
     assert err is not None
     assert "--full" in err

--- a/tests/test_memory_identity_audit.py
+++ b/tests/test_memory_identity_audit.py
@@ -1,0 +1,131 @@
+"""Tests for the read-only projected-memory identity audit."""
+
+from __future__ import annotations
+
+import json
+
+from brigade import cli, memory_identity_audit
+
+
+def _workspace(tmp_path, name: str, namespace: str):
+    workspace = tmp_path / name
+    cards = workspace / "memory" / "cards"
+    cards.mkdir(parents=True)
+    (workspace / "memory" / "NAMESPACE").write_text(namespace + "\n")
+    return workspace, cards
+
+
+def _card(cards, name: str, frontmatter: str) -> None:
+    (cards / name).write_text(f"---\n{frontmatter}\n---\n\n# Card\n")
+
+
+def test_audit_reports_coverage_collisions_legacy_keys_and_deterministic_aliases(tmp_path):
+    first, first_cards = _workspace(tmp_path, "first", "memory-11111111-1111-4111-8111-111111111111")
+    second, second_cards = _workspace(tmp_path, "second", "memory-22222222-2222-4222-8222-222222222222")
+    _card(first_cards, "explicit.md", "id: card-shared\ntopic: release")
+    _card(first_cards, "fallback.md", "topic: fallback-topic")
+    _card(first_cards, "malformed.md", "id: path:memory/cards/fallback.md")
+    _card(second_cards, "same.md", "id: card-shared")
+
+    audit = memory_identity_audit.audit_workspaces([first, second])
+
+    assert audit["summary"] == {
+        "workspaces": 2,
+        "cards": 4,
+        "explicit_ids": 3,
+        "path_fallbacks": 1,
+        "malformed_ids": 1,
+        "duplicate_ids_within_namespace": 1,
+        "duplicate_ids_across_namespaces": 1,
+        "legacy_keys": 6,
+        "collisions": 2,
+    }
+    assert audit["alias_readiness"]["ready"] is False
+    assert audit["alias_readiness"]["blocking_reasons"] == [
+        "malformed_ids",
+        "duplicate_ids_within_namespace",
+        "duplicate_ids_across_namespaces",
+    ]
+    assert audit["mappings"] == [
+        {
+            "namespace": "memory-11111111-1111-4111-8111-111111111111",
+            "old_id": "path:memory/cards/fallback.md",
+            "new_id": "card-a7bee672-2ad2-590a-ad2b-51992afbeddc",
+            "path": "memory/cards/fallback.md",
+        }
+    ]
+    assert {item["kind"] for item in audit["legacy_keys"]} == {"filename_stem", "topic"}
+    malformed = audit["malformed_ids"]
+    assert malformed == [
+        {
+            "workspace": "first",
+            "namespace": "memory-11111111-1111-4111-8111-111111111111",
+            "path": "memory/cards/malformed.md",
+            "detail": "explicit ID does not meet the future card-<uuid> policy",
+        }
+    ]
+
+
+def test_audit_uses_the_engine_id_precedence_and_coercion_rules(tmp_path):
+    workspace, cards = _workspace(tmp_path, "one", "memory-99999999-9999-4999-8999-999999999999")
+    _card(cards, "precedence.md", "id: primary\ncard_id: ignored")
+    _card(cards, "bool.md", "id: true")
+
+    audit = memory_identity_audit.audit_workspaces([workspace])
+
+    assert [card["identity"] for card in audit["cards"]] == ["true", "primary"]
+    assert audit["summary"]["explicit_ids"] == 2
+
+
+def test_audit_reports_duplicates_inside_a_namespace_without_writing_cards(tmp_path):
+    workspace, cards = _workspace(tmp_path, "one", "memory-33333333-3333-4333-8333-333333333333")
+    _card(cards, "a.md", "id: card-duplicate")
+    _card(cards, "b.md", "card_id: card-duplicate")
+    before = {path.name: path.read_text() for path in cards.glob("*.md")}
+
+    audit = memory_identity_audit.audit_workspaces([workspace])
+
+    assert audit["summary"]["duplicate_ids_within_namespace"] == 1
+    assert audit["collisions"] == [
+        {
+            "scope": "namespace",
+            "namespace": "memory-33333333-3333-4333-8333-333333333333",
+            "id": "card-duplicate",
+            "paths": ["memory/cards/a.md", "memory/cards/b.md"],
+        }
+    ]
+    assert {path.name: path.read_text() for path in cards.glob("*.md")} == before
+
+
+def test_evidence_memory_audit_cli_is_read_only_and_json_safe(tmp_path, capsys):
+    workspace, cards = _workspace(tmp_path, "one", "memory-44444444-4444-4444-8444-444444444444")
+    _card(cards, "card.md", "id: card-safe\ntopic: safe")
+    before = (cards / "card.md").read_text()
+
+    assert cli.main(["evidence", "memory", "audit", str(workspace), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "brigade.memory-identity-audit.v1"
+    assert payload["summary"]["explicit_ids"] == 1
+    assert "# Card" not in json.dumps(payload)
+    assert (cards / "card.md").read_text() == before
+
+
+def test_audit_reports_persisted_care_search_and_eval_legacy_keys(tmp_path):
+    workspace, cards = _workspace(tmp_path, "one", "memory-55555555-5555-4555-8555-555555555555")
+    _card(cards, "legacy-card.md", "topic: legacy-topic")
+    (workspace / ".brigade" / "memory").mkdir(parents=True)
+    (workspace / ".brigade" / "memory" / "search-log.jsonl").write_text('{"card_ids":["legacy-card"]}\n')
+    care = workspace / ".brigade" / "memory-care" / "decay"
+    care.mkdir(parents=True)
+    (care / "scan-latest.json").write_text('{"cards":[{"card_id":"legacy-topic"}]}')
+    evaluation = workspace / "evals" / "memory-retrieval"
+    evaluation.mkdir(parents=True)
+    (evaluation / "queries.json").write_text('{"queries":[{"gold":["legacy-card"]}]}')
+
+    audit = memory_identity_audit.audit_workspaces([workspace])
+
+    kinds = {(item["consumer"], item["kind"], item["key"]) for item in audit["legacy_keys"]}
+    assert ("care", "care_card_id", "legacy-topic") in kinds
+    assert ("search", "search_log_card_id", "legacy-card") in kinds
+    assert ("eval", "eval_gold_card_id", "legacy-card") in kinds

--- a/tests/test_memory_identity_audit.py
+++ b/tests/test_memory_identity_audit.py
@@ -22,10 +22,11 @@ def _card(cards, name: str, frontmatter: str) -> None:
 def test_audit_reports_coverage_collisions_legacy_keys_and_deterministic_aliases(tmp_path):
     first, first_cards = _workspace(tmp_path, "first", "memory-11111111-1111-4111-8111-111111111111")
     second, second_cards = _workspace(tmp_path, "second", "memory-22222222-2222-4222-8222-222222222222")
-    _card(first_cards, "explicit.md", "id: card-shared\ntopic: release")
+    shared_id = "card-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    _card(first_cards, "explicit.md", f"id: {shared_id}\ntopic: release")
     _card(first_cards, "fallback.md", "topic: fallback-topic")
     _card(first_cards, "malformed.md", "id: path:memory/cards/fallback.md")
-    _card(second_cards, "same.md", "id: card-shared")
+    _card(second_cards, "same.md", f"id: {shared_id}")
 
     audit = memory_identity_audit.audit_workspaces([first, second])
 
@@ -79,8 +80,8 @@ def test_audit_uses_the_engine_id_precedence_and_coercion_rules(tmp_path):
 
 def test_audit_reports_duplicates_inside_a_namespace_without_writing_cards(tmp_path):
     workspace, cards = _workspace(tmp_path, "one", "memory-33333333-3333-4333-8333-333333333333")
-    _card(cards, "a.md", "id: card-duplicate")
-    _card(cards, "b.md", "card_id: card-duplicate")
+    _card(cards, "a.md", "id: card-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    _card(cards, "b.md", "card_id: card-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
     before = {path.name: path.read_text() for path in cards.glob("*.md")}
 
     audit = memory_identity_audit.audit_workspaces([workspace])
@@ -90,7 +91,7 @@ def test_audit_reports_duplicates_inside_a_namespace_without_writing_cards(tmp_p
         {
             "scope": "namespace",
             "namespace": "memory-33333333-3333-4333-8333-333333333333",
-            "id": "card-duplicate",
+            "id": "card-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
             "paths": ["memory/cards/a.md", "memory/cards/b.md"],
         }
     ]
@@ -99,7 +100,7 @@ def test_audit_reports_duplicates_inside_a_namespace_without_writing_cards(tmp_p
 
 def test_evidence_memory_audit_cli_is_read_only_and_json_safe(tmp_path, capsys):
     workspace, cards = _workspace(tmp_path, "one", "memory-44444444-4444-4444-8444-444444444444")
-    _card(cards, "card.md", "id: card-safe\ntopic: safe")
+    _card(cards, "card.md", "id: card-cccccccc-cccc-4ccc-8ccc-cccccccccccc\ntopic: safe")
     before = (cards / "card.md").read_text()
 
     assert cli.main(["evidence", "memory", "audit", str(workspace), "--json"]) == 0


### PR DESCRIPTION
## Summary

- add the read-only `brigade evidence memory audit` facade for identity coverage, collisions, legacy keys, alias readiness, and deterministic proposed mappings
- expose body-free projection health states, including timed out, missing, partial, stale, and failed, so dashboard polling can diagnose the condition
- route projection-only `--rebuild` through the existing capability preflight while retaining the `--full` refusal

## Scope

#867 owns stable ID minting and aliases. This change reports existing identities and proposed mappings only; it does not write cards, add aliases, or change card identifiers.

## Verification

- focused suite passed after rebase: `20260812-171259-work-verify-eedb93`
- staged content guard passed: `20260812-171237-work-verify-76fb70`
- memory handoff lint passed: `20260812-171246-work-verify-3b1861`
- `./scripts/verify` reached 7,100 passing tests and failed three host-level probes: two cannot write `/var/spool/cron`, and one pre-push fixture cannot remove its temporary directory (receipt `20260812-170012-work-verify-e62fbb`)

Closes #844.