### PR TITLE
fix(center): lead Code Graph with insights, not a hairball

### DIFF
--- a/schemas/code-graph-export.v1.schema.json
+++ b/schemas/code-graph-export.v1.schema.json
@@ -28,7 +28,8 @@
           "type": "array",
           "items": {"$ref": "#/$defs/module_edge"}
         },
-        "truncation": {"$ref": "#/$defs/truncation"}
+        "truncation": {"$ref": "#/$defs/truncation"},
+        "insights": {"$ref": "#/$defs/insights"}
       }
     },
     "impact": {
@@ -51,7 +52,53 @@
         "label": {"type": "string"},
         "symbol_count": {"type": "integer", "minimum": 0},
         "file_count": {"type": "integer", "minimum": 0},
-        "changed": {"type": "boolean"}
+        "changed": {"type": "boolean"},
+        "package": {"type": "string"},
+        "inbound_count": {"type": "integer", "minimum": 0},
+        "dependents": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "top_files": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/top_file"}
+        },
+        "attributed_tests": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "top_file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "symbol_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "symbol_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "insight_module": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label"],
+      "properties": {
+        "id": {"type": "string"},
+        "label": {"type": "string"},
+        "symbol_count": {"type": "integer", "minimum": 0},
+        "inbound": {"type": "integer", "minimum": 0}
+      }
+    },
+    "insights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total_modules", "isolated_count"],
+      "properties": {
+        "total_modules": {"type": "integer", "minimum": 0},
+        "isolated_count": {"type": "integer", "minimum": 0},
+        "core": {"$ref": "#/$defs/insight_module"},
+        "most_connected": {"$ref": "#/$defs/insight_module"},
+        "biggest_change": {"$ref": "#/$defs/insight_module"}
       }
     },
     "module_edge": {

--- a/src/brigade/center_cmd/dashboard/views/code_graph.py
+++ b/src/brigade/center_cmd/dashboard/views/code_graph.py
@@ -1,4 +1,7 @@
-"""Code Graph dashboard view — module map, impact drill-down, change overlay.
+"""Code Graph dashboard view: module map, impact drill-down, change overlay.
+
+Operator question: What parts of the codebase matter, which module is the hub,
+and what breaks if I touch a changed file?
 
 Contract-only: ``brigade code export --json`` (and ``--symbol`` for impact).
 No direct graph database reads.
@@ -6,6 +9,7 @@ No direct graph database reads.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -30,13 +34,14 @@ _BOX_STROKE = "#c3c2b7"
 _CHANGED_FILL = "#fff4e0"
 _CHANGED_STROKE = "#fab219"
 
-_COLS = 6
+_COLS = 5
 _BOX_W = 132
 _BOX_MIN_H = 36
-_BOX_MAX_H = 88
+_BOX_MAX_H = 72
 _GAP_X = 28
-_GAP_Y = 22
+_GAP_Y = 36
 _PAD = 20
+_LABEL_W = 96
 
 
 def fetch(target: Path, query: dict[str, str] | None = None) -> dict[str, Any]:
@@ -86,33 +91,45 @@ def _mode_tabs(impact_active: bool) -> str:
 def _summary_strip(export: dict) -> str:
     stats = export.get("stats") if isinstance(export.get("stats"), dict) else {}
     module_map = export.get("module_map") if isinstance(export.get("module_map"), dict) else {}
-    trunc = module_map.get("truncation") if isinstance(module_map.get("truncation"), dict) else {}
-    modules = module_map.get("modules") if isinstance(module_map.get("modules"), list) else []
-    overlay = export.get("change_overlay") if isinstance(export.get("change_overlay"), dict) else {}
+    insights = module_map.get("insights") if isinstance(module_map.get("insights"), dict) else {}
+    modules = [row for row in module_map.get("modules", []) if isinstance(row, dict)]
 
-    symbols = stats.get("symbols")
-    files = stats.get("files")
-    sentences: list[str] = []
-    if isinstance(symbols, int) and isinstance(files, int):
-        sentences.append(f"This graph indexes {symbols:,} symbols across {files:,} files.")
-    else:
-        sentences.append("This graph summarizes how code is connected in the repository.")
+    core = insights.get("core") if isinstance(insights.get("core"), dict) else {}
+    hub = insights.get("most_connected") if isinstance(insights.get("most_connected"), dict) else {}
+    change = insights.get("biggest_change") if isinstance(insights.get("biggest_change"), dict) else {}
+    isolated = insights.get("isolated_count")
+    total = insights.get("total_modules")
+    if not isinstance(total, int):
+        total = len(modules)
 
-    changed = overlay.get("changed_modules") if isinstance(overlay.get("changed_modules"), list) else []
-    if changed:
-        sentences.append(f"{len(changed)} module(s) include files changed on this branch.")
-    elif modules:
-        top = max(modules, key=lambda row: int(row.get("symbol_count") or 0) if isinstance(row, dict) else 0)
-        if isinstance(top, dict):
-            sentences.append(f"Largest module by symbol count: {top.get('label') or top.get('id')}.")
+    core_label = str(core.get("label") or "this repository")
+    core_symbols = core.get("symbol_count")
+    if not isinstance(core_symbols, int):
+        core_symbols = stats.get("symbols") if isinstance(stats.get("symbols"), int) else 0
+    hub_label = str(hub.get("label") or core_label)
+    hub_id = str(hub.get("id") or "")
+    hub_in = hub.get("inbound") if isinstance(hub.get("inbound"), int) else 0
+    isolated_n = isolated if isinstance(isolated, int) else 0
+    change_label = str(change.get("label") or "none on this branch")
+    change_id = str(change.get("id") or "")
 
-    note = trunc.get("note")
-    if isinstance(note, str) and note.strip():
-        sentences.append(note.strip())
-
-    body = " ".join(sentences[:3])
+    s1 = (
+        f'<a href="#cg-map" data-cg-jump="map">'
+        f"{html.esc(core_label)}'s core package: {core_symbols:,} symbols "
+        f"across {total} modules.</a>"
+    )
+    s2 = (
+        f'<a href="#cg-hub" data-cg-jump="{html.esc(hub_id)}">'
+        f"Most connected: {html.esc(hub_label)} (imported by {hub_in} others).</a>"
+    )
+    s3 = f'<a href="#cg-isolated" data-cg-jump="isolated">{isolated_n} modules are isolated.</a>'
+    s4 = (
+        f'<a href="#cg-changed" data-cg-jump="{html.esc(change_id)}">'
+        f"Biggest recent change impact: {html.esc(change_label)}.</a>"
+    )
     return (
-        f'<section class="cg-summary" aria-label="{html.esc("Code graph summary")}"><p>{html.esc(body)}</p></section>'
+        f'<section class="cg-summary" data-cg-summary="1" aria-label="{html.esc("Code graph summary")}">'
+        f"<p>{s1} {s2} {s3} {s4}</p></section>"
     )
 
 
@@ -126,52 +143,136 @@ def _render_module_map(export: dict) -> str:
         return html.panel(html.esc("Module map"), f"<p>{html.esc('Nothing here.')}</p>")
 
     trunc_note = ""
-    if isinstance(trunc.get("note"), str) and trunc["note"].strip():
-        trunc_note = f'<p class="cg-muted">{html.esc(trunc["note"])}</p>'
+    note = trunc.get("note")
+    if isinstance(note, str) and note.strip():
+        trunc_note = f'<p class="cg-muted" data-cg-truncation="1" id="cg-isolated">{html.esc(note.strip())}</p>'
+
+    hub_id = ""
+    insights = module_map.get("insights") if isinstance(module_map.get("insights"), dict) else {}
+    hub = insights.get("most_connected") if isinstance(insights.get("most_connected"), dict) else {}
+    if isinstance(hub.get("id"), str):
+        hub_id = hub["id"]
 
     return (
         _summary_strip(export)
-        + html.panel(html.esc("Module map"), trunc_note + _module_map_svg(modules, edges))
+        + html.panel(
+            html.esc("Module map"),
+            trunc_note + _module_map_svg(modules, edges, hub_id=hub_id) + _module_card_shell(),
+        )
         + _debug_details(export)
     )
 
 
-def _module_map_svg(modules: list[dict], edges: list[dict]) -> str:
+def _module_card_shell() -> str:
+    return (
+        '<aside id="cg-card" class="cg-card" hidden>'
+        f"<h3 data-cg-card-title>{html.esc('Module')}</h3>"
+        f"<p data-cg-card-meaning>{html.esc('What it is.')}</p>"
+        f"<h4>{html.esc('Top files (by symbol count)')}</h4>"
+        "<ul data-cg-card-files></ul>"
+        f"<h4>{html.esc('Imported by (who depends on it)')}</h4>"
+        "<ul data-cg-card-dependents></ul>"
+        f"<h4>{html.esc('Attributed tests')}</h4>"
+        "<ul data-cg-card-tests></ul>"
+        f'<button type="button" data-cg-card-close>{html.esc("Close")}</button>'
+        "</aside>"
+    )
+
+
+def _module_meaning(module: dict) -> str:
+    package = str(module.get("package") or module.get("label") or "this module")
+    files = int(module.get("file_count") or 0)
+    symbols = int(module.get("symbol_count") or 0)
+    return f"{package} package: {files} files, {symbols} symbols."
+
+
+def _module_card_payload(module: dict) -> str:
+    payload = {
+        "id": str(module.get("id") or ""),
+        "label": str(module.get("label") or module.get("id") or ""),
+        "meaning": _module_meaning(module),
+        "top_files": [
+            f"{row.get('path')} ({row.get('symbol_count')})"
+            for row in module.get("top_files", [])
+            if isinstance(row, dict)
+        ],
+        "dependents": [str(item) for item in module.get("dependents", []) if item],
+        "tests": [str(item) for item in module.get("attributed_tests", []) if item],
+    }
+    return html.esc(json.dumps(payload, separators=(",", ":")))
+
+
+def _modules_by_package(modules: list[dict]) -> list[tuple[str, list[dict]]]:
+    grouped: dict[str, list[dict]] = {}
+    order: list[str] = []
+    for module in modules:
+        package = str(module.get("package") or module.get("label") or "(root)")
+        if package not in grouped:
+            grouped[package] = []
+            order.append(package)
+        grouped[package].append(module)
+    return [(package, grouped[package]) for package in order]
+
+
+def _module_map_svg(modules: list[dict], edges: list[dict], *, hub_id: str = "") -> str:
     if not modules:
         return f"<p>{html.esc('Nothing here.')}</p>"
 
     positions: dict[str, tuple[int, int, int, int]] = {}
     max_symbols = max(int(row.get("symbol_count") or 0) for row in modules) or 1
-    cols = min(_COLS, max(1, len(modules)))
-    rows = (len(modules) + cols - 1) // cols
-
+    grouped = _modules_by_package(modules)
     boxes: list[str] = []
-    for index, module in enumerate(modules):
-        col = index % cols
-        row = index // cols
-        x = _PAD + col * (_BOX_W + _GAP_X)
-        y = _PAD + row * (_BOX_MAX_H + _GAP_Y)
-        symbol_count = int(module.get("symbol_count") or 0)
-        ratio = symbol_count / max_symbols
-        height = int(_BOX_MIN_H + ratio * (_BOX_MAX_H - _BOX_MIN_H))
-        module_id = str(module.get("id") or "")
-        label = str(module.get("label") or module_id)
-        visible, full = code_export.fit_svg_label(label, _BOX_W - 16)
-        count_text = f" ({symbol_count})" if symbol_count else ""
-        fill = _CHANGED_FILL if module.get("changed") else _BOX_FILL
-        stroke = _CHANGED_STROKE if module.get("changed") else _BOX_STROKE
-        chip = _status_chip(x, y, height, "CHANGED" if module.get("changed") else "OK", module.get("changed") is True)
-        positions[module_id] = (x, y, _BOX_W, height)
-        boxes.append(
-            f'<g class="cg-module" role="img">'
-            f"<title>{html.esc(full)}{html.esc(count_text)}</title>"
-            f'<rect x="{x}" y="{y}" width="{_BOX_W}" height="{height}" rx="6" ry="6" '
-            f'fill="{html.esc(fill)}" stroke="{html.esc(stroke)}" stroke-width="1.5"/>'
-            f'<text x="{x + 8}" y="{y + 20}" class="cg-svg-label">{html.esc(visible)}{html.esc(count_text)}</text>'
-            f"{chip}"
-            f"</g>"
-        )
+    package_labels: list[str] = []
+    y = _PAD
+    max_x = _PAD + _LABEL_W + _BOX_W
+    marked_changed = False
 
+    for package, rows in grouped:
+        package_labels.append(
+            f'<text x="{_PAD}" y="{y + 22}" class="cg-svg-heading">{html.esc(code_export.fit_svg_label(package, _LABEL_W - 8)[0])}</text>'
+        )
+        x = _PAD + _LABEL_W
+        row_height = _BOX_MAX_H
+        for module in rows:
+            if x > _PAD + _LABEL_W + _COLS * (_BOX_W + _GAP_X) - _GAP_X:
+                x = _PAD + _LABEL_W
+                y += _BOX_MAX_H + _GAP_Y
+            symbol_count = int(module.get("symbol_count") or 0)
+            ratio = symbol_count / max_symbols
+            height = int(_BOX_MIN_H + ratio * (_BOX_MAX_H - _BOX_MIN_H))
+            module_id = str(module.get("id") or "")
+            label = str(module.get("label") or module_id)
+            visible, full = code_export.fit_svg_label(label, _BOX_W - 16)
+            count_text = f" ({symbol_count})" if symbol_count else ""
+            fill = _CHANGED_FILL if module.get("changed") else _BOX_FILL
+            stroke = _CHANGED_STROKE if module.get("changed") else _BOX_STROKE
+            chip = _status_chip(
+                x, y, height, "CHANGED" if module.get("changed") else "OK", module.get("changed") is True
+            )
+            positions[module_id] = (x, y, _BOX_W, height)
+            extra_ids = []
+            if hub_id and module_id == hub_id:
+                extra_ids.append("cg-hub")
+            if module.get("changed") and not marked_changed:
+                extra_ids.append("cg-changed")
+                marked_changed = True
+            id_attr = f'id="cg-module-{html.esc(module_id)}"'
+            extra = "".join(f'<g id="{html.esc(item)}"></g>' for item in extra_ids)
+            boxes.append(
+                f'<g class="cg-module" {id_attr} role="button" tabindex="0" data-cg-card="{_module_card_payload(module)}">'
+                f"<title>{html.esc(full)}{html.esc(count_text)}</title>"
+                f'<rect x="{x}" y="{y}" width="{_BOX_W}" height="{height}" rx="6" ry="6" '
+                f'fill="{html.esc(fill)}" stroke="{html.esc(stroke)}" stroke-width="1.5"/>'
+                f'<text x="{x + 8}" y="{y + 20}" class="cg-svg-label">{html.esc(visible)}{html.esc(count_text)}</text>'
+                f"{chip}"
+                f"</g>"
+                f"{extra}"
+            )
+            x += _BOX_W + _GAP_X
+            max_x = max(max_x, x)
+        y += row_height + _GAP_Y
+
+    max_weight = max((int(edge.get("weight") or 0) for edge in edges), default=1) or 1
     edge_lines: list[str] = []
     for edge in edges:
         source = str(edge.get("from") or "")
@@ -180,17 +281,21 @@ def _module_map_svg(modules: list[dict], edges: list[dict]) -> str:
             continue
         sx, sy, sw, sh = positions[source]
         tx, ty, tw, th = positions[target]
-        x1, y1 = sx + sw, sy + sh // 2
-        x2, y2 = tx, ty + th // 2
+        x1, y1 = sx + sw // 2, sy + sh
+        x2, y2 = tx + tw // 2, ty
         weight = int(edge.get("weight") or 0)
+        cx = (x1 + x2) // 2
+        cy = min(y1, y2) - 18
+        width = min(4, 1 + weight // 3)
+        opacity = 0.25 + 0.75 * (weight / max_weight)
         edge_lines.append(
             f'<g class="cg-edge"><title>{html.esc(f"{source} → {target} ({weight})")}</title>'
-            f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{html.esc(_BOX_STROKE)}" '
-            f'stroke-width="{min(4, 1 + weight // 3)}" marker-end="url(#cg-arrow)"/></g>'
+            f'<path d="M {x1} {y1} Q {cx} {cy} {x2} {y2}" fill="none" stroke="{html.esc(_BOX_STROKE)}" '
+            f'stroke-width="{width}" stroke-opacity="{opacity:.2f}" marker-end="url(#cg-arrow)"/></g>'
         )
 
-    width = _PAD * 2 + cols * _BOX_W + max(0, cols - 1) * _GAP_X
-    height = _PAD * 2 + rows * _BOX_MAX_H + max(0, rows - 1) * _GAP_Y
+    width = max(max_x + _PAD, 720)
+    height = y + _PAD
 
     return (
         f'<div class="cg-map-wrap"><svg class="cg-map" viewBox="0 0 {width} {height}" width="100%" '
@@ -199,7 +304,7 @@ def _module_map_svg(modules: list[dict], edges: list[dict]) -> str:
         '<marker id="cg-arrow" viewBox="0 0 10 10" refX="9" refY="5" '
         'markerWidth="6" markerHeight="6" orient="auto-start-reverse">'
         f'<path d="M 0 0 L 10 5 L 0 10 z" fill="{html.esc(_BOX_STROKE)}"/>'
-        "</marker></defs>" + "".join(edge_lines) + "".join(boxes) + "</svg></div>"
+        "</marker></defs>" + "".join(edge_lines) + "".join(package_labels) + "".join(boxes) + "</svg></div>"
     )
 
 
@@ -394,8 +499,18 @@ def _stylesheet(nonce: str) -> str:
   background:{_SURFACE}; color:{_TEXT_PRIMARY};
 }}
 .cg-summary p {{ margin:0; }}
