### PR TITLE
fix(center): name the Code Graph package and stop OK chip overlap

### DIFF
--- a/src/brigade/center_cmd/dashboard/views/code_graph.py
+++ b/src/brigade/center_cmd/dashboard/views/code_graph.py
@@ -21,10 +21,7 @@ NAME = "code"
 TITLE = "Code Graph"
 ORDER = 6.25
 
-_STATUS_GOOD = "#0ca30c"
 _STATUS_WARNING = "#fab219"
-_STATUS_SERIOUS = "#ec835a"
-_STATUS_CRITICAL = "#d03b3b"
 _TEXT_PRIMARY = "#0b0b0b"
 _TEXT_SECONDARY = "#52514e"
 _SURFACE = "#fcfcfb"
@@ -35,13 +32,18 @@ _CHANGED_FILL = "#fff4e0"
 _CHANGED_STROKE = "#fab219"
 
 _COLS = 5
-_BOX_W = 132
+_BOX_MIN_W = 96
+_BOX_MAX_W = 220
 _BOX_MIN_H = 36
 _BOX_MAX_H = 72
+_BOX_PAD_X = 8
+_CHIP_GAP = 6
+_CHIP_H = 16
 _GAP_X = 28
 _GAP_Y = 36
 _PAD = 20
 _LABEL_W = 96
+_MAX_ROW_X = _PAD + _LABEL_W + _COLS * (132 + _GAP_X)
 
 
 def fetch(target: Path, query: dict[str, str] | None = None) -> dict[str, Any]:
@@ -97,6 +99,7 @@ def _summary_strip(export: dict) -> str:
     core = insights.get("core") if isinstance(insights.get("core"), dict) else {}
     hub = insights.get("most_connected") if isinstance(insights.get("most_connected"), dict) else {}
     change = insights.get("biggest_change") if isinstance(insights.get("biggest_change"), dict) else {}
+    largest = insights.get("largest") if isinstance(insights.get("largest"), dict) else {}
     isolated = insights.get("isolated_count")
     total = insights.get("total_modules")
     if not isinstance(total, int):
@@ -106,6 +109,12 @@ def _summary_strip(export: dict) -> str:
     core_symbols = core.get("symbol_count")
     if not isinstance(core_symbols, int):
         core_symbols = stats.get("symbols") if isinstance(stats.get("symbols"), int) else 0
+    largest_label = str(largest.get("label") or "")
+    largest_n = largest.get("symbol_count") if isinstance(largest.get("symbol_count"), int) else 0
+    if not largest_label and modules:
+        top = max(modules, key=lambda row: int(row.get("symbol_count") or 0))
+        largest_label = str(top.get("label") or "")
+        largest_n = int(top.get("symbol_count") or 0)
     hub_label = str(hub.get("label") or core_label)
     hub_id = str(hub.get("id") or "")
     hub_in = hub.get("inbound") if isinstance(hub.get("inbound"), int) else 0
@@ -113,10 +122,13 @@ def _summary_strip(export: dict) -> str:
     change_label = str(change.get("label") or "none on this branch")
     change_id = str(change.get("id") or "")
 
