### PR TITLE
feat(care): namespace scheduler registrations by target identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,10 +251,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required set fails closed with typed `no-admissible-tool` and one bounded
   replan instead of letting the model improvise tools.
 - `brigade care install|status|uninstall` (#759): opt-in scaffold that writes
-  hash-stamped managed entries into the operator's crontab (or systemd user
-  units), matching `docs/scheduled-care.md`. Memory-care recipes invoke the
-  shipped runbooks so scheduled fires write normal receipts; Windows prints
-  Task Scheduler equivalents instead of silently no-oping; tampered blocks are
+  target-namespaced systemd user timers on Linux or launchd agents on
+  macOS, matching `docs/scheduled-care.md`. Memory-care recipes invoke the
+  shipped runbooks so scheduled fires write normal receipts; other platforms report explicit unsupported scheduling; tampered blocks are
   reported and not clobbered without `--adopt`.
 - Worker event stream field classification and fail-closed scrubbed projections
   for the Codex app-server transport (#592): closed scrub/export classification

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -22,8 +22,11 @@ A scheduled invocation is still an explicit invocation: the same command runs wh
 
 ## Opt-in care scaffold
 
-`brigade care install --target .` writes managed entries into the operator's
-own scheduler (crontab by default; `--backend systemd` writes user units).
+`brigade care install --target .` explicitly opts the target into the operator's
+own scheduler: namespaced systemd user timers on Linux or namespaced launchd
+agents on macOS. Other platforms report that managed scheduling is unsupported.
+Each registration includes a hash of the absolute target path, so status and
+uninstall can never select another target's entries.
 `brigade care status` audits those entries and shows the latest runbook
 receipt for each recipe. `brigade care uninstall` removes only the
 hash-stamped Brigade block. The schedule still belongs to the operator:

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -80,7 +80,7 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 
 ## Boundary
 
-Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md). Opt-in `brigade care install` can scaffold the operator's own crontab or systemd user timers without Brigade owning a daemon.
+Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md). Opt-in `brigade care install` can install target-namespaced systemd user timers on Linux or launchd agents on macOS without Brigade owning a daemon.
 
 ## Session-start recall (#466 Slice 1)
 

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -2,12 +2,12 @@
 
 The schedule belongs to the operator. Brigade only runs when invoked. Copy one
 of the recipes below into your own crontab, user timer, or CI job after
-`brigade init` wires the target, or let `brigade care install --target .`
-scaffold the same recipes as a hash-stamped managed block in your crontab
-(systemd user units with `--backend systemd`). `care status` audits the block
-and latest runbook receipts; `care uninstall` removes only that block. On
-Windows, `care install` prints Task Scheduler equivalents and does not write
-tasks. Brigade still does not own a daemon or background supervisor.
+`brigade init` wires the target, or explicitly opt in with
+`brigade care install --target .`. It installs systemd user timers on Linux or
+launchd agents on macOS and reports an unsupported scheduler elsewhere. Every
+registration is namespaced by a hash of the absolute target path, so status and
+uninstall operate only on that target; uninstalling a missing registration is
+a clear no-op. Brigade still does not own a daemon or background supervisor.
 
 Prerequisites:
 

--- a/src/brigade/care_cmd.py
+++ b/src/brigade/care_cmd.py
@@ -424,13 +424,14 @@ def _launchd_plists(*, workspace: Path, home: Path | None = None) -> dict[str, b
         }
         # launchd supports interval timers directly; calendar recipes use their
         # documented local hour/minute (weekly additionally pins Monday).
+        # launchd Weekday uses the same numbering as cron (0/7=Sunday, 1=Monday).
         if entry.entry_id == "ingest-sweep":
             payload["StartInterval"] = 1800
         else:
             fields = entry.schedule.split()
             calendar: dict[str, int] = {"Minute": int(fields[0]), "Hour": int(fields[1])}
             if fields[4] != "*":
-                calendar["Weekday"] = int(fields[4]) + 1
+                calendar["Weekday"] = int(fields[4])
             payload["StartCalendarInterval"] = calendar
         result[f"{label}.plist"] = plistlib.dumps(payload, sort_keys=True)
     return result

--- a/src/brigade/care_cmd.py
+++ b/src/brigade/care_cmd.py
@@ -12,9 +12,11 @@ normal runbook receipt.
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import subprocess
 import sys