+.cg-summary a {{ color:{_TEXT_PRIMARY}; text-decoration:underline; text-underline-offset:2px; }}
 .cg-muted {{ color:{_TEXT_SECONDARY}; font-size:0.9rem; }}
 .cg-map-wrap {{ overflow-x:auto; max-width:100%; }}
+.cg-module {{ cursor:pointer; }}
+.cg-card {{
+  margin:1rem 0 0; padding:0.85rem 1rem; border:1px solid {_BORDER}; border-radius:0.35rem;
+  background:{_SURFACE}; color:{_TEXT_PRIMARY}; max-width:36rem;
+}}
+.cg-card h3, .cg-card h4 {{ margin:0.6rem 0 0.25rem; }}
+.cg-card h3 {{ margin-top:0; }}
+.cg-card ul {{ margin:0; padding-left:1.2rem; }}
+.cg-card[hidden] {{ display:none; }}
 .cg-map {{ display:block; min-width:720px; height:auto; }}
 .cg-svg-label {{ fill:{_TEXT_PRIMARY}; font-size:12px; font-family:system-ui,sans-serif; }}
 .cg-svg-heading {{ fill:{_TEXT_SECONDARY}; font-size:11px; font-weight:700; font-family:system-ui,sans-serif; }}
@@ -431,11 +546,70 @@ def _script(nonce: str) -> str:
       panels[j].hidden = panels[j].getAttribute("data-cg-panel") !== mode;
     }}
   }}
