### PR TITLE
feat(care): per-job care-managed schedule entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Activity Cloud card rows when the registry has entries. Cursor cloud stays
   unwired until an API key exists; GitHub is ground truth for branches/PRs.
   (#890)
-
+- `brigade care install|status|uninstall --entry JOB_ID` selects one
+  namespaced registration keyed by `(target identity, job_id)`. The five
+  maintainer memory jobs (`handoff-ingest`, `care-scan`, `memory-refresh`,
+  `evidence-crawl`, `memory-closeout`) are in the catalog; a job whose
+  operator-approved runbook is missing installs nothing and says why.
+  Omitting `--entry` still writes the atomic scheduled-care set. (#762)
 - Bundled template-profile selection and render-hash snapshot for #494: named
   presets (`repo-claude`, `workspace-claude-codex`, `repo-claude-full`) via
   `brigade init --profile`, deterministic rendered-file digests checked by

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -26,7 +26,11 @@ A scheduled invocation is still an explicit invocation: the same command runs wh
 own scheduler: namespaced systemd user timers on Linux or namespaced launchd
 agents on macOS. Other platforms report that managed scheduling is unsupported.
 Each registration includes a hash of the absolute target path, so status and
-uninstall can never select another target's entries.
+uninstall can never select another target's entries. Repeatable `--entry JOB_ID`
+installs, reports, or removes one named job without touching the others;
+omitting it still writes the atomic scheduled-care set. `memory-refresh` and
+`evidence-crawl` refuse to install when their operator-approved runbook is
+missing.
 `brigade care status` audits those entries and shows the latest runbook
 receipt for each recipe. `brigade care uninstall` removes only the
 hash-stamped Brigade block. The schedule still belongs to the operator:

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -28,7 +28,9 @@ Replace `WORKSPACE` with the absolute path to your Brigade-wired repo or operato
 brigade memory care init --with-runbooks --target .
 brigade extras on   # runbook + center report are extras-gated
 brigade care install --target .
-brigade care status --target .
+brigade care install --target . --entry handoff-ingest --entry care-scan
+brigade care status --target . --entry care-scan
+# brigade care uninstall --target . --entry handoff-ingest
 # brigade care uninstall --target .
 ```
 
@@ -43,6 +45,18 @@ receipt; nightly ops calls
 `.brigade/runbooks/nightly-maintenance.json` (operator-authored). Entries live
 inside a `# BEGIN BRIGADE CARE ... hash:...` managed block so status can detect
 drift and uninstall can remove only Brigade's span.
+
+To install one job without the rest of that set, pass `--entry JOB_ID`
+(repeatable). The five maintainer memory jobs from the care-managed inventory
+are `handoff-ingest`, `care-scan`, `memory-refresh`, `evidence-crawl`, and
+`memory-closeout`. `memory-refresh` and `evidence-crawl` require an
+operator-approved runbook at `.brigade/memory-care/runbooks/<job-id>.json`; if
+that file is missing, install writes nothing and says why. Omitting `--entry`
+still installs the atomic five-recipe set above. Status and uninstall take the
+same selector, and namespaced backends still key registrations by
+`(target identity, job_id)`. The optional crontab backend stays one atomic
+managed block and rejects `--entry`; use systemd or launchd for per-job
+installs.
 
 Related docs: [memory care](memory-care.md), [scanner registry](scanner-registry.md), [operator center](operator-center.md), [agents guide](agents-guide.md), [execution model](execution-model.md).
 

--- a/src/brigade/care_cmd.py
+++ b/src/brigade/care_cmd.py
@@ -56,7 +56,7 @@ DAILY_OBSERVABILITY_RUNBOOK_PAYLOAD: dict[str, Any] = {
 
 @dataclass(frozen=True)
 class CareEntry:
-    """One scheduled care recipe from docs/scheduled-care.md."""
+    """One scheduled care recipe from docs/scheduled-care.md or the #762 memory-job inventory."""
 
     entry_id: str
     schedule: str  # crontab five-field expression
@@ -66,6 +66,7 @@ class CareEntry:
     runbook_rel: str | None = None
     shell: str | None = None  # multi-command shell body without cd/PATH
     runbook_id: str | None = None
+    requires_existing_runbook: bool = False
 
 
 # Schedules and recipes mirror docs/scheduled-care.md. Where a shipped
@@ -117,6 +118,131 @@ CARE_ENTRIES: tuple[CareEntry, ...] = (
         runbook_id="nightly-maintenance",
     ),
 )
+
+# Maintainer memory jobs from docs/proposals/2026-08-12-care-managed-memory-jobs.md.
+# Selected with ``brigade care install --entry <job_id>``. Not part of the
+# default atomic scheduled-care set.
+MEMORY_JOB_RUNBOOK_REL = {
+    "handoff-ingest": MEMORY_CARE_RUNBOOK_REL["ingest-sweep"],
+    "care-scan": MEMORY_CARE_RUNBOOK_REL["daily-care"],
+    "memory-refresh": ".brigade/memory-care/runbooks/memory-refresh.json",
+    "evidence-crawl": ".brigade/memory-care/runbooks/evidence-crawl.json",
+    "memory-closeout": ".brigade/memory-care/runbooks/memory-closeout.json",
+}
+MEMORY_CLOSEOUT_RUNBOOK_NAME = "memory-closeout.json"
+MEMORY_CLOSEOUT_RUNBOOK_PAYLOAD: dict[str, Any] = {
+    "id": "memory-closeout",
+    "description": (
+        "Daily memory-care closeout. Run from the repo or workspace root: "
+        "brigade runbook run --approved .brigade/memory-care/runbooks/memory-closeout.json"
+    ),
+    "allowed_commands": ["brigade"],
+    "steps": [
+        {"id": "closeout", "run": "brigade memory care closeout --target ."},
+    ],
+}
+MEMORY_JOB_ENTRIES: tuple[CareEntry, ...] = (
+    CareEntry(
+        entry_id="handoff-ingest",
+        schedule="*/30 * * * *",
+        on_calendar="*:0/30",
+        description="Brigade handoff ingest",
+        kind="runbook",
+        runbook_rel=MEMORY_JOB_RUNBOOK_REL["handoff-ingest"],
+        runbook_id="ingest-sweep",
+    ),
+    CareEntry(
+        entry_id="care-scan",
+        schedule="15 6 * * *",
+        on_calendar="*-*-* 06:15:00",
+        description="Brigade memory care scan",
+        kind="runbook",
+        runbook_rel=MEMORY_JOB_RUNBOOK_REL["care-scan"],
+        runbook_id="daily-care-pass",
+    ),
+    CareEntry(
+        entry_id="memory-refresh",
+        schedule="0 7 * * *",
+        on_calendar="*-*-* 07:00:00",
+        description="Brigade reviewed memory refresh",
+        kind="runbook",
+        runbook_rel=MEMORY_JOB_RUNBOOK_REL["memory-refresh"],
+        runbook_id="memory-refresh",
+        requires_existing_runbook=True,
+    ),
+    CareEntry(
+        entry_id="evidence-crawl",
+        schedule="0 8 * * *",
+        on_calendar="*-*-* 08:00:00",
+        description="Brigade local evidence crawl",
+        kind="runbook",
+        runbook_rel=MEMORY_JOB_RUNBOOK_REL["evidence-crawl"],
+        runbook_id="evidence-crawl",
+        requires_existing_runbook=True,
+    ),
+    CareEntry(
+        entry_id="memory-closeout",
+        schedule="0 9 * * *",
+        on_calendar="*-*-* 09:00:00",
+        description="Brigade memory care closeout",
+        kind="runbook",
+        runbook_rel=MEMORY_JOB_RUNBOOK_REL["memory-closeout"],
+        runbook_id="memory-closeout",
+    ),
+)
+
+
+def _catalog_by_id() -> dict[str, CareEntry]:
+    return {entry.entry_id: entry for entry in (*CARE_ENTRIES, *MEMORY_JOB_ENTRIES)}
+
+
+def _resolve_selected_entries(
+    entry_ids: list[str] | None,
+) -> tuple[tuple[CareEntry, ...] | None, str | None]:
+    """Return the default atomic set, or the named catalog entries in request order."""
+    if not entry_ids:
+        return CARE_ENTRIES, None
+    catalog = _catalog_by_id()
+    selected: list[CareEntry] = []
+    seen: set[str] = set()
+    for raw in entry_ids:
+        job_id = str(raw or "").strip()
+        if not job_id or job_id in seen:
+            continue
+        entry = catalog.get(job_id)
+        if entry is None:
+            return None, f"unknown care entry: {job_id}"
+        selected.append(entry)
+        seen.add(job_id)
+    if not selected:
+        return None, "unknown care entry: "
+    return tuple(selected), None
+
+
+def _required_runbook_error(target: Path, entries: tuple[CareEntry, ...]) -> str | None:
+    """Refuse operator-authored jobs whose runbook is missing or malformed."""
+    for entry in entries:
+        if not entry.requires_existing_runbook:
+            continue
+        assert entry.runbook_rel is not None
+        path = target / entry.runbook_rel
+        if not path.is_file():
+            return (
+                f"care entry {entry.entry_id} is not installable: missing operator-approved runbook {entry.runbook_rel}"
+            )
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return f"care entry {entry.entry_id} is not installable: invalid runbook {entry.runbook_rel}: {exc}"
+        if not isinstance(payload, dict):
+            return f"care entry {entry.entry_id} is not installable: runbook {entry.runbook_rel} is not a JSON object"
+        found_id = str(payload.get("id") or "")
+        if entry.runbook_id and found_id != entry.runbook_id:
+            return (
+                f"care entry {entry.entry_id} is not installable: runbook id {found_id!r} "
+                f"does not match {entry.runbook_id!r}"
+            )
+    return None
 
 
 def _is_windows() -> bool:
@@ -201,9 +327,15 @@ def _cron_command(entry: CareEntry, *, workspace: Path) -> str:
     return f'cd "{quoted_workspace}" && {body}'
 
 
-def _crontab_body(*, workspace: Path, home: Path | None = None) -> str:
+def _crontab_body(
+    *,
+    workspace: Path,
+    home: Path | None = None,
+    entries: tuple[CareEntry, ...] | None = None,
+) -> str:
+    selected = entries if entries is not None else CARE_ENTRIES
     lines = [f"PATH={_path_prefix(home)}"]
-    for entry in CARE_ENTRIES:
+    for entry in selected:
         lines.append(f"{entry.schedule} {_cron_command(entry, workspace=workspace)}")
     return "\n".join(lines)
 
@@ -301,6 +433,33 @@ def _write_daily_observability_runbook(target: Path) -> int:
             temp.unlink()
 
 
+def _write_memory_closeout_runbook(target: Path) -> int:
+    """Materialize the shipped memory-closeout runbook when missing."""
+    dest = memory_cmd._memory_care_runbooks_dir(target) / MEMORY_CLOSEOUT_RUNBOOK_NAME
+    if dest.is_file():
+        return 0
+    temp = dest.parent / f".{MEMORY_CLOSEOUT_RUNBOOK_NAME}.init-tmp"
+    try:
+        from .localio import write_json as _write_json
+
+        temp.parent.mkdir(parents=True, exist_ok=True)
+        _write_json(temp, dict(MEMORY_CLOSEOUT_RUNBOOK_PAYLOAD))
+        validated, error = runbook_cmd._read_runbook(temp, require_pin_hashes=False)
+        if validated is None:
+            print(f"error: {error}", file=sys.stderr)
+            return 2
+        pins, pin_error = runbook_cmd._pin_payload_from_runbook(target, validated)
+        if pins is None:
+            print(f"error: {pin_error}", file=sys.stderr)
+            return 2
+        validated["pins"] = pins
+        _write_json(dest, validated)
+        return 0
+    finally:
+        if temp.is_file():
+            temp.unlink()
+
+
 def _ensure_care_runbooks(target: Path) -> int:
     rc = _ensure_memory_care_runbooks(target)
     if rc != 0:
@@ -343,13 +502,14 @@ def _entry_status(target: Path, entry: CareEntry) -> dict[str, Any]:
     return payload
 
 
-def _windows_print(*, workspace: Path) -> int:
+def _windows_print(*, workspace: Path, entries: tuple[CareEntry, ...] | None = None) -> int:
     """Print Task Scheduler equivalents; never silently no-op on Windows."""
+    selected = entries if entries is not None else CARE_ENTRIES
     print("care install: Windows Task Scheduler is not written automatically.")
     print("Print the equivalent schtasks commands below, then create the tasks yourself.")
     print(f"workspace: {workspace}")
     print("")
-    for entry in CARE_ENTRIES:
+    for entry in selected:
         task_name = f"BrigadeCare-{entry.entry_id}"
         command = _cron_command(entry, workspace=workspace)
         # schtasks /SC requires a schedule family; print a reviewable template.
@@ -402,10 +562,31 @@ def _launchd_dir(home: Path | None = None) -> Path:
     return (home if home is not None else Path.home()) / "Library" / "LaunchAgents"
 
 
-def _launchd_plists(*, workspace: Path, home: Path | None = None) -> dict[str, bytes]:
+def _launchd_interval_seconds(schedule: str) -> int | None:
+    fields = schedule.split()
+    if len(fields) != 5:
+        return None
+    minute, hour, day, month, weekday = fields
+    if hour == day == month == weekday == "*" and minute.startswith("*/"):
+        try:
+            every = int(minute[2:])
+        except ValueError:
+            return None
+        if every > 0:
+            return every * 60
+    return None
+
+
+def _launchd_plists(
+    *,
+    workspace: Path,
+    home: Path | None = None,
+    entries: tuple[CareEntry, ...] | None = None,
+) -> dict[str, bytes]:
     identity = _target_identity(workspace)
+    selected = entries if entries is not None else CARE_ENTRIES
     result: dict[str, bytes] = {}
-    for entry in CARE_ENTRIES:
+    for entry in selected:
         assert entry.runbook_rel is not None
         label = f"dev.brigade.care.{identity}.{entry.entry_id}"
         payload: dict[str, Any] = {
@@ -426,8 +607,9 @@ def _launchd_plists(*, workspace: Path, home: Path | None = None) -> dict[str, b
         # launchd supports interval timers directly; calendar recipes use their
         # documented local hour/minute (weekly additionally pins Monday).
         # launchd Weekday uses the same numbering as cron (0/7=Sunday, 1=Monday).
-        if entry.entry_id == "ingest-sweep":
-            payload["StartInterval"] = 1800
+        interval = _launchd_interval_seconds(entry.schedule)
+        if interval is not None:
+            payload["StartInterval"] = interval
         else:
             fields = entry.schedule.split()
             calendar: dict[str, int] = {"Minute": int(fields[0]), "Hour": int(fields[1])}
@@ -438,9 +620,16 @@ def _launchd_plists(*, workspace: Path, home: Path | None = None) -> dict[str, b
     return result
 
 
-def _launchd_install(*, target: Path, dry_run: bool, json_output: bool, home: Path | None) -> int:
+def _launchd_install(
+    *,
+    target: Path,
+    dry_run: bool,
+    json_output: bool,
+    home: Path | None,
+    entries: tuple[CareEntry, ...],
+) -> int:
     directory = _launchd_dir(home)
-    plists = _launchd_plists(workspace=target, home=home)
+    plists = _launchd_plists(workspace=target, home=home, entries=entries)
     if not dry_run:
         directory.mkdir(parents=True, exist_ok=True)
         for name, contents in plists.items():
@@ -461,9 +650,15 @@ def _launchd_install(*, target: Path, dry_run: bool, json_output: bool, home: Pa
     return 0
 
 
-def _launchd_status(*, target: Path, json_output: bool, home: Path | None) -> int:
+def _launchd_status(
+    *,
+    target: Path,
+    json_output: bool,
+    home: Path | None,
+    entries: tuple[CareEntry, ...],
+) -> int:
     directory = _launchd_dir(home)
-    expected = _launchd_plists(workspace=target, home=home)
+    expected = _launchd_plists(workspace=target, home=home, entries=entries)
     states = []
     for name, desired in expected.items():
         path = directory / name
@@ -480,16 +675,30 @@ def _launchd_status(*, target: Path, json_output: bool, home: Path | None) -> in
     elif any(item["status"] == "missing" for item in states):
         state = "missing"
     _print_payload(
-        {"target": str(target), "backend": "launchd", "status": state, "registrations": states}, json_output=json_output
+        {
+            "target": str(target),
+            "backend": "launchd",
+            "status": state,
+            "registrations": states,
+            "entries": [_entry_status(target, entry) for entry in entries],
+        },
+        json_output=json_output,
     )
     return 1 if state == "tampered" else 0
 
 
-def _launchd_uninstall(*, target: Path, dry_run: bool, json_output: bool, home: Path | None) -> int:
+def _launchd_uninstall(
+    *,
+    target: Path,
+    dry_run: bool,
+    json_output: bool,
+    home: Path | None,
+    entries: tuple[CareEntry, ...],
+) -> int:
     directory = _launchd_dir(home)
     removed: list[str] = []
     refused: list[str] = []
-    for name, expected in _launchd_plists(workspace=target, home=home).items():
+    for name, expected in _launchd_plists(workspace=target, home=home, entries=entries).items():
         path = directory / name
         if path.is_symlink():
             print(f"error: refusing to remove symlink registration: {path}", file=sys.stderr)
@@ -521,6 +730,7 @@ def install(
     adopt: bool = False,
     json_output: bool = False,
     home: Path | None = None,
+    entry_ids: list[str] | None = None,
 ) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
@@ -528,6 +738,14 @@ def install(
         return 2
     if backend not in SUPPORTED_BACKENDS:
         print(f"error: unsupported care backend: {backend}", file=sys.stderr)
+        return 2
+    entries, entry_error = _resolve_selected_entries(entry_ids)
+    if entries is None:
+        print(f"error: {entry_error}", file=sys.stderr)
+        return 2
+    runbook_error = _required_runbook_error(target, entries)
+    if runbook_error:
+        print(f"error: {runbook_error}", file=sys.stderr)
         return 2
     backend = _resolve_backend(backend) or ""
     if not backend:
@@ -537,18 +755,38 @@ def install(
         )
         return 3
     if _is_windows():
-        return _windows_print(workspace=target)
+        return _windows_print(workspace=target, entries=entries)
 
     rc = _ensure_care_runbooks(target)
     if rc != 0:
         return rc
+    if any(entry.entry_id == "memory-closeout" for entry in entries):
+        rc = _write_memory_closeout_runbook(target)
+        if rc != 0:
+            return rc
 
     if backend == "launchd":
-        return _launchd_install(target=target, dry_run=dry_run, json_output=json_output, home=home)
+        return _launchd_install(target=target, dry_run=dry_run, json_output=json_output, home=home, entries=entries)
 
     if backend == "crontab":
-        return _install_crontab(target=target, dry_run=dry_run, adopt=adopt, json_output=json_output, home=home)
-    return _install_systemd(target=target, dry_run=dry_run, adopt=adopt, json_output=json_output, home=home)
+        if entry_ids:
+            print(
+                "error: care --entry is not supported on the crontab backend; "
+                "crontab remains one atomic managed block. Use systemd or launchd.",
+                file=sys.stderr,
+            )
+            return 2
+        return _install_crontab(
+            target=target,
+            dry_run=dry_run,
+            adopt=adopt,
+            json_output=json_output,
+            home=home,
+            entries=entries,
+        )
+    return _install_systemd(
+        target=target, dry_run=dry_run, adopt=adopt, json_output=json_output, home=home, entries=entries
+    )
 
 
 def _install_crontab(
@@ -558,12 +796,13 @@ def _install_crontab(
     adopt: bool,
     json_output: bool,
     home: Path | None,
+    entries: tuple[CareEntry, ...],
 ) -> int:
     current, error = _read_crontab()
     if error:
         print(f"error: failed to read crontab: {error}", file=sys.stderr)
         return 2
-    desired_body = _crontab_body(workspace=target, home=home)
+    desired_body = _crontab_body(workspace=target, home=home, entries=entries)
     assessment = managed_block.assess_block(
         current,
         desired=desired_body,
@@ -579,7 +818,7 @@ def _install_crontab(
             "action": managed_block.ACTION_NONE,
             "hash": assessment.desired_hash,
             "dry_run": dry_run,
-            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+            "entries": [_entry_status(target, entry) for entry in entries],
         }
         _print_payload(payload, json_output=json_output)
         return 0
@@ -594,7 +833,7 @@ def _install_crontab(
             "desired_hash": assessment.desired_hash,
             "detail": assessment.detail,
             "fix_command": "brigade care install --target . --adopt",
-            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+            "entries": [_entry_status(target, entry) for entry in entries],
         }
         _print_payload(payload, json_output=json_output)
         print("error: care crontab block was hand-edited; refusing to clobber without --adopt", file=sys.stderr)
@@ -607,7 +846,7 @@ def _install_crontab(
             "action": managed_block.ACTION_PRESERVE,
             "desired_hash": assessment.desired_hash,
             "detail": assessment.detail,
-            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+            "entries": [_entry_status(target, entry) for entry in entries],
         }
         _print_payload(payload, json_output=json_output)
         print("error: care crontab block has malformed markers; refusing to install", file=sys.stderr)
@@ -629,7 +868,7 @@ def _install_crontab(
         "action": plan.action,
         "hash": plan.desired_hash,
         "dry_run": dry_run,
-        "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        "entries": [_entry_status(target, entry) for entry in entries],
     }
     if dry_run:
         payload["rendered_block"] = managed_block.render_block(
@@ -673,11 +912,17 @@ def _systemd_user_dir(home: Path | None = None) -> Path:
     return Path.home() / ".config" / "systemd" / "user"
 
 
-def _systemd_unit_bodies(*, workspace: Path, home: Path | None = None) -> dict[str, str]:
+def _systemd_unit_bodies(
+    *,
+    workspace: Path,
+    home: Path | None = None,
+    entries: tuple[CareEntry, ...] | None = None,
+) -> dict[str, str]:
     path_value = _path_prefix(home)
     identity = _target_identity(workspace)
+    selected = entries if entries is not None else CARE_ENTRIES
     units: dict[str, str] = {}
-    for entry in CARE_ENTRIES:
+    for entry in selected:
         service_name = f"brigade-care-{identity}-{entry.entry_id}.service"
         timer_name = f"brigade-care-{identity}-{entry.entry_id}.timer"
         assert entry.kind == "runbook" and entry.runbook_rel is not None
@@ -723,10 +968,11 @@ def _install_systemd(
     adopt: bool,
     json_output: bool,
     home: Path | None,
+    entries: tuple[CareEntry, ...],
 ) -> int:
     unit_dir = _systemd_user_dir(home)
     identity = _target_identity(target)
-    units = _systemd_unit_bodies(workspace=target, home=home)
+    units = _systemd_unit_bodies(workspace=target, home=home, entries=entries)
     results: list[dict[str, Any]] = []
     blocked = False
     for name, desired_text in units.items():
@@ -810,10 +1056,10 @@ def _install_systemd(
         "dry_run": dry_run,
         "blocked": blocked,
         "units": results,
-        "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        "entries": [_entry_status(target, entry) for entry in entries],
         "next_commands": [
             "systemctl --user daemon-reload",
-            f"systemctl --user enable --now brigade-care-{identity}-daily-care.timer",
+            f"systemctl --user enable --now brigade-care-{identity}-{entries[0].entry_id}.timer",
             f"systemctl --user list-timers 'brigade-care-{identity}-*.timer'",
         ],
     }
@@ -899,7 +1145,12 @@ def _aggregate_systemd_status(unit_statuses: list[str]) -> str:
     return worst
 
 
-def _crontab_backend_status(*, target: Path, home: Path | None = None) -> dict[str, Any]:
+def _crontab_backend_status(
+    *,
+    target: Path,
+    home: Path | None = None,
+    entries: tuple[CareEntry, ...] | None = None,
+) -> dict[str, Any]:
     current, error = _read_crontab()
     if error:
         return {
@@ -914,7 +1165,7 @@ def _crontab_backend_status(*, target: Path, home: Path | None = None) -> dict[s
             "detail": error,
             "profile": None,
         }
-    desired_body = _crontab_body(workspace=target, home=home)
+    desired_body = _crontab_body(workspace=target, home=home, entries=entries)
     assessment = managed_block.assess_block(
         current,
         desired=desired_body,
@@ -953,9 +1204,14 @@ def _crontab_backend_status(*, target: Path, home: Path | None = None) -> dict[s
     return payload
 
 
-def _systemd_backend_status(*, target: Path, home: Path | None = None) -> dict[str, Any]:
+def _systemd_backend_status(
+    *,
+    target: Path,
+    home: Path | None = None,
+    entries: tuple[CareEntry, ...] | None = None,
+) -> dict[str, Any]:
     unit_dir = _systemd_user_dir(home)
-    units = _systemd_unit_bodies(workspace=target, home=home)
+    units = _systemd_unit_bodies(workspace=target, home=home, entries=entries)
     results: list[dict[str, Any]] = []
     unit_statuses: list[str] = []
     installed_workspace: Path | None = None
@@ -1052,6 +1308,7 @@ def status(
     backend: str = DEFAULT_BACKEND,
     json_output: bool = False,
     home: Path | None = None,
+    entry_ids: list[str] | None = None,
 ) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
@@ -1059,6 +1316,10 @@ def status(
         return 2
     if backend not in SUPPORTED_BACKENDS:
         print(f"error: unsupported care backend: {backend}", file=sys.stderr)
+        return 2
+    entries, entry_error = _resolve_selected_entries(entry_ids)
+    if entries is None:
+        print(f"error: {entry_error}", file=sys.stderr)
         return 2
     backend = _resolve_backend(backend) or ""
     if not backend:
@@ -1073,33 +1334,40 @@ def status(
             "backend": "windows",
             "status": "unsupported-backend",
             "detail": "care status does not read Task Scheduler in this release; use schtasks /Query",
-            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+            "entries": [_entry_status(target, entry) for entry in entries],
         }
         _print_payload(windows_payload, json_output=json_output)
         return 3
 
     if backend == "launchd":
-        return _launchd_status(target=target, json_output=json_output, home=home)
+        return _launchd_status(target=target, json_output=json_output, home=home, entries=entries)
 
     if backend == "crontab":
-        crontab = _crontab_backend_status(target=target, home=home)
+        if entry_ids:
+            print(
+                "error: care --entry is not supported on the crontab backend; "
+                "crontab remains one atomic managed block. Use systemd or launchd.",
+                file=sys.stderr,
+            )
+            return 2
+        crontab = _crontab_backend_status(target=target, home=home, entries=entries)
         if crontab.get("error"):
             print(f"error: failed to read crontab: {crontab['error']}", file=sys.stderr)
             return 2
         crontab_payload: dict[str, Any] = {
             "target": str(target),
             **{k: v for k, v in crontab.items() if k != "error"},
-            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+            "entries": [_entry_status(target, entry) for entry in entries],
         }
         public_status = str(crontab_payload.get("status"))
         _print_payload(crontab_payload, json_output=json_output)
         return 0 if public_status in {"current", managed_block.STATUS_MISSING} else 1
 
-    systemd = _systemd_backend_status(target=target, home=home)
+    systemd = _systemd_backend_status(target=target, home=home, entries=entries)
     payload = {
         "target": str(target),
         **{k: v for k, v in systemd.items() if k != "error"},
-        "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        "entries": [_entry_status(target, entry) for entry in entries],
     }
     worst = str(payload.get("status"))
     _print_payload(payload, json_output=json_output)
@@ -1113,6 +1381,7 @@ def uninstall(
     dry_run: bool = False,
     json_output: bool = False,
     home: Path | None = None,
+    entry_ids: list[str] | None = None,
 ) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
@@ -1120,6 +1389,10 @@ def uninstall(
         return 2
     if backend not in SUPPORTED_BACKENDS:
         print(f"error: unsupported care backend: {backend}", file=sys.stderr)
+        return 2
+    entries, entry_error = _resolve_selected_entries(entry_ids)
+    if entries is None:
+        print(f"error: {entry_error}", file=sys.stderr)
         return 2
     backend = _resolve_backend(backend) or ""
     if not backend:
@@ -1131,15 +1404,22 @@ def uninstall(
     if _is_windows():
         print("care uninstall: Windows Task Scheduler is not mutated automatically.")
         print("Remove BrigadeCare-* tasks with schtasks /Delete, or Task Scheduler UI.")
-        for entry in CARE_ENTRIES:
+        for entry in entries:
             print(f'schtasks /Delete /TN "BrigadeCare-{entry.entry_id}" /F')
         print("error: care uninstall does not mutate the Windows scheduler in this release", file=sys.stderr)
         return 3
 
     if backend == "launchd":
-        return _launchd_uninstall(target=target, dry_run=dry_run, json_output=json_output, home=home)
+        return _launchd_uninstall(target=target, dry_run=dry_run, json_output=json_output, home=home, entries=entries)
 
     if backend == "crontab":
+        if entry_ids:
+            print(
+                "error: care --entry is not supported on the crontab backend; "
+                "crontab remains one atomic managed block. Use systemd or launchd.",
+                file=sys.stderr,
+            )
+            return 2
         current, error = _read_crontab()
         if error:
             print(f"error: failed to read crontab: {error}", file=sys.stderr)
@@ -1183,7 +1463,7 @@ def uninstall(
     refused: list[str] = []
     blocked = False
     identity = _target_identity(target)
-    for entry in CARE_ENTRIES:
+    for entry in entries:
         for suffix in (".service", ".timer"):
             name = f"brigade-care-{identity}-{entry.entry_id}{suffix}"
             path = unit_dir / name

--- a/src/brigade/cli/care.py
+++ b/src/brigade/cli/care.py
@@ -34,6 +34,13 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Replace a hand-edited managed block instead of reporting a conflict.",
     )
     p_install.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_install.add_argument(
+        "--entry",
+        dest="entry_ids",
+        action="append",
+        metavar="JOB_ID",
+        help="Install one named care entry. Repeatable. Default: the atomic scheduled-care set.",
+    )
 
     p_status = care_sub.add_parser(
         "status",
@@ -47,6 +54,13 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Scheduler backend (default: systemd on Linux, launchd on macOS).",
     )
     p_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_status.add_argument(
+        "--entry",
+        dest="entry_ids",
+        action="append",
+        metavar="JOB_ID",
+        help="Report one named care entry. Repeatable. Default: the atomic scheduled-care set.",
+    )
 
     p_uninstall = care_sub.add_parser(
         "uninstall",
@@ -63,6 +77,13 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_uninstall.add_argument("--dry-run", action="store_true", help="Show the plan without writing.")
     p_uninstall.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_uninstall.add_argument(
+        "--entry",
+        dest="entry_ids",
+        action="append",
+        metavar="JOB_ID",
+        help="Remove one named care entry. Repeatable. Default: the atomic scheduled-care set.",
+    )
 
     p_care.set_defaults(func=dispatch)
 
@@ -77,15 +98,22 @@ def dispatch(args) -> int:
             dry_run=args.dry_run,
             adopt=args.adopt,
             json_output=args.json,
+            entry_ids=args.entry_ids,
         )
     if args.care_command == "status":
-        return care_cmd.status(target=args.target, backend=args.backend, json_output=args.json)
+        return care_cmd.status(
+            target=args.target,
+            backend=args.backend,
+            json_output=args.json,
+            entry_ids=args.entry_ids,
+        )
     if args.care_command == "uninstall":
         return care_cmd.uninstall(
             target=args.target,
             backend=args.backend,
             dry_run=args.dry_run,
             json_output=args.json,
+            entry_ids=args.entry_ids,
         )
     args._brigade_parser.error(f"unknown care command: {args.care_command}")
     return 2

--- a/tests/test_care_cmd.py
+++ b/tests/test_care_cmd.py
@@ -736,3 +736,236 @@ def test_care_systemd_uninstall_skips_symlink_swap(tmp_path, monkeypatch):
     assert care_cmd.uninstall(target=target, backend="systemd", home=home) == 2
     assert secret.read_text(encoding="utf-8").startswith("[Unit]")
     assert service.is_symlink()
+
+
+def _unit_path(home: Path, target: Path, entry_id: str, suffix: str) -> Path:
+    identity = care_cmd._target_identity(target)
+    return home / ".config" / "systemd" / "user" / f"brigade-care-{identity}-{entry_id}{suffix}"
+
+
+def _write_operator_runbook(target: Path, name: str, runbook_id: str) -> Path:
+    path = target / ".brigade" / "memory-care" / "runbooks" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "id": runbook_id,
+                "description": f"Operator-approved {runbook_id} runbook.",
+                "allowed_commands": ["brigade"],
+                "steps": [{"id": "noop", "run": "brigade --version"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_memory_job_catalog_matches_design_doc():
+    by_id = {entry.entry_id: entry for entry in care_cmd.MEMORY_JOB_ENTRIES}
+    assert list(by_id) == [
+        "handoff-ingest",
+        "care-scan",
+        "memory-refresh",
+        "evidence-crawl",
+        "memory-closeout",
+    ]
+    assert by_id["handoff-ingest"].schedule == "*/30 * * * *"
+    assert by_id["handoff-ingest"].runbook_rel.endswith("ingest-sweep.json")
+    assert by_id["care-scan"].schedule == "15 6 * * *"
+    assert by_id["care-scan"].runbook_rel.endswith("daily-care-pass.json")
+    assert by_id["memory-refresh"].schedule == "0 7 * * *"
+    assert by_id["memory-refresh"].runbook_rel.endswith("memory-refresh.json")
+    assert by_id["memory-refresh"].requires_existing_runbook is True
+    assert by_id["evidence-crawl"].schedule == "0 8 * * *"
+    assert by_id["evidence-crawl"].runbook_rel.endswith("evidence-crawl.json")
+    assert by_id["evidence-crawl"].requires_existing_runbook is True
+    assert by_id["memory-closeout"].schedule == "0 9 * * *"
+    assert by_id["memory-closeout"].runbook_rel.endswith("memory-closeout.json")
+
+
+def test_care_install_one_entry_does_not_touch_sibling_or_other_target(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=first, backend="systemd", home=home, entry_ids=["handoff-ingest"]) == 0
+    assert care_cmd.install(target=first, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    assert care_cmd.install(target=second, backend="systemd", home=home, entry_ids=["handoff-ingest"]) == 0
+
+    assert _unit_path(home, first, "handoff-ingest", ".service").is_file()
+    assert _unit_path(home, first, "care-scan", ".timer").is_file()
+    assert _unit_path(home, second, "handoff-ingest", ".service").is_file()
+    assert not _unit_path(home, first, "daily-care", ".service").exists()
+    assert not _unit_path(home, first, "nightly-ops", ".timer").exists()
+    assert not _unit_path(home, second, "care-scan", ".service").exists()
+
+
+def test_care_uninstall_one_entry_does_not_touch_sibling_or_other_target(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=first, backend="systemd", home=home, entry_ids=["handoff-ingest"]) == 0
+    assert care_cmd.install(target=first, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    assert care_cmd.install(target=second, backend="systemd", home=home, entry_ids=["handoff-ingest"]) == 0
+
+    assert care_cmd.uninstall(target=first, backend="systemd", home=home, entry_ids=["handoff-ingest"]) == 0
+    assert not _unit_path(home, first, "handoff-ingest", ".service").exists()
+    assert not _unit_path(home, first, "handoff-ingest", ".timer").exists()
+    assert _unit_path(home, first, "care-scan", ".service").is_file()
+    assert _unit_path(home, second, "handoff-ingest", ".service").is_file()
+
+    capsys.readouterr()
+    assert care_cmd.uninstall(target=first, backend="systemd", home=home, entry_ids=["handoff-ingest"]) == 0
+    assert "no scheduler registration found" in capsys.readouterr().out
+    assert _unit_path(home, first, "care-scan", ".timer").is_file()
+    assert _unit_path(home, second, "handoff-ingest", ".timer").is_file()
+
+
+def test_care_status_reports_named_entry_without_requiring_atomic_set(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    capsys.readouterr()
+    assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True, entry_ids=["care-scan"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "current"
+    assert [entry["id"] for entry in payload["entries"]] == ["care-scan"]
+    unit_names = {item["name"] for item in payload["units"]}
+    identity = care_cmd._target_identity(target)
+    assert f"brigade-care-{identity}-care-scan.service" in unit_names
+    assert f"brigade-care-{identity}-daily-care.service" not in unit_names
+
+
+def test_care_install_without_entry_still_writes_atomic_default_set(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=target, backend="systemd", home=home) == 0
+    for entry_id in ("daily-care", "ingest-sweep", "weekly-outcome-ratchet", "daily-observability", "nightly-ops"):
+        assert _unit_path(home, target, entry_id, ".timer").is_file()
+    for entry_id in ("handoff-ingest", "care-scan", "memory-refresh", "evidence-crawl", "memory-closeout"):
+        assert not _unit_path(home, target, entry_id, ".service").exists()
+
+
+def test_care_install_memory_refresh_without_runbook_refuses(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["memory-refresh"]) == 2
+    err = capsys.readouterr().err
+    assert "memory-refresh" in err
+    assert "runbook" in err.lower()
+    assert not _unit_path(home, target, "memory-refresh", ".service").exists()
+    assert not _unit_path(home, target, "memory-refresh", ".timer").exists()
+    assert not list((home / ".config" / "systemd" / "user").glob("brigade-care-*"))
+
+
+def test_care_install_memory_refresh_with_operator_runbook(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    _write_operator_runbook(target, "memory-refresh.json", "memory-refresh")
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["memory-refresh"]) == 0
+    service = _unit_path(home, target, "memory-refresh", ".service")
+    assert service.is_file()
+    text = service.read_text(encoding="utf-8")
+    assert "memory-refresh.json" in text
+    assert f"brigade-care-{care_cmd._target_identity(target)}-memory-refresh" in service.name
+
+
+def test_care_unknown_entry_is_error(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["not-a-job"]) == 2
+    assert "unknown care entry" in capsys.readouterr().err
+    assert not list((home / ".config" / "systemd" / "user").glob("brigade-care-*"))
+
+
+def test_care_launchd_uninstall_one_entry_preserves_sibling_and_other_target(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=first, backend="launchd", home=home, entry_ids=["handoff-ingest"]) == 0
+    assert care_cmd.install(target=first, backend="launchd", home=home, entry_ids=["care-scan"]) == 0
+    assert care_cmd.install(target=second, backend="launchd", home=home, entry_ids=["handoff-ingest"]) == 0
+
+    first_ingest = f"dev.brigade.care.{care_cmd._target_identity(first)}.handoff-ingest.plist"
+    first_scan = f"dev.brigade.care.{care_cmd._target_identity(first)}.care-scan.plist"
+    second_ingest = f"dev.brigade.care.{care_cmd._target_identity(second)}.handoff-ingest.plist"
+
+    assert care_cmd.uninstall(target=first, backend="launchd", home=home, entry_ids=["handoff-ingest"]) == 0
+    agents = care_cmd._launchd_dir(home)
+    assert not (agents / first_ingest).exists()
+    assert (agents / first_scan).is_file()
+    assert (agents / second_ingest).is_file()
+
+
+def test_care_cli_dispatch_passes_entry(monkeypatch, tmp_path):
+    seen: dict[str, dict] = {}
+
+    def fake_install(**kwargs):
+        seen["install"] = kwargs
+        return 0
+
+    def fake_status(**kwargs):
+        seen["status"] = kwargs
+        return 0
+
+    def fake_uninstall(**kwargs):
+        seen["uninstall"] = kwargs
+        return 0
+
+    monkeypatch.setattr("brigade.care_cmd.install", fake_install)
+    monkeypatch.setattr("brigade.care_cmd.status", fake_status)
+    monkeypatch.setattr("brigade.care_cmd.uninstall", fake_uninstall)
+
+    assert (
+        cli.main(
+            [
+                "care",
+                "install",
+                "--target",
+                str(tmp_path),
+                "--entry",
+                "handoff-ingest",
+                "--entry",
+                "care-scan",
+            ]
+        )
+        == 0
+    )
+    assert seen["install"]["entry_ids"] == ["handoff-ingest", "care-scan"]
+    assert cli.main(["care", "status", "--target", str(tmp_path), "--entry", "care-scan", "--json"]) == 0
+    assert seen["status"]["entry_ids"] == ["care-scan"]
+    assert cli.main(["care", "uninstall", "--target", str(tmp_path), "--entry", "handoff-ingest"]) == 0
+    assert seen["uninstall"]["entry_ids"] == ["handoff-ingest"]


### PR DESCRIPTION
## Summary
- Adds repeatable `--entry JOB_ID` to `brigade care install|status|uninstall`, keyed by `(target identity, job_id)`, so one named job can be installed or removed without touching siblings or another target.
- Catalogues the five maintainer memory jobs from the merged design (`handoff-ingest`, `care-scan`, `memory-refresh`, `evidence-crawl`, `memory-closeout`). `memory-refresh` and `evidence-crawl` refuse to install when the operator-approved runbook is missing, and write no scheduler units.
- Omitting `--entry` still writes the atomic five-recipe scheduled-care set from #898. Crontab stays that atomic block and rejects `--entry`; systemd and launchd are the per-job backends.

Motivation from the 2026-08-12 cutover stop-report: the merged scheduler ships only the atomic five-recipe `brigade care install`, not per-job target-namespaced entries. Running that install on the maintainer workspace would have scheduled three out-of-scope jobs and double-fired nightly-ops. Refresh had no approved runbook; that case must be a clean refusal, not a crash. This PR is the #762 slice that unblocks a later, entry-by-entry cutover.

## Test plan
- [x] `pytest tests/test_care_cmd.py -q` (36 passed; two host `crontab -n` probes deselected, pre-existing spool permission denial)
- [x] Cross-target #898 uninstall tests still pass
- [x] Per-entry systemd/launchd: uninstall job A on target X leaves job B on X and everything on Y
- [x] `care install --entry memory-refresh` with no runbook exits 2 and writes nothing
- [ ] Reviewer: confirm crontab `--entry` refusal is the intended compatibility stance

Refs #762

Made with [Cursor](https://cursor.com)