### PR TITLE
feat(center): code graph module map, impact view, and export contract

### DIFF
--- a/schemas/code-graph-export.v1.schema.json
+++ b/schemas/code-graph-export.v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://brigade.tools/schemas/code-graph-export.v1.schema.json",
+  "title": "Brigade code graph export v1",
+  "description": "Read-only Center/operator contract for module map, impact drill-down, and optional change overlay.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "schema_version", "target", "generated_at", "stats", "module_map"],
+  "properties": {
+    "schema": {"const": "brigade.code-graph-export.v1"},
+    "schema_version": {"const": 1},
+    "target": {"type": "string", "minLength": 1},
+    "generated_at": {"type": "string", "minLength": 1},
+    "stats": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "module_map": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["modules", "edges", "truncation"],
+      "properties": {
+        "modules": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/module"}
+        },
+        "edges": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/module_edge"}
+        },
+        "truncation": {"$ref": "#/$defs/truncation"}
+      }
+    },
+    "impact": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "change_overlay": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "error": {"type": "string"}
+  },
+  "$defs": {
+    "module": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "symbol_count", "file_count"],
+      "properties": {
+        "id": {"type": "string"},
+        "label": {"type": "string"},
+        "symbol_count": {"type": "integer", "minimum": 0},
+        "file_count": {"type": "integer", "minimum": 0},
+        "changed": {"type": "boolean"}
+      }
+    },
+    "module_edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to", "weight"],
+      "properties": {
+        "from": {"type": "string"},
+        "to": {"type": "string"},
+        "weight": {"type": "integer", "minimum": 0}
+      }
+    },
+    "truncation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shown_modules", "hidden_modules", "shown_edges", "hidden_edges"],
+      "properties": {
+        "shown_modules": {"type": "integer", "minimum": 0},
+        "hidden_modules": {"type": "integer", "minimum": 0},
+        "shown_edges": {"type": "integer", "minimum": 0},
+        "hidden_edges": {"type": "integer", "minimum": 0},
+        "note": {"type": "string"}
+      }
+    }
+  }
+}