+  function fillList(node, items) {{
+    node.innerHTML = "";
+    if (!items || !items.length) {{
+      var empty = document.createElement("li");
+      empty.textContent = "None listed.";
+      node.appendChild(empty);
+      return;
+    }}
+    for (var i = 0; i < items.length; i++) {{
+      var li = document.createElement("li");
+      li.textContent = items[i];
+      node.appendChild(li);
+    }}
+  }}
+  function showCard(raw) {{
+    var card = document.getElementById("cg-card");
+    if (!card) return;
+    var data;
+    try {{ data = JSON.parse(raw); }} catch (err) {{ return; }}
+    var title = card.querySelector("[data-cg-card-title]");
+    var meaning = card.querySelector("[data-cg-card-meaning]");
+    if (title) title.textContent = data.label || "Module";
+    if (meaning) meaning.textContent = data.meaning || "";
+    fillList(card.querySelector("[data-cg-card-files]"), data.top_files);
+    fillList(card.querySelector("[data-cg-card-dependents]"), data.dependents);
+    fillList(card.querySelector("[data-cg-card-tests]"), data.tests);
+    card.hidden = false;
+    if (card.scrollIntoView) card.scrollIntoView({{ block: "nearest" }});
+  }}
+  function closestAttr(el, name) {{
+    while (el && el.getAttribute) {{
+      var value = el.getAttribute(name);
+      if (value) return {{ el: el, value: value }};
+      el = el.parentNode;
+    }}
+    return null;
+  }}
   document.addEventListener("click", function (e) {{
     var t = e.target;
     if (!t || !t.getAttribute) return;
     var mode = t.getAttribute("data-cg-mode");
-    if (mode) {{ e.preventDefault(); selectMode(mode); }}
+    if (mode) {{ e.preventDefault(); selectMode(mode); return; }}
+    if (t.getAttribute("data-cg-card-close") !== null) {{
+      var card = document.getElementById("cg-card");
+      if (card) card.hidden = true;
+      return;
+    }}
+    var jump = closestAttr(t, "data-cg-jump");
+    if (jump && jump.value && jump.value !== "map" && jump.value !== "isolated") {{
+      var target = document.getElementById("cg-module-" + jump.value) || document.getElementById("cg-hub");
+      if (target) {{
+        var raw = target.getAttribute("data-cg-card");
+        if (raw) showCard(raw);
+      }}
+    }}
+    var cardHit = closestAttr(t, "data-cg-card");
+    if (cardHit) showCard(cardHit.value);
+  }});
+  document.addEventListener("keydown", function (e) {{
+    if (e.key !== "Enter" && e.key !== " ") return;
+    var hit = closestAttr(e.target, "data-cg-card");
+    if (!hit) return;
+    e.preventDefault();
+    showCard(hit.value);
   }});
   var params = new URLSearchParams(window.location.search || "");
   selectMode(params.get("symbol") ? "impact" : "map");