+    largest_clause = ""
+    if largest_label:
+        largest_clause = f"; largest: {html.esc(largest_label)} ({largest_n:,})"
     s1 = (
         f'<a href="#cg-map" data-cg-jump="map">'
-        f"{html.esc(core_label)}'s core package: {core_symbols:,} symbols "
-        f"across {total} modules.</a>"
+        f"{html.esc(core_label)}: {core_symbols:,} symbols "
+        f"across {total} modules{largest_clause}.</a>"
     )
     s2 = (
         f'<a href="#cg-hub" data-cg-jump="{html.esc(hub_id)}">'
@@ -224,51 +236,50 @@ def _module_map_svg(modules: list[dict], edges: list[dict], *, hub_id: str = "")
     boxes: list[str] = []
     package_labels: list[str] = []
     y = _PAD
-    max_x = _PAD + _LABEL_W + _BOX_W
+    max_x = _PAD + _LABEL_W + _BOX_MIN_W
     marked_changed = False
+    start_x = _PAD + _LABEL_W
 
     for package, rows in grouped:
         package_labels.append(
             f'<text x="{_PAD}" y="{y + 22}" class="cg-svg-heading">{html.esc(code_export.fit_svg_label(package, _LABEL_W - 8)[0])}</text>'
         )
-        x = _PAD + _LABEL_W
+        x = start_x
         row_height = _BOX_MAX_H
         for module in rows:
-            if x > _PAD + _LABEL_W + _COLS * (_BOX_W + _GAP_X) - _GAP_X:
-                x = _PAD + _LABEL_W
-                y += _BOX_MAX_H + _GAP_Y
             symbol_count = int(module.get("symbol_count") or 0)
             ratio = symbol_count / max_symbols
             height = int(_BOX_MIN_H + ratio * (_BOX_MAX_H - _BOX_MIN_H))
             module_id = str(module.get("id") or "")
             label = str(module.get("label") or module_id)
-            visible, full = code_export.fit_svg_label(label, _BOX_W - 16)
-            count_text = f" ({symbol_count})" if symbol_count else ""
-            fill = _CHANGED_FILL if module.get("changed") else _BOX_FILL
-            stroke = _CHANGED_STROKE if module.get("changed") else _BOX_STROKE
-            chip = _status_chip(
-                x, y, height, "CHANGED" if module.get("changed") else "OK", module.get("changed") is True
-            )
-            positions[module_id] = (x, y, _BOX_W, height)
+            changed = module.get("changed") is True
+            box_w, visible, full, chip = _module_box_parts(label, symbol_count, x, y, height, changed)
+            if x > start_x and x + box_w > _MAX_ROW_X:
+                x = start_x
+                y += _BOX_MAX_H + _GAP_Y
+                box_w, visible, full, chip = _module_box_parts(label, symbol_count, x, y, height, changed)
+            fill = _CHANGED_FILL if changed else _BOX_FILL
+            stroke = _CHANGED_STROKE if changed else _BOX_STROKE
+            positions[module_id] = (x, y, box_w, height)
             extra_ids = []
             if hub_id and module_id == hub_id:
                 extra_ids.append("cg-hub")
-            if module.get("changed") and not marked_changed:
+            if changed and not marked_changed:
                 extra_ids.append("cg-changed")
                 marked_changed = True
             id_attr = f'id="cg-module-{html.esc(module_id)}"'
             extra = "".join(f'<g id="{html.esc(item)}"></g>' for item in extra_ids)
             boxes.append(
                 f'<g class="cg-module" {id_attr} role="button" tabindex="0" data-cg-card="{_module_card_payload(module)}">'
-                f"<title>{html.esc(full)}{html.esc(count_text)}</title>"
-                f'<rect x="{x}" y="{y}" width="{_BOX_W}" height="{height}" rx="6" ry="6" '
+                f"<title>{html.esc(full)}</title>"
+                f'<rect x="{x}" y="{y}" width="{box_w}" height="{height}" rx="6" ry="6" '
                 f'fill="{html.esc(fill)}" stroke="{html.esc(stroke)}" stroke-width="1.5"/>'
-                f'<text x="{x + 8}" y="{y + 20}" class="cg-svg-label">{html.esc(visible)}{html.esc(count_text)}</text>'
+                f'<text x="{x + _BOX_PAD_X}" y="{y + 20}" class="cg-svg-label">{html.esc(visible)}</text>'
                 f"{chip}"
                 f"</g>"
                 f"{extra}"
             )
-            x += _BOX_W + _GAP_X
+            x += box_w + _GAP_X
             max_x = max(max_x, x)
         y += row_height + _GAP_Y
 
@@ -308,19 +319,43 @@ def _module_map_svg(modules: list[dict], edges: list[dict], *, hub_id: str = "")
     )
 
 
-def _status_chip(box_x: int, box_y: int, box_h: int, word: str, changed: bool) -> str:
-    if changed:
-        color, icon = _STATUS_WARNING, "!"
-    else:
-        color, icon = _STATUS_GOOD, "\u2713"
-    chip_x = box_x + _BOX_W - 58
+def _chip_width(word: str) -> int:
+    return max(50, 18 + code_export.svg_text_width(word, font_size=8))
+
+
+def _module_box_parts(
+    label: str,
+    symbol_count: int,
+    box_x: int,
+    box_y: int,
+    box_h: int,
+    changed: bool,
+) -> tuple[int, str, str, str]:
+    count_text = f" ({symbol_count})" if symbol_count else ""
+    full_label = f"{label}{count_text}"
+    chip_w = _chip_width("CHANGED") if changed else 0
+    right = chip_w + _CHIP_GAP + _BOX_PAD_X if chip_w else _BOX_PAD_X
+    text_w = code_export.svg_text_width(full_label)
+    needed = _BOX_PAD_X + text_w + right
+    box_w = max(_BOX_MIN_W, min(_BOX_MAX_W, needed))
+    budget = max(8, box_w - _BOX_PAD_X - right)
+    visible, full = code_export.fit_svg_label(full_label, budget)
+    chip = _status_chip(box_x, box_y, box_h, box_w, "CHANGED") if changed else ""
+    return box_w, visible, full, chip
+
+
+def _status_chip(box_x: int, box_y: int, box_h: int, box_w: int, word: str) -> str:
+    color, icon = _STATUS_WARNING, "!"
+    chip_w = _chip_width(word)
+    chip_x = box_x + box_w - chip_w - _BOX_PAD_X
     chip_y = box_y + box_h - 24