+import plistlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -24,8 +26,8 @@ from . import managed_block, memory_cmd, runbook_cmd
 CARE_KIND = "CARE"
 CARE_MARKER_VERSION = 1
 CARE_MARKER_STYLE = managed_block.MARKER_STYLE_HASH
-DEFAULT_BACKEND: Literal["crontab", "systemd"] = "crontab"
-SUPPORTED_BACKENDS = ("crontab", "systemd")
+DEFAULT_BACKEND = "auto"
+SUPPORTED_BACKENDS = ("auto", "crontab", "systemd", "launchd")
 
 MEMORY_CARE_RUNBOOK_REL = {
     "daily-care": ".brigade/memory-care/runbooks/daily-care-pass.json",
@@ -118,6 +120,22 @@ CARE_ENTRIES: tuple[CareEntry, ...] = (
 
 def _is_windows() -> bool:
     return sys.platform == "win32"
+
+
+def _target_identity(target: Path) -> str:
+    """Return the stable, non-secret namespace for one absolute target path."""
+    absolute = target.expanduser().resolve()
+    return hashlib.sha256(os.fsencode(absolute)).hexdigest()[:16]
+
+
+def _resolve_backend(backend: str) -> str | None:
+    if backend != "auto":
+        return backend
+    if sys.platform.startswith("linux"):
+        return "systemd"
+    if sys.platform == "darwin":
+        return "launchd"
+    return None
 
 
 def _path_prefix(home: Path | None = None) -> str:
@@ -379,6 +397,120 @@ def _print_payload(payload: dict[str, Any], *, json_output: bool) -> None:
             print(f"{key}: {value}")
 
 
+def _launchd_dir(home: Path | None = None) -> Path:
+    return (home if home is not None else Path.home()) / "Library" / "LaunchAgents"
+
+
+def _launchd_plists(*, workspace: Path, home: Path | None = None) -> dict[str, bytes]:
+    identity = _target_identity(workspace)
+    result: dict[str, bytes] = {}
+    for entry in CARE_ENTRIES:
+        assert entry.runbook_rel is not None
+        label = f"dev.brigade.care.{identity}.{entry.entry_id}"
+        payload: dict[str, Any] = {
+            "Label": label,
+            "ProgramArguments": [
+                "/usr/bin/env",
+                "brigade",
+                "runbook",
+                "run",
+                "--approved",
+                entry.runbook_rel,
+                "--target",
+                ".",
+            ],
+            "WorkingDirectory": str(workspace),
+            "EnvironmentVariables": {"PATH": _path_prefix(home)},
+        }
+        # launchd supports interval timers directly; calendar recipes use their
+        # documented local hour/minute (weekly additionally pins Monday).
+        if entry.entry_id == "ingest-sweep":
+            payload["StartInterval"] = 1800
+        else:
+            fields = entry.schedule.split()
+            calendar: dict[str, int] = {"Minute": int(fields[0]), "Hour": int(fields[1])}
+            if fields[4] != "*":
+                calendar["Weekday"] = int(fields[4]) + 1
+            payload["StartCalendarInterval"] = calendar
+        result[f"{label}.plist"] = plistlib.dumps(payload, sort_keys=True)
+    return result
+
+
+def _launchd_install(*, target: Path, dry_run: bool, json_output: bool, home: Path | None) -> int:
+    directory = _launchd_dir(home)
+    plists = _launchd_plists(workspace=target, home=home)
+    if not dry_run:
+        directory.mkdir(parents=True, exist_ok=True)
+        for name, contents in plists.items():
+            path = directory / name
+            if path.is_symlink():
+                print(f"error: refusing to follow symlink registration: {path}", file=sys.stderr)
+                return 2
+            path.write_bytes(contents)
+    _print_payload(
+        {
+            "target": str(target),
+            "backend": "launchd",
+            "dry_run": dry_run,
+            "registrations": [str(directory / name) for name in plists],
+        },
+        json_output=json_output,
+    )
+    return 0
+
+
+def _launchd_status(*, target: Path, json_output: bool, home: Path | None) -> int:
+    directory = _launchd_dir(home)
+    expected = _launchd_plists(workspace=target, home=home)
+    states = []
+    for name, desired in expected.items():
+        path = directory / name
+        if path.is_symlink():
+            registration_status = "tampered"
+        elif not path.is_file():
+            registration_status = "missing"
+        else:
+            registration_status = "current" if path.read_bytes() == desired else "tampered"
+        states.append({"name": name, "status": registration_status})
+    state = "current"
+    if any(item["status"] == "tampered" for item in states):
+        state = "tampered"
+    elif any(item["status"] == "missing" for item in states):
+        state = "missing"
+    _print_payload(
+        {"target": str(target), "backend": "launchd", "status": state, "registrations": states}, json_output=json_output
+    )
+    return 1 if state == "tampered" else 0
+
+
+def _launchd_uninstall(*, target: Path, dry_run: bool, json_output: bool, home: Path | None) -> int:
+    directory = _launchd_dir(home)
+    removed: list[str] = []
+    refused: list[str] = []
+    for name, expected in _launchd_plists(workspace=target, home=home).items():
+        path = directory / name
+        if path.is_symlink():
+            print(f"error: refusing to remove symlink registration: {path}", file=sys.stderr)
+            return 2
+        if path.is_file():
+            if path.read_bytes() != expected:
+                refused.append(name)
+                continue
+            removed.append(name)
+            if not dry_run:
+                path.unlink()
+    _print_payload(
+        {"target": str(target), "backend": "launchd", "dry_run": dry_run, "removed": removed, "refused": refused},
+        json_output=json_output,
+    )
+    if not removed and not refused:
+        print(f"no scheduler registration found for target: {target}")
+    if refused:
+        print("error: one or more launchd registrations were modified; refusing to remove", file=sys.stderr)
+        return 1
+    return 0
+
+
 def install(
     *,
     target: Path,
@@ -395,12 +527,22 @@ def install(
     if backend not in SUPPORTED_BACKENDS:
         print(f"error: unsupported care backend: {backend}", file=sys.stderr)
         return 2
+    backend = _resolve_backend(backend) or ""
+    if not backend:
+        print(
+            f"error: care scheduler is unsupported on {sys.platform}; supported platforms: Linux (systemd user timers), macOS (launchd)",
+            file=sys.stderr,
+        )
+        return 3
     if _is_windows():
         return _windows_print(workspace=target)
 
     rc = _ensure_care_runbooks(target)
     if rc != 0:
         return rc
+
+    if backend == "launchd":
+        return _launchd_install(target=target, dry_run=dry_run, json_output=json_output, home=home)
 
     if backend == "crontab":
         return _install_crontab(target=target, dry_run=dry_run, adopt=adopt, json_output=json_output, home=home)
@@ -531,10 +673,11 @@ def _systemd_user_dir(home: Path | None = None) -> Path:
 
 def _systemd_unit_bodies(*, workspace: Path, home: Path | None = None) -> dict[str, str]:
     path_value = _path_prefix(home)
+    identity = _target_identity(workspace)
     units: dict[str, str] = {}
     for entry in CARE_ENTRIES:
-        service_name = f"brigade-{entry.entry_id}.service"
-        timer_name = f"brigade-{entry.entry_id}.timer"
+        service_name = f"brigade-care-{identity}-{entry.entry_id}.service"
+        timer_name = f"brigade-care-{identity}-{entry.entry_id}.timer"
         assert entry.kind == "runbook" and entry.runbook_rel is not None
         exec_start = _systemd_exec_start_runbook(entry.runbook_rel)
         service_body = "\n".join(
@@ -580,6 +723,7 @@ def _install_systemd(
     home: Path | None,
 ) -> int:
     unit_dir = _systemd_user_dir(home)
+    identity = _target_identity(target)
     units = _systemd_unit_bodies(workspace=target, home=home)
     results: list[dict[str, Any]] = []
     blocked = False
@@ -667,8 +811,8 @@ def _install_systemd(
         "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
         "next_commands": [
             "systemctl --user daemon-reload",
-            "systemctl --user enable --now brigade-daily-care.timer",
-            "systemctl --user list-timers 'brigade-*.timer'",
+            f"systemctl --user enable --now brigade-care-{identity}-daily-care.timer",
+            f"systemctl --user list-timers 'brigade-care-{identity}-*.timer'",
         ],
     }
     _print_payload(payload, json_output=json_output)
@@ -698,6 +842,13 @@ def status(
     if backend not in SUPPORTED_BACKENDS:
         print(f"error: unsupported care backend: {backend}", file=sys.stderr)
         return 2
+    backend = _resolve_backend(backend) or ""
+    if not backend:
+        print(
+            f"error: care scheduler is unsupported on {sys.platform}; supported platforms: Linux (systemd user timers), macOS (launchd)",
+            file=sys.stderr,
+        )
+        return 3
     if _is_windows():
         windows_payload: dict[str, Any] = {
             "target": str(target),
@@ -708,6 +859,9 @@ def status(
         }
         _print_payload(windows_payload, json_output=json_output)
         return 3
+
+    if backend == "launchd":
+        return _launchd_status(target=target, json_output=json_output, home=home)
 
     if backend == "crontab":
         current, error = _read_crontab()
@@ -832,6 +986,13 @@ def uninstall(
     if backend not in SUPPORTED_BACKENDS:
         print(f"error: unsupported care backend: {backend}", file=sys.stderr)
         return 2
+    backend = _resolve_backend(backend) or ""
+    if not backend:
+        print(
+            f"error: care scheduler is unsupported on {sys.platform}; supported platforms: Linux (systemd user timers), macOS (launchd)",
+            file=sys.stderr,
+        )
+        return 3
     if _is_windows():
         print("care uninstall: Windows Task Scheduler is not mutated automatically.")
         print("Remove BrigadeCare-* tasks with schtasks /Delete, or Task Scheduler UI.")
@@ -839,6 +1000,9 @@ def uninstall(
             print(f'schtasks /Delete /TN "BrigadeCare-{entry.entry_id}" /F')
         print("error: care uninstall does not mutate the Windows scheduler in this release", file=sys.stderr)
         return 3
+
+    if backend == "launchd":
+        return _launchd_uninstall(target=target, dry_run=dry_run, json_output=json_output, home=home)
 
     if backend == "crontab":
         current, error = _read_crontab()
@@ -883,9 +1047,10 @@ def uninstall(
     skipped: list[str] = []
     refused: list[str] = []
     blocked = False
+    identity = _target_identity(target)
     for entry in CARE_ENTRIES:
         for suffix in (".service", ".timer"):
-            name = f"brigade-{entry.entry_id}{suffix}"
+            name = f"brigade-care-{identity}-{entry.entry_id}{suffix}"
             path = unit_dir / name
             if not path.exists():
                 skipped.append(name)
@@ -939,6 +1104,8 @@ def uninstall(
         "next_commands": ["systemctl --user daemon-reload"],
     }
     _print_payload(payload, json_output=json_output)
+    if not removed and not refused:
+        print(f"no scheduler registration found for target: {target}")
     if blocked:
         print(
             "error: one or more systemd units were hand-edited; refusing to remove without repair",

--- a/src/brigade/cli/care.py
+++ b/src/brigade/cli/care.py
@@ -23,9 +23,9 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_install.add_argument(
         "--backend",
-        choices=["crontab", "systemd"],
-        default="crontab",
-        help="Scheduler backend to write (default: crontab). Windows prints Task Scheduler equivalents.",
+        choices=["auto", "systemd", "launchd"],
+        default="auto",
+        help="Scheduler backend (default: systemd on Linux, launchd on macOS).",
     )
     p_install.add_argument("--dry-run", action="store_true", help="Show the plan without writing.")
     p_install.add_argument(
@@ -42,9 +42,9 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_status.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_status.add_argument(
         "--backend",
-        choices=["crontab", "systemd"],
-        default="crontab",
-        help="Scheduler backend to inspect (default: crontab).",
+        choices=["auto", "systemd", "launchd"],
+        default="auto",
+        help="Scheduler backend (default: systemd on Linux, launchd on macOS).",
     )
     p_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
@@ -57,9 +57,9 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_uninstall.add_argument(
         "--backend",
-        choices=["crontab", "systemd"],
-        default="crontab",
-        help="Scheduler backend to clean (default: crontab).",
+        choices=["auto", "systemd", "launchd"],
+        default="auto",
+        help="Scheduler backend (default: systemd on Linux, launchd on macOS).",
     )
     p_uninstall.add_argument("--dry-run", action="store_true", help="Show the plan without writing.")
     p_uninstall.add_argument("--json", action="store_true", help="Print machine-readable JSON.")

--- a/tests/test_care_cmd.py
+++ b/tests/test_care_cmd.py
@@ -62,6 +62,19 @@ def test_care_launchd_registrations_are_target_namespaced(tmp_path, monkeypatch,
     assert "no scheduler registration found" in capsys.readouterr().out
 
 
+def test_care_launchd_weekly_weekday_matches_cron_monday(tmp_path):
+    import plistlib
+
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    plists = care_cmd._launchd_plists(workspace=target, home=home)
+    weekly_name = next(name for name in plists if "weekly-outcome-ratchet" in name)
+    payload = plistlib.loads(plists[weekly_name])
+    # cron "0 7 * * 1" and launchd both use 1 = Monday
+    assert payload["StartCalendarInterval"] == {"Minute": 0, "Hour": 7, "Weekday": 1}
+
+
 def test_care_auto_backend_is_explicitly_unsupported_elsewhere(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(care_cmd.sys, "platform", "plan9")
     assert care_cmd.status(target=tmp_path) == 3

--- a/tests/test_care_cmd.py
+++ b/tests/test_care_cmd.py
@@ -3,11 +3,69 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from pathlib import Path
 
 import pytest
 
 from brigade import care_cmd, cli, managed_block, memory_cmd
+
+
+def test_care_registration_identity_is_stable_and_target_specific(tmp_path):
+    first = (tmp_path / "first").resolve()
+    second = (tmp_path / "second").resolve()
+    expected = hashlib.sha256(str(first).encode()).hexdigest()[:16]
+    assert care_cmd._target_identity(first) == expected
+    assert care_cmd._target_identity(first) != care_cmd._target_identity(second)
+
+
+def _daily_service(home: Path, target: Path) -> Path:
+    identity = care_cmd._target_identity(target)
+    return home / ".config" / "systemd" / "user" / f"brigade-care-{identity}-daily-care.service"
+
+
+def test_care_systemd_uninstall_only_invoking_target(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=first, backend="systemd", home=home) == 0
+    assert care_cmd.install(target=second, backend="systemd", home=home) == 0
+    second_units = set(care_cmd._systemd_unit_bodies(workspace=second, home=home))
+
+    assert care_cmd.uninstall(target=first, backend="systemd", home=home) == 0
+    unit_dir = care_cmd._systemd_user_dir(home)
+    assert all((unit_dir / name).is_file() for name in second_units)
+
+    assert care_cmd.uninstall(target=first, backend="systemd", home=home) == 0
+    assert "no scheduler registration found" in capsys.readouterr().out
+
+
+def test_care_launchd_registrations_are_target_namespaced(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=first, backend="launchd", home=home) == 0
+    assert care_cmd.install(target=second, backend="launchd", home=home) == 0
+    second_names = set(care_cmd._launchd_plists(workspace=second, home=home))
+    assert care_cmd.uninstall(target=first, backend="launchd", home=home) == 0
+    assert all((care_cmd._launchd_dir(home) / name).is_file() for name in second_names)
+    assert care_cmd.uninstall(target=first, backend="launchd", home=home) == 0
+    assert "no scheduler registration found" in capsys.readouterr().out
+
+
+def test_care_auto_backend_is_explicitly_unsupported_elsewhere(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(care_cmd.sys, "platform", "plan9")
+    assert care_cmd.status(target=tmp_path) == 3
+    assert "unsupported on plan9" in capsys.readouterr().err
 
 
 def test_care_managed_block_round_trip_preserves_neighbor_content():
@@ -90,7 +148,7 @@ def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch)
     # Seed memory-care runbooks so status can report presence.
     assert memory_cmd._write_memory_care_runbooks(target) == 0
 
-    assert care_cmd.install(target=target, json_output=True) == 0
+    assert care_cmd.install(target=target, backend="crontab", json_output=True) == 0
     assert "# BEGIN BRIGADE CARE" in store["text"]
     assert "<!-- BEGIN" not in store["text"]
     assert "keep-me" in store["text"]
@@ -110,11 +168,11 @@ def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch)
     assert len(digest.meta.recorded_hash or "") == 64
 
     # Idempotent reinstall is a no-op write path (status current).
-    assert care_cmd.install(target=target, json_output=True) == 0
+    assert care_cmd.install(target=target, backend="crontab", json_output=True) == 0
 
-    assert care_cmd.status(target=target, json_output=True) == 0
+    assert care_cmd.status(target=target, backend="crontab", json_output=True) == 0
     # Uninstall restores prior crontab bytes.
-    assert care_cmd.uninstall(target=target, json_output=True) == 0
+    assert care_cmd.uninstall(target=target, backend="crontab", json_output=True) == 0
     assert store["text"] == before
 
 
@@ -134,11 +192,11 @@ def test_care_status_reports_tampered_block_without_clobber(tmp_path, monkeypatc
     monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
     monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
 
-    assert care_cmd.status(target=tmp_path, json_output=True) == 1
+    assert care_cmd.status(target=tmp_path, backend="crontab", json_output=True) == 1
     out = json.loads(capsys.readouterr().out)
     assert out["status"] == "tampered"
 
-    assert care_cmd.install(target=tmp_path, json_output=True) == 1
+    assert care_cmd.install(target=tmp_path, backend="crontab", json_output=True) == 1
     assert "16 6 * * *" in store["text"]  # unchanged
 
 
@@ -157,7 +215,7 @@ def test_care_uninstall_refuses_tampered_crontab_block(tmp_path, monkeypatch, ca
     )
     monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
 
-    assert care_cmd.uninstall(target=tmp_path, json_output=True) == 1
+    assert care_cmd.uninstall(target=tmp_path, backend="crontab", json_output=True) == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "tampered"
     assert payload["action"] == managed_block.ACTION_PRESERVE
@@ -194,7 +252,7 @@ def test_care_status_includes_latest_runbook_receipt(tmp_path, monkeypatch, caps
     }
     (runs / "receipt.json").write_text(json.dumps(receipt), encoding="utf-8")
 
-    assert care_cmd.status(target=tmp_path, json_output=True) == 0
+    assert care_cmd.status(target=tmp_path, backend="crontab", json_output=True) == 0
     payload = json.loads(capsys.readouterr().out)
     daily = next(entry for entry in payload["entries"] if entry["id"] == "daily-care")
     assert daily["last_receipt"]["run_id"] == receipt["run_id"]
@@ -223,7 +281,7 @@ def test_care_crontab_install_refuses_malformed_markers_without_write(tmp_path, 
     monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
     monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
 
-    assert care_cmd.install(target=tmp_path, json_output=True) == 1
+    assert care_cmd.install(target=tmp_path, backend="crontab", json_output=True) == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == managed_block.STATUS_MALFORMED
     assert payload["action"] == managed_block.ACTION_PRESERVE
@@ -239,7 +297,7 @@ def test_care_crontab_percent_in_path_is_escaped(tmp_path, monkeypatch):
     monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda t: 0)
     monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
 
-    assert care_cmd.install(target=target, json_output=True) == 0
+    assert care_cmd.install(target=target, backend="crontab", json_output=True) == 0
     body = care_cmd._crontab_body(workspace=target)
     assert r'cd "ws\%pct"' in body or rf'cd "{target}"'.replace("%", "\\%") in body
     assert "\\%" in body
@@ -253,7 +311,7 @@ def test_care_systemd_install_refuses_malformed_unit_without_write(tmp_path, mon
     target.mkdir()
 
     assert care_cmd.install(target=target, backend="systemd", home=home) == 0
-    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service = _daily_service(home, target)
     before = service.read_text(encoding="utf-8")
     html = managed_block.render_block(
         "tampered-body\n",
@@ -267,7 +325,7 @@ def test_care_systemd_install_refuses_malformed_unit_without_write(tmp_path, mon
     assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["blocked"] is True
-    unit = next(item for item in payload["units"] if item["name"] == "brigade-daily-care.service")
+    unit = next(item for item in payload["units"] if item["name"] == _daily_service(home, target).name)
     assert unit["status"] == managed_block.STATUS_MALFORMED
     assert unit["action"] == managed_block.ACTION_PRESERVE
     assert unit["detail"]
@@ -331,8 +389,8 @@ def test_care_systemd_install_writes_hash_stamped_units(tmp_path, monkeypatch):
 
     assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
     unit_dir = home / ".config" / "systemd" / "user"
-    service = unit_dir / "brigade-daily-care.service"
-    timer = unit_dir / "brigade-daily-care.timer"
+    service = _daily_service(home, target)
+    timer = unit_dir / f"brigade-care-{care_cmd._target_identity(target)}-daily-care.timer"
     assert service.is_file()
     assert timer.is_file()
     text = service.read_text(encoding="utf-8")
@@ -357,7 +415,7 @@ def test_care_systemd_unit_quotes_workspace_paths_with_spaces(tmp_path, monkeypa
     target.mkdir()
 
     assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
-    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service = _daily_service(home, target)
     text = service.read_text(encoding="utf-8")
     parsed = managed_block.parse_blocks(text, kind=care_cmd.CARE_KIND, style=care_cmd.CARE_MARKER_STYLE)
     assert parsed.status == "ok"
@@ -376,7 +434,7 @@ def test_care_systemd_environment_path_quotes_home_with_spaces(tmp_path, monkeyp
     target.mkdir()
 
     assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
-    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service = _daily_service(home, target)
     parsed = managed_block.parse_blocks(
         service.read_text(encoding="utf-8"),
         kind=care_cmd.CARE_KIND,
@@ -395,7 +453,7 @@ def test_care_systemd_percent_in_path_is_escaped(tmp_path, monkeypatch):
     target.mkdir()
 
     assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
-    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service = _daily_service(home, target)
     parsed = managed_block.parse_blocks(
         service.read_text(encoding="utf-8"),
         kind=care_cmd.CARE_KIND,
@@ -414,7 +472,7 @@ def test_care_systemd_uninstall_refuses_tampered_unit(tmp_path, monkeypatch):
     target.mkdir()
 
     assert care_cmd.install(target=target, backend="systemd", home=home) == 0
-    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service = _daily_service(home, target)
     tampered = service.read_text(encoding="utf-8").replace("daily-care-pass", "daily-care-TAMPERED")
     service.write_text(tampered, encoding="utf-8")
 
@@ -536,14 +594,14 @@ def test_care_systemd_status_reports_broken_symlink_as_malformed(tmp_path, monke
     target.mkdir()
 
     assert care_cmd.install(target=target, backend="systemd", home=home) == 0
-    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service = _daily_service(home, target)
     service.unlink()
     service.symlink_to(home / "missing.service")
     capsys.readouterr()
 
     assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 1
     payload = json.loads(capsys.readouterr().out)
-    unit = next(item for item in payload["units"] if item["name"] == "brigade-daily-care.service")
+    unit = next(item for item in payload["units"] if item["name"] == _daily_service(home, target).name)
     assert unit["status"] == managed_block.STATUS_MALFORMED
 
 
@@ -555,7 +613,7 @@ def test_care_systemd_uninstall_skips_symlink_swap(tmp_path, monkeypatch):
     target.mkdir()
 
     assert care_cmd.install(target=target, backend="systemd", home=home) == 0
-    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service = _daily_service(home, target)
     secret = tmp_path / "secret.service"
     secret.write_text("[Unit]\nDescription=secret\n", encoding="utf-8")
     service.unlink()


### PR DESCRIPTION
## Summary
- Namespace systemd user units and launchd agents by a hash of the absolute target path.
- Prove uninstall of target A leaves target B registrations intact (systemd + launchd).
- Update care docs/changelog for the target-scoped install/status/uninstall model.

Fixes #759

## Scrutiny
Previous attempt was rejected for cross-target uninstall risk. This diff includes and passes:
- `test_care_registration_identity_is_stable_and_target_specific`
- `test_care_systemd_uninstall_only_invoking_target`
- `test_care_launchd_registrations_are_target_namespaced`

## Test plan
- [x] Cross-target identity + uninstall tests via `brigade work verify run`
- [x] Broader `tests/test_care_cmd.py` excluding host-permission `crontab -n` probes

Note: `test_care_crontab_block_passes_crontab_syntax_check` and `test_care_crontab_percent_path_passes_crontab_syntax_check` fail on this host with `/var/spool/cron/: mkstemp: Permission denied` (environment), not cross-target uninstall logic.


Made with [Cursor](https://cursor.com)