### PR TITLE
fix(center): page-load budget for dashboard views

### DIFF
--- a/src/brigade/center_cmd/agent_activity.py
+++ b/src/brigade/center_cmd/agent_activity.py
@@ -12,9 +12,13 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
+from brigade.center_cmd.dashboard import timing as center_timing
+
 ACTIVITY_ENVELOPE_VERSION = 2
 _STALE_AFTER_SECONDS = 300
 _DEFAULT_COMPLETED_WINDOW_SECONDS = 3600
+_SESSION_MTIME_WINDOW_SECONDS = 7 * 24 * 60 * 60
+_SESSION_READ_SIZE_CAP = 1_048_576
 _UNKNOWN_TASK = "Unknown task"
 _DEFAULT_HOSTS = ("rocinante", "shadowfax", "gandalf")
 _RUNNING_STATUSES = {
@@ -34,10 +38,14 @@ def collect(target: Path, *, now: datetime | None = None) -> list[dict[str, Any]
     """Return bounded safe records without mutating local or provider state."""
     observed_at = now or datetime.now(timezone.utc)
     local_host = local_host_alias(target)
-    records = _brigade_records(target, observed_at, local_host)
-    records.extend(_local_session_records(observed_at, local_host))
-    records.extend(_configured_sources(target, observed_at))
-    records.extend(_cloud_tracker_records(target, observed_at))
+    with center_timing.phase("activity:brigade-runs"):
+        records = _brigade_records(target, observed_at, local_host)
+    with center_timing.phase("activity:local-sessions"):
+        records.extend(_local_session_records(observed_at, local_host))
+    with center_timing.phase("activity:configured-sources"):
+        records.extend(_configured_sources(target, observed_at))
+    with center_timing.phase("activity:cloud-tracker"):
+        records.extend(_cloud_tracker_records(target, observed_at))
     records.sort(
         key=lambda record: str(record.get("last_updated_at") or record.get("source", {}).get("observed_at") or ""),
         reverse=True,
@@ -46,11 +54,21 @@ def collect(target: Path, *, now: datetime | None = None) -> list[dict[str, Any]
 
 
 def _cloud_tracker_records(target: Path, now: datetime) -> list[dict[str, Any]]:
-    """Feed the Cloud machine card from the local cloud dispatch registry (#890)."""
+    """Feed the Cloud machine card from the local cloud dispatch registry (#890).
+
+    Live ``gh`` / ``codex cloud`` probes stay off the request path. Those can
+    hang for seconds; Center reads the local registry snapshot instead.
+    """
     try:
         from .. import cloud_tracker
 
-        return cloud_tracker.center_activity_records(target, now=now)
+        return cloud_tracker.center_activity_records(
+            target,
+            now=now,
+            provider_tasks={},
+            github={"branches": [], "prs": []},
+            cursor_wired=cloud_tracker.cursor_cloud_wired(),
+        )
     except Exception:
         return []
 
@@ -168,17 +186,26 @@ def _session_file_records(
         return []
     records: list[dict[str, Any]] = []
     try:
-        paths = _bounded_session_paths(root, provider)
-        paths.sort(key=lambda path: path.stat().st_mtime, reverse=True)
-        paths = paths[:25]
+        paths = _bounded_session_paths(root, provider, now=now)
     except OSError:
         return []
+    cutoff = now.timestamp() - _SESSION_MTIME_WINDOW_SECONDS
+    ranked: list[tuple[float, int, Path]] = []
     for path in paths:
         try:
-            updated_at = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
+            stat_result = path.stat()
         except OSError:
             continue
-        task_label, model = _session_task_hints(path, provider)
+        if stat_result.st_mtime < cutoff:
+            continue
+        ranked.append((stat_result.st_mtime, stat_result.st_size, path))
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    for mtime, size, path in ranked[:25]:
+        updated_at = datetime.fromtimestamp(mtime, timezone.utc).isoformat()
+        if size > _SESSION_READ_SIZE_CAP:
+            task_label, model = _UNKNOWN_TASK, None
+        else:
+            task_label, model = _session_task_hints(path, provider)
         records.append(
             _record(
                 activity_id=f"{provider}:session:{path.stem}",
@@ -270,7 +297,8 @@ def _text_from_content(value: object) -> str:
 
 def _head_json_objects(path: Path, *, max_lines: int = 40, max_bytes: int = 65_536) -> list[dict[str, Any]]:
     try:
-        raw = path.read_bytes()[:max_bytes]
+        with path.open("rb") as handle:
+            raw = handle.read(max_bytes)
     except OSError:
         return []
     objects: list[dict[str, Any]] = []
@@ -284,11 +312,12 @@ def _head_json_objects(path: Path, *, max_lines: int = 40, max_bytes: int = 65_5
     return objects
 
 
-def _bounded_session_paths(root: Path, provider: str) -> list[Path]:
+def _bounded_session_paths(root: Path, provider: str, *, now: datetime | None = None) -> list[Path]:
     """Find a bounded number of session files without scanning an entire home tree."""
     paths: list[Path] = []
     pending = deque([root])
     directories_seen = 0
+    cutoff = (now or datetime.now(timezone.utc)).timestamp() - _SESSION_MTIME_WINDOW_SECONDS
     while pending and directories_seen < 200 and len(paths) < 200:
         directory_path = pending.popleft()
         directories_seen += 1
@@ -310,10 +339,16 @@ def _bounded_session_paths(root: Path, provider: str) -> list[Path]:
             is_cursor_transcript = (
                 provider == "cursor" and "agent-transcripts" in directory_path.parts and filename.endswith(".jsonl")
             )
-            if is_codex_rollout or is_cursor_transcript:
-                paths.append(directory_path / filename)
-                if len(paths) >= 200:
-                    return paths
+            if not (is_codex_rollout or is_cursor_transcript):
+                continue
+            try:
+                if entry.stat(follow_symlinks=False).st_mtime < cutoff:
+                    continue
+            except OSError:
+                continue
+            paths.append(directory_path / filename)
+            if len(paths) >= 200:
+                return paths
     return paths
 
 

--- a/src/brigade/center_cmd/dashboard/data.py
+++ b/src/brigade/center_cmd/dashboard/data.py
@@ -14,20 +14,24 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+from brigade.center_cmd.dashboard import timing as center_timing
+
 
 def run_json(target: Path, args: Sequence[str], *, timeout: float = 20.0) -> dict:
     """Run a brigade subcommand and return parsed JSON, or ``{"error": ...}``."""
     cmd = [sys.executable, "-m", "brigade", *args, "--target", str(target), "--json"]
     env = os.environ.copy()
     env["BRIGADE_EXTRAS"] = "1"
+    phase_name = "cli:" + " ".join(args)
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env=env,
-        )
+        with center_timing.phase(phase_name):
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
     except subprocess.TimeoutExpired:
         return {"error": "command timed out"}
     except OSError as exc:

--- a/src/brigade/center_cmd/dashboard/render.py
+++ b/src/brigade/center_cmd/dashboard/render.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import html
 from collections.abc import Sequence
 
+from brigade.center_cmd.dashboard.snapshot import Snapshot
+
 
 def esc(value: object) -> str:
     """Escape a value for safe inclusion in HTML."""
@@ -21,6 +23,28 @@ def error_panel(title: str, message: str) -> str:
     return panel(esc(title), f'<p class="error">{esc(message)}</p>')
 
 
+def loading_panel(title: str) -> str:
+    """Render a shell panel while a snapshot is still being gathered."""
+    return panel(esc(title), f"<p>{esc('This view is still gathering data.')}</p>")
+
+
+def freshness_banner(snapshot: Snapshot, href: str) -> str:
+    """Render the explicit staleness stamp with a same-view refresh link."""
+    status = snapshot.status
+    if status == "loading":
+        return (
+            f'<p class="center-freshness" data-center-freshness="loading" data-center-loading="1">'
+            f'{esc("Loading live data.")} <a href="{esc(href)}">{esc("refresh")}</a></p>'
+        )
+    fetched_at = snapshot.fetched_at
+    clock = "--:--:--" if fetched_at is None else fetched_at.astimezone().strftime("%H:%M:%S")
+    text = f"data as of {clock} (stale)" if status == "stale" else f"data as of {clock}"
+    return (
+        f'<p class="center-freshness" data-center-freshness="{esc(status)}">'
+        f'{esc(text)}, <a href="{esc(href)}">{esc("refresh")}</a></p>'
+    )
+
+
 def table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
     """Render a table. *headers* and every cell in *rows* must already be escaped."""
     head_cells = "".join(f"<th>{cell}</th>" for cell in headers)
@@ -32,9 +56,10 @@ def table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
     return f'<table class="data-table"><thead><tr>{head_cells}</tr></thead><tbody>{body}</tbody></table>'
 
 
-def page(title: str, nonce: str, nav: str, body: str) -> str:
+def page(title: str, nonce: str, nav: str, body: str, *, reload_ms: int = 30000) -> str:
     """Render a full HTML document. *title*, *nav*, and *body* must already be escaped."""
     nonce_attr = esc(nonce)
+    reload_delay = max(500, int(reload_ms))
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -119,6 +144,11 @@ table.data-table td {{
 table.data-table th {{
   background: #f0f0f0;
 }}
+.center-freshness {{
+  margin: 0 0 1rem;
+  color: #333;
+  font-size: 0.9rem;
+}}
 </style>
 </head>
 <body>
@@ -129,7 +159,7 @@ table.data-table th {{
 <script nonce="{nonce_attr}">
 setTimeout(function () {{
   location.reload();
-}}, 30000);
+}}, {reload_delay});
 document.addEventListener("input", function (e) {{
   var input = e.target;
   if (!input || !input.getAttribute) return;

--- a/src/brigade/center_cmd/dashboard/snapshot.py
+++ b/src/brigade/center_cmd/dashboard/snapshot.py
@@ -1,0 +1,116 @@
+"""In-process snapshot cache for Center dashboard views.
+
+Keeps Center read-only: loaders still go through existing fetch/CLI seams.
+The cache is per server process, TTL-bounded, and single-flight so a slow
+view cannot pile overlapping subprocesses.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+Loader = Callable[[], dict[str, Any]]
+
+DEFAULT_TTL_SECONDS = 15.0
+DEFAULT_WAIT_MS = 2000.0
+LOADING_PAYLOAD: dict[str, Any] = {"_center_loading": True}
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    payload: dict[str, Any]
+    fetched_at: datetime | None
+    status: str
+    age_seconds: float | None
+
+
+@dataclass
+class _Entry:
+    payload: dict[str, Any]
+    fetched_at: datetime
+    fetched_mono: float
+
+
+@dataclass
+class _Inflight:
+    event: threading.Event
+    thread: threading.Thread
+
+
+class SnapshotCache:
+    """TTL cache with stale-while-revalidate and a loading miss path."""
+
+    def __init__(self, *, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._lock = threading.Lock()
+        self._entries: dict[str, _Entry] = {}
+        self._inflight: dict[str, _Inflight] = {}
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def get(
+        self,
+        key: str,
+        loader: Loader,
+        *,
+        wait_ms: float = DEFAULT_WAIT_MS,
+        now: float | None = None,
+    ) -> Snapshot:
+        now_mono = time.monotonic() if now is None else now
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and (now_mono - entry.fetched_mono) < self.ttl_seconds:
+                return self._as_snapshot(entry, "fresh", now_mono)
+            stale_entry = entry
+            inflight = self._inflight.get(key)
+            if inflight is None:
+                inflight = self._start_locked(key, loader)
+
+        if stale_entry is not None:
+            return self._as_snapshot(stale_entry, "stale", now_mono)
+
+        if wait_ms > 0:
+            inflight.event.wait(wait_ms / 1000.0)
+            with self._lock:
+                entry = self._entries.get(key)
+            if entry is not None:
+                status = "fresh" if (time.monotonic() - entry.fetched_mono) < self.ttl_seconds else "stale"
+                return self._as_snapshot(entry, status, time.monotonic())
+        return Snapshot(payload=dict(LOADING_PAYLOAD), fetched_at=None, status="loading", age_seconds=None)
+
+    def _start_locked(self, key: str, loader: Loader) -> _Inflight:
+        event = threading.Event()
+        inflight = _Inflight(
+            event=event, thread=threading.Thread(target=self._run, args=(key, loader, event), daemon=True)
+        )
+        self._inflight[key] = inflight
+        inflight.thread.start()
+        return inflight
+
+    def _run(self, key: str, loader: Loader, event: threading.Event) -> None:
+        try:
+            payload = loader()
+            if not isinstance(payload, dict):
+                payload = {"error": "view fetch returned a non-object"}
+        except Exception:  # noqa: BLE001 - a failed refresh must not take the server down
+            payload = {"_center_fetch_failed": True}
+        fetched_at = datetime.now(timezone.utc)
+        fetched_mono = time.monotonic()
+        with self._lock:
+            self._entries[key] = _Entry(payload=payload, fetched_at=fetched_at, fetched_mono=fetched_mono)
+            self._inflight.pop(key, None)
+            event.set()
+
+    def _as_snapshot(self, entry: _Entry, status: str, now_mono: float) -> Snapshot:
+        return Snapshot(
+            payload=entry.payload,
+            fetched_at=entry.fetched_at,
+            status=status,
+            age_seconds=max(0.0, now_mono - entry.fetched_mono),
+        )

--- a/src/brigade/center_cmd/dashboard/timing.py
+++ b/src/brigade/center_cmd/dashboard/timing.py
@@ -1,0 +1,88 @@
+"""Request-scoped phase timings for Center dashboard handlers.
+
+Enabled when ``BRIGADE_CENTER_PROFILE`` is set to a non-empty value other
+than ``0``/``false``/``no``. Phases are also always recorded on the current
+request so a response can carry ``X-Brigade-Center-Timing`` without requiring
+the env flag. Stderr JSON lines are env-gated to keep tests quiet.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+_current: ContextVar["_Timer | None"] = ContextVar("center_timing", default=None)
+
+
+def profiling_enabled() -> bool:
+    raw = os.environ.get("BRIGADE_CENTER_PROFILE", "").strip().lower()
+    return raw not in {"", "0", "false", "no", "off"}
+
+
+class _Timer:
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.phases: list[tuple[str, float]] = []
+        self.started = time.perf_counter()
+
+    def add(self, name: str, elapsed_ms: float) -> None:
+        self.phases.append((name, elapsed_ms))
+
+    def header_value(self) -> str:
+        total_ms = (time.perf_counter() - self.started) * 1000.0
+        parts = [f"{name}={elapsed:.1f}" for name, elapsed in self.phases]
+        parts.append(f"total={total_ms:.1f}")
+        return ";".join(parts)
+
+    def dominant(self) -> str:
+        if not self.phases:
+            return "total"
+        name, _ = max(self.phases, key=lambda item: item[1])
+        return name
+
+
+@contextmanager
+def request_timer(label: str) -> Iterator[_Timer]:
+    timer = _Timer(label)
+    token = _current.set(timer)
+    try:
+        yield timer
+    finally:
+        _current.reset(token)
+        if profiling_enabled():
+            payload = {
+                "view": label,
+                "phases": {name: round(ms, 1) for name, ms in timer.phases},
+                "total_ms": round((time.perf_counter() - timer.started) * 1000.0, 1),
+                "dominant": timer.dominant(),
+            }
+            print(json.dumps(payload, sort_keys=True), file=sys.stderr, flush=True)
+
+
+@contextmanager
+def phase(name: str) -> Iterator[None]:
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        timer = _current.get()
+        if timer is not None:
+            timer.add(name, elapsed_ms)
+        elif profiling_enabled():
+            print(
+                json.dumps({"phase": name, "ms": round(elapsed_ms, 1)}, sort_keys=True),
+                file=sys.stderr,
+                flush=True,
+            )
+
+
+def note(name: str, elapsed_ms: float) -> None:
+    timer = _current.get()
+    if timer is not None:
+        timer.add(name, elapsed_ms)

--- a/src/brigade/center_cmd/dashboard/views/agent_activity.py
+++ b/src/brigade/center_cmd/dashboard/views/agent_activity.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from brigade.center_cmd import agent_activity as activity_records
-from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
 NAME = "agents"
@@ -51,10 +50,16 @@ _MACHINE_KIND = {
 
 
 def fetch(target: Path) -> dict:
-    payload = data.run_json(target, ["center", "activity", "--limit", "100"])
-    if "error" not in payload:
-        payload.setdefault("completed_window_seconds", activity_records.completed_window_seconds(target))
-    return payload
+    # In-process collect: a fresh `python -m brigade center activity` subprocess
+    # paid ~15s of import tax on this host and made the view look hung.
+    records = activity_records.collect(target)
+    return {
+        "activity_envelope_version": activity_records.ACTIVITY_ENVELOPE_VERSION,
+        "agent_activity": records,
+        "agent_activity_count": len(records),
+        "agent_activity_summary": activity_records.summary(records),
+        "completed_window_seconds": activity_records.completed_window_seconds(target),
+    }
 
 
 def render(payload: dict, nonce: str) -> str:

--- a/src/brigade/center_cmd/dashboard/views/status_grid.py
+++ b/src/brigade/center_cmd/dashboard/views/status_grid.py
@@ -13,7 +13,7 @@ ORDER = 1
 
 
 def fetch(target: Path) -> dict:
-    return data.run_json(target, ["work", "brief"])
+    return data.run_json(target, ["work", "brief"], timeout=60.0)
 
 
 def render(payload: dict, nonce: str) -> str:

--- a/src/brigade/center_cmd/serve.py
+++ b/src/brigade/center_cmd/serve.py
@@ -14,10 +14,19 @@ from typing import Sequence
 from urllib.parse import parse_qs, urlparse
 
 from brigade.center_cmd.dashboard import render
+from brigade.center_cmd.dashboard import timing as center_timing
+from brigade.center_cmd.dashboard.snapshot import SnapshotCache
 from brigade.center_cmd.dashboard.views import all_views, render_nav, view_by_name
 
 _DEFAULT_PORT = 8765
 _VIEW_PREFIX = "/view/"
+
+
+def _view_cache_key(view_name: str, query: dict[str, str]) -> str:
+    if not query:
+        return view_name
+    encoded = "&".join(f"{key}={value}" for key, value in sorted(query.items()))
+    return f"{view_name}?{encoded}"
 
 
 def _has_port(host: str) -> bool:
@@ -79,6 +88,8 @@ class _DashboardHandler(BaseHTTPRequestHandler):
     _allowed_exact: set[str] = set()
     _allowed_bare: set[str] = set()
     _target: Path = Path(".")
+    _snapshots: SnapshotCache | None = None
+    _snapshot_wait_ms: float = 2000.0
 
     def _write_response(
         self,
@@ -108,6 +119,9 @@ class _DashboardHandler(BaseHTTPRequestHandler):
         self.send_header("Referrer-Policy", "no-referrer")
         self.send_header("Cache-Control", "no-store")
         self.send_header("Content-Length", str(len(data)))
+        timing_header = getattr(self, "_timing_header", None)
+        if isinstance(timing_header, str) and timing_header:
+            self.send_header("X-Brigade-Center-Timing", timing_header)
         self.end_headers()
         if self.command != "HEAD":
             self.wfile.write(data)
@@ -192,25 +206,41 @@ class _DashboardHandler(BaseHTTPRequestHandler):
         module = view_by_name(view_name)
         if module is None:
             raise KeyError(view_name)
+        cache = self._snapshots if self._snapshots is not None else SnapshotCache()
         # A view that raises must degrade to an inline panel, not a 500. The
         # default error path would answer without the security headers and
         # would put a traceback on the page.
-        try:
+        with center_timing.request_timer(view_name) as timer:
             query = self._parse_query()
-            fetch = module.fetch
-            if "query" in inspect.signature(fetch).parameters:
-                payload = fetch(self._target, query=query)
-            else:
-                payload = fetch(self._target)
-            fragment = module.render(payload, nonce)
-        except Exception:  # noqa: BLE001 - one broken panel must not take the page down
-            fragment = render.error_panel(module.TITLE, "This view failed to render.")
-        title = render.esc(f"{module.TITLE} - Brigade Center")
-        heading = f'<h1 class="page-title">{render.esc(module.TITLE)}</h1>'
-        body = f"{heading}{fragment}"
-        nav = render_nav(view_name)
-        page = render.page(title, nonce, nav, body)
-        return page.encode("utf-8")
+            cache_key = _view_cache_key(view_name, query)
+
+            def loader() -> dict:
+                fetch = module.fetch
+                if "query" in inspect.signature(fetch).parameters:
+                    return fetch(self._target, query=query)
+                return fetch(self._target)
+
+            with center_timing.phase("fetch"):
+                snapshot = cache.get(cache_key, loader, wait_ms=self._snapshot_wait_ms)
+            with center_timing.phase("render"):
+                try:
+                    if snapshot.payload.get("_center_fetch_failed"):
+                        fragment = render.error_panel(module.TITLE, "This view failed to render.")
+                    elif snapshot.status == "loading":
+                        fragment = render.loading_panel(module.TITLE)
+                    else:
+                        fragment = module.render(snapshot.payload, nonce)
+                except Exception:  # noqa: BLE001 - one broken panel must not take the page down
+                    fragment = render.error_panel(module.TITLE, "This view failed to render.")
+            banner = render.freshness_banner(snapshot, f"/view/{view_name}")
+            title = render.esc(f"{module.TITLE} - Brigade Center")
+            heading = f'<h1 class="page-title">{render.esc(module.TITLE)}</h1>'
+            body = f"{heading}{banner}{fragment}"
+            nav = render_nav(view_name)
+            reload_ms = 1500 if snapshot.status == "loading" else 30000
+            page = render.page(title, nonce, nav, body, reload_ms=reload_ms)
+            self._timing_header = timer.header_value()
+            return page.encode("utf-8")
 
     def do_GET(self) -> None:
         view_name = self._parse_view_name(self.path)
@@ -260,6 +290,8 @@ def _make_server(
     class _BoundHandler(_DashboardHandler):
         _token = token
         _target = target if target is not None else Path(".")
+        _snapshots = SnapshotCache()
+        _snapshot_wait_ms = 2000.0
 
     host_lc = host.strip().lower()
     server = ThreadingHTTPServer((host, port), _BoundHandler)

--- a/tests/test_center_page_load.py
+++ b/tests/test_center_page_load.py
@@ -1,0 +1,195 @@
+"""Page-load budget mechanisms: snapshot cache, scan bounds, staleness stamps."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from brigade.center_cmd import agent_activity as activity_records
+from brigade.center_cmd.dashboard import render
+from brigade.center_cmd.dashboard.snapshot import Snapshot, SnapshotCache
+from brigade.center_cmd.serve import _make_server
+from tests.test_center_serve import _headers_and_body, _raw_request, _status_code, _wait_until_ready
+
+
+def test_snapshot_cache_hit_does_not_recall_loader():
+    cache = SnapshotCache(ttl_seconds=30)
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return {"ok": True, "n": len(calls)}
+
+    first = cache.get("status", loader, wait_ms=1000)
+    second = cache.get("status", loader, wait_ms=1000)
+    assert first.status == "fresh"
+    assert second.status == "fresh"
+    assert first.payload == second.payload == {"ok": True, "n": 1}
+    assert calls == [1]
+
+
+def test_snapshot_cache_serves_stale_copy_while_refresh_runs():
+    cache = SnapshotCache(ttl_seconds=0.05)
+    phase = {"n": 0}
+
+    def loader():
+        phase["n"] += 1
+        if phase["n"] == 1:
+            return {"generation": 1}
+        time.sleep(0.2)
+        return {"generation": 2}
+
+    first = cache.get("memory", loader, wait_ms=1000)
+    time.sleep(0.08)
+    second = cache.get("memory", loader, wait_ms=0)
+    assert first.payload == {"generation": 1}
+    assert second.payload == {"generation": 1}
+    assert second.status == "stale"
+    assert second.fetched_at is not None
+
+
+def test_snapshot_cache_returns_loading_when_miss_exceeds_wait():
+    cache = SnapshotCache(ttl_seconds=30)
+    started = threading.Event()
+    release = threading.Event()
+
+    def loader():
+        started.set()
+        release.wait(timeout=2)
+        return {"ok": True}
+
+    snap = cache.get("agents", loader, wait_ms=50)
+    assert started.wait(timeout=1)
+    assert snap.status == "loading"
+    assert snap.payload.get("_center_loading") is True
+    release.set()
+
+
+def test_freshness_banner_includes_clock_and_refresh_link():
+    fetched = datetime(2026, 8, 13, 15, 34, 52, tzinfo=timezone.utc)
+    snap = Snapshot(
+        payload={"ok": True},
+        fetched_at=fetched,
+        status="stale",
+        age_seconds=12.0,
+    )
+    html = render.freshness_banner(snap, "/view/status")
+    assert "data as of" in html.lower()
+    assert "refresh" in html.lower()
+    assert 'href="/view/status"' in html
+    assert 'data-center-freshness="stale"' in html
+
+
+def test_freshness_banner_marks_loading_shell():
+    snap = Snapshot(payload={"_center_loading": True}, fetched_at=None, status="loading", age_seconds=None)
+    html = render.freshness_banner(snap, "/view/agents")
+    assert 'data-center-loading="1"' in html
+    assert "loading" in html.lower()
+
+
+def test_head_json_objects_does_not_slurp_whole_file(tmp_path, monkeypatch):
+    path = tmp_path / "rollout-huge.jsonl"
+    line = json.dumps({"type": "session_meta", "payload": {"cwd": "/tmp/demo-task"}}) + "\n"
+    path.write_bytes(line.encode("utf-8") + (b"x" * 250_000))
+    read_sizes: list[int] = []
+    real_open = Path.open
+
+    def tracking_open(self, mode="r", *args, **kwargs):
+        handle = real_open(self, mode, *args, **kwargs)
+        if self.resolve() != path.resolve():
+            return handle
+        orig_read = handle.read
+
+        def tracked_read(size=-1):
+            data = orig_read() if size is None or size < 0 else orig_read(size)
+            read_sizes.append(len(data) if size is None or size < 0 else size)
+            return data
+
+        handle.read = tracked_read  # type: ignore[method-assign]
+        return handle
+
+    def boom(self):  # noqa: ARG001
+        raise AssertionError("read_bytes slurps the whole file")
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+    monkeypatch.setattr(Path, "read_bytes", boom)
+    objects = activity_records._head_json_objects(path, max_bytes=4096)
+    assert objects
+    assert read_sizes
+    assert all(size <= 4096 for size in read_sizes)
+
+
+def test_session_scan_skips_old_files_and_oversized_reads(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 13, 15, 0, tzinfo=timezone.utc)
+    root = tmp_path / "sessions" / "2026" / "08"
+    root.mkdir(parents=True)
+    recent = root / "rollout-recent.jsonl"
+    old = root / "rollout-old.jsonl"
+    huge = root / "rollout-huge.jsonl"
+    recent.write_text('{"type":"session_meta","payload":{"cwd":"/tmp/recent-task"}}\n')
+    old.write_text('{"type":"session_meta","payload":{"cwd":"/tmp/old-task"}}\n')
+    huge.write_bytes(b'{"type":"x"}\n' + (b"z" * (activity_records._SESSION_READ_SIZE_CAP + 50)))
+    recent_mtime = now.timestamp()
+    old_mtime = (now - timedelta(days=21)).timestamp()
+    huge_mtime = now.timestamp()
+    import os
+
+    os.utime(recent, (recent_mtime, recent_mtime))
+    os.utime(old, (old_mtime, old_mtime))
+    os.utime(huge, (huge_mtime, huge_mtime))
+
+    read_paths: list[str] = []
+    real_head = activity_records._head_json_objects
+
+    def tracked_head(path, **kwargs):
+        read_paths.append(path.name)
+        return real_head(path, **kwargs)
+
+    monkeypatch.setattr(activity_records, "_head_json_objects", tracked_head)
+    records = activity_records._session_file_records(
+        root.parent.parent, "codex", "codex-cli", "Codex session", now, "rocinante"
+    )
+    labels = {record["task_label"] for record in records}
+    assert any("recent" in label.lower() or label != activity_records._UNKNOWN_TASK for label in labels) or records
+    assert "rollout-old.jsonl" not in read_paths
+    assert "rollout-huge.jsonl" not in read_paths
+
+
+def test_collect_does_not_live_probe_cloud_providers(tmp_path, monkeypatch):
+    called = []
+
+    def fake_observe(target):  # noqa: ARG001
+        called.append(1)
+        return {}, {"branches": [], "prs": []}, False
+
+    monkeypatch.setattr("brigade.cloud_tracker.observe_providers", fake_observe)
+    activity_records.collect(tmp_path)
+    assert called == []
+
+
+def test_status_view_renders_freshness_stamp(monkeypatch):
+    from brigade.center_cmd.dashboard.views import status_grid
+
+    def fake_fetch(target):
+        del target
+        return {"pending_tasks": []}
+
+    monkeypatch.setattr(status_grid, "fetch", fake_fetch)
+    server = _make_server(host="127.0.0.1", port=0, token=None, allowed_hosts=None, target=Path("."))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        _wait_until_ready(server)
+        host, port = server.server_address
+        response = _raw_request(server, f"{host}:{port}", path="/view/status")
+        assert _status_code(response) == "200"
+        _, body = _headers_and_body(response)
+        assert "data as of" in body.lower()
+        assert "refresh" in body.lower()
+        assert 'data-center-freshness="' in body
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_dashboard_status.py
+++ b/tests/test_dashboard_status.py
@@ -5,16 +5,16 @@ from brigade.center_cmd.dashboard.views import status_grid
 
 def test_fetch_uses_work_brief_json(monkeypatch, tmp_path):
     expected = {"handoff_issues": {"count": 2}}
-    calls: list[tuple[Path, list[str]]] = []
+    calls: list[tuple[Path, list[str], float | None]] = []
 
-    def fake_run_json(target: Path, args: list[str]) -> dict:
-        calls.append((target, args))
+    def fake_run_json(target: Path, args: list[str], *, timeout: float | None = None) -> dict:
+        calls.append((target, args, timeout))
         return expected
 
     monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
 
     assert status_grid.fetch(tmp_path) == expected
-    assert calls == [(tmp_path, ["work", "brief"])]
+    assert calls == [(tmp_path, ["work", "brief"], 60.0)]
 
 
 def test_render_displays_status_signals():


### PR DESCRIPTION
## Summary

Fixes #902. Operator verdict after merged main: Agent Activity never loads, Status does not load, and the rest of the dashboard is too slow to evaluate.

Profiled every Center view handler against the Brigade development checkout (large session/journal history) before changing behavior. Two hangs first:

- `/view/status` shells out to `brigade work brief --json` on every request. On this checkout that exceeds `data.run_json`'s 20s timeout, so the page always waited 20s and then showed `command timed out`.
- `/view/agents` shells out to `brigade center activity`, which respawns a full Brigade CLI (~15s import) and used to live-probe `gh api` plus `codex cloud list`. Session discovery was already dir-capped at 200, but `_head_json_objects` did `Path.read_bytes()[:max_bytes]` and therefore slurped whole Codex rollouts (one file here is 109MB).

Fix:

- Per-view snapshot cache (15s TTL, stale-while-revalidate, single-flight refresh).
- Explicit stamp on every page: `data as of HH:MM:SS, refresh`. Loading misses wait 2s then render a shell and reload at 1.5s instead of blocking out to the CLI timeout.
- Agent Activity `fetch` calls `collect()` in-process. Cloud cards read the local registry only.
- Session scans: 7-day mtime window, skip reads over 1 MiB, prefix-read with `read(max_bytes)`.
- Status `work brief` timeout raised to 60s so the background fill can finish and populate the cache.

## Before (handler end-to-end, same checkout)

| route | cold ms | warm ms | dominant phase |
|---|---:|---:|---|
| `/view/status` | 20277 | 20244 | `cli:work brief` (hit 20s timeout) |
| `/view/handoffs` | 317 | 287 | `cli:handoff lint` |
| `/view/memory` | 5633 | 5609 | `cli:memory topology` |
| `/view/outcomes` | 326 | 321 | `cli:outcome rank` |
| `/view/runs` | 300 | 310 | `cli:work verify runs` |
| `/view/activity` | 309 | 298 | `cli:work verify runs` |
| `/view/agents` | 18969 | 18372 | `cli:center activity --limit 100` |
| `/view/code` | 10927 | 2871 | `cli:code export --overlay` |
| `/view/graph` | 289 | 290 | `cli:work ready --explain --parallel-safe` |
| `/view/waves` | 288 | 300 | `cli:work ready --explain --parallel-safe` |
| `/view/claims` | 293 | 287 | `cli:work tasks --all` |

## After (same method: curl per route, then settled cache)

| route | cold ms | warm ms | dominant phase |
|---|---:|---:|---|
| `/view/status` | 2002 (loading shell) | 2 | snapshot wait, then cache |
| `/view/handoffs` | 292 | 1 | `cli:handoff lint`, then cache |
| `/view/memory` | 2001 (loading shell) | 2 | snapshot wait, then cache |
| `/view/outcomes` | 397 | 1 | `cli:outcome rank`, then cache |
| `/view/runs` | 329 | 4 | `cli:work verify runs`, then cache |
| `/view/activity` | 316 | 2 | `cli:work verify runs`, then cache |
| `/view/agents` | 42 | 7 | in-process `collect()`, then cache |
| `/view/code` | 2002 (loading shell) | 2 | snapshot wait, then cache |
| `/view/graph` | 282 | 1 | `cli:work ready`, then cache |
| `/view/waves` | 292 | 2 | `cli:work ready`, then cache |
| `/view/claims` | 287 | 1 | `cli:work tasks`, then cache |

Budget: every view under 2s warm and under 10s cold; hangs gone. Status/memory/code miss the 2s wait and return a loading shell (still under the 10s cold cap), then serve stamped data from cache. Agents is 42ms on first paint.

## Test plan

- [x] Mechanism tests (cache hit, stale-while-revalidate, loading miss, staleness stamp, capped session read, mtime/size skip, no live cloud probe): `pytest -q tests/test_center_page_load.py tests/test_center_agent_activity.py tests/test_center_dashboard.py tests/test_center_serve.py` (84 passed via `brigade work verify run --capture brigade-work`)
- [x] Curl every `/view/*` cold then warm against the development checkout; Status and Agent Activity render real tables/cards with a freshness stamp
- [ ] CI `./scripts/verify` on this branch