--- a/src/brigade/code_export.py
+++ b/src/brigade/code_export.py
@@ -20,8 +20,10 @@ from .localio import utc_now_iso_z
 SCHEMA = "brigade.code-graph-export.v1"
 SCHEMA_VERSION = 1
 
-MODULE_CAP = 48
-EDGE_CAP = 96
+MODULE_CAP = 15
+EDGE_CAP = 24
+_TOP_FILES = 5
+_TEST_CAP = 8
 _SEARCH_LIMIT = 12
 _GRAPH_TIMEOUT = 30.0
 
@@ -202,16 +204,33 @@ def _load_file_graph(binary: str, db_path: Path, target: Path) -> dict[str, Any]
     return {"nodes": nodes, "edges": edges}
 
 
+def _canonical_file_path(file_path: str) -> str | None:
+    """Return a repo-relative POSIX path, or None to drop (worktrees / empty)."""
+    normalized = file_path.replace("\\", "/").strip()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    parts = PurePosixPath(normalized).parts
+    if not parts or parts == (".",):
+        return None
+    if ".worktrees" in parts:
+        return None
+    return str(PurePosixPath(*parts))
+
+
 def _module_key(file_path: str) -> str:
-    parts = PurePosixPath(file_path.replace("\\", "/")).parts
+    canonical = _canonical_file_path(file_path)
+    if canonical is None:
+        return ""
+    parts = PurePosixPath(canonical).parts
     if not parts:
         return "(root)"
