### PR TITLE
feat(update): authorize GitHub API with GITHUB_TOKEN

### DIFF
--- a/src/brigade/update_cmd.py
+++ b/src/brigade/update_cmd.py
@@ -98,28 +98,35 @@ class _DefaultHttp:
         url: str,
         *,
         accept: str,
+        github_token: str | None = None,
         final_url_is_allowed: Callable[[str], bool],
         redirect_error: str,
         request_error: str,
     ) -> bytes:
-        request = urllib.request.Request(
-            url,
-            headers={"Accept": accept, "User-Agent": "brigade-update/1"},
-        )
-        try:
-            with urllib.request.urlopen(request, timeout=30) as response:
-                final = response.geturl()
-                if not final_url_is_allowed(final):
-                    raise UpdateError(f"{redirect_error}: {final}")
-                return response.read()
-        except urllib.error.HTTPError as exc:
-            raise UpdateError(f"{request_error}: {url} HTTP {exc.code}") from exc
-        except urllib.error.URLError as exc:
-            raise UpdateError(f"{request_error}: {url}") from exc
+        tokens: tuple[str | None, ...] = (github_token, None) if github_token else (None,)
+        for index, token in enumerate(tokens):
+            headers = {"Accept": accept, "User-Agent": "brigade-update/1"}
+            if token is not None:
+                headers["Authorization"] = f"Bearer {token}"
+            request = urllib.request.Request(url, headers=headers)
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    final = response.geturl()
+                    if not final_url_is_allowed(final):
+                        raise UpdateError(f"{redirect_error}: {final}")
+                    return response.read()
+            except urllib.error.HTTPError as exc:
+                if token is not None and exc.code in {401, 403} and index + 1 < len(tokens):
+                    continue
+                raise UpdateError(f"{request_error}: {url} HTTP {exc.code}") from exc
+            except urllib.error.URLError as exc:
+                raise UpdateError(f"{request_error}: {url}") from exc
+        raise AssertionError("HTTP request attempts unexpectedly exhausted")
 
     def json(self, url: str) -> Any:
         if _is_github_api_url(url):
             accept = "application/vnd.github+json"
+            github_token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
 
             def final_url_is_allowed(final: str) -> bool:
                 return final == url and _is_github_api_url(final)
@@ -129,6 +136,7 @@ class _DefaultHttp:
             invalid_json = f"GitHub request returned invalid JSON: {url}"
         elif _is_pypi_project_json_url(url):
             accept = "application/json"
+            github_token = None
 
             def final_url_is_allowed(final: str) -> bool:
                 return final == url and _is_pypi_project_json_url(final)
@@ -143,6 +151,7 @@ class _DefaultHttp:
                 self._read(
                     url,
                     accept=accept,
+                    github_token=github_token,
                     final_url_is_allowed=final_url_is_allowed,
                     redirect_error=redirect_error,
                     request_error=request_error,

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import urllib.error
 from pathlib import Path
 from unittest.mock import patch
+
 import pytest
 
 from brigade import component_manifest, update_cmd
@@ -247,6 +249,82 @@ def test_default_http_rejects_api_redirect_outside_exact_api_path():
     ):
         with pytest.raises(update_cmd.UpdateError, match="GitHub API request redirected"):
             update_cmd._DefaultHttp().json(url)
+
+
+def test_default_http_uses_github_token_for_github_api_requests(monkeypatch):
+    url = "https://api.github.com/repos/escoffier-labs/brigade/releases/latest"
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-example")
+    monkeypatch.setenv("GH_TOKEN", "gh-token-example")
+    requests = []
+
+    def urlopen(request, *, timeout):
+        requests.append(request)
+        assert timeout == 30
+        return _Response(b"{}", url)
+
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        assert update_cmd._DefaultHttp().json(url) == {}
+
+    assert requests[0].get_header("Authorization") == "Bearer github-token-example"
+
+
+def test_default_http_uses_gh_token_when_github_token_is_absent(monkeypatch):
+    url = "https://api.github.com/repos/escoffier-labs/brigade/releases/latest"
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "gh-token-example")
+
+    with patch("urllib.request.urlopen", return_value=_Response(b"{}", url)) as urlopen:
+        assert update_cmd._DefaultHttp().json(url) == {}
+
+    request = urlopen.call_args.args[0]
+    assert request.get_header("Authorization") == "Bearer gh-token-example"
+
+
+@pytest.mark.parametrize("status", (401, 403))
+def test_default_http_retries_github_api_without_rejected_token(monkeypatch, status):
+    url = "https://api.github.com/repos/escoffier-labs/brigade/releases/latest"
+    secret = "rejected-token-example"
+    monkeypatch.setenv("GITHUB_TOKEN", secret)
+    requests = []
+
+    def urlopen(request, *, timeout):
+        requests.append(request)
+        assert timeout == 30
+        if len(requests) == 1:
+            raise urllib.error.HTTPError(url, status, "Bad credentials", {}, None)
+        return _Response(b"{}", url)
+
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        assert update_cmd._DefaultHttp().json(url) == {}
+
+    assert requests[0].get_header("Authorization") == f"Bearer {secret}"
+    assert requests[1].get_header("Authorization") is None
+
+
+def test_default_http_rejected_token_is_absent_from_final_error(monkeypatch):
+    url = "https://api.github.com/repos/escoffier-labs/brigade/releases/latest"
+    secret = "rejected-token-example"
+    monkeypatch.setenv("GITHUB_TOKEN", secret)
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.HTTPError(url, 401, "Bad credentials", {}, None),
+    ):
+        with pytest.raises(update_cmd.UpdateError) as caught:
+            update_cmd._DefaultHttp().json(url)
+
+    assert secret not in str(caught.value)
+
+
+def test_default_http_never_sends_github_token_to_non_api_requests(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-example")
+    url = BASE + "component-manifest-v1.json"
+
+    with patch("urllib.request.urlopen", return_value=_Response(b"manifest", url)) as urlopen:
+        assert update_cmd._DefaultHttp().bytes(url) == b"manifest"
+
+    request = urlopen.call_args.args[0]
+    assert request.get_header("Authorization") is None
 
 
 def test_cache_manifest_preserves_verified_crlf_bytes_without_text_round_trip(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Send `Authorization: Bearer` for GitHub API requests when `GITHUB_TOKEN` or `GH_TOKEN` is set.
- Retry once without the token on 401/403; never attach tokens to non-API downloads.
- Keep rejected token values out of `UpdateError` strings (covered by tests).

Fixes #751

## Test plan
- [x] Focused update HTTP auth + token-absence tests via `brigade work verify run`


Made with [Cursor](https://cursor.com)