+    word_x = chip_x + 16 + (chip_w - 20) / 2
     return (
-        f'<rect x="{chip_x}" y="{chip_y}" width="50" height="16" rx="8" ry="8" fill="{html.esc(_SURFACE)}" '
+        f'<rect x="{chip_x}" y="{chip_y}" width="{chip_w}" height="{_CHIP_H}" rx="8" ry="8" fill="{html.esc(_SURFACE)}" '
         f'stroke="{html.esc(color)}" stroke-width="1.2"/>'
         f'<circle cx="{chip_x + 8}" cy="{chip_y + 8}" r="4" fill="{html.esc(color)}"/>'
         f'<text x="{chip_x + 8}" y="{chip_y + 11}" text-anchor="middle" class="cg-svg-chip-icon">{html.esc(icon)}</text>'
-        f'<text x="{chip_x + 30}" y="{chip_y + 11}" text-anchor="middle" class="cg-svg-chip-word">{html.esc(word)}</text>'
+        f'<text x="{word_x}" y="{chip_y + 11}" text-anchor="middle" class="cg-svg-chip-word">{html.esc(word)}</text>'
     )
 
 

--- a/src/brigade/code_export.py
+++ b/src/brigade/code_export.py
@@ -384,21 +384,34 @@ def _build_module_map(file_graph: dict[str, Any], *, changed_files: list[str]) -
     hidden_edges = max(0, len(module_edges) - len(shown_edge_rows))
     edges = [{"from": source, "to": target, "weight": weight} for (source, target), weight in shown_edge_rows]
 
-    core_id = max(module_symbols, key=lambda module_id: (module_symbols[module_id], module_id), default="")
+    production_ids = [module_id for module_id in module_symbols if not _is_test_path(module_id)]
+    insight_ids = production_ids or list(module_symbols)
+    package_symbols: dict[str, int] = defaultdict(int)
+    for module_id in insight_ids:
+        package_symbols[_package_group(module_id)] += module_symbols[module_id]
+    core_package = max(package_symbols, key=lambda name: (package_symbols[name], name), default="")
+    core_id = max(
+        (module_id for module_id in insight_ids if _package_group(module_id) == core_package),
+        key=lambda module_id: (module_symbols[module_id], module_id),
+        default="",
+    )
+    largest_id = max(module_symbols, key=lambda module_id: (module_symbols[module_id], module_id), default="")
     hub_id = max(
-        module_symbols,
+        insight_ids,
         key=lambda module_id: (len(inbound_mods[module_id]), inbound_weight[module_id], module_id),
         default="",
     )
-    isolated_count = sum(
-        1 for module_id in module_symbols if not inbound_mods[module_id] and not outbound_mods[module_id]
-    )
+    isolated_count = sum(1 for module_id in insight_ids if not inbound_mods[module_id] and not outbound_mods[module_id])
+    total_symbols = sum(module_symbols.values())
     insights: dict[str, Any] = {
         "total_modules": total_modules,
         "isolated_count": isolated_count,
+        "total_symbols": total_symbols,
     }
-    if core_id:
-        insights["core"] = _insight_ref(core_id, symbol_count=module_symbols[core_id])
+    if core_package:
+        insights["core"] = {"id": core_id, "label": core_package, "symbol_count": total_symbols}
+    if largest_id:
+        insights["largest"] = _insight_ref(largest_id, symbol_count=module_symbols[largest_id])
     if hub_id:
         insights["most_connected"] = _insight_ref(hub_id, inbound=len(inbound_mods[hub_id]))
     changed_ranked = [module_id for module_id in ranked if module_id in changed_modules]
@@ -527,12 +540,30 @@ def _git_changed_files(target: Path) -> list[str]:
     return sorted(files)
 
 