+    if "tests" in parts:
+        index = parts.index("tests")
+        return str(PurePosixPath(*parts[: index + 1]))
     if parts[0] == "src" and len(parts) >= 4:
         return str(PurePosixPath(*parts[:3]))
     if parts[0] == "src" and len(parts) == 3:
         return str(PurePosixPath(*parts[:2]))
-    if parts[0] == "tests":
-        return "tests" if len(parts) <= 2 else str(PurePosixPath(*parts[:2]))
     if parts[0] == "engines" and len(parts) >= 4:
         return str(PurePosixPath(*parts[:3]))
     if parts[0] == "engines" and len(parts) == 3:
@@ -222,8 +241,42 @@ def _module_key(file_path: str) -> str:
 
 
 def _module_label(module_id: str) -> str:
-    name = PurePosixPath(module_id).name
+    parts = PurePosixPath(module_id).parts
+    name = parts[-1] if parts else module_id
+    if name == "tests" and len(parts) >= 2:
+        return f"{parts[-2]} tests"
     return name or module_id
+
+
+def _package_group(module_id: str) -> str:
+    parts = PurePosixPath(module_id).parts
+    if not parts:
+        return "(root)"
+    if parts[0] == "src":
+        return parts[1] if len(parts) > 1 else "src"
+    if parts[0] == "engines":
+        return parts[1] if len(parts) > 1 else "engines"
+    if parts[-1] == "tests" and len(parts) >= 2:
+        return f"{parts[-2]} tests"
+    return parts[0]
+
+
+def _is_test_path(file_path: str) -> bool:
+    return "tests" in PurePosixPath(file_path).parts
+
+
+def _insight_ref(
+    module_id: str,
+    *,
+    symbol_count: int | None = None,
+    inbound: int | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"id": module_id, "label": _module_label(module_id)}
+    if symbol_count is not None:
+        payload["symbol_count"] = symbol_count
+    if inbound is not None:
+        payload["inbound"] = inbound
+    return payload
 
 
 def _build_module_map(file_graph: dict[str, Any], *, changed_files: list[str]) -> dict[str, Any]:
@@ -232,53 +285,129 @@ def _build_module_map(file_graph: dict[str, Any], *, changed_files: list[str]) -
     raw_edge_list = file_graph.get("edges")
     raw_edges: list[tuple[str, str, int]] = raw_edge_list if isinstance(raw_edge_list, list) else []
 
+    seen_files: set[str] = set()
     module_symbols: dict[str, int] = defaultdict(int)
     module_files: dict[str, int] = defaultdict(int)
-    changed_modules = {_module_key(path) for path in changed_files}
+    files_by_module: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    changed_modules = {key for path in changed_files if (key := _module_key(path))}
 
     for file_path, symbol_count in nodes.items():
-        module_id = _module_key(file_path)
-        module_symbols[module_id] += symbol_count
+        canonical = _canonical_file_path(str(file_path))
+        if canonical is None or canonical in seen_files:
+            continue
+        seen_files.add(canonical)
+        module_id = _module_key(canonical)
+        if not module_id:
+            continue
+        count = int(symbol_count) if isinstance(symbol_count, int) and symbol_count >= 0 else 0
+        module_symbols[module_id] += count
         module_files[module_id] += 1
+        files_by_module[module_id].append((canonical, count))
 
     module_edges: dict[tuple[str, str], int] = defaultdict(int)
+    tests_for_module: dict[str, set[str]] = defaultdict(set)
+    seen_edge_files: set[tuple[str, str]] = set()
     for source, target_file, weight in raw_edges:
-        source_mod = _module_key(source)
-        target_mod = _module_key(target_file)
-        if source_mod == target_mod:
+        source_path = _canonical_file_path(str(source))
+        target_path = _canonical_file_path(str(target_file))
+        if source_path is None or target_path is None:
             continue
-        module_edges[(source_mod, target_mod)] += weight
+        edge_key = (source_path, target_path)
+        if edge_key in seen_edge_files:
+            continue
+        seen_edge_files.add(edge_key)
+        source_mod = _module_key(source_path)
+        target_mod = _module_key(target_path)
+        if not source_mod or not target_mod or source_mod == target_mod:
+            continue
+        amount = int(weight) if isinstance(weight, int) and weight >= 0 else 1
+        module_edges[(source_mod, target_mod)] += amount
+        if _is_test_path(source_path) and not _is_test_path(target_path):
+            tests_for_module[target_mod].add(source_path)
+        elif _is_test_path(target_path) and not _is_test_path(source_path):
+            tests_for_module[source_mod].add(target_path)
 