--- a/src/brigade/center_cmd/dashboard/views/__init__.py
+++ b/src/brigade/center_cmd/dashboard/views/__init__.py
@@ -19,6 +19,7 @@ from brigade.center_cmd.dashboard import render
 from brigade.center_cmd.dashboard.views import (
     activity_heatmap,
     agent_activity,
+    code_graph,
     dispatch_waves,
     handoff_inbox,
     memory_operations,
@@ -37,6 +38,7 @@ _VIEW_MODULES: tuple[ModuleType, ...] = (
     run_timeline,
     activity_heatmap,
     agent_activity,
+    code_graph,
     ready_graph,
     dispatch_waves,
     task_claims,

--- a/src/brigade/center_cmd/dashboard/views/code_graph.py
+++ b/src/brigade/center_cmd/dashboard/views/code_graph.py
@@ -1,0 +1,443 @@
+"""Code Graph dashboard view — module map, impact drill-down, change overlay.
+
+Contract-only: ``brigade code export --json`` (and ``--symbol`` for impact).
+No direct graph database reads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from brigade import code_export
+from brigade.center_cmd.dashboard import data
+from brigade.center_cmd.dashboard import render as html
+
+NAME = "code"
+TITLE = "Code Graph"
+ORDER = 6.25
+
+_STATUS_GOOD = "#0ca30c"
+_STATUS_WARNING = "#fab219"
+_STATUS_SERIOUS = "#ec835a"
+_STATUS_CRITICAL = "#d03b3b"
+_TEXT_PRIMARY = "#0b0b0b"
+_TEXT_SECONDARY = "#52514e"
+_SURFACE = "#fcfcfb"
+_BORDER = "rgba(11,11,11,0.10)"
+_BOX_FILL = "#f3f3f1"
+_BOX_STROKE = "#c3c2b7"
+_CHANGED_FILL = "#fff4e0"
+_CHANGED_STROKE = "#fab219"
+
+_COLS = 6
+_BOX_W = 132
+_BOX_MIN_H = 36
+_BOX_MAX_H = 88
+_GAP_X = 28
+_GAP_Y = 22
+_PAD = 20
+
+
+def fetch(target: Path, query: dict[str, str] | None = None) -> dict[str, Any]:
+    symbol = (query or {}).get("symbol", "").strip() or None
+    args = ["code", "export"]
+    if symbol:
+        args.extend(["--symbol", symbol])
+    args.append("--overlay")
+    export = data.run_json(target, args, timeout=60.0)
+    return {"export": export, "symbol": symbol}
+
+
+def render(payload: dict, nonce: str) -> str:
+    export = payload.get("export") if isinstance(payload.get("export"), dict) else {}
+    symbol = payload.get("symbol")
+
+    if export.get("error"):
+        return html.error_panel(TITLE, str(export["error"]))
+
+    parts = [
+        _stylesheet(nonce),
+        _mode_tabs(bool(symbol)),
+        '<div id="cg-map" class="cg-panel" data-cg-panel="map" role="tabpanel">',
+        _render_module_map(export),
+        "</div>",
+        '<div id="cg-impact" class="cg-panel" data-cg-panel="impact" role="tabpanel">',
+        _render_impact(export, symbol),
+        "</div>",
+        _script(nonce),
+    ]
+    return "".join(parts)
+
+
+def _mode_tabs(impact_active: bool) -> str:
+    map_sel = "false" if impact_active else "true"
+    impact_sel = "true" if impact_active else "false"
+    return (
+        '<div class="cg-modes" role="tablist" aria-label="' + html.esc("Code graph modes") + '">'
+        f'<a href="#cg-map" class="cg-mode" data-cg-mode="map" aria-selected="{map_sel}" '
+        f'tabindex="{"0" if not impact_active else "-1"}">' + html.esc("Module map") + "</a>"
+        f'<a href="#cg-impact" class="cg-mode" data-cg-mode="impact" aria-selected="{impact_sel}" '
+        f'tabindex="{"0" if impact_active else "-1"}">' + html.esc("Impact") + "</a>"
+        "</div>"
+    )
+
+
+def _summary_strip(export: dict) -> str:
+    stats = export.get("stats") if isinstance(export.get("stats"), dict) else {}
+    module_map = export.get("module_map") if isinstance(export.get("module_map"), dict) else {}
+    trunc = module_map.get("truncation") if isinstance(module_map.get("truncation"), dict) else {}
+    modules = module_map.get("modules") if isinstance(module_map.get("modules"), list) else []
+    overlay = export.get("change_overlay") if isinstance(export.get("change_overlay"), dict) else {}
+
+    symbols = stats.get("symbols")
+    files = stats.get("files")
+    sentences: list[str] = []
+    if isinstance(symbols, int) and isinstance(files, int):
+        sentences.append(f"This graph indexes {symbols:,} symbols across {files:,} files.")
+    else:
+        sentences.append("This graph summarizes how code is connected in the repository.")
+
+    changed = overlay.get("changed_modules") if isinstance(overlay.get("changed_modules"), list) else []
+    if changed:
+        sentences.append(f"{len(changed)} module(s) include files changed on this branch.")
+    elif modules:
+        top = max(modules, key=lambda row: int(row.get("symbol_count") or 0) if isinstance(row, dict) else 0)
+        if isinstance(top, dict):
+            sentences.append(f"Largest module by symbol count: {top.get('label') or top.get('id')}.")
+
+    note = trunc.get("note")
+    if isinstance(note, str) and note.strip():
+        sentences.append(note.strip())
+
+    body = " ".join(sentences[:3])
+    return (
+        f'<section class="cg-summary" aria-label="{html.esc("Code graph summary")}"><p>{html.esc(body)}</p></section>'
+    )
+
+
+def _render_module_map(export: dict) -> str:
+    module_map = export.get("module_map") if isinstance(export.get("module_map"), dict) else {}
+    modules = [row for row in module_map.get("modules", []) if isinstance(row, dict)]
+    edges = [row for row in module_map.get("edges", []) if isinstance(row, dict)]
+    trunc = module_map.get("truncation") if isinstance(module_map.get("truncation"), dict) else {}
+
+    if not modules:
+        return html.panel(html.esc("Module map"), f"<p>{html.esc('Nothing here.')}</p>")
+
+    trunc_note = ""
+    if isinstance(trunc.get("note"), str) and trunc["note"].strip():
+        trunc_note = f'<p class="cg-muted">{html.esc(trunc["note"])}</p>'
+
+    return (
+        _summary_strip(export)
+        + html.panel(html.esc("Module map"), trunc_note + _module_map_svg(modules, edges))
+        + _debug_details(export)
+    )
+
+
+def _module_map_svg(modules: list[dict], edges: list[dict]) -> str:
+    if not modules:
+        return f"<p>{html.esc('Nothing here.')}</p>"
+
+    positions: dict[str, tuple[int, int, int, int]] = {}
+    max_symbols = max(int(row.get("symbol_count") or 0) for row in modules) or 1
+    cols = min(_COLS, max(1, len(modules)))
+    rows = (len(modules) + cols - 1) // cols
+
+    boxes: list[str] = []
+    for index, module in enumerate(modules):
+        col = index % cols
+        row = index // cols
+        x = _PAD + col * (_BOX_W + _GAP_X)
+        y = _PAD + row * (_BOX_MAX_H + _GAP_Y)
+        symbol_count = int(module.get("symbol_count") or 0)
+        ratio = symbol_count / max_symbols
+        height = int(_BOX_MIN_H + ratio * (_BOX_MAX_H - _BOX_MIN_H))
+        module_id = str(module.get("id") or "")
+        label = str(module.get("label") or module_id)
+        visible, full = code_export.fit_svg_label(label, _BOX_W - 16)
+        count_text = f" ({symbol_count})" if symbol_count else ""
+        fill = _CHANGED_FILL if module.get("changed") else _BOX_FILL
+        stroke = _CHANGED_STROKE if module.get("changed") else _BOX_STROKE
+        chip = _status_chip(x, y, height, "CHANGED" if module.get("changed") else "OK", module.get("changed") is True)
+        positions[module_id] = (x, y, _BOX_W, height)
+        boxes.append(
+            f'<g class="cg-module" role="img">'
+            f"<title>{html.esc(full)}{html.esc(count_text)}</title>"
+            f'<rect x="{x}" y="{y}" width="{_BOX_W}" height="{height}" rx="6" ry="6" '
+            f'fill="{html.esc(fill)}" stroke="{html.esc(stroke)}" stroke-width="1.5"/>'
+            f'<text x="{x + 8}" y="{y + 20}" class="cg-svg-label">{html.esc(visible)}{html.esc(count_text)}</text>'
+            f"{chip}"
+            f"</g>"
+        )
+
+    edge_lines: list[str] = []
+    for edge in edges:
+        source = str(edge.get("from") or "")
+        target = str(edge.get("to") or "")
+        if source not in positions or target not in positions:
+            continue
+        sx, sy, sw, sh = positions[source]
+        tx, ty, tw, th = positions[target]
+        x1, y1 = sx + sw, sy + sh // 2
+        x2, y2 = tx, ty + th // 2
+        weight = int(edge.get("weight") or 0)
+        edge_lines.append(
+            f'<g class="cg-edge"><title>{html.esc(f"{source} → {target} ({weight})")}</title>'
+            f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{html.esc(_BOX_STROKE)}" '
+            f'stroke-width="{min(4, 1 + weight // 3)}" marker-end="url(#cg-arrow)"/></g>'
+        )
+
+    width = _PAD * 2 + cols * _BOX_W + max(0, cols - 1) * _GAP_X
+    height = _PAD * 2 + rows * _BOX_MAX_H + max(0, rows - 1) * _GAP_Y
+
+    return (
+        f'<div class="cg-map-wrap"><svg class="cg-map" viewBox="0 0 {width} {height}" width="100%" '
+        f'role="img" aria-label="{html.esc("Module map")}">'
+        "<defs>"
+        '<marker id="cg-arrow" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="6" markerHeight="6" orient="auto-start-reverse">'
+        f'<path d="M 0 0 L 10 5 L 0 10 z" fill="{html.esc(_BOX_STROKE)}"/>'
+        "</marker></defs>" + "".join(edge_lines) + "".join(boxes) + "</svg></div>"
+    )
+
+
+def _status_chip(box_x: int, box_y: int, box_h: int, word: str, changed: bool) -> str:
+    if changed:
+        color, icon = _STATUS_WARNING, "!"
+    else:
+        color, icon = _STATUS_GOOD, "\u2713"
+    chip_x = box_x + _BOX_W - 58
+    chip_y = box_y + box_h - 24
+    return (
+        f'<rect x="{chip_x}" y="{chip_y}" width="50" height="16" rx="8" ry="8" fill="{html.esc(_SURFACE)}" '
+        f'stroke="{html.esc(color)}" stroke-width="1.2"/>'
+        f'<circle cx="{chip_x + 8}" cy="{chip_y + 8}" r="4" fill="{html.esc(color)}"/>'
+        f'<text x="{chip_x + 8}" y="{chip_y + 11}" text-anchor="middle" class="cg-svg-chip-icon">{html.esc(icon)}</text>'
+        f'<text x="{chip_x + 30}" y="{chip_y + 11}" text-anchor="middle" class="cg-svg-chip-word">{html.esc(word)}</text>'
+    )
+
+
+def _render_impact(export: dict, symbol: str | None) -> str:
+    search_form = (
+        '<form class="cg-search" method="get" action="/view/code">'
+        f"<label>{html.esc('Symbol or file')} "
+        f'<input type="search" name="symbol" value="{html.esc(symbol or "")}" '
+        f'placeholder="{html.esc("e.g. dispatch or src/brigade/proc.py")}" '
+        f'aria-label="{html.esc("Symbol search")}"></label>'
+        f'<button type="submit">{html.esc("Show impact")}</button>'
+        "</form>"
+    )
+
+    impact = export.get("impact") if isinstance(export.get("impact"), dict) else None
+    if not symbol:
+        return html.panel(
+            html.esc("Impact"),
+            search_form
+            + f"<p>{html.esc('Search for a symbol to see callers, blast radius, and attributed tests.')}</p>",
+        )
+    if not impact:
+        return html.panel(
+            html.esc("Impact"),
+            search_form + f"<p>{html.esc('No impact data for that symbol.')}</p>",
+        )
+
+    resolved = impact.get("resolved_symbol") if isinstance(impact.get("resolved_symbol"), dict) else {}
+    plain_name = str(resolved.get("name") or resolved.get("qualified_name") or symbol)
+    file_path = str(resolved.get("file_path") or "")
+    intro = f"Blast radius for {plain_name}."
+    if file_path:
+        intro += f" Defined in {file_path}."
+
+    callers = impact.get("callers") if isinstance(impact.get("callers"), list) else []
+    edges = impact.get("edges") if isinstance(impact.get("edges"), list) else []
+    affected = impact.get("affected_tests") if isinstance(impact.get("affected_tests"), dict) else {}
+
+    sections = [
+        search_form,
+        f'<p class="cg-impact-intro">{html.esc(intro)}</p>',
+        _impact_diagram(plain_name, callers, edges),
+        _impact_table("Direct callers", callers, limit=20),
+        _impact_table("Impact set", edges, limit=40),
+        _affected_tests_table(affected),
+        _impact_debug(impact),
+    ]
+    return html.panel(html.esc("Impact"), "".join(sections))
+
+
+def _impact_diagram(focus: str, callers: list, edges: list) -> str:
+    layers = [
+        ("Callers", callers[:8]),
+        ("Focus", [{"source": row.get("source"), "target": focus} for row in callers[:1]] or [{"target": focus}]),
+        ("Impact", edges[:10]),
+    ]
+    width = 720
+    height = 200
+    parts = [
+        f'<svg class="cg-impact-diagram" viewBox="0 0 {width} {height}" width="100%" role="img" '
+        f'aria-label="{html.esc("Impact layers")}">'
+    ]
+    x_positions = [80, width // 2, width - 120]
+    for (title, rows), x in zip(layers, x_positions, strict=False):
+        parts.append(f'<text x="{x}" y="24" text-anchor="middle" class="cg-svg-heading">{html.esc(title)}</text>')
+        for index, row in enumerate(rows):
+            if not isinstance(row, dict):
+                continue
+            label = str(row.get("source") or row.get("target") or "?")
+            visible, full = code_export.fit_svg_label(label, 120)
+            box_y = 40 + index * 22
+            parts.append(
+                f"<g><title>{html.esc(full)}</title>"
+                f'<rect x="{x - 60}" y="{box_y}" width="120" height="18" rx="4" fill="{html.esc(_BOX_FILL)}" '
+                f'stroke="{html.esc(_BOX_STROKE)}"/>'
+                f'<text x="{x}" y="{box_y + 13}" text-anchor="middle" class="cg-svg-label">{html.esc(visible)}</text>'
+                f"</g>"
+            )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _impact_table(title: str, rows: list, *, limit: int) -> str:
+    shown = [row for row in rows if isinstance(row, dict)][:limit]
+    hidden = max(0, len(rows) - len(shown))
+    note = ""
+    if hidden:
+        note = f'<p class="cg-muted">{html.esc(f"showing top {len(shown)} rows, {hidden} hidden")}</p>'
+    if not shown:
+        return f"<h3>{html.esc(title)}</h3><p>{html.esc('Nothing here.')}</p>"
+
+    body_rows: list[list[str]] = []
+    for row in shown:
+        source = str(row.get("source") or "-")
+        target = str(row.get("target") or "-")
+        kind = str(row.get("kind") or "-")
+        hops = str(row.get("hops") if row.get("hops") is not None else "-")
+        body_rows.append(
+            [
+                f"{html.esc(source)} "
+                f'<details class="cg-debug"><summary>{html.esc("Ids")}</summary>'
+                f"<code>{html.esc(str(row.get('source_id') or '-'))} → {html.esc(str(row.get('target_id') or '-'))}</code>"
+                f"</details>",
+                html.esc(target),
+                html.esc(kind),
+                html.esc(hops),
+            ]
+        )
+    table = html.table(
+        [html.esc("From"), html.esc("To"), html.esc("Kind"), html.esc("Hops")],
+        body_rows,
+    )
+    return f'<h3>{html.esc(title)}</h3>{note}<div class="cg-scroll">{table}</div>'
+
+
+def _affected_tests_table(affected: dict) -> str:
+    tests = affected.get("affected_tests") if isinstance(affected.get("affected_tests"), list) else []
+    if not tests:
+        return f"<h3>{html.esc('Attributed tests')}</h3><p>{html.esc('No attributed tests.')}</p>"
+    attr = affected.get("attribution")
+    note = f'<p class="cg-muted">{html.esc(str(attr))}</p>' if isinstance(attr, str) and attr else ""
+    rows = []
+    for row in tests:
+        if not isinstance(row, dict):
+            continue
+        path = str(row.get("file_path") or "-")
+        hops = str(row.get("min_hops") if row.get("min_hops") is not None else "-")
+        via = row.get("via") if isinstance(row.get("via"), list) else []
+        via_text = ", ".join(str(item) for item in via[:5])
+        rows.append([html.esc(path), html.esc(hops), html.esc(via_text or "-")])
+    table = html.table([html.esc("Test file"), html.esc("Hops"), html.esc("Via")], rows)
+    return f'<h3>{html.esc("Attributed tests")}</h3>{note}<div class="cg-scroll">{table}</div>'
+
+
+def _impact_debug(impact: dict) -> str:
+    hits = impact.get("search_hits") if isinstance(impact.get("search_hits"), list) else []
+    if not hits:
+        return ""
+    lines = []
+    for row in hits:
+        if not isinstance(row, dict):
+            continue
+        lines.append(
+            f"<li>{html.esc(str(row.get('qualified_name') or row.get('name') or '?'))} "
+            f"({html.esc(str(row.get('file_path') or '-'))})</li>"
+        )
+    return (
+        '<details class="cg-debug-panel">'
+        f"<summary>{html.esc('Search matches (raw)')}</summary>"
+        f"<ul>{''.join(lines)}</ul></details>"
+    )
+
+
+def _debug_details(export: dict) -> str:
+    stats = export.get("stats") if isinstance(export.get("stats"), dict) else {}
+    if not stats:
+        return ""
+    bits = ", ".join(f"{key}={value}" for key, value in sorted(stats.items()))
+    return (
+        '<details class="cg-debug-panel">'
+        f"<summary>{html.esc('Graph stats (raw)')}</summary>"
+        f"<code>{html.esc(bits)}</code></details>"
+    )
+
+
+def _stylesheet(nonce: str) -> str:
+    return f"""<style nonce="{html.esc(nonce)}">
+.cg-modes {{ display:flex; flex-wrap:wrap; gap:0.5rem; margin:0 0 1rem; }}
+.cg-mode {{
+  font:inherit; padding:0.4rem 0.75rem; border:1px solid #666; border-radius:0.25rem;
+  background:#f8f8f8; color:{_TEXT_PRIMARY}; cursor:pointer; text-decoration:none;
+}}
+.cg-mode[aria-selected="true"] {{ background:#0066cc; border-color:#0066cc; color:#fff; font-weight:600; }}
+.cg-summary {{
+  margin:0 0 1rem; padding:0.85rem 1rem; border:1px solid {_BORDER}; border-radius:0.35rem;
+  background:{_SURFACE}; color:{_TEXT_PRIMARY};
+}}
+.cg-summary p {{ margin:0; }}
+.cg-muted {{ color:{_TEXT_SECONDARY}; font-size:0.9rem; }}
+.cg-map-wrap {{ overflow-x:auto; max-width:100%; }}
+.cg-map {{ display:block; min-width:720px; height:auto; }}
+.cg-svg-label {{ fill:{_TEXT_PRIMARY}; font-size:12px; font-family:system-ui,sans-serif; }}
+.cg-svg-heading {{ fill:{_TEXT_SECONDARY}; font-size:11px; font-weight:700; font-family:system-ui,sans-serif; }}
+.cg-svg-chip-word {{ fill:{_TEXT_PRIMARY}; font-size:8px; font-weight:700; font-family:system-ui,sans-serif; }}
+.cg-svg-chip-icon {{ fill:#fff; font-size:7px; font-family:system-ui,sans-serif; }}
+.cg-search {{ display:flex; flex-wrap:wrap; gap:0.75rem; align-items:flex-end; margin:0 0 1rem; }}
+.cg-search label {{ display:flex; flex-direction:column; gap:0.25rem; font-size:0.9rem; }}
+.cg-search input {{ font:inherit; min-width:16rem; padding:0.35rem 0.5rem; }}
+.cg-search button {{ font:inherit; padding:0.4rem 0.75rem; }}
+.cg-impact-intro {{ color:{_TEXT_PRIMARY}; }}
+.cg-impact-diagram {{ display:block; margin:0 0 1rem; min-height:160px; }}
+.cg-scroll {{ overflow-x:auto; max-width:100%; }}
+.cg-debug, .cg-debug-panel {{ margin-top:0.35rem; color:{_TEXT_SECONDARY}; font-size:0.85rem; }}
+.cg-debug summary, .cg-debug-panel summary {{ cursor:pointer; }}
+.cg-panel[hidden] {{ display:none; }}
+</style>
+<noscript><style nonce="{html.esc(nonce)}">.cg-panel[hidden] {{ display:block !important; }}</style></noscript>"""
+
+
+def _script(nonce: str) -> str:
+    return f"""<script nonce="{html.esc(nonce)}">
+(function () {{
+  function selectMode(mode) {{
+    var tabs = document.querySelectorAll("[data-cg-mode]");
+    var panels = document.querySelectorAll("[data-cg-panel]");
+    for (var i = 0; i < tabs.length; i++) {{
+      var tab = tabs[i];
+      var active = tab.getAttribute("data-cg-mode") === mode;
+      tab.setAttribute("aria-selected", active ? "true" : "false");
+      tab.tabIndex = active ? 0 : -1;
+    }}
+    for (var j = 0; j < panels.length; j++) {{
+      panels[j].hidden = panels[j].getAttribute("data-cg-panel") !== mode;
+    }}
+  }}
+  document.addEventListener("click", function (e) {{
+    var t = e.target;
+    if (!t || !t.getAttribute) return;
+    var mode = t.getAttribute("data-cg-mode");
+    if (mode) {{ e.preventDefault(); selectMode(mode); }}
+  }});
+  var params = new URLSearchParams(window.location.search || "");
+  selectMode(params.get("symbol") ? "impact" : "map");
+}})();
+</script>"""

--- a/src/brigade/center_cmd/serve.py
+++ b/src/brigade/center_cmd/serve.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import hmac
 import ipaddress
+import inspect
 import secrets
 import socket
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Sequence
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from brigade.center_cmd.dashboard import render
 from brigade.center_cmd.dashboard.views import all_views, render_nav, view_by_name
@@ -182,6 +183,11 @@ class _DashboardHandler(BaseHTTPRequestHandler):
             return None
         return slug
 
+    def _parse_query(self) -> dict[str, str]:
+        parsed = urlparse(self.path)
+        raw = parse_qs(parsed.query, keep_blank_values=False)
+        return {key: values[0] for key, values in raw.items() if values}
+
     def _render_view(self, view_name: str, nonce: str) -> bytes:
         module = view_by_name(view_name)
         if module is None:
@@ -190,7 +196,12 @@ class _DashboardHandler(BaseHTTPRequestHandler):
         # default error path would answer without the security headers and
         # would put a traceback on the page.
         try:
-            payload = module.fetch(self._target)
+            query = self._parse_query()
+            fetch = module.fetch
+            if "query" in inspect.signature(fetch).parameters:
+                payload = fetch(self._target, query=query)
+            else:
+                payload = fetch(self._target)
             fragment = module.render(payload, nonce)
         except Exception:  # noqa: BLE001 - one broken panel must not take the page down
             fragment = render.error_panel(module.TITLE, "This view failed to render.")

--- a/src/brigade/cli/code.py
+++ b/src/brigade/cli/code.py
@@ -20,7 +20,7 @@ ENGINE_VERBS: dict[str, str] = {
     "affected": "List tests statically attributed to changed files.",
     "evaluate": "Dry-run extraction: print what a sync would store, writing nothing.",
     "explain": "Explain how call edges between two symbols resolved.",
-    "export": "Export the graph as Graphviz dot, GraphML, or JSON Lines.",
+    "export": "Export the graph (dot/graphml/jsonl) or the Center JSON contract (--json).",
     "stats": "Show code graph statistics.",
     "doctor": "Check code graph engine health.",
     "diff": "Diff two indexed graph databases.",

--- a/src/brigade/code_cmd.py
+++ b/src/brigade/code_cmd.py
@@ -81,6 +81,18 @@ def _rebrand(text: str) -> str:
 def run(verb: str, arguments: Sequence[str]) -> int:
     """Run one GraphTrail command and relay its output and exit status."""
 
+    target, forwarded, target_error = _extract_target(arguments)
+    if target_error is not None:
+        print(
+            f"error: {target_error} (usage: brigade code {verb} --target <dir> [engine arguments])",
+            file=sys.stderr,
+        )
+        return 2
+    if verb == "export" and "--json" in forwarded:
+        from . import code_export
+
+        return code_export.run_cli(target or Path("."), list(forwarded))
+
     timeout = _SHORT_OPERATION_TIMEOUT_SECONDS
     timeout_env = _LONG_OPERATION_TIMEOUT_ENVS.get(verb)
     if timeout_env is not None:
@@ -90,13 +102,6 @@ def run(verb: str, arguments: Sequence[str]) -> int:
             return 2
         timeout = configured_timeout
 
-    target, forwarded, target_error = _extract_target(arguments)
-    if target_error is not None:
-        print(
-            f"error: {target_error} (usage: brigade code {verb} --target <dir> [engine arguments])",
-            file=sys.stderr,
-        )
-        return 2
     cwd: Path | None = None
     if target is not None:
         cwd = target.expanduser()

--- a/src/brigade/code_export.py
+++ b/src/brigade/code_export.py
@@ -1,0 +1,407 @@
+"""Versioned code-graph export contract for Center and operators (#887).
+
+Assembles module map, impact drill-down, and optional change overlay by calling
+the Brigade Code facade (graphtrail subprocess). Dashboard code must use
+``brigade code export --json`` via ``data.run_json``; it never opens the graph
+database directly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from . import context_cmd, proc
+from .localio import utc_now_iso_z
+
+SCHEMA = "brigade.code-graph-export.v1"
+SCHEMA_VERSION = 1
+
+MODULE_CAP = 48
+EDGE_CAP = 96
+_SEARCH_LIMIT = 12
+_GRAPH_TIMEOUT = 30.0
+
+
+def export_payload(
+    target: Path,
+    *,
+    symbol: str | None = None,
+    overlay: bool = False,
+) -> dict[str, Any]:
+    """Build the versioned export JSON contract for *target*."""
+    target = target.expanduser().resolve()
+    binary = context_cmd._graphtrail_bin()
+    if binary is None:
+        return _error_payload(target, "graphtrail is not installed; run `brigade setup`")
+
+    db_path = target / ".graphtrail" / "graphtrail.db"
+    if not db_path.is_file():
+        return _error_payload(target, "code graph is not indexed; run `brigade code sync`")
+
+    stats = _run_json(binary, db_path, target, "stats", "--json")
+    if stats is None:
+        return _error_payload(target, "code graph stats unavailable")
+
+    file_graph = _load_file_graph(binary, db_path, target)
+    if file_graph is None:
+        return _error_payload(target, "code graph export unavailable")
+
+    changed_files = _git_changed_files(target) if overlay else []
+    module_map = _build_module_map(file_graph, changed_files=changed_files)
+
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "target": ".",
+        "generated_at": utc_now_iso_z(),
+        "stats": stats,
+        "module_map": module_map,
+    }
+
+    if symbol and symbol.strip():
+        payload["impact"] = _impact_section(binary, db_path, target, symbol.strip())
+
+    if overlay:
+        payload["change_overlay"] = {
+            "changed_files": changed_files,
+            "changed_modules": sorted({_module_key(path) for path in changed_files if _module_key(path)}),
+        }
+
+    return payload
+
+
+def run_cli(target: Path, forwarded: list[str]) -> int:
+    """Dispatch ``brigade code export`` when ``--json`` is present."""
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+
+    json_output = False
+    symbol: str | None = None
+    overlay = False
+    index = 0
+    while index < len(forwarded):
+        token = forwarded[index]
+        if token == "--json":
+            json_output = True
+            index += 1
+            continue
+        if token == "--symbol":
+            if index + 1 >= len(forwarded):
+                print("error: --symbol requires a value", file=sys.stderr)
+                return 2
+            symbol = forwarded[index + 1]
+            index += 2
+            continue
+        if token.startswith("--symbol="):
+            symbol = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token == "--overlay":
+            overlay = True
+            index += 1
+            continue
+        if token in {"--format", "--scope", "--out"}:
+            if token in {"--format", "--scope", "--out"} and index + 1 < len(forwarded):
+                index += 2
+                continue
+        index += 1
+
+    if not json_output:
+        print(
+            "error: brigade code export requires --json for the Center contract "
+            "(use graphtrail export for dot/graphml/jsonl)",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = export_payload(target, symbol=symbol, overlay=overlay)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if "error" not in payload else 1
+
+
+def _error_payload(target: Path, message: str) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "target": ".",
+        "generated_at": utc_now_iso_z(),
+        "stats": {},
+        "module_map": {
+            "modules": [],
+            "edges": [],
+            "truncation": _truncation_note(0, 0, 0, 0),
+        },
+        "error": message,
+    }
+
+
+def _run_json(binary: str, db_path: Path, target: Path, verb: str, *extra: str) -> Any | None:
+    argv = [binary, "--db", str(db_path), verb, *extra]
+    result = proc.run(argv, timeout=_GRAPH_TIMEOUT, cwd=target)
+    if result.code != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _run_text(binary: str, db_path: Path, target: Path, verb: str, *extra: str) -> str | None:
+    argv = [binary, "--db", str(db_path), verb, *extra]
+    result = proc.run(argv, timeout=_GRAPH_TIMEOUT, cwd=target)
+    if result.code != 0:
+        return None
+    return result.stdout
+
+
+def _load_file_graph(binary: str, db_path: Path, target: Path) -> dict[str, Any] | None:
+    raw = _run_text(
+        binary,
+        db_path,
+        target,
+        "export",
+        "--format",
+        "jsonl",
+        "--scope",
+        "files",
+    )
+    if raw is None:
+        return None
+    nodes: dict[str, int] = {}
+    edges: list[tuple[str, str, int]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        if row.get("type") == "node":
+            file_id = str(row.get("id") or "")
+            symbols = row.get("symbols")
+            count = int(symbols) if isinstance(symbols, int) and symbols >= 0 else 0
+            if file_id:
+                nodes[file_id] = count
+        elif row.get("type") == "edge":
+            source = str(row.get("source") or "")
+            target_file = str(row.get("target") or "")
+            weight = row.get("calls")
+            if not isinstance(weight, int) or weight < 0:
+                weight = 1
+            if source and target_file:
+                edges.append((source, target_file, weight))
+    return {"nodes": nodes, "edges": edges}
+
+
+def _module_key(file_path: str) -> str:
+    parts = PurePosixPath(file_path.replace("\\", "/")).parts
+    if not parts:
+        return "(root)"
+    if parts[0] == "src" and len(parts) >= 4:
+        return str(PurePosixPath(*parts[:3]))
+    if parts[0] == "src" and len(parts) == 3:
+        return str(PurePosixPath(*parts[:2]))
+    if parts[0] == "tests":
+        return "tests" if len(parts) <= 2 else str(PurePosixPath(*parts[:2]))
+    if parts[0] == "engines" and len(parts) >= 4:
+        return str(PurePosixPath(*parts[:3]))
+    if parts[0] == "engines" and len(parts) == 3:
+        return str(PurePosixPath(*parts[:2]))
+    if len(parts) >= 2:
+        return str(PurePosixPath(*parts[:-1]))
+    return parts[0]
+
+
+def _module_label(module_id: str) -> str:
+    name = PurePosixPath(module_id).name
+    return name or module_id
+
+
+def _build_module_map(file_graph: dict[str, Any], *, changed_files: list[str]) -> dict[str, Any]:
+    raw_nodes = file_graph.get("nodes")
+    nodes: dict[str, int] = raw_nodes if isinstance(raw_nodes, dict) else {}
+    raw_edge_list = file_graph.get("edges")
+    raw_edges: list[tuple[str, str, int]] = raw_edge_list if isinstance(raw_edge_list, list) else []
+
+    module_symbols: dict[str, int] = defaultdict(int)
+    module_files: dict[str, int] = defaultdict(int)
+    changed_modules = {_module_key(path) for path in changed_files}
+
+    for file_path, symbol_count in nodes.items():
+        module_id = _module_key(file_path)
+        module_symbols[module_id] += symbol_count
+        module_files[module_id] += 1
+
+    module_edges: dict[tuple[str, str], int] = defaultdict(int)
+    for source, target_file, weight in raw_edges:
+        source_mod = _module_key(source)
+        target_mod = _module_key(target_file)
+        if source_mod == target_mod:
+            continue
+        module_edges[(source_mod, target_mod)] += weight
+
+    modules_sorted = sorted(
+        module_symbols.items(),
+        key=lambda item: (-item[1], item[0]),
+    )
+    total_modules = len(modules_sorted)
+    shown_modules = modules_sorted[:MODULE_CAP]
+    hidden_modules = max(0, total_modules - len(shown_modules))
+    shown_ids = {module_id for module_id, _ in shown_modules}
+
+    modules = [
+        {
+            "id": module_id,
+            "label": _module_label(module_id),
+            "symbol_count": count,
+            "file_count": module_files.get(module_id, 0),
+            **({"changed": True} if module_id in changed_modules else {}),
+        }
+        for module_id, count in shown_modules
+    ]
+
+    edges_sorted = sorted(module_edges.items(), key=lambda item: (-item[1], item[0][0], item[0][1]))
+    filtered_edges = [(pair, weight) for pair, weight in edges_sorted if pair[0] in shown_ids and pair[1] in shown_ids]
+    total_edges = len(filtered_edges)
+    shown_edge_rows = filtered_edges[:EDGE_CAP]
+    hidden_edges = max(0, total_edges - len(shown_edge_rows))
+
+    edges = [{"from": source, "to": target, "weight": weight} for (source, target), weight in shown_edge_rows]
+
+    trunc = _truncation_note(len(modules), hidden_modules, len(edges), hidden_edges)
+    return {"modules": modules, "edges": edges, "truncation": trunc}
+
+
+def _truncation_note(
+    shown_modules: int,
+    hidden_modules: int,
+    shown_edges: int,
+    hidden_edges: int,
+) -> dict[str, Any]:
+    note_parts: list[str] = []
+    if hidden_modules:
+        note_parts.append(f"showing top {shown_modules} modules, {hidden_modules} hidden")
+    if hidden_edges:
+        note_parts.append(f"showing top {shown_edges} edges, {hidden_edges} hidden")
+    note = "; ".join(note_parts) if note_parts else ""
+    return {
+        "shown_modules": shown_modules,
+        "hidden_modules": hidden_modules,
+        "shown_edges": shown_edges,
+        "hidden_edges": hidden_edges,
+        **({"note": note} if note else {}),
+    }
+
+
+def _impact_argv(binary: str, db: str, verb: str, query: str) -> list[str]:
+    if query.startswith("-"):
+        return [binary, "--db", db, verb, "--json", "--", query]
+    return [binary, "--db", db, verb, query, "--json"]
+
+
+def _impact_section(binary: str, db_path: Path, target: Path, query: str) -> dict[str, Any]:
+    db = str(db_path)
+    search = _run_json(binary, db_path, target, "search", query, "--json")
+    search_hits = search if isinstance(search, list) else []
+    resolved = search_hits[0] if search_hits and isinstance(search_hits[0], dict) else None
+    impact_query = str((resolved or {}).get("qualified_name") or query)
+
+    impact_result = proc.run(_impact_argv(binary, db, "impact", impact_query), timeout=_GRAPH_TIMEOUT, cwd=target)
+    impact_edges: list[Any] = []
+    if impact_result.code == 0:
+        try:
+            parsed = json.loads(impact_result.stdout)
+            if isinstance(parsed, list):
+                impact_edges = parsed
+        except json.JSONDecodeError:
+            impact_edges = []
+
+    callers_result = proc.run(_impact_argv(binary, db, "callers", impact_query), timeout=_GRAPH_TIMEOUT, cwd=target)
+    callers: list[Any] = []
+    if callers_result.code == 0:
+        try:
+            parsed = json.loads(callers_result.stdout)
+            if isinstance(parsed, list):
+                callers = parsed
+        except json.JSONDecodeError:
+            callers = []
+
+    impacted_files = sorted(
+        {
+            str(row.get("source_file") or row.get("target_file") or "").strip()
+            for row in impact_edges
+            if isinstance(row, dict)
+        }
+        - {""}
+    )
+    affected: dict[str, Any] | None = None
+    if impacted_files:
+        argv = [binary, "--db", db, "affected", *impacted_files[:12], "--json"]
+        affected_result = proc.run(argv, timeout=_GRAPH_TIMEOUT, cwd=target)
+        if affected_result.code == 0:
+            try:
+                parsed = json.loads(affected_result.stdout)
+                if isinstance(parsed, dict):
+                    affected = parsed
+            except json.JSONDecodeError:
+                affected = None
+
+    return {
+        "query": query,
+        "resolved_symbol": resolved,
+        "search_hits": search_hits[:_SEARCH_LIMIT],
+        "callers": callers,
+        "edges": impact_edges,
+        "affected_tests": affected,
+    }
+
+
+def _git_changed_files(target: Path) -> list[str]:
+    """Return changed file paths for overlay (best-effort, read-only)."""
+    commands = [
+        ["git", "-C", str(target), "diff", "--name-only", "HEAD"],
+        ["git", "-C", str(target), "diff", "--name-only", "--cached"],
+    ]
+    for base_cmd in (
+        ["git", "-C", str(target), "merge-base", "HEAD", "origin/main"],
+        ["git", "-C", str(target), "merge-base", "HEAD", "main"],
+    ):
+        base_result = proc.run(base_cmd, timeout=5.0)
+        if base_result.code == 0:
+            base = (base_result.stdout or "").strip()
+            if base:
+                commands.append(["git", "-C", str(target), "diff", "--name-only", base, "HEAD"])
+                break
+
+    files: list[str] = []
+    seen: set[str] = set()
+    for argv in commands:
+        result = proc.run(argv, timeout=5.0)
+        if result.code != 0:
+            continue
+        for line in (result.stdout or "").splitlines():
+            path = line.strip()
+            if path and path not in seen:
+                seen.add(path)
+                files.append(path)
+    return sorted(files)
+
+
+def fit_svg_label(text: str, max_width: int, *, font_size: int = 12) -> tuple[str, str]:
+    """Return (visible label, full label) with width-aware truncation for SVG."""
+    full = text.strip() or "?"
+    approx_char = max(1, int(max_width / max(6.0, font_size * 0.62)))
+    if len(full) <= approx_char:
+        return full, full
+    if approx_char <= 1:
+        return "…", full
+    return full[: approx_char - 1] + "…", full

--- a/tests/test_code_export.py
+++ b/tests/test_code_export.py
@@ -1,0 +1,163 @@
+"""Tests for the versioned code-graph export contract (#887)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import code_export
+
+
+def _write_fake_db(target: Path) -> Path:
+    db = target / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.write_bytes(b"fake-graphtrail-index")
+    return db
+
+
+def test_export_payload_schema_and_module_map_from_jsonl(monkeypatch, tmp_path):
+    _write_fake_db(tmp_path)
+    jsonl = "\n".join(
+        [
+            json.dumps({"type": "node", "id": "src/pkg/mod.py", "language": "python", "symbols": 4}),
+            json.dumps({"type": "node", "id": "src/other/util.py", "language": "python", "symbols": 2}),
+            json.dumps({"type": "node", "id": "tests/test_mod.py", "language": "python", "symbols": 1}),
+            json.dumps(
+                {
+                    "type": "edge",
+                    "source": "src/pkg/mod.py",
+                    "target": "src/other/util.py",
+                    "calls": 3,
+                }
+            ),
+        ]
+    )
+
+    def fake_run(argv, **kwargs):
+        from brigade import proc
+
+        joined = " ".join(argv)
+        if " stats " in f" {joined} " and "--json" in argv:
+            return proc.Result(0, json.dumps({"files": 3, "symbols": 7}), "")
+        if " export " in f" {joined} ":
+            return proc.Result(0, jsonl, "")
+        return proc.Result(1, "", "unexpected")
+
+    monkeypatch.setattr(code_export.proc, "run", fake_run)
+    monkeypatch.setattr(code_export.context_cmd, "_graphtrail_bin", lambda: "/bin/graphtrail")
+
+    payload = code_export.export_payload(tmp_path)
+    assert payload["schema"] == "brigade.code-graph-export.v1"
+    assert payload["schema_version"] == 1
+    assert payload["module_map"]["truncation"]["hidden_modules"] == 0
+    modules = {row["label"]: row for row in payload["module_map"]["modules"]}
+    assert modules["pkg"]["symbol_count"] == 4
+    assert modules["other"]["symbol_count"] == 2
+    assert payload["module_map"]["edges"][0]["weight"] == 3
+
+
+def test_export_truncation_labels_hidden_modules(monkeypatch, tmp_path):
+    _write_fake_db(tmp_path)
+    lines = []
+    for index in range(code_export.MODULE_CAP + 5):
+        lines.append(
+            json.dumps({"type": "node", "id": f"src/m{index}/file.py", "language": "python", "symbols": index + 1})
+        )
+    jsonl = "\n".join(lines)
+
+    def fake_run(argv, **kwargs):
+        from brigade import proc
+
+        if "stats" in argv and "--json" in argv:
+            return proc.Result(0, "{}", "")
+        if "export" in argv:
+            return proc.Result(0, jsonl, "")
+        return proc.Result(1, "", "")
+
+    monkeypatch.setattr(code_export.proc, "run", fake_run)
+    monkeypatch.setattr(code_export.context_cmd, "_graphtrail_bin", lambda: "/bin/graphtrail")
+
+    payload = code_export.export_payload(tmp_path)
+    trunc = payload["module_map"]["truncation"]
+    assert trunc["shown_modules"] == code_export.MODULE_CAP
+    assert trunc["hidden_modules"] == 5
+    assert "showing top" in (trunc.get("note") or "").lower()
+
+
+def test_export_impact_section_matches_graphtrail_edges(monkeypatch, tmp_path):
+    _write_fake_db(tmp_path)
+    impact_edges = [
+        {
+            "source": "caller_fn",
+            "target": "target_fn",
+            "kind": "calls",
+            "hops": 1,
+            "source_file": "src/a.py",
+            "target_file": "src/b.py",
+        }
+    ]
+    search_rows = [
+        {
+            "qualified_name": "target_fn",
+            "name": "target_fn",
+            "file_path": "src/b.py",
+            "kind": "function",
+        }
+    ]
+    affected = {
+        "affected_tests": [{"file_path": "tests/test_b.py", "min_hops": 1, "via": ["test_x"]}],
+        "impacted_files": [],
+        "changed_files": ["src/b.py"],
+        "missing_files": [],
+        "truncated": False,
+    }
+
+    def fake_run(argv, **kwargs):
+        from brigade import proc
+
+        if "stats" in argv and "--json" in argv:
+            return proc.Result(0, "{}", "")
+        if "export" in argv:
+            return proc.Result(0, "", "")
+        if "search" in argv:
+            return proc.Result(0, json.dumps(search_rows), "")
+        if "impact" in argv:
+            return proc.Result(0, json.dumps(impact_edges), "")
+        if "callers" in argv:
+            return proc.Result(0, "[]", "")
+        if "affected" in argv:
+            return proc.Result(0, json.dumps(affected), "")
+        return proc.Result(1, "", "")
+
+    monkeypatch.setattr(code_export.proc, "run", fake_run)
+    monkeypatch.setattr(code_export.context_cmd, "_graphtrail_bin", lambda: "/bin/graphtrail")
+
+    payload = code_export.export_payload(tmp_path, symbol="target_fn")
+    assert payload["impact"]["edges"] == impact_edges
+    assert payload["impact"]["affected_tests"] == affected
+
+
+def test_cli_export_json_prints_contract(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        code_export,
+        "export_payload",
+        lambda target, **kwargs: {"schema": "brigade.code-graph-export.v1", "schema_version": 1},
+    )
+    assert code_export.run_cli(tmp_path, ["--json"]) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["schema_version"] == 1
+
+
+def test_code_cmd_routes_export_json_to_contract(monkeypatch, tmp_path):
+    from brigade import code_cmd
+
+    called: list[str] = []
+
+    def fake_cli(target, forwarded):
+        called.append("cli")
+        assert "--json" in forwarded
+        return 0
+
+    monkeypatch.setattr(code_export, "run_cli", fake_cli)
+    assert code_cmd.run("export", ["--target", str(tmp_path), "--json"]) == 0
+    assert called == ["cli"]

--- a/tests/test_code_verbs_and_target.py
+++ b/tests/test_code_verbs_and_target.py
@@ -15,6 +15,8 @@ from brigade import cli, completions, context_cmd, proc
 from brigade.cli.code import ENGINE_VERBS
 
 NEW_VERBS = sorted(set(ENGINE_VERBS) - {"sync", "context", "impact"})
+# `brigade code export --json` is the Center contract, not an engine passthrough.
+PASSTHROUGH_JSON_VERBS = [verb for verb in NEW_VERBS if verb != "export"]
 
 
 def _patch_graphtrail(monkeypatch, *, run_calls: list | None = None, stderr: str = ""):
@@ -35,7 +37,7 @@ def test_engine_verb_table_covers_required_surface():
     assert {"callers", "callees", "affected", "search"} <= set(ENGINE_VERBS)
 
 
-@pytest.mark.parametrize("verb", NEW_VERBS)
+@pytest.mark.parametrize("verb", PASSTHROUGH_JSON_VERBS)
 def test_new_verbs_forward_exact_argv(monkeypatch, verb):
     calls: list[dict] = []
     _patch_graphtrail(monkeypatch, run_calls=calls)
@@ -44,6 +46,17 @@ def test_new_verbs_forward_exact_argv(monkeypatch, verb):
 
     assert rc == 0
     assert calls[0]["args"] == ["/fake/graphtrail", verb, "some-symbol", "--json"]
+    assert calls[0]["kwargs"] == {}
+
+
+def test_export_without_json_still_forwards_to_engine(monkeypatch):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["code", "export", "--format", "dot"])
+
+    assert rc == 0
+    assert calls[0]["args"] == ["/fake/graphtrail", "export", "--format", "dot"]
     assert calls[0]["kwargs"] == {}
 
 

--- a/tests/test_dashboard_code_graph.py
+++ b/tests/test_dashboard_code_graph.py
@@ -1,0 +1,97 @@
+"""Unit tests for the Code Graph Center view (#887)."""
+
+from __future__ import annotations
+
+import re
+
+from brigade import code_export
+from brigade.center_cmd.dashboard.views import code_graph
+
+
+def test_fetch_uses_code_export_contract(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+
+    def fake_run_json(target, args, **kwargs):
+        calls.append(list(args))
+        return {
+            "schema": "brigade.code-graph-export.v1",
+            "module_map": {
+                "modules": [],
+                "edges": [],
+                "truncation": {"shown_modules": 0, "hidden_modules": 0, "shown_edges": 0, "hidden_edges": 0},
+            },
+            "stats": {},
+        }
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+    payload = code_graph.fetch(tmp_path, query={"symbol": "dispatch"})
+    assert payload["symbol"] == "dispatch"
+    assert calls == [["code", "export", "--symbol", "dispatch", "--overlay"]]
+
+
+def test_render_module_map_truncation_note():
+    payload = {
+        "export": {
+            "stats": {"symbols": 100, "files": 10},
+            "module_map": {
+                "modules": [
+                    {"id": "src/pkg", "label": "pkg", "symbol_count": 12, "file_count": 2},
+                ],
+                "edges": [],
+                "truncation": {
+                    "shown_modules": 1,
+                    "hidden_modules": 4,
+                    "shown_edges": 0,
+                    "hidden_edges": 0,
+                    "note": "showing top 1 modules, 4 hidden",
+                },
+            },
+        },
+        "symbol": None,
+    }
+    fragment = code_graph.render(payload, "nonce-test")
+    assert "showing top 1 modules, 4 hidden" in fragment
+    assert 'class="cg-map"' in fragment
+    assert "pkg" in fragment
+    assert "<title>" in fragment
+
+
+def test_render_impact_hides_raw_ids_in_primary_cells():
+    payload = {
+        "export": {
+            "module_map": {
+                "modules": [],
+                "edges": [],
+                "truncation": {"shown_modules": 0, "hidden_modules": 0, "shown_edges": 0, "hidden_edges": 0},
+            },
+            "stats": {},
+            "impact": {
+                "query": "fn",
+                "resolved_symbol": {"name": "fn", "file_path": "src/a.py"},
+                "callers": [
+                    {
+                        "source": "caller",
+                        "target": "fn",
+                        "kind": "calls",
+                        "hops": 1,
+                        "source_id": "deadbeef",
+                        "target_id": "cafebabe",
+                    }
+                ],
+                "edges": [],
+                "affected_tests": {"affected_tests": []},
+            },
+        },
+        "symbol": "fn",
+    }
+    fragment = code_graph.render(payload, "nonce-impact")
+    assert "Direct callers" in fragment
+    assert "deadbeef" not in fragment.split("<summary>")[0]
+    assert "deadbeef" in fragment
+    assert re.search(r"\bon\w+\s*=", fragment, re.IGNORECASE) is None
+
+
+def test_fit_svg_label_truncates_with_tooltip_source():
+    visible, full = code_export.fit_svg_label("brigade.work_cmd.footprint.predict", 80)
+    assert len(visible) < len(full)
+    assert full.startswith("brigade")


### PR DESCRIPTION
## Summary

- Adds versioned `brigade code export --json` contract (`brigade.code-graph-export.v1`) assembled over the Brigade Code facade: module map, optional `--symbol` impact drill-down (callers + impact edges matching `grigade code impact --json` + attributed tests), and `--overlay` branch change highlighting on the module map.
- Adds read-only Center **Code Graph** view (`/view/code`) following #877/#889 v1 language: plain-language summary, server-rendered SVG with width-aware labels + `title` tooltips, icon+word status chips, labeled truncation notes, raw ids in expanders only.
- Center `serve` passes GET query params to views that accept `query=` (used for impact symbol search).

## Follow-up

Change overlay is shipped at module granularity via git diff + `change_overlay` in the contract. A dedicated overlay tab with per-symbol drill-down from verify-receipt graph deltas is tracked as a follow-up if reviewers want it split from this PR.

## Test plan

- [x] `pytest tests/test_code_export.py tests/test_dashboard_code_graph.py tests/test_center_dashboard.py tests/test_center_serve.py -q`
- [x] `brigade work verify run --target . --command "pytest tests/test_code_export.py tests/test_dashboard_code_graph.py tests/test_center_dashboard.py tests/test_center_serve.py -q" --capture brigade-work`
- [x] Served-page smoke: `/view/code` and `/view/code?symbol=dispatch` return 200 with module map + impact UI
- [x] `brigade code sync .` then `brigade code export --json --target .` on brigade repo

Closes #887

Made with [Cursor](https://cursor.com)