+_SVG_CHAR_EM = 0.62
+
+
+def svg_text_width(text: str, *, font_size: int = 12) -> int:
+    """Approximate rendered SVG text width in pixels for layout."""
+    return max(0, int(round(len(text) * max(6.0, font_size * _SVG_CHAR_EM))))
+
+
 def fit_svg_label(text: str, max_width: int, *, font_size: int = 12) -> tuple[str, str]:
     """Return (visible label, full label) with width-aware truncation for SVG."""
     full = text.strip() or "?"
-    approx_char = max(1, int(max_width / max(6.0, font_size * 0.62)))
-    if len(full) <= approx_char:
+    if svg_text_width(full, font_size=font_size) <= max_width:
         return full, full
-    if approx_char <= 1:
-        return "…", full
-    return full[: approx_char - 1] + "…", full
+    ellipsis = "…"
+    if svg_text_width(ellipsis, font_size=font_size) >= max_width:
+        return ellipsis, full
+    lo, hi = 0, len(full)
+    visible = ellipsis
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        candidate = full[:mid] + ellipsis
+        if svg_text_width(candidate, font_size=font_size) <= max_width:
+            visible = candidate
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return visible, full

--- a/tests/test_code_export.py
+++ b/tests/test_code_export.py
@@ -259,3 +259,35 @@ def test_module_map_insights_name_hub_isolated_and_change():
     assert "other" in hub["dependents"] or "util" in " ".join(hub["dependents"]).lower()
     assert hub["attributed_tests"]
     assert hub["top_files"][0]["path"].endswith("cli.py")
+
+
+def test_module_map_insights_name_package_not_largest_test_module():
+    file_graph = {
+        "nodes": {
+            "src/brigade/cli.py": 100,
+            "src/brigade/work_cmd/run.py": 40,
+            "src/other/util.py": 2,
+            "src/lonely/x.py": 1,
+            "tests/test_cli.py": 9000,
+            "engines/code-graph/tests/graph_tests.rs": 80,
+            "src/a/a.py": 1,
+            "src/b/b.py": 1,
+        },
+        "edges": [
+            ("src/other/util.py", "src/brigade/cli.py", 6),
+            ("src/brigade/work_cmd/run.py", "src/brigade/cli.py", 3),
+            ("tests/test_cli.py", "src/brigade/cli.py", 2),
+            ("src/a/a.py", "tests/test_cli.py", 4),
+            ("src/b/b.py", "tests/test_cli.py", 4),
+            ("src/other/util.py", "tests/test_cli.py", 4),
+        ],
+    }
+    insights = code_export._build_module_map(file_graph, changed_files=[])["insights"]
+    assert insights["core"]["label"] == "brigade"
+    assert "test" not in insights["core"]["label"].lower()
+    assert insights["largest"]["label"] == "tests"
+    assert insights["largest"]["symbol_count"] == 9000
+    assert insights["core"]["symbol_count"] == 9225
+    assert "brigade" in insights["most_connected"]["label"]
+    assert "test" not in insights["most_connected"]["label"].lower()
+    assert insights["isolated_count"] == 1

--- a/tests/test_dashboard_code_graph.py
+++ b/tests/test_dashboard_code_graph.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import html as html_lib
 import re
 
 from brigade import code_export
 from brigade.center_cmd.dashboard.views import code_graph
+
+_SVG_CHAR_EM = 0.62
+
+
+def _approx_label_width(text: str, font_size: int = 12) -> int:
+    return max(0, int(round(len(text) * max(6.0, font_size * _SVG_CHAR_EM))))
 
 
 def test_fetch_uses_code_export_contract(monkeypatch, tmp_path):
