### PR TITLE
fix(work): bound graph snapshot copies to the graphtrail timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Graph snapshot copies during `brigade work verify run` now honor the same
+  `graphtrail_delta_timeout_seconds` cap as `graphtrail sync`. A snapshot that
+  exceeds that cap marks `code_graph_delta` `sync_timed_out` with a reason and
+  leaves the verification command result unchanged, so a slow graph cannot
+  reject a passing check. The 10s default and per-target `.brigade/config.json`
+  key are unchanged.
 - Source and pipx-from-checkout installs now declare `0.27.0`, which PEP 440
   sorts at or above the publish-dev `0.27.0.devYYYYMMDD` wheel line. The
   previous `0.26.1` pin version-sorted below those wheels, so a current main

--- a/src/brigade/graphtrail_delta.py
+++ b/src/brigade/graphtrail_delta.py
@@ -47,7 +47,17 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
         if sync.get("timed_out"):
             if db_existed_before_sync:
                 snapshot_path = run_dir / SNAPSHOT_NAME
-                _backup_sqlite(db_path, snapshot_path)
+                try:
+                    _backup_sqlite(db_path, snapshot_path, timeout=timeout)
+                except TimeoutError:
+                    return _status(
+                        "sync_timed_out",
+                        f"code graph delta unavailable: graphtrail {sync_stage} sync timed out after {timeout:g}s",
+                        binary=binary,
+                        db_path=str(db_path),
+                        sync=sync,
+                        graphtrail_timeout_seconds=timeout,
+                    )
                 return {
                     "ok": True,
                     "status": "captured",
@@ -87,7 +97,7 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
                 graphtrail_timeout_seconds=timeout,
             )
         snapshot_path = run_dir / SNAPSHOT_NAME
-        _backup_sqlite(db_path, snapshot_path)
+        _backup_sqlite(db_path, snapshot_path, timeout=timeout)
         return {
             "ok": True,
             "status": "captured",
@@ -152,7 +162,7 @@ def capture_after_and_diff(
             return _write_and_compact(run_dir, payload, snapshot_path=snapshot_path)
 
         after_snapshot_path = run_dir / SNAPSHOT_AFTER_NAME
-        _backup_sqlite(db_path, after_snapshot_path)
+        _backup_sqlite(db_path, after_snapshot_path, timeout=timeout)
         after_snapshot_sha256 = _file_sha256(after_snapshot_path)
         diff = _run_graphtrail(
             binary,
@@ -359,13 +369,28 @@ def _command_result(
     return result
 
 
-def _backup_sqlite(source: Path, destination: Path) -> None:
+def _backup_sqlite(source: Path, destination: Path, *, timeout: float | None = None) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.unlink(missing_ok=True)
     source_uri = f"file:{source}?mode=ro"
-    with sqlite3.connect(source_uri, uri=True) as source_conn:
-        with sqlite3.connect(destination) as dest_conn:
-            source_conn.backup(dest_conn)
+    started = time.monotonic()
+
+    def progress(_status: int, _remaining: int, _total: int) -> None:
+        if timeout is not None and time.monotonic() - started >= timeout:
+            raise TimeoutError(f"timeout after {timeout:g}s")
+
+    try:
+        with sqlite3.connect(source_uri, uri=True) as source_conn:
+            with sqlite3.connect(destination) as dest_conn:
+                if timeout is None:
+                    source_conn.backup(dest_conn)
+                else:
+                    source_conn.backup(dest_conn, pages=32, progress=progress)
+                    if time.monotonic() - started >= timeout:
+                        raise TimeoutError(f"timeout after {timeout:g}s")
+    except Exception:
+        destination.unlink(missing_ok=True)
+        raise
 
 
 def _failure_payload(

--- a/tests/test_graphtrail_delta.py
+++ b/tests/test_graphtrail_delta.py
@@ -1,3 +1,5 @@
+import sqlite3
+import time
 from pathlib import Path
 
 import pytest
@@ -41,6 +43,23 @@ def test_compact_summary_propagates_process_signals(signal_type):
 
     with pytest.raises(signal_type):
         graphtrail_delta._compact_summary(SignalMapping())
+
+
+def test_backup_sqlite_honors_timeout(tmp_path):
+    src = tmp_path / "src.db"
+    dst = tmp_path / "dst.db"
+    with sqlite3.connect(src) as con:
+        con.execute("create table t (b blob)")
+        blob = b"x" * (256 * 1024)
+        for _ in range(40):
+            con.execute("insert into t values (?)", (blob,))
+        con.commit()
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="timeout after"):
+        graphtrail_delta._backup_sqlite(src, dst, timeout=0.001)
+    assert time.monotonic() - started < 0.5
+    assert not dst.exists()
 
 
 def test_capture_before_still_fails_open_for_regular_exceptions(monkeypatch, tmp_path):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2301,6 +2301,37 @@ def test_work_verify_graphtrail_delta_rejects_invalid_per_invocation_timeout_ove
     assert _count_verify_run_dirs(tmp_path) == 0
 
 
+def test_work_verify_graph_snapshot_timeout_marks_delta_unavailable(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    _seed_graphtrail_db(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path, sync_delay_seconds=0.2)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    def timeout_backup(*args, **kwargs):
+        raise TimeoutError("timeout after 0.05s")
+
+    monkeypatch.setattr(graphtrail_delta, "_backup_sqlite", timeout_backup)
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            graphtrail_timeout=0.05,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    compact_delta = receipt["code_graph_delta"]
+
+    assert receipt["status"] == "completed"
+    assert receipt["commands"][0]["status"] == "completed"
+    assert receipt["commands"][0]["exit_code"] == 0
+    assert compact_delta["ok"] is False
+    assert compact_delta["status"] == "sync_timed_out"
+    assert "timed out after 0.05s" in compact_delta["summary"]
+
+
 def test_work_verify_graphtrail_delta_preexisting_db_timeout_uses_stale_baseline(tmp_path, capsys, monkeypatch):
     _init_git_repo(tmp_path)
     _seed_graphtrail_db(tmp_path)


### PR DESCRIPTION
## Summary
- Graph snapshot copies during `brigade work verify run` now use the same `graphtrail_delta_timeout_seconds` cap as `graphtrail sync` (10s default, overridable in `.brigade/config.json`).
- If that copy exceeds the cap, the receipt records `code_graph_delta` as `sync_timed_out` with a reason and leaves the verification command result unchanged. A slow graph cannot turn a passing check into a rejected run.

## Test plan
- [x] New unit test: `_backup_sqlite` raises `TimeoutError` and deletes the partial destination
- [x] New verify test: snapshot timeout keeps receipt `completed` with `code_graph_delta.status == sync_timed_out`
- [x] Existing graphtrail timeout tests still pass
- [x] `ruff check`, `ruff format --check`, `mypy`, version/snapshot checks
- [x] Full pytest: 7349 passed, coverage 83.37%


Made with [Cursor](https://cursor.com)