### PR TITLE
feat(roster): promote Gemini 3.7 Flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The shipped review-heavy `reviewer_flash` preset now uses Gemini 3.7 Flash Low
+  on Antigravity. Security-sensitive or cross-file decisions still route to the
+  independent `reviewer` or `reviewer_codex` seat. (#920)
+
 ### Fixed
 - Graph snapshot copies during `brigade work verify run` now honor the same
   `graphtrail_delta_timeout_seconds` cap as `graphtrail sync`. A snapshot that

--- a/docs/seat-catalog.md
+++ b/docs/seat-catalog.md
@@ -34,7 +34,7 @@ The mini and nano tiers also answer through harnesses that front the ChatGPT OAu
 
 ### Cursor subscription
 
-Flat-sub plans carry far more than the headline models. Verified answering on one Ultra plan: `composer-2.5`, `grok-4.5` tiers, `kimi-k2.7-code`, `glm-5.2-high`, `gemini-3.5-flash`, `claude-sonnet-5` tiers, and the `gpt-5.4-mini`/`nano` ladder. An open-weight worker at zero marginal cost:
+Flat-sub plans carry far more than the headline models. Verified answering on one Ultra plan: `composer-2.5`, `grok-4.5` tiers, `kimi-k2.7-code`, `glm-5.2-high`, `gemini-3.7-flash` tiers, `claude-sonnet-5` tiers, and the `gpt-5.4-mini`/`nano` ladder. An open-weight worker at zero marginal cost:
 
 ```toml
 [agents.kimi27]
@@ -86,14 +86,14 @@ role = "Light reviewer and worker for routine passes."
 
 Keep the flagship interactive model out of headless seats entirely: one operator machine logged 502 API calls in an evening after review seats defaulted to the top tier with internal subagent fan-out. One dispatch should be one flat pass. Parallelism belongs in `brigade run` workers, where each lane is metered and receipted.
 
-### Antigravity (free Google lane)
+### Antigravity (Google subscription lane)
 
 Often the most idle capacity an operator owns: two accounts can sit at 0-1% of weekly quota while paid lanes run hot. Route scans, summaries, research reads, and small changes here first.
 
 ```toml
 [agents.flash]
 cli = "antigravity"
-model = "Gemini 3.5 Flash (Low)"
+model = "Gemini 3.7 Flash (Low)"
 role = "Fast worker for research, summaries, scans, and small code changes."
 
 [agents.reviewer2]
@@ -101,6 +101,8 @@ cli = "antigravity"
 model = "Claude Sonnet 4.6 (Thinking)"
 role = "Cross-model reviewer on the Google lane; verify claims without spending the Claude subscription."
 ```
+
+Harness filters can change the result before inference. In author receipts, Antigravity served a Gemini 3.7 Flash security canary that Cursor rejected at the provider boundary. Record provider refusals separately from model output.
 
 Remember: every seat's `cli` value must appear in `limits.allow_models`, in the same edit. Brigade validates at roster load, not at edit time, and a missing entry fails every run against that roster.
 

--- a/docs/seat-catalog.md
+++ b/docs/seat-catalog.md
@@ -17,7 +17,7 @@ Assign every seat one job. Mixed-purpose seats make outcome capture useless beca
 
 ## Lane recipes
 
-Model IDs drift. Every ID below was verified answering on 2026-07-17. Confirm against your harness's live inventory before wiring (see the validation pattern at the end, and issue #299 for making that check automatic).
+Model IDs drift. Every ID below was verified answering on 2026-07-17, with Gemini 3.7 Flash re-verified on 2026-08-13. Confirm against your harness's live inventory before wiring (see the validation pattern at the end, and issue #299 for making that check automatic).
 
 ### Codex / ChatGPT subscription
 
@@ -43,7 +43,7 @@ model = "kimi-k2.7-code"
 role = "Open-weight implementation worker on the flat sub; overflow relief for the primary worker."
 ```
 
-Known gap: Composer models return empty text in read-only plan mode (issue #206). Pin a non-composer model for read-only seats.
+Known gap: Composer models return empty text in read-only plan mode (issue #206). Pin a non-composer model for read-only seats. In the August author receipts, Cursor rejected the Gemini 3.7 Flash security canary at the provider boundary before inference. Do not use that harness-model pairing for security review.
 
 Mark direct Cursor Composer and Grok seats as incapable so the chef cannot route
 `--read-only` work to them:
@@ -94,7 +94,7 @@ Often the most idle capacity an operator owns: two accounts can sit at 0-1% of w
 [agents.flash]
 cli = "antigravity"
 model = "Gemini 3.7 Flash (Low)"
-role = "Fast worker for research, summaries, scans, and small code changes."
+role = "Fast worker for research, summaries, scans, and small code changes; retain a stronger independent reviewer for security-sensitive or cross-file decisions."
 
 [agents.reviewer2]
 cli = "antigravity"

--- a/docs/seat-catalog.md
+++ b/docs/seat-catalog.md
@@ -17,7 +17,7 @@ Assign every seat one job. Mixed-purpose seats make outcome capture useless beca
 
 ## Lane recipes
 
-Model IDs drift. Every ID below was verified answering on 2026-07-17, with Gemini 3.7 Flash re-verified on 2026-08-13. Confirm against your harness's live inventory before wiring (see the validation pattern at the end, and issue #299 for making that check automatic).
+Model IDs drift. Every ID below was verified answering on 2026-07-17, with Gemini 3.7 Flash re-verified on both Antigravity and Cursor on 2026-08-13. Confirm against your harness's live inventory before wiring (see the validation pattern at the end, and issue #299 for making that check automatic).
 
 ### Codex / ChatGPT subscription
 
@@ -102,7 +102,7 @@ model = "Claude Sonnet 4.6 (Thinking)"
 role = "Cross-model reviewer on the Google lane; verify claims without spending the Claude subscription."
 ```
 
-Harness filters can change the result before inference. In author receipts, Antigravity served a Gemini 3.7 Flash security canary that Cursor rejected at the provider boundary. Record provider refusals separately from model output.
+Harness filters can change the result before inference. In August 2026 author receipts, Antigravity served a Gemini 3.7 Flash security canary that Cursor rejected at the provider boundary. Record provider refusals separately from model output.
 
 Remember: every seat's `cli` value must appear in `limits.allow_models`, in the same edit. Brigade validates at roster load, not at edit time, and a missing entry fails every run against that roster.
 

--- a/src/brigade/templates/rosters/review-heavy.toml
+++ b/src/brigade/templates/rosters/review-heavy.toml
@@ -23,7 +23,7 @@ caveats = ["Grok review quality varies by task complexity."]
 [agents.reviewer_flash]
 cli = "antigravity"
 model = "Gemini 3.7 Flash (Low)"
-role = "Fast routine review and summary lane."
+role = "Fast routine review and summary lane; route security-sensitive or cross-file decisions to the reviewer or reviewer_codex seat."
 purpose = "Low-cost review and summary when premium lanes are saturated."
 requires = { cli = "antigravity" }
 fallback = []

--- a/src/brigade/templates/rosters/review-heavy.toml
+++ b/src/brigade/templates/rosters/review-heavy.toml
@@ -22,13 +22,13 @@ caveats = ["Grok review quality varies by task complexity."]
 
 [agents.reviewer_flash]
 cli = "antigravity"
-model = "Gemini 3.5 Flash (Low)"
-role = "Fast non-security review and summary lane."
+model = "Gemini 3.7 Flash (Low)"
+role = "Fast routine review and summary lane."
 purpose = "Low-cost review and summary when premium lanes are saturated."
 requires = { cli = "antigravity" }
 fallback = []
-stats = { speed = "fast", source = "author-receipts-2026-07" }
-caveats = ["Refuses security-audit work; use grok or codex lanes for security review."]
+stats = { speed = "fast", source = "author-receipts-2026-08" }
+caveats = ["Use a stronger independent reviewer for high-risk or cross-file security decisions."]
 
 [agents.reviewer_cursor]
 cli = "cursor"

--- a/src/brigade/templates/rosters/review-heavy.toml
+++ b/src/brigade/templates/rosters/review-heavy.toml
@@ -28,7 +28,7 @@ purpose = "Low-cost review and summary when premium lanes are saturated."
 requires = { cli = "antigravity" }
 fallback = []
 stats = { speed = "fast", source = "author-receipts-2026-08" }
-caveats = ["Use a stronger independent reviewer for high-risk or cross-file security decisions."]
+caveats = ["Route security-sensitive or cross-file decisions to the reviewer or reviewer_codex lane."]
 
 [agents.reviewer_cursor]
 cli = "cursor"

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -707,7 +707,9 @@ def test_roster_suggest_prints_every_seat_resolution_when_roots_satisfiable(tmp_
     resolved_path = tmp_target / "resolved-roster.toml"
     resolved_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_path.write_text(emitted)
-    assert roster.load_roster(resolved_path).orchestrator == "chef"
+    resolved = roster.load_roster(resolved_path)
+    assert resolved.orchestrator == "chef"
+    assert resolved.agents["reviewer_flash"].model == "Gemini 3.7 Flash (Low)"
 
 
 def test_roster_cli_registers_suggest_and_stats_commands(tmp_target):

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -709,7 +709,11 @@ def test_roster_suggest_prints_every_seat_resolution_when_roots_satisfiable(tmp_
     resolved_path.write_text(emitted)
     resolved = roster.load_roster(resolved_path)
     assert resolved.orchestrator == "chef"
-    assert resolved.agents["reviewer_flash"].model == "Gemini 3.7 Flash (Low)"
+    flash = resolved.agents["reviewer_flash"]
+    assert flash.model == "Gemini 3.7 Flash (Low)"
+    assert "security-sensitive or cross-file decisions" in flash.role
+    assert "reviewer_codex" in flash.role
+    assert any("reviewer_codex" in caveat for caveat in flash.caveats)
 
 
 def test_roster_cli_registers_suggest_and_stats_commands(tmp_target):

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -711,9 +711,13 @@ def test_roster_suggest_prints_every_seat_resolution_when_roots_satisfiable(tmp_
     assert resolved.orchestrator == "chef"
     flash = resolved.agents["reviewer_flash"]
     assert flash.model == "Gemini 3.7 Flash (Low)"
-    assert "security-sensitive or cross-file decisions" in flash.role
-    assert "reviewer_codex" in flash.role
-    assert any("reviewer_codex" in caveat for caveat in flash.caveats)
+    assert flash.role == (
+        "Fast routine review and summary lane; route security-sensitive or "
+        "cross-file decisions to the reviewer or reviewer_codex seat."
+    )
+    assert flash.caveats == (
+        "Route security-sensitive or cross-file decisions to the reviewer or reviewer_codex lane.",
+    )
 
 
 def test_roster_cli_registers_suggest_and_stats_commands(tmp_target):


### PR DESCRIPTION
## Summary

- Move the review-heavy Antigravity seat from Gemini 3.5 Flash Low to Gemini 3.7 Flash Low.
- Update its role and caveat using the August 2026 benchmark receipts.
- Document the Cursor provider refusal seen on the security canary.
- Add the Unreleased changelog entry and explicit independent-review routing.
- Pin the shipped model through the resolved-roster test.

## Why

Gemini 3.7 Flash Low scored 97.5/100 across the t1, t6, t8, and t13 benchmark tasks in 39.7 seconds through Antigravity. It found all 7 planted security issues in t6. The same model through Cursor matched Antigravity on the three prompts Cursor served, but Cursor rejected t6 before inference. The catalog now tells operators to record provider refusals separately from model output.

## Verification

- `env CI=1 ./scripts/verify`
- `env CI=1 .venv/bin/pytest tests/test_roster_cmd.py::test_roster_suggest_prints_every_seat_resolution_when_roots_satisfiable tests/test_graphtrail_delta.py tests/test_work_cmd_verification.py -q`
- `env CI=1 brigade scrub --target . --policy public-repo --no-receipt`
- Vale check on the added public prose
