### PR TITLE
feat(release): require security evidence for candidate commit

### DIFF
--- a/src/brigade/release_cmd/evidence.py
+++ b/src/brigade/release_cmd/evidence.py
@@ -536,6 +536,14 @@ def _assess(
     if int(sweep_review.get("issue_count") or 0) > 0:
         blockers.append(f"scanner sweep has unresolved issue(s): {sweep_review.get('issue_count')}")
     security = evidence.get("security") if isinstance(evidence.get("security"), dict) else {}
+    security_evidence = security.get("evidence") if isinstance(security.get("evidence"), dict) else {}
+    candidate_commit = git.get("head")
+    evidence_commit = security_evidence.get("candidate_commit")
+    if not candidate_commit or evidence_commit != candidate_commit:
+        blockers.append(
+            f"security evidence does not cover candidate commit {candidate_commit or 'unknown'}; "
+            "remediation: brigade security scan --target ."
+        )
     security_checks = [item for item in security.get("checks", []) if isinstance(item, dict)]
     open_finding_checks = [
         item for item in security_checks if item.get("name") == "security_open_findings" and item.get("status") != OK

--- a/src/brigade/security_cmd/commands.py
+++ b/src/brigade/security_cmd/commands.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -485,6 +486,15 @@ def scan(
     report["config"] = str(effective.config_path)
     report["config_loaded"] = effective.config_loaded
     report["generated_at"] = _utc_iso()
+    candidate_commit = subprocess.run(
+        ["git", "-C", str(target), "rev-parse", "HEAD"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if candidate_commit.returncode == 0 and candidate_commit.stdout.strip():
+        report["candidate_commit"] = candidate_commit.stdout.strip()
     if suppression_migrations:
         report["suppression_migrations"] = suppression_migrations
     _write_suppression_health_cache_from_report(target, effective, report)

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -804,6 +804,7 @@ def inspect_evidence_bundle(path: Path) -> dict[str, Any]:
         "ready": True,
         "path": str(path),
         "generated_at": payload.get("generated_at"),
+        "candidate_commit": payload.get("candidate_commit"),
         "finding_count": payload.get("finding_count"),
         "policy": payload.get("policy"),
         "sarif_ready": sarif_path.is_file(),

--- a/tests/test_center_actions_cmd.py
+++ b/tests/test_center_actions_cmd.py
@@ -88,6 +88,12 @@ def _seed_release_prereqs(path: Path):
     )
 
 
+def _git_head(target: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
 def _patch_release_health(monkeypatch):
     monkeypatch.setattr(
         security_cmd,
@@ -98,7 +104,7 @@ def _patch_release_health(monkeypatch):
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
+            "evidence": {"ready": True, "finding_count": 0, "candidate_commit": _git_head(target)},
             "checks": [],
         },
     )

--- a/tests/test_center_report_cmd.py
+++ b/tests/test_center_report_cmd.py
@@ -286,7 +286,13 @@ def test_center_report_integrates_with_work_and_release(tmp_path, monkeypatch, c
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
+            "evidence": {
+                "ready": True,
+                "finding_count": 0,
+                "candidate_commit": subprocess.run(
+                    ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+                ).stdout.strip(),
+            },
         },
     )
     monkeypatch.setattr(

--- a/tests/test_context_learning_closeout_cmd.py
+++ b/tests/test_context_learning_closeout_cmd.py
@@ -817,7 +817,13 @@ def test_security_closeout_and_release_candidate_compare_closeout(tmp_path, monk
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
+            "evidence": {
+                "ready": True,
+                "finding_count": 0,
+                "candidate_commit": subprocess.run(
+                    ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+                ).stdout.strip(),
+            },
         },
     )
     monkeypatch.setattr(

--- a/tests/test_fleet_action_dispatch_cmd.py
+++ b/tests/test_fleet_action_dispatch_cmd.py
@@ -79,18 +79,24 @@ def _seed_action_queue(path: Path, actions: list[dict]):
 
 
 def _patch_release_health(monkeypatch):
-    monkeypatch.setattr(
-        security_cmd,
-        "health",
-        lambda target: {
+    def clean_security_health(target):
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        return {
             "config_path": str(target / ".brigade" / "security.toml"),
             "valid": True,
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
+            "evidence": {"ready": True, "finding_count": 0, "candidate_commit": head},
             "checks": [],
-        },
+        }
+
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        clean_security_health,
     )
     monkeypatch.setattr(
         handoff_cmd,

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -77,16 +77,22 @@ def _seed_ready_evidence(path: Path):
 
 
 def _patch_clean_health(monkeypatch):
-    monkeypatch.setattr(
-        security_cmd,
-        "health",
-        lambda target: {
+    def clean_security_health(target):
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        return {
             "valid": True,
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
-        },
+            "evidence": {"ready": True, "finding_count": 0, "candidate_commit": head},
+        }
+
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        clean_security_health,
     )
     monkeypatch.setattr(
         handoff_cmd,
@@ -1240,6 +1246,39 @@ def test_release_readiness_blocks_unusable_security_evidence(tmp_path, monkeypat
     assert payload["evidence"]["security"]["open_finding_count"] is None
     assert "security_evidence: missing security report; remediation: brigade security scan" in blockers
     assert "security_open_findings" not in blockers
+
+
+@pytest.mark.parametrize("evidence_commit", [None, "0" * 40])
+def test_release_readiness_requires_security_evidence_for_candidate_commit(
+    tmp_path, monkeypatch, capsys, evidence_commit
+):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        lambda target: {
+            "valid": True,
+            "issue_count": 0,
+            "open_finding_count": 0,
+            "raw_open_finding_count": 0,
+            "top_issue": None,
+            "top_finding": None,
+            "checks": [],
+            "evidence": {"ready": True, "finding_count": 0, "candidate_commit": evidence_commit},
+        },
+    )
+
+    assert release_cmd.plan(target=tmp_path, base_ref=None, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["status"] == "blocked"
+    assert any(
+        "security evidence does not cover candidate commit" in blocker and "brigade security scan --target ." in blocker
+        for blocker in payload["blockers"]
+    )
 
 
 def test_release_readiness_formats_exact_open_security_count_without_top_finding(tmp_path, monkeypatch, capsys):

--- a/tests/test_report_review_closeout_cmd.py
+++ b/tests/test_report_review_closeout_cmd.py
@@ -313,7 +313,13 @@ def test_report_closeout_integrates_with_work_and_release_compare(tmp_path, monk
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
+            "evidence": {
+                "ready": True,
+                "finding_count": 0,
+                "candidate_commit": subprocess.run(
+                    ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+                ).stdout.strip(),
+            },
         },
     )
     monkeypatch.setattr(

--- a/tests/test_repos_actions_cmd.py
+++ b/tests/test_repos_actions_cmd.py
@@ -110,18 +110,24 @@ def _seed_release_prereqs(path: Path):
 
 
 def _patch_release_health(monkeypatch):
-    monkeypatch.setattr(
-        security_cmd,
-        "health",
-        lambda target: {
+    def clean_security_health(target):
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        return {
             "config_path": str(target / ".brigade" / "security.toml"),
             "valid": True,
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
+            "evidence": {"ready": True, "finding_count": 0, "candidate_commit": head},
             "checks": [],
-        },
+        }
+
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        clean_security_health,
     )
     monkeypatch.setattr(
         handoff_cmd,

--- a/tests/test_repos_sweep_health_cmd.py
+++ b/tests/test_repos_sweep_health_cmd.py
@@ -61,18 +61,24 @@ def _seed_workspace(path: Path, repo_a: Path, repo_b: Path | None = None, *, dis
 
 
 def _patch_release_health(monkeypatch):
-    monkeypatch.setattr(
-        security_cmd,
-        "health",
-        lambda target: {
+    def clean_security_health(target):
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=target, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        return {
             "config_path": str(target / ".brigade" / "security.toml"),
             "valid": True,
             "issue_count": 0,
             "top_issue": None,
             "top_finding": None,
-            "evidence": {"ready": True, "finding_count": 0},
+            "evidence": {"ready": True, "finding_count": 0, "candidate_commit": head},
             "checks": [],
-        },
+        }
+
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        clean_security_health,
     )
     monkeypatch.setattr(
         handoff_cmd,

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 
 import pytest
 
@@ -3082,6 +3083,26 @@ def test_security_finding_outputs_redact_private_url_token_and_path(tmp_path, ca
     assert fingerprint in plain
     assert safe_path in plain
     assert "[REDACTED-URL]" in plain or "[REDACTED]" in plain or "[REDACTED-PATH]" in plain
+
+
+def test_security_scan_records_candidate_commit_in_evidence(tmp_path, capsys):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "dev@example.invalid"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Dev"], cwd=tmp_path, check=True)
+    (tmp_path / "README.md").write_text("fixture\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=tmp_path, check=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+
+    report = json.loads((output_dir / "security-report.json").read_text())
+    assert report["candidate_commit"] == head
+    assert security_cmd.health(tmp_path)["evidence"]["candidate_commit"] == head
 
 
 def test_security_enrich_writes_local_enrichment_bundle(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Record `candidate_commit` in security scan evidence bundles.
- Block `brigade release` readiness when evidence does not cover the candidate HEAD.
- Add focused release and security tests for the commit-coverage gate.

Fixes #675

## Test plan
- [x] `brigade work verify run --target . --command "python -m pytest -q tests/test_release_cmd.py::test_release_readiness_requires_security_evidence_for_candidate_commit tests/test_security_cmd.py::test_security_scan_records_candidate_commit_in_evidence --tb=short" --capture brigade-work`


Made with [Cursor](https://cursor.com)