### PR TITLE
docs: simplify the Brigade landing page

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -51,6 +51,13 @@ pipx install brigade-cli
 brigade setup
 ```
 
+If you already use uv, install the same package with:
+
+```bash
+uv tool install brigade-cli
+brigade setup
+```
+
 For an intentional Brigade development machine on the `0.27` preview line:
 
 ```bash
@@ -180,7 +187,7 @@ brigade reconfigure --target . --harnesses claude --prune
 
 The starter handoff template lives at `<inbox>/TEMPLATE.md`. Copy it to a new dated file (e.g. `2026-05-16-1430-fixed-X.md`), fill it in, and the ingester promotes safe card handoffs into `memory/cards/`, appends targeted updates to the right file, and kicks ambiguous material to the review inbox.
 
-When Claude Code is a selected writer harness, commit the managed `.claude/memory-handoffs/TEMPLATE.md` so the handoff format travels with the repository and Claude onboarding can verify it; other files under `.claude/` and session handoff notes in that inbox stay local-only. The same tracked-template pattern applies to other writer inboxes. If a global Git exclude hides the Claude template, use the repo-local recovery steps in [docs/new-user-quickstart.md](docs/new-user-quickstart.md#claude-handoff-template-hidden-by-a-global-git-exclude) — Brigade never edits global Git configuration.
+When Claude Code is a selected writer harness, commit the managed `.claude/memory-handoffs/TEMPLATE.md` so the handoff format travels with the repository and Claude onboarding can verify it. Other files under `.claude/` and session handoff notes in that inbox stay local-only. The same tracked-template pattern applies to other writer inboxes. If a global Git exclude hides the Claude template, use the repo-local recovery steps in [docs/new-user-quickstart.md](docs/new-user-quickstart.md#claude-handoff-template-hidden-by-a-global-git-exclude). Brigade never edits global Git configuration.
 
 See the [Solo Cookbook](https://github.com/escoffier-labs/solos-cookbook) for the longer-form guidance on what makes a good handoff and when to use which routing.
 

--- a/README.md
+++ b/README.md
@@ -1,307 +1,102 @@
 <p align="center">
-  <img src="docs/assets/brigade-kitchen-scene.jpg" alt="Brigade brand art: kitchen brigade at the pass (metaphor for coordinated agents)" width="900">
-</p>
-
-<h1 align="center">Brigade</h1>
-
-<p align="center">
-  <strong>One command to start. One command to keep it maintained.</strong>
+  <img src="docs/assets/brigade-wordmark.svg" alt="Brigade (by Escoffier Labs)" width="640">
 </p>
 
 <p align="center">
-  <strong>Built for coding agents to run end to end</strong> (install, setup, verify, handoffs), not as a human day-to-day terminal app.
-  When an agent says tests passed, you get a file with the real exit code, a <strong>code graph</strong> of what changed (<code>brigade code</code>), and an <strong>evidence log</strong> you can search later (<code>brigade evidence</code>).
-  Optional: one MCP and tools catalog across agents, and shared notes with a review gate.
-  Brigade owns the memory-care primitives and runbooks. An external scheduler (cron, systemd, CI, your agent cron) invokes them. Local files. No daemon. No lock-in.
-  Boundary: <a href="docs/execution-model.md">execution model</a>.
+  Brigade keeps coding-agent work trackable across tools, repos, and sessions: tasks, receipts, shared memory, and synced tools.
 </p>
 
 <p align="center">
-  <a href="https://brigade.tools">Website</a> · <a href="https://brigade.tools/docs">Docs</a> · <a href="#install">Install</a> · <a href="https://escoffierlabs.dev/cookbook/">Cookbook</a>
+  <a href="https://brigade.tools/docs/getting-started/install">Install</a> ·
+  <a href="https://brigade.tools/docs">Docs</a> ·
+  <a href="docs/comparison.md">Compare</a> ·
+  <a href="QUICKSTART.md">Quickstart</a>
 </p>
 
-<p align="center">
-  <img src="https://shieldcn.dev/github/ci/escoffier-labs/brigade.svg?workflow=ci.yml&branch=main&label=ci&size=xs" alt="CI status">
-  <img src="https://shieldcn.dev/pypi/v/brigade-cli.svg?label=pypi&size=xs" alt="PyPI version">
-  <img src="https://shieldcn.dev/pypi/dm/brigade-cli.svg?size=xs" alt="PyPI downloads per month">
-  <img src="https://shieldcn.dev/badge/python-3.10+-blue.svg?logo=python&logoColor=white&size=xs" alt="Python 3.10+">
-  <img src="https://shieldcn.dev/badge/rust-code_graph-b7410e.svg?logo=rust&logoColor=white&size=xs" alt="Rust: code graph engine">
-  <img src="https://shieldcn.dev/badge/go-evidence_log-00add8.svg?logo=go&logoColor=white&size=xs" alt="Go: evidence log engine">
-  <img src="https://shieldcn.dev/badge/license-MIT-4e7247.svg?size=xs" alt="MIT license">
-</p>
+Published **v0.26.1** is the stable install (`brigade-cli==0.26.1`). Current main / **0.27 beta** adds per-repo parallel-safe work waves, cross-repo ready-work campaigns, Memory Operations, activity and cloud status, code-graph views, bounded recall, and declared budgets. Cross-repo wave composition remains deferred. Cells below mark that split.
 
-<p align="center">
-  <img src="docs/assets/brigade-demo.svg" alt="Recording: an agent claims tests pass. A verify run writes a receipt with the real exit code, the code graph shows what the change touched, evidence search finds the run in the ledger, and outcome rank scores the skill that did the work" width="800">
-</p>
+## What it does
 
-<p align="center"><em>An agent said "tests pass." This is the claim becoming a record: receipt, code graph, evidence log, rank.</em></p>
+- **Ready work and claim safety.** Brigade lists unblocked tasks and uses atomic claims so two agents cannot take the same item. Stable in v0.26.1.
+- **Declared run limits and registered cloud activity.** Current main / 0.27 beta enforces declared wall-clock and worker-dispatch ceilings and reconciles registered cloud work against provider and GitHub state.
+- **Verification receipts.** A check run through Brigade writes the command, the real exit code, and the Git state. Stable in v0.26.1. Not every Brigade command writes a receipt.
+- **Owner-mediated handoffs and bounded recall.** Handoffs are linted and routed by the memory owner. Safe targeted notes may auto-file, while ambiguous or risky notes wait for review. Current main / 0.27 beta adds capped session-start recall.
+- **Explicit dry-run-first harness projection.** MCP servers, tools, and skills are previewed before Brigade writes them into a harness. Stable in v0.26.1.
 
-## The loop
-
-Every piece of work Brigade touches runs the same circuit:
-
-1. Intent and acceptance criteria go in.
-2. Prior evidence and code impact attach to the brief.
-3. Replaceable workers execute, bounded.
-4. Verification runs with a real exit code.
-5. The receipt, graph delta, and outcome land where the next run starts.
-
-Work enters as intent and leaves as evidence.
+Learning in Brigade is outcome-based skill scoring, promotion, and rollback from captured verification receipts. It is not autonomous reflective memory learning.
 
 ## Install
 
-**Default path: give the job to an agent.** Paste something like this into Claude Code, Codex, Cursor, OpenClaw, or any agent with shell access:
+Install with `pipx install brigade-cli` or `uv tool install brigade-cli`, then follow the [install guide](https://brigade.tools/docs/getting-started/install), [QUICKSTART.md](QUICKSTART.md), or give [first 10 minutes](docs/first-10-minutes.md) and [docs/agents-guide.md](docs/agents-guide.md) to your coding agent.
 
-```text
-Read https://github.com/escoffier-labs/brigade and follow AGENTS.md.
-Install brigade-cli with pipx if missing. Run operator quickstart with
---dry-run first and show the plan. Then apply, run brigade operator doctor,
-and report ready: yes. Keep existing memory layout. Do not touch remotes,
-do not commit, stop before anything destructive.
-```
+Stable channel: published v0.26.1. Preview channel: `brigade update --channel beta` for `0.27.0.devYYYYMMDD` wheels. Details: [update channels](docs/update-channels.md).
 
-The agent installs, runs `brigade setup`, wires harnesses, and leaves files on disk. You review when the gate is ambiguous or risky. You do not have to type the install path yourself.
+## How it compares
 
-**If you prefer a shell** (same commands the agent would run):
+Brigade overlaps several categories. Most adjacent projects specialize in one layer. Brigade connects those layers around trackable coding-agent work. Where a neighbor is stronger, that cell says so. Dated sources and longer notes: [docs/comparison.md](docs/comparison.md) (2026-08-13).
 
-```bash
-pipx install brigade-cli  # or: uv tool install brigade-cli
-pipx ensurepath           # then open a new shell so `brigade` is on PATH
-brigade setup             # install the verified native engines
-brigade operator quickstart --target ./my-repo --harnesses codex
-```
+### Work and orchestration
 
-**One and done (Claude Code).** Instead of wiring repos one at a time, install
-the work-loop hooks once at user scope:
+| Project | Ready work | Claim safety | Parallel and run control | Task-store boundary | Verification |
+| --- | --- | --- | --- | --- | --- |
+| [Brigade](https://github.com/escoffier-labs/brigade) | Stable ready set | Fail-closed CAS claims | 0.27: per-repo waves, cross-repo ready aggregation, declared limits | Local JSON files, no shared store | Command receipts |
+| [Beads](https://github.com/gastownhall/beads) | Built in | Atomic claim | Agent workflow + Dolt sync | Dolt-backed distributed store | Task history |
+| [Gas Town](https://github.com/gastownhall/gastown) | Beads-backed | Not documented | Multi-agent runtime | Beads ledger | Operational state |
+| [nWave](https://github.com/nWave-ai/nWave) | Wave artifacts | Not documented | 7 reviewed phases + TDD gates | Git-tracked artifacts | Phase validation |
+| [ActiveGraph](https://github.com/yoheinakajima/activegraph) | Reactive graph | Application-defined | Behaviors + runs | Append-only event log | Replay, fork, and diff |
 
-```bash
-brigade work hooks install --scope user
-```
+### Memory
 
-From then on, every repo the agent opens gets the work brief injected at
-session start, and an unwired repo gets the exact `brigade init` command
-printed for the agent to run - so agents wire new repos themselves and the
-verified-work loop closes everywhere without another human command. Remove it
-any time with `brigade work hooks uninstall --scope user`; only Brigade-owned
-hook entries are touched.
+| Project | Durable memory | Capture and recall | Care and operations | Learning | Provenance |
+| --- | --- | --- | --- | --- | --- |
+| [Brigade](https://github.com/escoffier-labs/brigade) | Shared files + cards | Handoffs. 0.27: bounded recall | Owner policy. 0.27: Memory Operations | Outcome score + promote + rollback | Work receipts + sources |
+| [Mem0 / OpenMemory](https://github.com/mem0ai/mem0) | User + agent + session | Automatic + hybrid search | History + metadata | Extraction + retrieval | Timestamps + entities |
+| [Letta](https://github.com/letta-ai/letta) | Agent state + blocks | Agent-managed tools | Editable state | Persistent agent runtime | Persistent agent state |
+| [agentmemory](https://github.com/rohitg00/agentmemory) | Shared coding-agent memory | Hooks + MCP + REST | Lifecycle + decay | Not documented | Searchable memory |
+| [Hindsight](https://github.com/vectorize-io/hindsight) | Facts + experiences + models | Retain + recall | Reflect + feedback | Reflective memory learning | Temporal + causal links |
+| [Built-in harness memory](https://code.claude.com/docs/en/memory) | Tool-specific | Rules + auto memories | Varies by harness | Harness-specific | Harness-specific |
+| [OpenClaw](https://docs.openclaw.ai/concepts/memory) | Plain files + index | Keyword + optional vector search | File-owned memory | Not documented | Files + source paths |
 
-Brigade prints a one-line notice when a new release is out. It checks at most
-once a day through an anonymous request. Set `BRIGADE_NO_UPDATE_CHECK=1` to
-disable it. Details are in [docs/update-channels.md](docs/update-channels.md).
+### Tools and configuration
 
-Two update channels exist and they are not interchangeable. **Stable** is the
-default: immutable, PyPI-published releases like `0.26.0`, pinned exactly -
-what production and operator machines should run. **Beta** is the intentional
-development-machine channel for the `0.27` preview line: it pins the newest
-non-yanked `brigade-cli==0.27.0.devYYYYMMDD` wheel from PyPI into the existing
-user-global pipx environment, not a mutable Git `main` SHA. Stable pinners may
-deliberately install an exact release with `pipx install brigade-cli==X.Y.Z`
-or refresh through `brigade update --channel stable`. Channel ownership, beta
-selection and rollback rules, and when to use `brigade update` are in
-[docs/update-channels.md](docs/update-channels.md).
+| Project | MCP | Reviewed rules and skills | Projection behavior | Source of truth | Audit and rollback |
+| --- | --- | --- | --- | --- | --- |
+| [Brigade](https://github.com/escoffier-labs/brigade) | MCP + tools catalog | Skills + adapters | Dry-run-first, then apply | Brigade catalog | Preserve + gate + rollback |
+| [add-mcp](https://github.com/neon-solutions/add-mcp) | MCP servers | Not documented | Maps fields into native files | Registry + native files | Warnings for dropped fields |
+| [Rulesync](https://github.com/dyoshikawa/rulesync) | Supported | Rules + skills + hooks | Per-target generation | Rulesync project | Generated outputs |
+| [config-sync](https://pypi.org/project/aiconfigsync/) | Not documented | Rules for 12 tools | Generated rule files | Single config | Generated outputs |
+| [chezmoi](https://www.chezmoi.io/) | As files | As files | Templates + apply | Git-backed source dir | Diff + templates + merge |
+| [agentsync](https://agentsync.cc/) | Many agent targets | Skills + hooks + commands | Native/lossy/skipped report | Canonical config | Native/lossy/skipped report |
 
-`brigade operator doctor --target ./my-repo --profile local-operator` prints `ready: yes` when the wiring is healthy (without the profile flag, doctor runs the stricter internal-dogfood checks and a fresh repo reports not ready). The default footprint is small: `AGENTS.md`, `SAFETY_RULES.md`, a handoff template, and `.brigade/` state. Add `--dry-run` to preview anything before it writes. Nothing leaves your machine.
+### Evidence and operations
 
-Per-OS setup (apt, Homebrew, Scoop, PowerShell), workspace depth, and multi-harness installs: [install guide](https://brigade.tools/docs/getting-started/install), [QUICKSTART.md](QUICKSTART.md), [first 10 minutes](docs/first-10-minutes.md). Homegrown setup already? `brigade operator adopt plan`.
+| Project | Receipts | Code impact | Agent activity | Cloud state | Learning / replay |
+| --- | --- | --- | --- | --- | --- |
+| [Brigade](https://github.com/escoffier-labs/brigade) | Command + Git + optional impact | Stable impact. 0.27: code-graph views | 0.27: center activity | 0.27: registered cloud status | Score + promote + rollback |
+| [ActiveGraph](https://github.com/yoheinakajima/activegraph) | Event trace | Not documented | Reactive behaviors | Not documented | Replay, fork, and diff |
+| [CocoIndex](https://github.com/cocoindex-io/cocoindex) | Data lineage | Not documented | Not documented | Not documented | Incremental recompute |
+| [Graphiti](https://github.com/getzep/graphiti) | Episode provenance | Not documented | Not documented | Not documented | Temporal fact updates |
+| [Hindsight](https://github.com/vectorize-io/hindsight) | Not documented | Not documented | Not documented | Not documented | Reflective memory learning |
+| [Neo4j Agent Memory](https://github.com/neo4j-labs/agent-memory) | Reasoning + tool traces | Not documented | Not documented | Not documented | Similar-task retrieval |
 
-**Contributing?** See [Your first PR](CONTRIBUTING.md#your-first-pr) in [CONTRIBUTING.md](CONTRIBUTING.md) for starter issues, the 48-hour claim convention, and local verification ([Local dev](CONTRIBUTING.md#local-dev): content-guard scan for docs-only changes; `./scripts/verify` for code).
+"Not documented" means the capability was not found in the project's official README or documentation on 2026-08-13. It is not proof that the capability is absent. An event trace, memory history, data lineage, and a command verification receipt answer different questions.
 
-## Auditable agents: every action leaves a receipt
+## Scope
 
-An agent that reports "tests pass, nothing else changed" is making a claim. Brigade turns the claim into a record. Run any check through Brigade and it writes a receipt: the command, the real exit code, the graph delta, the git state.
+Brigade is a local file-first control plane for coding agents. There is no Brigade daemon. Scheduling stays external, except optional operator-owned, target-scoped care registrations (`brigade care install`). The work ledger is machine-local JSON and is not a distributed task database. Ordinary runs have no hard run-budget unless one is declared. When declared, only wall-clock and worker-dispatch ceilings are enforced today. Model, tool, token, and cost dimensions stay observed unless an adapter owns an enforcement boundary. Campaigns aggregate ready work across repos, but do not yet compose parallel cross-repo waves. Center is read-only. External activity observations are best-effort. Cloud registry commands track work that another provider runs. Safe targeted handoffs may auto-file under owner policy. Ambiguous or risky notes wait for review.
 
-```bash
-brigade work verify run --target . --command "pytest -q" --capture brigade-work
-```
-
-```jsonc
-// .brigade/work/verify-runs/20260722-033355-work-verify-298ff5/receipt.json (abridged)
-{
-  "run_id": "20260722-033355-work-verify-298ff5",
-  "status": "completed",
-  "duration_seconds": 15.18,
-  "commands": { "check": { "argv": ["pytest", "-q"], "returncode": 0 } },
-  "code_graph_delta": { "changed_symbol_count": 0 },
-  "git": { "branch": "main", "dirty_files": 0 }
-}
-```
-
-Receipts land in the **evidence log** (`brigade evidence`), a Go engine installed by `brigade setup` (historically shipped as MiseLedger). Every consequential action elsewhere in Brigade (a memory write, a skill promotion, a sync) is logged the same way. `brigade evidence search` answers "what ran, when, and what did it change" from files, weeks later. Cross-model dispatches through `brigade run` carry the same paper trail. When someone asks what your agents did this week, the answer comes from receipts you can grep, not from scrollback. [Capability page](https://brigade.tools/evidence-memory).
-
-## Code graph, built in
-
-The `code_graph_delta` line in that receipt comes from the **code graph** (`brigade code`), a Rust engine installed by `brigade setup` (historically shipped as GraphTrail, digest-verified, no toolchain required). It indexes your repo once and keeps up incrementally. On this repository a sync pass over 652 files and 10,405 symbols reports in well under a second. A receipt names the exact symbols a change touched, and your agents stop grepping and start asking structural questions:
-
-```
-$ brigade code impact _write_receipt
-test_runbook_closeout_imports_failed_steps  --calls@31--> _write_receipt
-test_runbook_closeout_without_import_flag   --calls@45--> _write_receipt
-
-$ brigade code context "verify receipts"
-## Entry Points
-- function `_verify_receipts` at src/brigade/work_cmd/verification.py:185-192
-- function `_iter_verify_receipts` at src/brigade/workflow_cmd.py:142-167
-```
-
-The graph feeds the rest of Brigade instead of sitting idle: `brigade run` prepends a context pack when a graph exists, so a dispatched model starts from callers and blast radius instead of a cold grep, and an MCP server ships alongside so any harness can query the graph directly. [Capability page](https://brigade.tools/code-intelligence).
-
-## One MCP and tool catalog, synced into every tool
-
-Every agent tool reads its MCP servers from a different file in a different shape. The same servers wired across Claude Code, Cursor, Codex, VS Code, OpenCode, and Antigravity means hand-editing six configs and keeping them in sync forever. Brigade keeps one canonical catalog and merges it into each tool's native config for you.
-
-```bash
-brigade mcp init                  # scaffold .brigade/mcp.json
-brigade mcp add --name github --command npx \
-  --args "-y @modelcontextprotocol/server-github" \
-  --env GITHUB_AUTH_ENV=ref:BRIGADE_GITHUB_AUTH_ENV
-brigade mcp sync                  # dry-run: show the diff for every tool
-brigade mcp sync --write          # merge into each tool's config
-brigade mcp verify                # check initialize + tools/list at runtime
-```
-
-Run `brigade mcp sync` and you get the per-tool plan, server by server, before a single file changes:
-
-```
-brigade mcp sync (dry-run): ~/my-repo
-claude       github               missing        -> create
-claude       sentry               missing        -> create
-cursor       github               missing        -> create
-cursor       sentry               missing        -> create
-codex        github               missing        -> create
-codex        sentry               missing        -> create
-vscode       github               missing        -> create
-vscode       sentry               missing        -> create
-opencode     github               missing        -> create
-opencode     sentry               missing        -> create
-```
-
-| Tool | File it writes |
-|---|---|
-| Claude Code | `.mcp.json` |
-| Cursor | `.cursor/mcp.json` |
-| Codex CLI | `.codex/config.toml` (merged surgically, other tables preserved) |
-| Grok CLI | `.grok/config.toml` (same TOML shape as Codex) |
-| VS Code | `.vscode/mcp.json` (secrets become `inputs[]`) |
-| OpenCode | `opencode.json` |
-| Antigravity | `~/.gemini/config/mcp_config.json` (user-scoped) |
-
-Dry-run by default. Merges by server key, so servers you added by hand are never touched. Secrets are written as `${VAR}` references, never inlined. Ownership lives in a gitignored sidecar, so a fresh clone re-syncs without conflict. Tools and skills get the same treatment via `brigade tools sync`: one reviewed catalog, projected into each harness's native format. Full merge rules: [docs/mcp-sync.md](docs/mcp-sync.md). Evaluating options first? [The comparison page](https://brigade.tools/compare/sync-mcp-servers-across-coding-agents).
-
-## Shared memory and verified learning
-
-Writer harnesses leave handoff notes as they work. Brigade lints, guards, and classifies each one. Safe, targeted notes file themselves into durable memory. The ambiguous few wait for your review. Every consequential action is logged to a plain file you can grep, diff, and prune.
-
-<p align="center">
-  <img src="docs/assets/memory-workflow.svg" alt="Brigade memory workflow: writer handoffs pass through linting, guards, and classification before reaching durable memory or review" width="820">
-</p>
-
-Memory stays two layers deep: knowledge cards hold the detail, `MEMORY.md` stays a slim one-line-per-card index that loads every session. `brigade memory care scan` flags stale or contradictory cards instead of letting them rot, and `brigade evidence search` plus exported briefs mean the next session starts where this one stopped.
-
-Filing notes is the first loop. The second loop earns trust: Brigade promotes a learned skill only when a real signal proves it helped, and rolls it back the moment a signal says it broke. The model never grades its own work.
-
-```
-$ brigade outcome rank
-- brigade-work      score=0.692  helped=675  hurt=260
-- ultra-work-scout  score=0.563  helped=50   hurt=24
-- memory-handoff    score=0.490  helped=8    hurt=2
-```
-
-- `brigade outcome capture` records a verify run's real exit code against the skill that produced it.
-- `brigade outcome score` ranks by a Wilson lower bound, so two lucky passes never outrank twenty vetted runs.
-- `brigade outcome reconcile` is the gate: dry-run by default, `--apply` installs a skill that earned it or rolls a regressed one back.
-- `brigade outcome explain` prints the full signal trail behind any decision, so every promotion is as auditable as the runs that earned it.
-
-Scores are recomputed from the stored receipts every time you read them, so upgrading Brigade can move numbers with no new runs. Which failures count against a seat and which neutralize is in [docs/outcome-scoring.md](docs/outcome-scoring.md).
-
-The ledger is plain JSON and markdown under `memory/outcome/`, tracked in git, readable without Brigade. `brigade init` wires a `brigade-work` skill into each harness so agents run this loop without being told. With Claude Code it also installs project-scoped hooks that redirect raw test commands through verify runs.
-
-## Optional stations
-
-**Built in** (via `brigade setup`):
-
-| Surface | Commands | Notes |
-|---|---|---|
-| Code graph | `brigade code …` | Callers, impact, context. Formerly GraphTrail. |
-| Evidence log | `brigade evidence …` | Searchable ledger of runs and imports. Formerly MiseLedger. |
-| Content Guard | `brigade guard` / `brigade scrub` | Secrets and private detail before publish. |
-
-**Optional stations** (add when you need them). Core works with none installed. `brigade status` health-checks whatever is present.
-
-| Station | Install | Role |
-|---|---|---|
-| [Agent Pantry](https://github.com/escoffier-labs/agentpantry) | `brigade add pantry` | Encrypted browser-session and secret sync across machines |
-| [Token Glace](https://github.com/escoffier-labs/token-glace) | `brigade add tokens` | Compact noisy tool output before it burns context |
-| [Skillet](https://github.com/escoffier-labs/skillet) | optional roster | Portable skills that reconcile can promote or roll back |
-| [Bootstrap Doctor](https://github.com/escoffier-labs/bootstrap-doctor) | `brigade add bootstrap-doctor` | Audit OpenClaw bootstrap files (SOUL.md, TOOLS.md, AGENTS.md, IDENTITY.md, MEMORY.md, and the rest of the set) and trim oversize detail into cards |
-| Notifications | `brigade add notifications` | Optional `agent-notify` binary for Discord, Telegram, or Signal. Status and setup planning only until you wire hooks or pass an explicit `--send` |
-
-Upgrading from standalone GraphTrail or MiseLedger installs? `brigade setup` replaces both. The old `brigade add graphtrail` / `add evidence` paths remain as compatibility shims. Engine binaries and some paths still use the historical names. The operator surface is `brigade code` and `brigade evidence`. Details: [wiring guide](docs/wiring-graphtrail-miseledger.md), [station contract](docs/station-contract.md).
-
-Beyond the daily loop, the same review-and-receipt pattern covers cross-model runs (`brigade run` dispatches one bounded task across your roster), security scans, friction mining, research reports, and fleet health. All of it stays behind `brigade extras on` until you ask. The full tour: [docs/overview.md](docs/overview.md).
-
-## Why not something else?
-
-- **mem0, Letta, agentmemory, and friends** are memory layers for apps you are building, usually behind an API or a server. Brigade is for the agent CLIs you already run, and it is file-first: your memory is markdown in your repo, reviewable in git, readable without Brigade.
-- **add-mcp, chezmoi, and config-sync scripts** move MCP or dotfiles around, but they sync one thing with no review gate and no receipt. Brigade keeps MCP servers, tools, skills, and memory in one canonical source, shows the per-tool diff before any write, and leaves a receipt you can roll back.
-- **Native harness memory** is a per-tool silo. It does not cross harnesses, and it writes without review. Brigade gives every tool one shared format and one canonical owner, with a review gate in between.
-- **Already running Hermes, or any self-improving agent?** Keep it. Brigade is the verification layer on top: it promotes a skill only when a real signal confirms it, keeps every learned skill as portable markdown in your git, and runs one loop across your whole fleet.
-- **A plain CLAUDE.md / AGENTS.md** works great until it bloats past the context budget and goes stale. Brigade keeps bootstrap files slim, moves detail into indexed cards, and flags staleness instead of trusting last month's facts forever.
-- **A daemon or hosted service** would be simpler to demo and worse to trust. Brigade writes local files when you run a command, and that is all it does. See the [execution model](docs/execution-model.md).
-
-| | Across harnesses | MCP, tools, and memory in one source | Review gate + receipts | Local files, no daemon |
-|---|:---:|:---:|:---:|:---:|
-| **Brigade** | yes | yes | yes | yes |
-| mem0 / Letta / agentmemory | per-SDK | memory only | no | usually hosted or a server |
-| add-mcp / chezmoi / config-sync | partial | MCP or dotfiles only | no | yes |
-| Native harness memory | no | memory only | no | yes |
-
-## What Brigade is not
-
-Brigade is not a hosted memory service, a daemon, or an automatic release bot. It does not run in the background. Scheduling stays with the operator (see the [execution model](docs/execution-model.md)). It does not push to GitHub, publish packages, save every note automatically, or skip review for ambiguous, risky, or failed notes. `brigade work brief` and related status surfaces may report notification readiness or suggest installing the notifications station, but Brigade never sends a message unless the operator uses an explicit send action such as `brigade pantry expiry-alert --send`. That pause is the point: agent memory should be useful, not noisy.
-
-And it is not the other projects that share the name. This Brigade is the AI-agent operator CLI from [`escoffier-labs/brigade`](https://github.com/escoffier-labs/brigade), installed with `pipx install brigade-cli`. It is not the CNCF/Microsoft Brigade for Kubernetes event scripting (archived 2022), the Spinabot Brigade agent crew, or the 2017 `brigade` Python package that became Nornir.
-
-## Why I built this
-
-<p align="center">
-  <img src="docs/assets/brigade-social-preview.jpg" alt="Brigade social banner: kitchen metaphor brand art" width="900">
-</p>
-
-I run an always-on OpenClaw agent next to daily Codex and Claude Code sessions. Every one of those tools wakes up empty, and whatever a session learned scattered across tool-specific folders and died there. Two incidents shaped the design: a "dreaming" job that promoted raw session fragments straight into memory bloated `MEMORY.md` past the bootstrap budget, so every session started truncated and nobody noticed for weeks. And 195 handoff notes sat unread across 35 repos because an ingester had a hardcoded allowlist and nothing warned about the gap. Silence is the failure mode. Every part of Brigade that lints, warns, or writes a receipt exists because something once failed in silence. The full production stack, now 482 cards across daily multi-agent work, is documented in the [Cookbook](https://escoffierlabs.dev/cookbook/).
-
-## Names (public vs historical)
-
-| What you type / say | Historical name | Notes |
-|---|---|---|
-| Code graph · `brigade code` | GraphTrail | Built in via `brigade setup` |
-| Evidence log · `brigade evidence` | MiseLedger | Built in via `brigade setup` |
-| Content Guard · `brigade guard` / `scrub` | content-guard | Embedded |
-| Bootstrap Doctor | same | Full OpenClaw bootstrap set: SOUL, TOOLS, AGENTS, IDENTITY, MEMORY, and related session-start files |
-
-Kitchen language (*brigade de cuisine*, *mise en place*, station nicknames) is brand and deep docs. Commands and product surfaces stay plain: receipt, code graph, evidence log, sync, handoff.
-
-**Who runs what:** agents install, set up, verify, and write handoffs. Humans set policy and review gates when something is ambiguous or risky. The CLI is the control plane the fleet drives, not a tool you are expected to operate by hand all day.
-
-## Harnesses
-
-Nineteen harnesses get handoff inboxes and ingest coverage, from Codex, Claude Code, and Cursor to Goose, Aider, and OpenHands. Most also get projected tools and skills in their native format. The per-harness matrix is in the [technical guide](docs/technical-guide.md).
-
-## Questions
-
-[@brigadeclaw](https://x.com/brigadeclaw) answers questions about Brigade on X. Every sentence it posts cites the pinned documentation it came from, and it stays silent rather than guessing. How it works, including the gates and the refusals: [brigade.tools/brigadeclaw](https://brigade.tools/brigadeclaw).
+Brigade is not a hosted memory service, automatic release bot, or full autonomous fleet runtime. It does not push to GitHub, publish packages, or send chat messages unless the operator uses an explicit send action. Name collisions: this is `brigade-cli` from [escoffier-labs/brigade](https://github.com/escoffier-labs/brigade), not the archived CNCF/Microsoft Kubernetes Brigade, Spinabot Brigade, or the 2017 Python package that became Nornir.
 
 ## Docs
 
-- [First 10 minutes](docs/first-10-minutes.md) · [Overview](docs/overview.md) · [Technical guide](docs/technical-guide.md)
-- [Execution model](docs/execution-model.md) · [Memory care](docs/memory-care.md) · [MCP sync](docs/mcp-sync.md)
-- [Security and Content Guard](docs/security.md) · [Handoff promotion](docs/handoff-promotion.md)
-- [Command inventory](docs/command-inventory.md) · [Station contract](docs/station-contract.md)
-- [Maintainers](MAINTAINERS.md) · [Governance](GOVERNANCE.md) · [Security](SECURITY.md) · [Contributing](CONTRIBUTING.md) · [Roadmap](ROADMAP.md)
+- [First 10 minutes](docs/first-10-minutes.md) · [Overview](docs/overview.md) · [Technical guide](docs/technical-guide.md) · [Comparison](docs/comparison.md)
+- [Execution model](docs/execution-model.md) · [Work closeout](docs/work-closeout.md) · [Outcome scoring](docs/outcome-scoring.md)
+- [Memory care](docs/memory-care.md) · [Memory operations](docs/memory-operations.md) · [Code intelligence](docs/code-intelligence.md) · [MCP sync](docs/mcp-sync.md)
+- [Agents guide](docs/agents-guide.md) · [Agent-assisted setup](docs/agent-assisted-setup.md) · [README coverage](docs/readme-coverage.md)
+- [Security](docs/security.md) · [Command inventory](docs/command-inventory.md) · [Contributing](CONTRIBUTING.md) · [Roadmap](ROADMAP.md)
 
 ## License
 
 MIT. See [LICENSE](LICENSE).
 
-Project identity: GitHub [`escoffier-labs/brigade`](https://github.com/escoffier-labs/brigade), website [brigade.tools](https://brigade.tools), PyPI [`brigade-cli`](https://pypi.org/project/brigade-cli/), command `brigade`. The product name comes from a kitchen line (*brigade de cuisine*): coordinated stations, prep before service. You do not need the kitchen glossary to install or run it. Set up rules, memory, tools, and receipts before the session gets expensive.
-
-It is early-stage and moving fast. If you hit a broken workflow, a confusing command, or a setup issue, [open an issue](https://github.com/escoffier-labs/brigade/issues) and I will get it fixed.
+Project identity: GitHub [`escoffier-labs/brigade`](https://github.com/escoffier-labs/brigade), website [brigade.tools](https://brigade.tools), PyPI [`brigade-cli`](https://pypi.org/project/brigade-cli/), command `brigade`.

--- a/docs/agent-assisted-setup.md
+++ b/docs/agent-assisted-setup.md
@@ -1,10 +1,20 @@
 # Agent-Assisted Setup
 
-Point a coding agent at the Brigade repository (or paste a short prompt from the README). **The agent installs and wires Brigade.** Humans often never type `pipx` or `brigade setup`.
+Point a coding agent at the Brigade repository (or paste the prompt below). **The agent installs and wires Brigade.** Humans often never type `pipx` or `brigade setup`.
 
 Root `AGENTS.md` is for **developing Brigade**. For install and adapt, agents follow **`docs/agents-guide.md`** (this doc is supporting detail).
 
-Brigade is designed so agents run the control plane (install, setup, verify, handoffs) and humans review when a gate is ambiguous or risky. Adapt an existing homegrown setup; do not replace it wholesale. Keep the user's memory owner, workspace or repo layout, harness choices, and local habits unless Brigade needs a small compatibility file or handoff inbox.
+## Paste-ready install prompt
+
+```text
+Read https://github.com/escoffier-labs/brigade and follow docs/agents-guide.md.
+Install brigade-cli with pipx if missing (or uv tool install brigade-cli).
+Run operator quickstart with --dry-run first and show the plan. Then apply,
+run brigade operator doctor, and report ready: yes. Keep existing memory
+layout. Do not touch remotes, do not commit, stop before anything destructive.
+```
+
+Brigade is designed so agents run the control plane (install, setup, verify, handoffs) and humans review when a gate is ambiguous or risky. Adapt an existing homegrown setup. Do not replace it wholesale. Keep the user's memory owner, workspace or repo layout, harness choices, and local habits unless Brigade needs a small compatibility file or handoff inbox.
 
 Treat setup as local workspace wiring, not as a release, deploy, or remote mutation. Local-first means data on the operator-controlled machine first (laptop, workstation, or VPS) before any external service.
 
@@ -23,6 +33,7 @@ Then work inside the **target** repo or operator workspace and run:
 
 ```bash
 pipx install brigade-cli
+# alternative: uv tool install brigade-cli
 brigade setup
 brigade --version
 brigade operator quickstart --target . --harnesses codex --dry-run
@@ -97,6 +108,16 @@ brigade operator quickstart --target . --depth workspace --harnesses openclaw,he
 ```
 
 OpenClaw and Hermes can act as memory owners or writer surfaces depending on the user's setup. If the agent is unsure, it should start with the harness the user is currently using and report the next command needed to add another surface later.
+
+## Claude Code user-scope work hooks
+
+Install the verified-work loop once at user scope instead of wiring every repo by hand:
+
+```bash
+brigade work hooks install --scope user
+```
+
+Session start then injects the work brief. An unwired repo prints the exact `brigade init` command for the agent to run. Uninstall with `brigade work hooks uninstall --scope user`. Only Brigade-owned hook entries are touched.
 
 ## Success Check
 

--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -25,10 +25,22 @@ Standalone GraphTrail or MiseLedger product installs are replaced by `brigade se
 
 Read in this order:
 
-1. `README.md` (agent-first install paste + product surface)
+1. `README.md` (short landing page)
 2. This file (`docs/agents-guide.md`)
 3. `docs/agent-assisted-setup.md` (boundaries and adaptation detail)
 4. `docs/new-user-quickstart.md` if the target is a first-time human skim
+
+### Paste-ready install prompt
+
+When a human pastes a short job into Claude Code, Codex, Cursor, OpenClaw, or any agent with shell access, use this exact brief:
+
+```text
+Read https://github.com/escoffier-labs/brigade and follow docs/agents-guide.md.
+Install brigade-cli with pipx if missing (or uv tool install brigade-cli).
+Run operator quickstart with --dry-run first and show the plan. Then apply,
+run brigade operator doctor, and report ready: yes. Keep existing memory
+layout. Do not touch remotes, do not commit, stop before anything destructive.
+```
 
 Brigade is local-first workspace wiring. Local-first means data on the operator-controlled machine first (laptop, workstation, or VPS) before any external service. Adapt the user's existing memory, handoff, and agent workflow. Do not replace a working layout with someone else's exact tree.
 
@@ -42,6 +54,7 @@ Always dry-run before write. Then apply. Then doctor.
 
 ```bash
 pipx install brigade-cli
+# alternative: uv tool install brigade-cli
 brigade setup
 brigade --version
 brigade operator quickstart --target . --harnesses <harness> --dry-run
@@ -89,6 +102,16 @@ brigade harness uninstall cursor --scope user --dry-run
 brigade harness uninstall cursor --scope user --write
 ```
 
+### Claude Code user-scope work hooks
+
+Instead of wiring repos one at a time, install the work-loop hooks once at user scope:
+
+```bash
+brigade work hooks install --scope user
+```
+
+From then on, every repo the agent opens gets the work brief injected at session start, and an unwired repo gets the exact `brigade init` command printed for the agent to run. Agents can wire new repos themselves and close the verified-work loop without another human command. Remove it with `brigade work hooks uninstall --scope user`. Only Brigade-owned hook entries are touched.
+
 ## After install: the agent work loop
 
 Once doctor is healthy, **you** (the coding agent) should prefer:
@@ -126,7 +149,7 @@ Usually safe to commit after review:
 
 - `AGENTS.md`, `MEMORY.md` and reviewed memory cards if this repo owns memory
 - `rules/`, `tools/`, public docs
-- the managed handoff template for each selected writer harness — for Claude Code, `.claude/memory-handoffs/TEMPLATE.md` (required for Claude onboarding; `verify-harness` fails readiness when a global exclude hides it); for other writers, the matching `<inbox>/TEMPLATE.md`
+- the managed handoff template for each selected writer harness. Claude onboarding requires `.claude/memory-handoffs/TEMPLATE.md`, and `verify-harness` fails readiness when a global exclude hides it. Other writers use the matching `<inbox>/TEMPLATE.md`
 
 Handoff inboxes stay local except each inbox's managed `TEMPLATE.md`. Session handoff files in those folders stay ignored.
 

--- a/docs/assets/brigade-wordmark.svg
+++ b/docs/assets/brigade-wordmark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="200" viewBox="0 0 920 200" role="img" aria-labelledby="title desc">
+  <title id="title">Brigade (by Escoffier Labs)</title>
+  <desc id="desc">Dark wordmark for Brigade from Escoffier Labs</desc>
+  <rect x="1" y="1" width="918" height="198" rx="24" fill="#0d1117" stroke="#57606a" stroke-width="2"/>
+  <text x="54" y="126" font-family="Arial, Helvetica, sans-serif" font-size="86" font-weight="800" fill="#5d8dff">Brigade</text>
+  <text x="392" y="122" font-family="Arial, Helvetica, sans-serif" font-size="30" font-weight="600" fill="#f0f3f6">(by Escoffier Labs)</text>
+</svg>

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -1,0 +1,55 @@
+# Code intelligence
+
+Brigade's built-in code map (`brigade code`, historically GraphTrail) indexes a repository for structural queries and attaches a graph delta to verification receipts when the engine is present. Install it with `brigade setup`. No separate GraphTrail product install is required.
+
+## Sync
+
+```bash
+brigade setup
+brigade code sync --target .
+brigade code doctor --target .
+```
+
+`sync` builds or refreshes the local index. Status reports whether the index is present and usable. Without a synced index, verify still runs. The receipt simply omits or empties the graph delta.
+
+## Structural queries
+
+```bash
+brigade code callers <symbol>
+brigade code callees <symbol>
+brigade code impact <symbol>
+brigade code context "<task>"
+```
+
+Use these before edits that rename symbols or change call shape. `impact` and `context` are the usual entry points for agent briefs.
+
+## Receipt deltas
+
+When a check runs through `brigade work verify run` and the code map is available, the verify receipt (`schema_version: 2`) may include a `code_graph_delta` summary of symbols touched by the change. That delta is evidence for the run, not a substitute for the exit code.
+
+Not every Brigade command writes a receipt. Ad hoc shell commands outside `work verify run` do not automatically produce one.
+
+## Export and Center
+
+Current main / 0.27 beta adds a bounded JSON export contract and a Center view:
+
+```bash
+brigade code export --target . --json
+brigade code export --target . --json --symbol <symbol> --overlay
+```
+
+The export caps the module map at 48 modules and 96 edges. `--overlay` reads the local Git change set. The Center dashboard consumes this command contract instead of opening the graph database itself. Stable v0.26.1 already exposes the structural query surface above.
+
+## MCP access
+
+`brigade setup` can expose the code map through MCP so harnesses query callers, impact, and context without leaving their native tool loop. Historical MCP entry labels may still say `graphtrail`.
+
+## Limitations
+
+- The index is local to the machine and target. It is not a hosted code-intelligence service.
+- Queries depend on a successful sync. Stale checkouts need another sync pass.
+- Graph ranking inside `work verify plan` is advisory. The worker still chooses the command.
+- Static analysis has language and dynamic-dispatch blind spots. Treat impact results as evidence for choosing checks, not proof that no other code is affected.
+- Binary and path names under the engines tree may still use the GraphTrail label. The operator surface is `brigade code`.
+
+Related: [wiring guide](wiring-graphtrail-miseledger.md), [work closeout](work-closeout.md), [receipt schemas](receipt-schemas.md), [operator center](operator-center.md).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,106 @@
+# Brigade comparison notes
+
+Date: 2026-08-13
+
+This page backs the four README matrices. Cells use "Not documented" when the capability was not found in that project's official README or docs on this date. That is not proof of absence.
+
+Brigade stable claims refer to published **v0.26.1**. Current-main / **0.27 beta** cells are labeled as such.
+
+## How to read the tables
+
+Brigade overlaps work orchestration, memory, tool sync, and evidence products. Most neighbors specialize in one layer. Keep these record types separate:
+
+- task audit trail
+- command verification receipt
+- event trace / replay log
+- memory history
+- data lineage
+
+Learning columns also differ. Brigade scores captured verification receipts, then promotes or rolls back skills. Hindsight's documented loop is retain, recall, and reflect over facts, experiences, and mental models. Those are different jobs.
+
+## Work and orchestration
+
+| Project | Ready work | Claim safety | Parallel and run control | Task-store boundary | Verification | Official source |
+| --- | --- | --- | --- | --- | --- | --- |
+| Brigade | Stable ready set | Fail-closed compare-and-set claims | 0.27: waves, campaigns, declared wall-clock and worker-dispatch limits | Machine-local JSON under `.brigade/`, not distributed | Verify receipts (command, exit code, Git state) | [README](https://github.com/escoffier-labs/brigade) |
+| Beads | Built-in ready / dependency graph | Atomic claim | Agent workflow plus Dolt sync | Dolt-backed distributed store (`bd dolt push` / `pull`) | Task history | [README](https://github.com/gastownhall/beads) |
+| Gas Town | Beads-backed work | Not documented | Multi-agent runtime (Mayor, rigs, polecats, convoys) | Beads ledger | Operational state | [README](https://github.com/gastownhall/gastown) |
+| nWave | Artifacts across 7 waves | Not documented | Human approval between waves plus TDD gates | Git-tracked artifacts | Phase validation and audit logs | [README](https://github.com/nWave-ai/nWave) |
+| ActiveGraph | Reactive graph work | Application-defined | Behaviors and runs | Append-only event log | Replay, fork, and diff | [README](https://github.com/yoheinakajima/activegraph) |
+
+Honest neighbor strengths: Beads for the distributed Dolt store. Gas Town for the multi-agent runtime. nWave for phased delivery with audit artifacts. ActiveGraph for replay / fork / diff.
+
+## Memory
+
+| Project | Durable memory | Capture and recall | Care and operations | Learning | Provenance | Official source |
+| --- | --- | --- | --- | --- | --- | --- |
+| Brigade | Shared markdown cards plus index | Linted handoffs. 0.27: bounded session-start recall | Owner policy. 0.27: Memory Operations (topology, inventory) | Outcome score, promote, rollback from receipts | Work receipts and source paths | [README](https://github.com/escoffier-labs/brigade) |
+| Mem0 / OpenMemory | User, agent, session, application memory | Extraction and hybrid search | History and metadata APIs | Extraction plus retrieval | Timestamps and entities | [README](https://github.com/mem0ai/mem0) |
+| Letta | Agent state and memory blocks | Agent-managed memory tools | Editable memory | Persistent agent runtime state | Persistent agent state | [Memory blocks](https://docs.letta.com/guides/core-concepts/memory/memory-blocks) |
+| agentmemory (`rohitg00/agentmemory`) | Shared coding-agent memory | Hooks, MCP, REST, host plugins | Lifecycle and decay | Not documented | Searchable memory | [README](https://github.com/rohitg00/agentmemory) |
+| Hindsight | Facts, experiences, mental models | Retain and recall | Reflect and feedback | Reflective memory learning | Temporal and causal links | [README](https://github.com/vectorize-io/hindsight) |
+| Built-in harness memory | Per-tool stores | Rules and auto memories (varies) | Varies by harness | Harness-specific | Harness-specific | [Claude](https://code.claude.com/docs/en/memory), [Codex](https://developers.openai.com/codex/memories), [Cursor](https://docs.cursor.com/context/rules) |
+| OpenClaw | Plain Markdown plus index | Keyword search, optional vector search | File-owned memory | Not documented | Files and source paths | [Memory docs](https://docs.openclaw.ai/concepts/memory) |
+
+The name `agentmemory` is ambiguous. This table links `rohitg00/agentmemory` only. Other similarly named projects exist and are out of scope here.
+
+## Tools and configuration
+
+| Project | MCP | Reviewed rules and skills | Projection behavior | Source of truth | Audit and rollback | Official source |
+| --- | --- | --- | --- | --- | --- | --- |
+| Brigade | MCP and tools catalog | Skills and harness adapters | Dry-run-first (`mcp sync`, `tools plan`), then apply | Brigade catalog | Preserve unmanaged entries, gate writes, rollback via files | [README](https://github.com/escoffier-labs/brigade) |
+| add-mcp | MCP servers across native configs | Not documented | Maps supported fields into native files | Registry plus native files | Warns when a field is dropped | [README](https://github.com/neon-solutions/add-mcp) |
+| Rulesync | Supported | Rules, skills, hooks, commands, subagents | Per-target generation | Rulesync project | Generated outputs | [README](https://github.com/dyoshikawa/rulesync) |
+| config-sync (`aiconfigsync`) | Not documented | Rules for 12 assistants | Generated rule files | Single config | Generated outputs | https://pypi.org/project/aiconfigsync/ |
+| chezmoi | As ordinary files | As ordinary files | Templates and apply | Git-backed source directory | Diff, templates, merge | [Docs](https://www.chezmoi.io/) |
+| agentsync | Many agent targets | Skills, hooks, commands, subagents | Native / lossy / skipped report | Canonical config | Native / lossy / skipped report | [Docs](https://agentsync.cc/) |
+
+On 2026-08-13 the GitHub repository named in the `aiconfigsync` package metadata did not resolve. The PyPI package page remains the cited source.
+
+## Evidence and operations
+
+| Project | Receipts | Code impact | Agent activity | Cloud state | Learning / replay | Official source |
+| --- | --- | --- | --- | --- | --- | --- |
+| Brigade | Command, exit code, Git state, optional graph delta | Stable `brigade code` impact. 0.27: Center code-graph views | 0.27: Center activity | 0.27: registered cloud status (best-effort) | Score, promote, rollback | [README](https://github.com/escoffier-labs/brigade) |
+| ActiveGraph | Event trace | Not documented | Reactive behaviors | Not documented | Replay, fork, and diff | [README](https://github.com/yoheinakajima/activegraph) |
+| CocoIndex | Source-to-target data lineage | Not documented | Not documented | Not documented | Incremental recompute | [README](https://github.com/cocoindex-io/cocoindex) |
+| Graphiti | Episode provenance and validity windows | Not documented | Not documented | Not documented | Temporal fact updates | [README](https://github.com/getzep/graphiti) |
+| Hindsight | Not documented | Not documented | Not documented | Not documented | Reflective memory learning | [README](https://github.com/vectorize-io/hindsight) |
+| Neo4j Agent Memory | Reasoning and tool traces | Not documented | Not documented | Not documented | Similar-task retrieval | [README](https://github.com/neo4j-labs/agent-memory) |
+
+## Brigade scope (honest limits)
+
+- Local file-first control plane. No Brigade daemon.
+- Scheduling is external, except optional operator-owned, target-scoped care registrations.
+- Work ledger is machine-local JSON, not a distributed Beads/Dolt store.
+- Ordinary runs have no hard run-budget unless declared. Declared enforcement today covers wall-clock and worker-dispatch ceilings only.
+- Model, tool, token, and cost dimensions stay observed unless an adapter owns an enforcement boundary.
+- Cross-repo campaigns aggregate ready work. Campaign-aware parallel wave composition remains deferred.
+- Center views are read-only. Cloud registry commands track provider work. They do not execute that work.
+- External activity observations are best-effort.
+- Safe targeted handoffs may auto-file. Ambiguous or risky notes wait for review.
+- Outcome learning is scored verification, not reflective memory learning.
+
+## Source checklist (2026-08-13)
+
+- https://github.com/escoffier-labs/brigade
+- https://github.com/gastownhall/beads
+- https://github.com/gastownhall/gastown
+- https://github.com/nWave-ai/nWave
+- https://github.com/mem0ai/mem0
+- https://github.com/letta-ai/letta
+- https://github.com/rohitg00/agentmemory
+- https://code.claude.com/docs/en/memory
+- https://developers.openai.com/codex/memories
+- https://docs.cursor.com/context/rules
+- https://docs.openclaw.ai/concepts/memory
+- https://github.com/neon-solutions/add-mcp
+- https://github.com/dyoshikawa/rulesync
+- https://pypi.org/project/aiconfigsync/
+- https://www.chezmoi.io/
+- https://agentsync.cc/
+- https://github.com/yoheinakajima/activegraph
+- https://github.com/cocoindex-io/cocoindex
+- https://github.com/getzep/graphiti
+- https://github.com/vectorize-io/hindsight
+- https://github.com/neo4j-labs/agent-memory

--- a/docs/memory-operations.md
+++ b/docs/memory-operations.md
@@ -1,0 +1,71 @@
+# Memory operations
+
+Memory Operations is the read-only topology and inventory surface for Brigade-wired memory. Current main / **0.27 beta**. Stable v0.26.1 still has handoffs, care scan/plan, and owner-mediated filing. This page covers the operations facade added on the 0.27 line.
+
+## Topology
+
+```bash
+brigade memory topology --target .
+brigade memory topology --target . --json
+```
+
+Topology reports how writer inboxes, care jobs, evidence, and canonical destinations connect for one target. It assembles existing health helpers. It does not invent a new memory store or start a daemon.
+
+## Inventory
+
+```bash
+brigade memory inventory --target .
+brigade memory inventory --target . --json --limit 100
+```
+
+Inventory pages durable stores (cards, rules, tools, user, learnings) with freshness, review, and evidence filters. Default page size is 100. The maximum is 500. Field values are truncated for safe display.
+
+## Recall
+
+```bash
+brigade memory recall --target <hub-or-mirror> --cwd <session-cwd> --limit 5
+```
+
+Bounded session-start recall returns index-level matches only: title, tags, path. Card bodies never appear. Fail-open: missing or unreadable targets do not block the harness. Repo-depth installs need an explicit `memory_recall_target` in `.brigade/config.json`. Details: [memory care](memory-care.md#session-start-recall-466-slice-1).
+
+## Evidence projection and identity audit
+
+```bash
+brigade evidence memory audit . --json
+brigade evidence crawl memory . --dry-run --json
+brigade evidence crawl memory . --json
+```
+
+The identity audit is read-only. It reports explicit card ids versus path fallbacks and duplicate coverage without calling the evidence engine or rewriting frontmatter.
+
+The crawl command projects memory into the evidence log only when the installed engine advertises `memory-projection.v1`. It accepts `--dry-run`, `--json`, `--rebuild`, and a positive `--limit`. It rejects the broader `--full` scan. Completed scans may tombstone missing projection rows. Failed or interrupted scans preserve the last completed projection and mark it stale instead of deleting it. Evidence projection status also appears inside Memory Operations inventory rows when evidence artifacts are present or missing.
+
+## Care
+
+Care remains a separate mutating/planning family:
+
+```bash
+brigade memory care scan --target .
+brigade memory care plan-fixes --target .
+brigade memory care status --target .
+```
+
+Care does not auto-edit card bodies on scan. Scheduling stays operator-owned. See [scheduled care](scheduled-care.md) and [execution model](execution-model.md).
+
+## Ownership boundaries
+
+| Owner | Role |
+| --- | --- |
+| Canonical memory system | Long-term cards, rules, `MEMORY.md` index |
+| Brigade | Receipts, queues, topology/inventory views, review gate plumbing |
+| Scheduler | External cron, systemd, launchd, or CI that invokes Brigade |
+| Manual process | Human or agent commands run on demand |
+| External adapter | Harness-native memory that is not the Brigade owner |
+
+Safe targeted handoffs may auto-file under owner policy. Ambiguous or risky notes wait for review. Brigade does not replace OpenClaw, Hermes, or another chosen memory owner unless the operator asks for that migration.
+
+## Center view
+
+The Center dashboard Memory Operations view reads `memory topology --json` and paginated `memory inventory --json`. It does not perform filesystem writes, cron installs, or card body reads beyond the inventory contract.
+
+Related: [memory care](memory-care.md), [handoff promotion](handoff-promotion.md), [outcome scoring](outcome-scoring.md), [comparison](comparison.md).

--- a/docs/outcome-scoring.md
+++ b/docs/outcome-scoring.md
@@ -2,6 +2,32 @@
 
 Outcome capture scores runs at read time from stored receipts. The score is not frozen when the receipt is written. Upgrading Brigade changes how `outcome capture` and `outcome rank` classify the same historical `run.json` and `worker-results.json` files.
 
+This is outcome-based skill scoring, promotion, and rollback from verification evidence. It is not autonomous reflective memory learning.
+
+## Workflow
+
+```bash
+brigade work verify run --target . --command "pytest -q" --capture brigade-work
+# or, after a verify without --capture:
+brigade outcome capture brigade-work --run-id latest --kind skill
+
+brigade outcome rank --target .
+brigade outcome score --target .
+brigade outcome reconcile --target .          # dry-run
+brigade outcome reconcile --target . --apply  # install or roll back
+brigade outcome explain <skill-or-card-id> --target .
+```
+
+| Command | Role |
+| --- | --- |
+| `outcome capture` | Bind a verify/run receipt's real result to the skill or card that did the work (`+1` / `0` / `-1`) |
+| `outcome rank` | Order artifacts by current score (Wilson lower bound) |
+| `outcome score` | Recompute and show scores from stored receipts |
+| `outcome reconcile` | Dry-run by default. `--apply` promotes a proven registry skill or rolls a regressed one back across harnesses |
+| `outcome explain` | Print the signal trail behind a score or reconcile decision |
+
+Capture against an id that actually guided the work. Invented skill names pollute the ranking. Capture failures too: a `-1` is how a bad skill gets rolled back. Ledger files live under `memory/outcome/` as plain JSON and markdown.
+
 ## Read-time recomputation
 
 `brigade outcome capture` loads the run receipt, worker results, and any linked verify receipt, then applies the current classifier in `worker_failure.py` and `outcome_cmd.py`. The `signal_value` on the outcome record reflects that read-time classification, not the wording stamped on the receipt at run completion.
@@ -20,7 +46,7 @@ Verifier failure on a completed verify receipt after the run started forces **-1
 
 ## Kind to domain to verdict
 
-Run-level classification uses `run_failure_is_infrastructure_at_read_time`. Worker-level classification uses `normalized_failure` / `worker_result_failure` and the `domain` field on structured failures. Capture consults run level first; when run level defers (`worker-failure` or no kind), it aggregates failed workers by domain.
+Run-level classification uses `run_failure_is_infrastructure_at_read_time`. Worker-level classification uses `normalized_failure` / `worker_result_failure` and the `domain` field on structured failures. Capture consults run level first. When run level defers (`worker-failure` or no kind), it aggregates failed workers by domain.
 
 ### Run-owned failure kinds (nested `failure.kind` or legacy top-level `failure_kind`)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,33 @@
 # Brigade Overview
 
-The full tour: every station, diagram, and workflow. The [README](../README.md) covers the core memory loop and install. This document goes deeper. The detailed command walkthrough is in the [technical guide](technical-guide.md). Brigade runs only on explicit invocation: [execution model](execution-model.md).
+The full tour: every station, diagram, and workflow. The [README](../README.md) is the short landing page. This document goes deeper. The detailed command walkthrough is in the [technical guide](technical-guide.md). Adjacent-product matrices live in [comparison](comparison.md). Brigade runs only on explicit invocation: [execution model](execution-model.md).
+
+## Project identity
+
+| Surface | Value |
+| --- | --- |
+| GitHub | [`escoffier-labs/brigade`](https://github.com/escoffier-labs/brigade) |
+| Website | [brigade.tools](https://brigade.tools) |
+| PyPI | [`brigade-cli`](https://pypi.org/project/brigade-cli/) |
+| Command | `brigade` |
+| Stable release | v0.26.1 |
+| Preview line | 0.27 beta (`0.27.0.devYYYYMMDD` wheels) |
+
+This Brigade is the AI-agent operator CLI from Escoffier Labs. It is not the archived CNCF/Microsoft Kubernetes Brigade, Spinabot Brigade, or the 2017 Python package that became Nornir.
+
+## Verified-work loop
+
+A full Brigade work run can follow this circuit:
+
+1. Intent and acceptance criteria go in (`brigade work` tasks / brief).
+2. Prior evidence and code impact attach to the brief when available.
+3. Replaceable workers execute. Declared run budgets add hard wall-clock and worker-dispatch ceilings.
+4. Verification runs through `brigade work verify run` with a real exit code.
+5. The receipt, optional graph delta, and outcome land where the next run starts.
+
+Capture the outcome against the skill or card that did the work (`brigade outcome capture`), then rank and reconcile when you want promotion or rollback. The model never grades its own work. Details: [work closeout](work-closeout.md), [outcome scoring](outcome-scoring.md), [code intelligence](code-intelligence.md).
+
+Ordinary runs have no hard run-budget unless one is declared. When declared, only wall-clock and worker-dispatch ceilings are enforced today. External activity observations are best-effort.
 
 ## Stack At A Glance
 
@@ -16,7 +43,7 @@ The full tour: every station, diagram, and workflow. The [README](../README.md) 
 
 ## Why This Exists
 
-Agent tools are getting good enough that people use more than one of them. That creates a boring but important problem: each tool learns a little bit, but the learning is scattered.
+Agent tools are getting good enough that people use more than one of them. That creates a practical problem: each tool learns a little bit, but the learning is scattered.
 
 Brigade gives the setup a home base.
 
@@ -25,6 +52,13 @@ Brigade gives the setup a home base.
 - You can inspect and lint those notes before saving them.
 - Local receipts show what happened during work, scans, and reviews.
 - Risky actions stay manual.
+
+The first version came out of an always-on OpenClaw setup beside daily Codex and Claude Code sessions. Two failures set the design:
+
+- A "dreaming" job promoted raw session fragments into memory until `MEMORY.md` exceeded the bootstrap budget. New sessions started with truncated context for weeks.
+- An ingester used a hardcoded source allowlist. It left 195 handoff notes unread across 35 repos without raising an error.
+
+Brigade's handoff coverage checks, memory care, review queues, and receipts exist to make those failures visible while there is still time to fix them. The [Solo Cookbook](https://github.com/escoffier-labs/solos-cookbook) documents the larger setup this project came from.
 
 The goal is not to make a giant automation machine. The goal is to make agent memory understandable, reviewable, and portable across harnesses.
 
@@ -51,6 +85,7 @@ Install:
 
 ```bash
 pipx install brigade-cli
+# alternative: uv tool install brigade-cli
 brigade setup
 ```
 
@@ -511,8 +546,8 @@ brigade pantry expiry-alert          # preview near-expiry cookies
 brigade pantry expiry-alert --send   # optional agent-notify (install notifications first)
 ```
 
-- `brigade pantry status` / `brigade pantry doctor` — advisory health with next commands.
-- `brigade pantry setup plan` / `service plan` — review-only plans under `.brigade/pantry/plans/`.
+- `brigade pantry status` / `brigade pantry doctor`: advisory health with next commands.
+- `brigade pantry setup plan` / `service plan`: review-only plans under `.brigade/pantry/plans/`.
 - Pantry checks are advisory for workspace `doctor`. An unwired install warns but never fails a workspace run.
 
 ## Notifications

--- a/docs/readme-coverage.md
+++ b/docs/readme-coverage.md
@@ -1,0 +1,54 @@
+# README coverage map
+
+Migration date: 2026-08-13
+
+The root README is a short landing page. Every topic that left the previous README has a durable home below. Claims intentionally retired from the front page are listed at the end.
+
+## Topic mapping
+
+| Old README topic | Durable home |
+| --- | --- |
+| Kitchen scene / social banner / demo SVG | Kept as assets under `docs/assets/`, not linked from README. Brand metaphor: [overview](overview.md#mise-en-place-brand-metaphor) |
+| Badge row (CI, PyPI, Python, license) | Omitted from README by design. Live status remains on GitHub Actions and PyPI |
+| "The loop" five-step circuit | [overview](overview.md#verified-work-loop) |
+| Agent paste-ready install prompt | [agents guide](agents-guide.md#paste-ready-install-prompt), [agent-assisted setup](agent-assisted-setup.md#paste-ready-install-prompt) |
+| Shell install (`pipx`, `uv tool`, `brigade setup`, quickstart) | [QUICKSTART.md](../QUICKSTART.md), [first 10 minutes](first-10-minutes.md) |
+| User-scope Claude Code work hooks | [agents guide](agents-guide.md#claude-code-user-scope-work-hooks), [agent-assisted setup](agent-assisted-setup.md#claude-code-user-scope-work-hooks) |
+| Update channels (stable vs beta) | [update channels](update-channels.md) |
+| Anonymous once-daily update check and `BRIGADE_NO_UPDATE_CHECK=1` | [update channels](update-channels.md) |
+| Operator doctor profile, `ready: yes`, and default local footprint | [first 10 minutes](first-10-minutes.md), [new-user quickstart](new-user-quickstart.md), [agents guide](agents-guide.md) |
+| Homegrown setup adoption with `brigade operator adopt plan` | [agent-assisted setup](agent-assisted-setup.md#adapting-a-homegrown-setup), [technical guide](technical-guide.md) |
+| Contributor first-PR path and local checks | [CONTRIBUTING.md](../CONTRIBUTING.md#your-first-pr) |
+| Verify receipt example | [work closeout](work-closeout.md#abridged-receipt-example-schema_version-2) |
+| Evidence log / MiseLedger | [wiring guide](wiring-graphtrail-miseledger.md), [receipt schemas](receipt-schemas.md), [operator center](operator-center.md) |
+| Code graph queries and impact | [code intelligence](code-intelligence.md) |
+| MCP sync walkthrough and per-tool table | [mcp-sync](mcp-sync.md) |
+| Shared memory workflow diagram | [memory care](memory-care.md), [memory operations](memory-operations.md), assets under `docs/assets/` |
+| Outcome rank / capture / reconcile / explain | [outcome scoring](outcome-scoring.md) |
+| Optional stations table (Pantry, Token Glace, Skillet, Bootstrap Doctor, notifications) | [overview](overview.md), [station contract](station-contract.md) |
+| Short "why not something else" bullets | Expanded into [comparison](comparison.md) and the four README matrices |
+| "What Brigade is not" / name collisions | README Scope plus [execution model](execution-model.md) |
+| "Why I built this" origin story | [overview](overview.md#why-this-exists), Cookbook link retained there |
+| Public vs historical names | [overview](overview.md#mise-en-place-brand-metaphor), [technical guide](technical-guide.md) |
+| Harness matrix | [technical guide](technical-guide.md) |
+| Brigadeclaw Q&A pointer | [https://brigade.tools/brigadeclaw](https://brigade.tools/brigadeclaw) (site). Not required on README |
+| Docs index and license | README Docs + License sections |
+| Project identity (GitHub, site, PyPI, command) | README License / identity footer. Also [overview](overview.md#project-identity) |
+
+## Intentionally retired from the front page
+
+- Product art, terminal demo, and memory-workflow illustrations as README chrome
+- Shield/badge rows
+- Code fences, JSON receipt dumps, and YAML/TOML samples in README
+- Autonomous or "reflective memory learning" claims
+- Framing Brigade as a daemon, hosted memory service, distributed task database, or full autonomous fleet runtime
+- Claiming every Brigade command writes a receipt
+- One-checkout performance snapshots, source line numbers, and outcome scores that become stale as the repository changes
+- The volatile memory-card count from the origin story
+
+## Stable vs 0.27 beta labeling
+
+| Line | Meaning |
+| --- | --- |
+| Stable v0.26.1 | Published PyPI release `brigade-cli==0.26.1` |
+| Current main / 0.27 beta | Features on origin/main and `0.27.0.devYYYYMMDD` wheels. Labeled in README tables and this docs set |

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -3,11 +3,14 @@
 The schedule belongs to the operator. Brigade only runs when invoked. Copy one
 of the recipes below into your own crontab, user timer, or CI job after
 `brigade init` wires the target, or explicitly opt in with
-`brigade care install --target .`. It installs systemd user timers on Linux or
-launchd agents on macOS and reports an unsupported scheduler elsewhere. Every
-registration is namespaced by a hash of the absolute target path, so status and
-uninstall operate only on that target; uninstalling a missing registration is
-a clear no-op. Brigade still does not own a daemon or background supervisor.
+`brigade care install --target .`. With the default `auto` backend it installs
+systemd user timers on Linux or launchd agents on macOS and reports an
+unsupported scheduler elsewhere. The public CLI does not install crontab
+entries. Use the manual crontab recipes on this page when cron is your trigger.
+Every registration is namespaced by a hash of the absolute target path, so
+status and uninstall operate only on that target. Uninstalling a missing
+registration is a clear no-op. Brigade still does not own a daemon or
+background supervisor.
 
 Prerequisites:
 
@@ -54,9 +57,8 @@ operator-approved runbook at `.brigade/memory-care/runbooks/<job-id>.json`; if
 that file is missing, install writes nothing and says why. Omitting `--entry`
 still installs the atomic five-recipe set above. Status and uninstall take the
 same selector, and namespaced backends still key registrations by
-`(target identity, job_id)`. The optional crontab backend stays one atomic
-managed block and rejects `--entry`; use systemd or launchd for per-job
-installs.
+`(target identity, job_id)`. Per-job installs use systemd or launchd. The
+crontab examples below remain operator-owned manual recipes.
 
 Related docs: [memory care](memory-care.md), [scanner registry](scanner-registry.md), [operator center](operator-center.md), [agents guide](agents-guide.md), [execution model](execution-model.md).
 

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -4,7 +4,7 @@
 
 # Brigade Technical Guide
 
-This guide preserves the detailed command walkthroughs and operational notes that used to live on the project front page. The README now stays short; the nitty gritty lives here.
+This guide preserves the detailed command walkthroughs and operational notes that used to live on the project front page. The README stays short. Topic migration map: [readme-coverage](readme-coverage.md). Adjacent products: [comparison](comparison.md). Code map: [code-intelligence](code-intelligence.md). Memory Operations: [memory-operations](memory-operations.md).
 
 <h1 align="center">Brigade</h1>
 
@@ -114,7 +114,7 @@ The common rule is deliberate friction: Brigade writes local receipts and review
 
 The Agent Activity dashboard is visual-first: machine cards (rocinante / shadowfax / gandalf / cloud) group agent tiles, with the spreadsheet table retained as a secondary section. Completed items older than `completed_window_seconds` (configurable in the sources file, default 3600) collapse behind a per-card expander. The Cloud card is fed by the local cloud dispatch registry (`brigade run cloud status`); when empty it shows the #890 placeholder, and when the registry has entries it renders real cloud rows.
 
-Use `brigade run cloud register` / `adopt` (parser group `brigade run-cloud`) to record dispatches (Codex Cloud register-on-dispatch is automatic from `codex-cloud` seats; Cursor cloud remains an unwired source until an API key exists). `brigade run cloud status --json` joins the registry against best-effort provider state and GitHub branch/PR ground truth. `brigade run cloud sweep` writes a receipted report only — nothing is deleted automatically. Stale READY entries (threshold `stale_ready_hours`, default 6) surface in `brigade work brief`.
+Use `brigade run cloud register` / `adopt` (parser group `brigade run-cloud`) to record dispatches. Codex Cloud register-on-dispatch is automatic from `codex-cloud` seats. Cursor cloud remains an unwired source until an API key exists. `brigade run cloud status --json` joins the registry against best-effort provider state and GitHub branch/PR ground truth. `brigade run cloud sweep` writes a receipted report only. Nothing is deleted automatically. Stale READY entries (threshold `stale_ready_hours`, default 6) surface in `brigade work brief`.
 
 For a remote T3 controller journal already available locally, configure an alias and a repo-relative journal path in `.brigade/center/agent-activity-sources.json`:
 
@@ -249,8 +249,13 @@ Hard run-budget ceilings (`wall_clock_seconds`, `worker_dispatch_count`) apply
 only when a run persists `run_budget` or `verification_contract.budget` (#593).
 Ordinary `brigade run`, dogfood, and model-trial starts without those
 declarations stay unbounded for backward compatibility; per-agent
-`timeout_seconds` is not a run-budget declaration. See
-[`receipt-schemas.md`](receipt-schemas.md) (run budget lifecycle).
+`timeout_seconds` is not a run-budget declaration. Aggregate and split token
+budgets on a verification contract stay observed-only. Model, tool, token, and
+cost dimensions require an adapter-owned enforcement boundary. External
+activity and cloud-status observations are best-effort and do not invent hard
+run limits on their own.
+See [`receipt-schemas.md`](receipt-schemas.md) (run budget lifecycle) and
+[`work-closeout.md`](work-closeout.md).
 
 Plans may include integer `stage` values. Assignments in the same stage run in parallel, stages run from lowest to highest, and later-stage workers receive earlier-stage worker results in their prompt. Plans that omit `stage` remain compatible and run as stage 1.
 

--- a/docs/work-closeout.md
+++ b/docs/work-closeout.md
@@ -14,7 +14,7 @@ brigade work closeout latest
 brigade work closeout <session-id>
 ```
 
-`verify plan` inspects the repo and proposes local verification commands. It recognizes Python test layouts and package.json projects, and it reports blockers without running anything. When GraphTrail is installed and indexed, it also ranks affected-test candidates from changed files (`--file`, or `git diff --name-only HEAD`) with graph evidence and confidence; the ranking is advisory and the worker still chooses the command. Without GraphTrail the plan degrades cleanly and keeps the default command list.
+`verify plan` inspects the repo and proposes local verification commands. It recognizes Python test layouts and package.json projects, and it reports blockers without running anything. When the code map is installed and indexed, it also ranks affected-test candidates from changed files (`--file`, or `git diff --name-only HEAD`) with graph evidence and confidence. The ranking is advisory and the worker still chooses the command. Without the code map the plan degrades cleanly and keeps the default command list.
 
 `verify run` executes only explicit local commands, directly with `shell=False`. It supports simple leading environment assignments such as `PYTHONPATH=src`, rejects high-risk shell-like commands, captures stdout and stderr logs locally, and writes a receipt under:
 
@@ -31,6 +31,38 @@ brigade work closeout <session-id>
 ```
 
 The closeout includes the selected work session, task acceptance criteria when present, latest verification receipt, latest scanner sweep state, code review closeout state, handoff draft queue state, and blockers. It also stores a compact closeout reference on the session `session.json`.
+
+## Abridged receipt example (`schema_version` 2)
+
+New verify receipts use integer `schema_version: 2`. `commands` is an array of command objects. Each object carries `exit_code` (integer or `null` when interrupted or timed out without a child status). The sample below is abridged to show the shape. A valid on-disk receipt also includes the required target, timestamps, run path, baseline commit, tree fingerprint, and patch digest fields listed in the schema reference.
+
+```json
+{
+  "schema_version": 2,
+  "run_id": "20260813-133700-work-verify-example",
+  "status": "completed",
+  "duration_seconds": 15.18,
+  "commands": [
+    {
+      "command": "pytest -q",
+      "argv": ["pytest", "-q"],
+      "status": "completed",
+      "exit_code": 0
+    }
+  ],
+  "code_graph_delta": { "changed_symbol_count": 0 },
+  "git": { "branch": "main", "dirty_files": 0 }
+}
+```
+
+Full field list: [receipt schemas](receipt-schemas.md).
+
+## Receipt boundaries
+
+- A receipt is written when you run `brigade work verify run` (and by other mutating flows that document their own receipt paths).
+- Not every Brigade command writes a receipt. Read-only status surfaces and some care commands update local artifacts without a verify-style receipt.
+- Ad hoc shell tests outside `work verify run` leave no Brigade verify receipt.
+- Declared verification contracts and budgets attach when the verify manifest or runbook carries them. Hard wall-clock and worker-dispatch ceilings apply only when those budgets are declared. See [receipt schemas](receipt-schemas.md) and the run-control notes in [technical guide](technical-guide.md).
 
 ## Ready State
 


### PR DESCRIPTION
## Summary

- Replace README art, badges, demos, and embedded configuration examples with a short product landing page.
- Add source-dated comparisons across work orchestration, memory, agent configuration, and evidence.
- Move every removed operational topic into focused docs and add a coverage map.
- Label v0.26.1 stable capabilities separately from 0.27 beta work.

## Why

The previous README tried to teach the whole system on first load. The new page leads with trackable work, receipts, shared memory, and synced tools, then sends setup and operations detail to focused docs.

## Verification

- `./scripts/verify`
- Content Guard, Vale, command inventory, local links, and 26 external links
- Beta documentation commands: code export, memory topology and inventory, and memory identity audit

## Review notes

- The documented boundaries remain visible: no Brigade daemon, a local task store, a read-only Center, provider-owned cloud execution, observed-only token and cost budgets, and no cross-repo parallel wave composition.
