### PR TITLE
test(work): stop self-import sanitizer flake on uuid hex prefix

### DIFF
--- a/scripts/windows-native-acceptance.ps1
+++ b/scripts/windows-native-acceptance.ps1
@@ -111,6 +111,30 @@ function Initialize-PipxBootstrap {
     return $bootstrapPython
 }
 
+function Invoke-RetryBrigadeSetup {
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$SetupCommand,
+        [int]$MaxAttempts = 3
+    )
+    # Online setup downloads GitHub release assets. Windows runners periodically
+    # fail with `Remote end closed connection without response` in under a
+    # second; retry with exponential backoff so that transient drop does not
+    # fail the job. Offline setup is not retried (cache, no network).
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        & $SetupCommand
+        if ($LASTEXITCODE -eq 0) {
+            return
+        }
+        if ($attempt -eq $MaxAttempts) {
+            throw "brigade setup failed"
+        }
+        $delaySeconds = [int][Math]::Pow(2, $attempt)
+        Write-Host "brigade setup failed (attempt $attempt of $MaxAttempts); retrying in $delaySeconds seconds"
+        Start-Sleep -Seconds $delaySeconds
+    }
+}
+
 function Invoke-Pipx {
     param(
         [string]$BootstrapPython,
@@ -597,8 +621,7 @@ try {
         Write-Step "brigade setup (online)"
         # Standalone manifest + published_component_ids omits empty-asset entries
         # such as agent-notify; do not add flags that would request them.
-        & brigade setup --manifest-source standalone
-        if ($LASTEXITCODE -ne 0) { throw "brigade setup failed" }
+        Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup --manifest-source standalone }
 
         Write-Step "brigade setup --offline"
         & brigade setup --offline --manifest-source standalone
@@ -606,8 +629,7 @@ try {
     }
     else {
         Write-Step "brigade setup (online)"
-        & brigade setup
-        if ($LASTEXITCODE -ne 0) { throw "brigade setup failed" }
+        Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup }
 
         Write-Step "brigade setup --offline"
         & brigade setup --offline

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -404,8 +404,26 @@ def test_windows_native_acceptance_source_setup_uses_standalone_manifest_online_
     online_at = body.index('Write-Step "brigade setup (online)"')
     offline_at = body.index('Write-Step "brigade setup --offline"')
     assert unpublished_at < online_at < offline_at
-    assert "& brigade setup --manifest-source standalone" in body
+    assert "Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup --manifest-source standalone }" in body
     assert "& brigade setup --offline --manifest-source standalone" in body
+
+
+def test_windows_native_acceptance_retries_online_setup_with_backoff():
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+    helper = _extract_powershell_function(text, "Invoke-RetryBrigadeSetup")
+    assert "$MaxAttempts = 3" in helper
+    assert "Start-Sleep -Seconds $delaySeconds" in helper
+    assert "[Math]::Pow(2, $attempt)" in helper
+    assert "Remote end closed connection without response" in helper
+
+    main = text[text.index("$acceptRoot = $null") :]
+    setup = main[main.index("[string[]]$unpublishedIds = @()") : main.index("$report = Get-ComponentReport")]
+    source_block = setup[setup.index('if ($InstallMode -eq "source") {') : setup.index("else {")]
+    pypi_block = setup[setup.index("else {") :]
+    assert source_block.count("Invoke-RetryBrigadeSetup") == 1
+    assert "Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup --offline" not in source_block
+    assert pypi_block.count("Invoke-RetryBrigadeSetup") == 1
+    assert "Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup --offline" not in pypi_block
 
 
 def test_windows_native_acceptance_pypi_setup_keeps_exact_manifest_default_and_digest_check():
@@ -417,7 +435,7 @@ def test_windows_native_acceptance_pypi_setup_keeps_exact_manifest_default_and_d
 
     published = re.search(r"else \{(?P<body>.*?)\n    \}", setup, re.DOTALL)
     assert published is not None
-    assert re.search(r"(?m)^        & brigade setup$", published.group("body"))
+    assert "Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup }" in published.group("body")
     assert re.search(r"(?m)^        & brigade setup --offline$", published.group("body"))
     assert "--manifest-source standalone" not in published.group("body")
     assert "Assert-ManagedComponentDigests -Manifest $releaseManifest" in text
@@ -652,7 +670,7 @@ def test_windows_native_acceptance_source_mode_skips_only_bundled_unpublished_co
     assert source_block.index('Write-Step "brigade setup (online)"') < source_block.index(
         'Write-Step "brigade setup --offline"'
     )
-    assert "& brigade setup --manifest-source standalone" in source_block
+    assert "Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup --manifest-source standalone }" in source_block
     assert "& brigade setup --offline --manifest-source standalone" in source_block
     assert "[string[]]$unpublishedIds = @()" in main
     assert "Assert-AllComponentsHealthy -Report $report -Skippable $unpublishedIds" in main
@@ -690,7 +708,7 @@ def test_windows_native_acceptance_source_setup_command_contract_omits_empty_ass
 
     main = script[script.index("$acceptRoot = $null") :]
     source_block = main[main.index('if ($InstallMode -eq "source") {') : main.index("$report = Get-ComponentReport")]
-    online_cmd = "& brigade setup --manifest-source standalone"
+    online_cmd = "Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup --manifest-source standalone }"
     offline_cmd = "& brigade setup --offline --manifest-source standalone"
     assert source_block.count(online_cmd) == 1
     assert source_block.count(offline_cmd) == 1
@@ -712,7 +730,7 @@ def test_windows_native_acceptance_pypi_setup_command_contract_is_strict():
     published = re.search(r"else \{(?P<body>.*?)\n    \}", setup, re.DOTALL)
     assert published is not None
     body = published.group("body")
-    assert re.search(r"(?m)^        & brigade setup$", body)
+    assert "Invoke-RetryBrigadeSetup -SetupCommand { & brigade setup }" in body
     assert re.search(r"(?m)^        & brigade setup --offline$", body)
     assert "--manifest-source" not in body
     assert "Get-UnpublishedComponentIds" not in body

--- a/tests/test_work_cmd_scanners.py
+++ b/tests/test_work_cmd_scanners.py
@@ -1488,7 +1488,14 @@ enabled = true
     assert "disabled=chat-memory-sweep" in check["detail"]
 
 
-def test_scanners_run_sanitizes_malicious_self_importing_scanner(tmp_path, capsys):
+def test_scanners_run_sanitizes_malicious_self_importing_scanner(tmp_path, capsys, monkeypatch):
+    from brigade.work_cmd import scanners as scanners_mod
+
+    # Pin uuid hex to the colliding prefix that made `self-import-1` match
+    # `{scanner-id}-{uuid4().hex[:6]}` in CI (e.g. `self-import-1f92c7`).
+    colliding_hex = iter(SimpleNamespace(hex=f"1{index:05x}{'0' * 26}") for index in range(1, 32))
+    monkeypatch.setattr(scanners_mod, "uuid4", lambda: next(colliding_hex))
+
     _init_git_repo(tmp_path)
     script = tmp_path / "self_import.py"
     script.write_text(
@@ -1499,7 +1506,7 @@ from pathlib import Path
 inbox = Path.cwd() / ".brigade" / "work" / "imports" / "inbox.jsonl"
 inbox.parent.mkdir(parents=True, exist_ok=True)
 record = {
-    "id": "self-import-1",
+    "id": "forged-self-import-id",
     "kind": "task",
     "source": "forged-self-import",
     "text": "self-imported work",
@@ -1554,7 +1561,7 @@ conflict_window = "02:00-02:10"
     imports = [json.loads(line) for line in imports_path.read_text().splitlines()]
     assert len(imports) == 1
     item = imports[0]
-    assert item["id"] != "self-import-1"
+    assert item["id"] != "forged-self-import-id"
     assert item["source"] == "self-import"
     assert item["metadata"]["declared_source"] == "forged-self-import"
     assert item["metadata"]["scanner_run_id"] == run["run_id"]
@@ -1593,7 +1600,7 @@ conflict_window = "02:00-02:10"
     assert retained[0]["metadata"]["provenance"]["source"]["kind"] == "self-import"
     retained_serialized = json.dumps(retained[0], sort_keys=True)
     for marker in (
-        "self-import-1",
+        "forged-self-import-id",
         "forged-content-sha256",
         "forged-raw-sha256",
         "forged-content-digest",


### PR DESCRIPTION
## Summary

`test_scanners_run_sanitizes_malicious_self_importing_scanner` failed on GitHub Actions run 31662533270 (Python 3.12, `de3672b4`) with:

```
assert 'self-import-1' not in '...self-import-1f92c7...'
```

The sanitizer did replace the forged id. The leftover substring came from the minted `run_id`: `{timestamp}-self-import-{uuid4().hex[:6]}`. Hex that starts with `1` (about 1 in 16) produces `self-import-1f92c7`, which contains `self-import-1`.

This is not tmp_path reuse, a time-based full-id clash, pytest-randomly, or xdist. The suite does not enable those plugins. `payload["failed"]` and `self_import` created/rejected counts were not the failing asserts on that run.

Local repro (before the fix): failed at iteration 7 of 80, `scanner_run_id=20260813-173218-self-import-1f92c7`. A uuid-formula probe produced 5 collisions in 200 draws.

Fix: forged id is now `forged-self-import-id`, and the test pins uuid hex to the colliding `1xxxxx` prefix so CI always hits the old failure path.

After the fix: 80/80 with `-p no:randomly`. Brigade verify receipt `20260813-173749-work-verify-e3b554`: 34 passed, exit 0.

## Windows native acceptance

Run 31658248861 (and 31654657042, 31640360516, 31640274402, 31638049606) failed at online `brigade setup` with:

```
component setup: Remote end closed connection without response
```

The failure lands about one second after the setup step starts. That is a dropped GitHub asset download, not a setup-logic bug. The existing Windows cert retry does not cover this disconnect.

Online setup now retries 3 times with 2s/4s backoff. Offline setup stays a single attempt.

## Test plan

- [x] Reproduced the sanitizer failure at iteration 7 of 80
- [x] 80/80 green after the marker change, with colliding uuid hex pinned
- [x] `pytest tests/test_work_cmd_scanners.py::test_scanners_run_sanitizes_malicious_self_importing_scanner tests/test_ci_workflow.py -q` -> 34 passed
- [ ] CI test job and windows-native-acceptance on this PR

Made with [Cursor](https://cursor.com)