@@ -137,7 +144,8 @@ def _insight_payload() -> dict:
                 },
                 "insights": {
                     "total_modules": 48,
-                    "core": {"id": "src/brigade", "label": "brigade", "symbol_count": 2737},
+                    "core": {"id": "src/brigade", "label": "brigade", "symbol_count": 2741},
+                    "largest": {"id": "src/brigade", "label": "brigade", "symbol_count": 2737},
                     "most_connected": {
                         "id": "src/brigade",
                         "label": "brigade",
@@ -214,3 +222,101 @@ def test_code_view_warm_path_reuses_snapshot_cache(monkeypatch, tmp_path):
     finally:
         server.shutdown()
         server.server_close()
+
+
+def _tests_as_core_payload() -> dict:
+    return {
+        "export": {
+            "stats": {"symbols": 8966, "files": 40},
+            "module_map": {
+                "modules": [
+                    {
+                        "id": "tests",
+                        "label": "tests",
+                        "symbol_count": 8966,
+                        "file_count": 200,
+                        "package": "tests",
+                    },
+                    {
+                        "id": "src/brigade",
+                        "label": "brigade",
+                        "symbol_count": 100,
+                        "file_count": 12,
+                        "package": "brigade",
+                    },
+                    {
+                        "id": "src/brigade/work_cmd",
+                        "label": "work_cmd",
+                        "symbol_count": 7,
+                        "file_count": 3,
+                        "package": "brigade",
+                    },
+                    {
+                        "id": "src/brigade/claude_hooks",
+                        "label": "claude_hooks",
+                        "symbol_count": 12,
+                        "file_count": 2,
+                        "package": "brigade",
+                    },
+                    {
+                        "id": "src/other",
+                        "label": "other",
+                        "symbol_count": 4,
+                        "file_count": 1,
+                        "package": "other",
+                        "changed": True,
+                    },
+                ],
+                "edges": [],
+                "insights": {
+                    "total_modules": 37,
+                    "core": {"id": "src/brigade", "label": "brigade", "symbol_count": 9089},
+                    "largest": {"id": "tests", "label": "tests", "symbol_count": 8966},
+                    "most_connected": {"id": "src/brigade", "label": "brigade", "inbound": 3},
+                    "isolated_count": 2,
+                    "biggest_change": {"id": "src/other", "label": "other"},
+                },
+            },
+        },
+        "symbol": None,
+    }
+
+
+def test_summary_names_package_not_tests_and_calls_out_largest():
+    fragment = code_graph.render(_tests_as_core_payload(), "nonce-package")
+    summary = fragment.split("data-cg-summary", 1)[1].split("</section>", 1)[0]
+    assert "core package" not in summary
+    assert "tests's" not in summary
+    assert "brigade:" in summary
+    assert "8,966" in summary or "8966" in summary
+    assert "across 37 modules" in summary
+    assert "largest:" in summary.lower()
+    assert "tests" in summary
+    assert "Most connected" in summary
+    assert "isolated" in summary
+
+
+def test_module_labels_fit_in_boxes_without_ok_chips():
+    fragment = code_graph.render(_tests_as_core_payload(), "nonce-labels")
+    assert re.search(r'cg-svg-chip-word">OK<', fragment) is None
+    assert re.search(r'cg-svg-chip-word">CHANGED<', fragment)
+    assert "<title>work_cmd (7)</title>" in fragment
+    assert "<title>claude_hooks (12)</title>" in fragment
+
+    for match in re.finditer(r'<g class="cg-module"[^>]*>(.*?)</g>', fragment, re.DOTALL):
+        box = match.group(1)
+        box_rect = re.search(r'<rect x="(\d+)" y="[^"]*" width="(\d+)" height="(\d+)"', box)
+        label = re.search(r'<text x="(\d+)" y="[^"]*" class="cg-svg-label">([^<]*)</text>', box)
+        assert box_rect is not None
+        assert label is not None
+        box_x = int(box_rect.group(1))
+        box_w = int(box_rect.group(2))
+        text_x = int(label.group(1))
+        visible = html_lib.unescape(label.group(2))
+        text_end = text_x + _approx_label_width(visible)
+        assert text_end <= box_x + box_w - 4
+        chip = re.search(r'<rect x="(\d+)" y="[^"]*" width="(\d+)" height="16"', box)
+        if chip:
+            chip_x = int(chip.group(1))
+            assert text_end <= chip_x
+            assert "CHANGED" in box


### PR DESCRIPTION
## Summary
- Code Graph summary names the production package (for example `brigade`) instead of the largest module, which was often the `tests` aggregation. Largest module is called out separately.
- Module boxes are sized from text metrics. Labels truncate with a title tooltip and do not run under a chip.
- Always-OK status chips are gone. CHANGED remains, because that is a state the graph actually knows.

## Test plan
- [x] RED then GREEN: `pytest --override-ini pythonpath=src tests/test_dashboard_code_graph.py tests/test_code_export.py -q` via `brigade work verify run --capture brigade-work` (20 passed)
- [ ] Load `/view/code` and confirm the summary reads like `brigade: N symbols across M modules; largest: tests (N)` rather than `tests's core package`
- [ ] Confirm `work_cmd` / `claude_hooks` labels are not clipped, and unchanged modules have no OK chip


Made with [Cursor](https://cursor.com)