-    modules_sorted = sorted(
-        module_symbols.items(),
-        key=lambda item: (-item[1], item[0]),
+    inbound_mods: dict[str, set[str]] = defaultdict(set)
+    outbound_mods: dict[str, set[str]] = defaultdict(set)
+    inbound_weight: dict[str, int] = defaultdict(int)
+    outbound_weight: dict[str, int] = defaultdict(int)
+    for (source_mod, target_mod), weight in module_edges.items():
+        inbound_mods[target_mod].add(source_mod)
+        outbound_mods[source_mod].add(target_mod)
+        inbound_weight[target_mod] += weight
+        outbound_weight[source_mod] += weight
+
+    def connectivity(module_id: str) -> tuple[int, int, int, str]:
+        degree = len(inbound_mods[module_id]) + len(outbound_mods[module_id])
+        weight = inbound_weight[module_id] + outbound_weight[module_id]
+        return (degree, weight, module_symbols[module_id], module_id)
+
+    ranked = sorted(
+        module_symbols,
+        key=lambda module_id: (
+            -connectivity(module_id)[0],
+            -connectivity(module_id)[1],
+            -connectivity(module_id)[2],
+            module_id,
+        ),
     )
-    total_modules = len(modules_sorted)
-    shown_modules = modules_sorted[:MODULE_CAP]
-    hidden_modules = max(0, total_modules - len(shown_modules))
-    shown_ids = {module_id for module_id, _ in shown_modules}
+    pinned = [module_id for module_id in ranked if module_id in changed_modules]
+    remainder = [module_id for module_id in ranked if module_id not in changed_modules]
+    shown_ids_list = (pinned + remainder)[:MODULE_CAP]
+    shown_ids = set(shown_ids_list)
+    total_modules = len(module_symbols)
+    hidden_modules = max(0, total_modules - len(shown_ids_list))
 
-    modules = [
-        {
+    modules = []
+    for module_id in shown_ids_list:
+        top_files = sorted(files_by_module[module_id], key=lambda item: (-item[1], item[0]))[:_TOP_FILES]
+        dependents = sorted(_module_label(other) for other in inbound_mods[module_id])
+        tests = sorted(tests_for_module[module_id])[:_TEST_CAP]
+        row: dict[str, Any] = {
             "id": module_id,
             "label": _module_label(module_id),
-            "symbol_count": count,
-            "file_count": module_files.get(module_id, 0),
-            **({"changed": True} if module_id in changed_modules else {}),
+            "symbol_count": module_symbols[module_id],
+            "file_count": module_files[module_id],
+            "package": _package_group(module_id),
+            "inbound_count": len(inbound_mods[module_id]),
+            "dependents": dependents,
+            "top_files": [{"path": path, "symbol_count": count} for path, count in top_files],
+            "attributed_tests": tests,
         }
-        for module_id, count in shown_modules
-    ]
+        if module_id in changed_modules:
+            row["changed"] = True
+        modules.append(row)
 
     edges_sorted = sorted(module_edges.items(), key=lambda item: (-item[1], item[0][0], item[0][1]))
-    filtered_edges = [(pair, weight) for pair, weight in edges_sorted if pair[0] in shown_ids and pair[1] in shown_ids]
-    total_edges = len(filtered_edges)
-    shown_edge_rows = filtered_edges[:EDGE_CAP]
-    hidden_edges = max(0, total_edges - len(shown_edge_rows))
-
+    visible_edges = [(pair, weight) for pair, weight in edges_sorted if pair[0] in shown_ids and pair[1] in shown_ids]
+    shown_edge_rows = visible_edges[:EDGE_CAP]
+    hidden_edges = max(0, len(module_edges) - len(shown_edge_rows))
     edges = [{"from": source, "to": target, "weight": weight} for (source, target), weight in shown_edge_rows]
 
+    core_id = max(module_symbols, key=lambda module_id: (module_symbols[module_id], module_id), default="")
+    hub_id = max(
+        module_symbols,
+        key=lambda module_id: (len(inbound_mods[module_id]), inbound_weight[module_id], module_id),
+        default="",
+    )
+    isolated_count = sum(
+        1 for module_id in module_symbols if not inbound_mods[module_id] and not outbound_mods[module_id]
+    )
+    insights: dict[str, Any] = {
+        "total_modules": total_modules,
+        "isolated_count": isolated_count,
+    }
+    if core_id:
+        insights["core"] = _insight_ref(core_id, symbol_count=module_symbols[core_id])
+    if hub_id:
+        insights["most_connected"] = _insight_ref(hub_id, inbound=len(inbound_mods[hub_id]))
+    changed_ranked = [module_id for module_id in ranked if module_id in changed_modules]
+    if changed_ranked:
+        change_id = changed_ranked[0]
+        insights["biggest_change"] = _insight_ref(change_id, inbound=len(inbound_mods[change_id]))
+
     trunc = _truncation_note(len(modules), hidden_modules, len(edges), hidden_edges)
-    return {"modules": modules, "edges": edges, "truncation": trunc}
+    return {"modules": modules, "edges": edges, "truncation": trunc, "insights": insights}
 
 
 def _truncation_note(
@@ -287,12 +416,14 @@ def _truncation_note(
     shown_edges: int,
     hidden_edges: int,
 ) -> dict[str, Any]:
+    total_modules = shown_modules + hidden_modules
     note_parts: list[str] = []
     if hidden_modules:
-        note_parts.append(f"showing top {shown_modules} modules, {hidden_modules} hidden")
-    if hidden_edges:
-        note_parts.append(f"showing top {shown_edges} edges, {hidden_edges} hidden")
-    note = "; ".join(note_parts) if note_parts else ""
+        note_parts.append(f"showing top {shown_modules} of {total_modules} modules")
+        note_parts.append(f"{hidden_edges} edges hidden")
+    elif hidden_edges:
+        note_parts.append(f"{hidden_edges} edges hidden")
+    note = ", ".join(note_parts)
     return {
         "shown_modules": shown_modules,
         "hidden_modules": hidden_modules,

--- a/tests/test_code_export.py
+++ b/tests/test_code_export.py
@@ -161,3 +161,101 @@ def test_code_cmd_routes_export_json_to_contract(monkeypatch, tmp_path):
     monkeypatch.setattr(code_export, "run_cli", fake_cli)
     assert code_cmd.run("export", ["--target", str(tmp_path), "--json"]) == 0
     assert called == ["cli"]
+
+
+def test_module_map_excludes_worktrees_and_dedupes_by_repo_path():
+    file_graph = {
+        "nodes": {
+            "src/brigade/cli.py": 10,
+            "./src/brigade/cli.py": 10,
+            ".worktrees/pr-906/src/brigade/cli.py": 99,
+            ".worktrees/pr-906/tests/test_cli.py": 80,
+            "tests/test_cli.py": 2,
+        },
+        "edges": [
+            ("src/brigade/cli.py", "tests/test_cli.py", 1),
+            (".worktrees/pr-906/src/brigade/cli.py", ".worktrees/pr-906/tests/test_cli.py", 50),
+        ],
+    }
+    module_map = code_export._build_module_map(file_graph, changed_files=[])
+    ids = [row["id"] for row in module_map["modules"]]
+    labels = [row["label"] for row in module_map["modules"]]
+    assert all(".worktrees" not in module_id for module_id in ids)
+    assert labels.count("tests") <= 1
+    assert (
+        sum(
+            row["symbol_count"]
+            for row in module_map["modules"]
+            if row["id"].endswith("brigade") or "brigade" in row["id"]
+        )
+        == 10
+    )
+
+
+def test_module_map_disambiguates_test_labels_by_parent_package():
+    file_graph = {
+        "nodes": {
+            "tests/test_cli.py": 1,
+            "engines/code-graph/tests/graph_tests.rs": 4,
+            "src/brigade/cli.py": 8,
+        },
+        "edges": [],
+    }
+    module_map = code_export._build_module_map(file_graph, changed_files=[])
+    labels = {row["id"]: row["label"] for row in module_map["modules"]}
+    test_labels = [label for label in labels.values() if "test" in label.lower()]
+    assert len(set(test_labels)) == len(test_labels)
+    assert any("code-graph" in label for label in test_labels)
+
+
+def test_module_map_defaults_to_top_modules_by_connectivity():
+    nodes = {f"src/iso{index}/file.py": 100 + index for index in range(20)}
+    nodes["src/hub/core.py"] = 3
+    nodes["src/spoke/a.py"] = 1
+    nodes["src/spoke/b.py"] = 1
+    edges = [
+        ("src/spoke/a.py", "src/hub/core.py", 9),
+        ("src/spoke/b.py", "src/hub/core.py", 8),
+    ]
+    for index in range(20):
+        edges.append((f"src/iso{index}/file.py", f"src/iso{index}/file.py", 1))
+    module_map = code_export._build_module_map({"nodes": nodes, "edges": edges}, changed_files=[])
+    ids = [row["id"] for row in module_map["modules"]]
+    assert len(ids) == code_export.MODULE_CAP
+    assert code_export.MODULE_CAP == 15
+    assert any(module_id.endswith("hub") or module_id == "src/hub" for module_id in ids)
+    trunc = module_map["truncation"]
+    assert trunc["hidden_modules"] == 7
+    note = (trunc.get("note") or "").lower()
+    assert "showing top 15 of" in note
+    assert "edges hidden" in note
+
+
+def test_module_map_insights_name_hub_isolated_and_change():
+    file_graph = {
+        "nodes": {
+            "src/brigade/cli.py": 2737,
+            "src/other/util.py": 2,
+            "src/lonely/x.py": 1,
+            "tests/test_cli.py": 4,
+        },
+        "edges": [
+            ("src/other/util.py", "src/brigade/cli.py", 6),
+            ("tests/test_cli.py", "src/brigade/cli.py", 2),
+        ],
+    }
+    module_map = code_export._build_module_map(
+        file_graph,
+        changed_files=["src/other/util.py"],
+    )
+    insights = module_map["insights"]
+    assert insights["total_modules"] == 4
+    assert insights["most_connected"]["inbound"] >= 2
+    assert "brigade" in insights["most_connected"]["label"]
+    assert insights["isolated_count"] >= 1
+    assert "other" in insights["biggest_change"]["label"]
+    hub = next(row for row in module_map["modules"] if "brigade" in row["id"])
+    assert hub["inbound_count"] >= 2
+    assert "other" in hub["dependents"] or "util" in " ".join(hub["dependents"]).lower()
+    assert hub["attributed_tests"]
+    assert hub["top_files"][0]["path"].endswith("cli.py")

--- a/tests/test_dashboard_code_graph.py
+++ b/tests/test_dashboard_code_graph.py
@@ -95,3 +95,122 @@ def test_fit_svg_label_truncates_with_tooltip_source():
     visible, full = code_export.fit_svg_label("brigade.work_cmd.footprint.predict", 80)
     assert len(visible) < len(full)
     assert full.startswith("brigade")
+
+
+def _insight_payload() -> dict:
+    return {
+        "export": {
+            "stats": {"symbols": 2737, "files": 40},
+            "module_map": {
+                "modules": [
+                    {
+                        "id": "src/brigade",
+                        "label": "brigade",
+                        "symbol_count": 2737,
+                        "file_count": 12,
+                        "package": "brigade",
+                        "inbound_count": 9,
+                        "dependents": ["other"],
+                        "top_files": [{"path": "src/brigade/cli.py", "symbol_count": 80}],
+                        "attributed_tests": ["tests/test_cli.py"],
+                    },
+                    {
+                        "id": "src/other",
+                        "label": "other",
+                        "symbol_count": 4,
+                        "file_count": 1,
+                        "package": "other",
+                        "inbound_count": 0,
+                        "changed": True,
+                        "dependents": [],
+                        "top_files": [{"path": "src/other/util.py", "symbol_count": 4}],
+                        "attributed_tests": [],
+                    },
+                ],
+                "edges": [{"from": "src/other", "to": "src/brigade", "weight": 6}],
+                "truncation": {
+                    "shown_modules": 15,
+                    "hidden_modules": 33,
+                    "shown_edges": 1,
+                    "hidden_edges": 40,
+                    "note": "showing top 15 of 48 modules, 40 edges hidden",
+                },
+                "insights": {
+                    "total_modules": 48,
+                    "core": {"id": "src/brigade", "label": "brigade", "symbol_count": 2737},
+                    "most_connected": {
+                        "id": "src/brigade",
+                        "label": "brigade",
+                        "inbound": 9,
+                    },
+                    "isolated_count": 12,
+                    "biggest_change": {"id": "src/other", "label": "other"},
+                },
+            },
+            "change_overlay": {"changed_modules": ["src/other"], "changed_files": ["src/other/util.py"]},
+        },
+        "symbol": None,
+    }
+
+
+def test_render_leads_with_linked_plain_language_summary():
+    fragment = code_graph.render(_insight_payload(), "nonce-summary")
+    assert 'data-cg-summary="1"' in fragment
+    assert "2737" in fragment
+    assert "Most connected" in fragment
+    assert "imported by" in fragment
+    assert "isolated" in fragment
+    assert "Biggest recent change impact" in fragment
+    summary = fragment.split("data-cg-summary", 1)[1].split("</section>", 1)[0]
+    assert summary.count("<a ") >= 3
+    assert "#cg-hub" in summary or "cg-module-src/brigade" in summary or "data-cg-jump" in summary
+
+
+def test_render_shows_labeled_truncation_not_hairball_caption():
+    fragment = code_graph.render(_insight_payload(), "nonce-trunc")
+    assert 'data-cg-truncation="1"' in fragment
+    assert "showing top 15 of 48 modules, 40 edges hidden" in fragment
+
+
+def test_render_module_click_shows_plain_word_card_not_raw_rows():
+    fragment = code_graph.render(_insight_payload(), "nonce-card")
+    assert 'data-cg-card="' in fragment or "data-cg-card='" in fragment
+    assert 'id="cg-card"' in fragment
+    assert "Top files" in fragment or "top symbols" in fragment.lower()
+    assert "Attributed tests" in fragment
+    assert "who depends" in fragment.lower() or "Imported by" in fragment
+    assert "source_id" not in fragment.split('id="cg-card"', 1)[1].split("</aside>", 1)[0]
+
+
+def test_code_view_warm_path_reuses_snapshot_cache(monkeypatch, tmp_path):
+    import threading
+    from pathlib import Path
+
+    from brigade.center_cmd.serve import _make_server
+    from tests.test_center_serve import _headers_and_body, _raw_request, _status_code, _wait_until_ready
+
+    calls: list[int] = []
+
+    def fake_fetch(target, query=None):
+        del target, query
+        calls.append(1)
+        return _insight_payload()
+
+    monkeypatch.setattr(code_graph, "fetch", fake_fetch)
+    server = _make_server(host="127.0.0.1", port=0, token=None, allowed_hosts=None, target=Path(tmp_path))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        _wait_until_ready(server)
+        host, port = server.server_address
+        first = _raw_request(server, f"{host}:{port}", path="/view/code")
+        second = _raw_request(server, f"{host}:{port}", path="/view/code")
+        assert _status_code(first) == "200"
+        assert _status_code(second) == "200"
+        _, body = _headers_and_body(second)
+        assert 'data-cg-summary="1"' in body
+        assert "showing top 15 of 48 modules, 40 edges hidden" in body
+        assert calls == [1]
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
## Summary

- `/view/code` now leads with a linked summary strip derived from the graph: core package symbol count, most-connected module (imported by N others), isolated module count, and biggest recent change impact. Refs #903 / #904.
- Default module map is the top 15 modules by connectivity, grouped by package, with labeled truncation (`showing top 15 of N modules, M edges hidden`). `.worktrees/` paths are dropped, files dedupe by repo-relative path, and nested `tests` labels include the parent package.
- Clicking a module opens a plain-word card (what it is, top files, who depends on it, attributed tests) instead of raw graph rows. The export already rides the #905 per-view snapshot cache; the browser check asserts the summary strip and truncation label on a warm second request without a second fetch.

## Test plan

- [x] RED then GREEN: `brigade work verify run --capture brigade-work` with `pytest tests/test_code_export.py tests/test_dashboard_code_graph.py tests/test_center_page_load.py -q`
- [ ] Confirm `/view/code` summary names the hub in words and the map caption reports truncated module/edge counts
- [ ] Click a module and confirm the card lists dependents and tests, not raw ids
- [ ] Confirm worktree `tests` clones are not drawn as duplicate nodes


Made with [Cursor](https://cursor.com)