### PR TITLE
feat(projection): add recoverable multi-file transaction kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--force`. (#860)
 
 ### Added
+- Projection transaction kernel: an internal all-or-restored prepare/commit
+  engine, recovery journal, redacted receipts, injected-failure hooks, and a
+  reusable conformance fixture for multi-file projections, plus
+  `brigade projection recover <operation-id>`. Native stdlib implementation;
+  no production projector is migrated yet. (#910)
 - Cloud dispatch registry (`brigade run cloud`): register-on-dispatch and adopt
   paths, `status` JSON classification (pending / ready-to-land / landed / stale /
   orphaned / needs-investigation), receipted report-only `sweep`, configurable

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -46,6 +46,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade outcome`: 12 command path(s)
 - `brigade pantry` (extras): 5 command path(s)
 - `brigade profiles`: 2 command path(s)
+- `brigade projection`: 1 command path(s)
 - `brigade projects` (extras): 10 command path(s)
 - `brigade receipts`: 5 command path(s)
 - `brigade reconfigure`: 1 command path(s)
@@ -311,6 +312,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade pantry status` (extras)
 - `brigade profiles list`
 - `brigade profiles show`
+- `brigade projection recover`
 - `brigade projects audit` (extras)
 - `brigade projects closeout` (extras)
 - `brigade projects closeout-show` (extras)

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -75,6 +75,7 @@ from . import (
     security as _security_group,
     tools as _tools_group,
     mcp as _mcp_group,
+    projection as _projection_group,
     handoff_template as _handoff_template_group,
     ingest as _ingest_group,
     openclaw_fragments as _openclaw_fragments_group,
@@ -196,6 +197,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _security_group.register(sub)
     _tools_group.register(sub)
     _mcp_group.register(sub)
+    _projection_group.register(sub)
     _handoff_template_group.register(sub)
     _ingest_group.register(sub)
     _register_extras(sub, "openclaw-fragments", extras_enabled)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -53,6 +53,7 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
             "harness",
             "tools",
             "mcp",
+            "projection",
             "evidence",
             "code",
             "search",

--- a/src/brigade/cli/projection.py
+++ b/src/brigade/cli/projection.py
@@ -1,0 +1,40 @@
+"""brigade projection command group."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    parser = sub.add_parser("projection", help="Recover multi-file projection operations.")
+    projection_sub = parser.add_subparsers(dest="projection_command", metavar="<projection-command>")
+    projection_sub.required = True
+
+    recover = projection_sub.add_parser(
+        "recover",
+        help="Restore destinations for an unfinished projection operation.",
+    )
+    recover.add_argument("operation_id", help="Operation id from the projection receipt or journal.")
+    recover.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to operate on.")
+    recover.add_argument(
+        "--force",
+        action="store_true",
+        help="Restore even when a destination changed after the failed operation.",
+    )
+    recover.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    recover.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    from .. import projection_cmd
+
+    if args.projection_command == "recover":
+        return projection_cmd.recover(
+            operation_id=args.operation_id,
+            target=args.target,
+            force=args.force,
+            json_output=args.json,
+        )
+    args._brigade_parser.error(f"unknown projection command: {args.projection_command}")
+    return 2

--- a/src/brigade/projection/__init__.py
+++ b/src/brigade/projection/__init__.py
@@ -1,0 +1,48 @@
+"""Internal projection transaction kernel (issue #910).
+
+Standard library only. A projector supplies an immutable plan; the kernel
+either commits every destination mutation or restores every destination to its
+captured before-image. Production command modules do not belong here.
+"""
+
+from __future__ import annotations
+
+from . import kernel
+from .kernel import (
+    ABSENT,
+    DEPENDENCY_DECISION,
+    SCHEMA_VERSION,
+    DestinationChangedError,
+    DriftError,
+    FailureInjector,
+    OverlapBlockedError,
+    PlanError,
+    ProjectionError,
+    Receipt,
+    build_plan,
+    execute,
+    mutation,
+    operation_dir,
+    recover,
+    unfinished_operations,
+)
+
+__all__ = [
+    "ABSENT",
+    "DEPENDENCY_DECISION",
+    "SCHEMA_VERSION",
+    "DestinationChangedError",
+    "DriftError",
+    "FailureInjector",
+    "OverlapBlockedError",
+    "PlanError",
+    "ProjectionError",
+    "Receipt",
+    "build_plan",
+    "execute",
+    "kernel",
+    "mutation",
+    "operation_dir",
+    "recover",
+    "unfinished_operations",
+]

--- a/src/brigade/projection/fixture.py
+++ b/src/brigade/projection/fixture.py
@@ -1,0 +1,83 @@
+"""Reusable projection conformance fixture.
+
+Production projectors import this module to share the mixed create/replace/remove
+workspace and injected-failure boundaries. It does not import command modules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from brigade.projection import kernel
+
+
+def mixed_workspace(root: Path) -> tuple[Path, kernel.Plan]:
+    """Build one plan that creates, replaces, and removes files."""
+    workspace = root / "fixture-ws" if root.name != "fixture-ws" else root
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "b-replace.txt").write_bytes(b"old\n")
+    (workspace / "c-remove.txt").write_bytes(b"gone-soon\n")
+    created = b"created\n"
+    replacement = b"new\n"
+    plan = kernel.build_plan(
+        operation_id="fixture-mixed",
+        projector="conformance-fixture",
+        source_fingerprint=kernel.content_digest(b"canonical-source"),
+        mutations=[
+            kernel.mutation(
+                destination=workspace / "a-create.txt",
+                mutation="create",
+                expected_before=kernel.ABSENT,
+                desired_after=kernel.content_digest(created),
+                staged_bytes=created,
+            ),
+            kernel.mutation(
+                destination=workspace / "b-replace.txt",
+                mutation="replace",
+                expected_before=kernel.content_digest(b"old\n"),
+                desired_after=kernel.content_digest(replacement),
+                staged_bytes=replacement,
+            ),
+            kernel.mutation(
+                destination=workspace / "c-remove.txt",
+                mutation="remove",
+                expected_before=kernel.content_digest(b"gone-soon\n"),
+                desired_after=kernel.ABSENT,
+            ),
+        ],
+        target=workspace,
+    )
+    return workspace, plan
+
+
+def inject_boundaries() -> list[str]:
+    return [
+        "commit:0:before",
+        "commit:0:after",
+        "commit:1:before",
+        "commit:1:after",
+        "commit:2:before",
+        "commit:2:after",
+    ]
+
+
+def run_conformance(root: Path) -> dict[str, Any]:
+    """Run the shared kernel checks. Returns a report dict for callers."""
+    commit_root = root / "commit"
+    commit_root.mkdir()
+    workspace, plan = mixed_workspace(commit_root)
+    committed = kernel.execute(plan, target=workspace)
+    inject_root = root / "inject"
+    inject_root.mkdir()
+    inject_workspace, inject_plan = mixed_workspace(inject_root)
+    restored = kernel.execute(
+        inject_plan,
+        target=inject_workspace,
+        inject=kernel.FailureInjector(boundary="commit:1:after"),
+    )
+    return {
+        "committed": committed.terminal_state == "committed",
+        "restored_after_inject": restored.terminal_state == "restored",
+        "boundaries": inject_boundaries(),
+    }

--- a/src/brigade/projection/kernel.py
+++ b/src/brigade/projection/kernel.py
@@ -1,0 +1,712 @@
+"""Prepare, commit, and restore multi-file projection operations.
+
+A planned operation either publishes every destination mutation or restores
+every destination to its captured pre-operation state. The user-facing
+guarantee is all-or-restored completion when the process can run recovery, not
+simultaneous visibility across independent paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Literal, Mapping
+
+from brigade import localio
+
+SCHEMA_VERSION = 1
+ABSENT = "absent"
+JOURNAL_SCHEMA = "brigade.projection.journal.v1"
+RECEIPT_SCHEMA = "brigade.projection.receipt.v1"
+UNFINISHED_STATUSES = frozenset({"prepared", "committing", "restoring", "recovery-required"})
+MutationKind = Literal["create", "replace", "remove"]
+
+DEPENDENCY_DECISION: dict[str, Any] = {
+    "implementation": "native",
+    "runtime_package": None,
+    "reason": "standard-library implementation satisfies the issue gate; no runtime dependency admitted",
+}
+
+_HOME_TOKEN_RE = re.compile(r"(Authorization\s*:\s*[^\s]+)|(\bBearer\s+[A-Za-z0-9._\-+=/]+)", re.IGNORECASE)
+
+
+class ProjectionError(RuntimeError):
+    """Base class for projection-kernel failures. Carries a bounded diagnostic."""
+
+    def __init__(self, diagnostic: str) -> None:
+        super().__init__(diagnostic)
+        self.diagnostic = diagnostic
+
+
+class PlanError(ProjectionError):
+    """Plan is invalid and must not start prepare."""
+
+
+class DriftError(ProjectionError):
+    """Live destination state no longer matches the planned before-state."""
+
+
+class OverlapBlockedError(ProjectionError):
+    """A later mutating operation overlaps an unfinished recovery set."""
+
+
+class DestinationChangedError(ProjectionError):
+    """Recovery refused because a destination changed after the failed operation."""
+
+
+class InjectedFailure(ProjectionError):
+    """Test-only failure injected at a named mutation boundary."""
+
+
+@dataclass(frozen=True)
+class MutationSpec:
+    destination: Path
+    display_path: str
+    mutation: MutationKind
+    expected_before: str
+    desired_after: str
+    staged_bytes: bytes | None = None
+    mode: int | None = None
+    ownership: Mapping[str, Any] | None = None
+    conflict: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class Plan:
+    operation_id: str
+    projector: str
+    source_fingerprint: str
+    mutations: tuple[MutationSpec, ...]
+    validators: tuple[Callable[..., None], ...] = ()
+
+
+@dataclass(frozen=True)
+class OperationSummary:
+    operation_id: str
+    status: str
+    destinations: tuple[Path, ...]
+
+
+@dataclass
+class FailureInjector:
+    """Fail at a named commit or restore boundary. Production callers pass None."""
+
+    boundary: str | None = None
+    restore_boundary: str | None = None
+    error: BaseException | None = None
+    crash_after: int | None = None
+
+    def at(self, name: str) -> None:
+        if name == self.boundary or name == self.restore_boundary:
+            raise self.error or InjectedFailure(name)
+
+
+@dataclass(frozen=True)
+class Receipt:
+    schema_version: int
+    operation_id: str
+    projector: str
+    source_digest: str
+    destinations: tuple[dict[str, Any], ...]
+    validator_results: tuple[dict[str, Any], ...]
+    mutation_counts: dict[str, int]
+    terminal_state: str
+    recovery_command: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "schema": RECEIPT_SCHEMA,
+            "schema_version": self.schema_version,
+            "operation_id": self.operation_id,
+            "projector": self.projector,
+            "source_digest": self.source_digest,
+            "destinations": [dict(item) for item in self.destinations],
+            "validator_results": [dict(item) for item in self.validator_results],
+            "mutation_counts": dict(self.mutation_counts),
+            "terminal_state": self.terminal_state,
+            "recovery_command": self.recovery_command,
+        }
+        return json.loads(_redact_text(json.dumps(payload, sort_keys=True)))
+
+
+def mutation(
+    *,
+    destination: Path,
+    mutation: MutationKind,
+    expected_before: str,
+    desired_after: str,
+    staged_bytes: bytes | None = None,
+    display_path: str = "",
+    mode: int | None = None,
+    ownership: Mapping[str, Any] | None = None,
+    conflict: Mapping[str, Any] | None = None,
+) -> MutationSpec:
+    return MutationSpec(
+        destination=Path(destination),
+        display_path=display_path,
+        mutation=mutation,
+        expected_before=expected_before,
+        desired_after=desired_after,
+        staged_bytes=staged_bytes,
+        mode=mode,
+        ownership=ownership,
+        conflict=conflict,
+    )
+
+
+def content_digest(data: bytes | None) -> str:
+    if data is None:
+        return ABSENT
+    return hashlib.sha256(data).hexdigest()
+
+
+def operations_root(target: Path) -> Path:
+    return target.expanduser().resolve() / ".brigade" / "projection" / "operations"
+
+
+def operation_dir(target: Path, operation_id: str) -> Path:
+    if not operation_id or "/" in operation_id or "\\" in operation_id or ".." in operation_id:
+        raise PlanError("unsafe operation id")
+    return operations_root(target) / operation_id
+
+
+def safe_display_path(path: Path, *, target: Path, suggested: str = "") -> str:
+    resolved = _physical(path)
+    target_resolved = target.expanduser().resolve()
+    try:
+        return resolved.relative_to(target_resolved).as_posix()
+    except ValueError:
+        text = suggested or str(resolved)
+    home = str(Path.home().expanduser().resolve())
+    if text.startswith(home):
+        text = "~" + text[len(home) :]
+    return text.replace(home, "~")
+
+
+def build_plan(
+    *,
+    operation_id: str,
+    projector: str,
+    source_fingerprint: str,
+    mutations: Iterable[MutationSpec],
+    target: Path,
+    validators: Iterable[Callable[..., None]] = (),
+) -> Plan:
+    target = target.expanduser().resolve()
+    specs = tuple(mutations)
+    if not specs:
+        raise PlanError("plan has no mutations")
+    physical: list[tuple[MutationSpec, Path]] = []
+    seen: dict[str, Path] = {}
+    for spec in specs:
+        dest = _physical(spec.destination if spec.destination.is_absolute() else target / spec.destination)
+        key = dest.as_posix()
+        if key in seen:
+            raise PlanError("duplicate destination")
+        for existing in seen.values():
+            if _parent_child(existing, dest):
+                raise PlanError("parent-child destination collision")
+        seen[key] = dest
+        physical.append((spec, dest))
+    normalized: list[MutationSpec] = []
+    for spec, dest in physical:
+        _reject_symlink_and_type(dest, spec.mutation)
+        _validate_mutation_bytes(spec)
+        live = _live_digest(dest)
+        if live != spec.expected_before:
+            raise PlanError("live state does not match expected before-state")
+        display = safe_display_path(dest, target=target, suggested=spec.display_path)
+        normalized.append(
+            MutationSpec(
+                destination=dest,
+                display_path=display,
+                mutation=spec.mutation,
+                expected_before=spec.expected_before,
+                desired_after=spec.desired_after,
+                staged_bytes=spec.staged_bytes,
+                mode=spec.mode,
+                ownership=spec.ownership,
+                conflict=spec.conflict,
+            )
+        )
+    return Plan(
+        operation_id=operation_id,
+        projector=projector,
+        source_fingerprint=source_fingerprint,
+        mutations=tuple(normalized),
+        validators=tuple(validators),
+    )
+
+
+def execute(plan: Plan, *, target: Path, inject: FailureInjector | None = None) -> Receipt:
+    target = target.expanduser().resolve()
+    inject = inject or FailureInjector()
+    for spec in plan.mutations:
+        if _live_digest(spec.destination) != spec.expected_before:
+            raise DriftError("destination drift between plan and prepare")
+    _assert_no_overlap(target, {spec.destination for spec in plan.mutations}, exclude=plan.operation_id)
+    op_dir = operation_dir(target, plan.operation_id)
+    if op_dir.exists():
+        shutil.rmtree(op_dir)
+    op_dir.mkdir(parents=True)
+    try:
+        os.chmod(op_dir, 0o700)
+    except OSError:
+        pass
+    try:
+        return _prepare_and_commit(plan, target=target, op_dir=op_dir, inject=inject)
+    except (PlanError, DriftError, OverlapBlockedError, DestinationChangedError):
+        shutil.rmtree(op_dir, ignore_errors=True)
+        raise
+    except Exception:
+        shutil.rmtree(op_dir, ignore_errors=True)
+        raise
+
+
+def recover(operation_id: str, *, target: Path, force: bool = False) -> Receipt:
+    target = target.expanduser().resolve()
+    op_dir = operation_dir(target, operation_id)
+    journal = _read_journal(op_dir)
+    status = str(journal.get("status") or "")
+    if status == "committed":
+        return _receipt_from_file(op_dir)
+    if status == "restored":
+        return _receipt_from_file(op_dir)
+    mutations = _mutations_from_journal(journal)
+    for spec in mutations:
+        current = _recover_digest(spec.destination)
+        allowed = {spec.expected_before, spec.desired_after}
+        if current not in allowed and not force:
+            raise DestinationChangedError(
+                f"destination {spec.display_path} changed after the failed operation; pass --force to restore anyway"
+            )
+    _write_journal(op_dir, {**journal, "status": "restoring"})
+    for spec in reversed(mutations):
+        _restore_one(op_dir, spec)
+    receipt = _build_receipt(plan_from_journal(journal, mutations), terminal_state="restored", validator_results=())
+    _persist_receipt(op_dir, receipt, journal_update={**journal, "status": "restored", "committed_indexes": []})
+    return receipt
+
+
+def unfinished_operations(target: Path) -> list[OperationSummary]:
+    root = operations_root(target)
+    if not root.is_dir():
+        return []
+    found: list[OperationSummary] = []
+    for child in sorted(root.iterdir()):
+        journal_path = child / "journal.json"
+        if not journal_path.is_file():
+            continue
+        journal = localio.read_json_dict(journal_path) or {}
+        status = str(journal.get("status") or "")
+        if status not in UNFINISHED_STATUSES:
+            continue
+        dests = tuple(Path(item["destination"]) for item in journal.get("mutations", []) if item.get("destination"))
+        found.append(OperationSummary(operation_id=child.name, status=status, destinations=dests))
+    return found
+
+
+def write_crash_fixture(plan: Plan, *, target: Path, committed_count: int) -> None:
+    """Leave a committing journal after N successful mutations, as if the process crashed."""
+    execute(plan, target=target, inject=FailureInjector(crash_after=committed_count))
+
+
+def _prepare_and_commit(
+    plan: Plan,
+    *,
+    target: Path,
+    op_dir: Path,
+    inject: FailureInjector,
+) -> Receipt:
+    before_dir = op_dir / "before"
+    staged_dir = op_dir / "staged"
+    before_dir.mkdir()
+    staged_dir.mkdir()
+    ordered = tuple(sorted(plan.mutations, key=lambda spec: spec.destination.as_posix()))
+    for index, spec in enumerate(ordered):
+        _capture_before(before_dir, index, spec)
+        _stage_bytes(staged_dir, index, spec)
+    validator_results = _run_validators(plan, ordered)
+    journal = _journal_payload(plan, ordered, status="prepared", committed_indexes=[])
+    _write_journal(op_dir, journal)
+    committed: list[int] = []
+    crash_receipt: Receipt | None = None
+    try:
+        journal = {**journal, "status": "committing"}
+        _write_journal(op_dir, journal)
+        for index, spec in enumerate(ordered):
+            if inject.crash_after is not None and index >= inject.crash_after:
+                crash_receipt = _build_receipt(
+                    plan, terminal_state="recovery-required", validator_results=validator_results
+                )
+                _persist_receipt(
+                    op_dir,
+                    crash_receipt,
+                    journal_update={**journal, "status": "committing", "committed_indexes": committed},
+                    keep_before=True,
+                )
+                return crash_receipt
+            inject.at(f"commit:{index}:before")
+            _apply_mutation(spec)
+            committed.append(index)
+            _write_journal(op_dir, {**journal, "committed_indexes": committed})
+            inject.at(f"commit:{index}:after")
+        receipt = _build_receipt(plan, terminal_state="committed", validator_results=validator_results)
+        _persist_receipt(
+            op_dir, receipt, journal_update={**journal, "status": "committed", "committed_indexes": committed}
+        )
+        return receipt
+    except (InjectedFailure, OSError):
+        return _restore_after_failure(
+            plan,
+            op_dir=op_dir,
+            ordered=ordered,
+            committed=committed,
+            journal=journal,
+            inject=inject,
+            validator_results=validator_results,
+        )
+
+
+def _restore_after_failure(
+    plan: Plan,
+    *,
+    op_dir: Path,
+    ordered: tuple[MutationSpec, ...],
+    committed: list[int],
+    journal: dict[str, Any],
+    inject: FailureInjector,
+    validator_results: tuple[dict[str, Any], ...],
+) -> Receipt:
+    _write_journal(op_dir, {**journal, "status": "restoring", "committed_indexes": committed})
+    try:
+        for index in reversed(committed):
+            inject.at(f"restore:{index}:before")
+            _restore_one(op_dir, ordered[index], index=index)
+            inject.at(f"restore:{index}:after")
+    except (InjectedFailure, OSError):
+        receipt = _build_receipt(plan, terminal_state="recovery-required", validator_results=validator_results)
+        _persist_receipt(
+            op_dir,
+            receipt,
+            journal_update={**journal, "status": "recovery-required", "committed_indexes": committed},
+            keep_before=True,
+        )
+        return receipt
+    receipt = _build_receipt(plan, terminal_state="restored", validator_results=validator_results)
+    _persist_receipt(
+        op_dir,
+        receipt,
+        journal_update={**journal, "status": "restored", "committed_indexes": []},
+        keep_before=True,
+    )
+    return receipt
+
+
+def _apply_mutation(spec: MutationSpec) -> None:
+    if spec.mutation == "remove":
+        spec.destination.unlink()
+        return
+    if spec.staged_bytes is None:
+        raise PlanError("staged bytes required")
+    spec.destination.parent.mkdir(parents=True, exist_ok=True)
+    localio.write_bytes_atomic(spec.destination, spec.staged_bytes)
+    if spec.mode is not None:
+        os.chmod(spec.destination, spec.mode)
+
+
+def _restore_one(op_dir: Path, spec: MutationSpec, index: int | None = None) -> None:
+    if index is None:
+        index = _index_for(op_dir, spec)
+    absent_marker = op_dir / "before" / f"{index}.absent"
+    data_path = op_dir / "before" / f"{index}.bin"
+    meta_path = op_dir / "before" / f"{index}.meta.json"
+    if absent_marker.is_file() or spec.expected_before == ABSENT:
+        if spec.destination.exists() or spec.destination.is_symlink():
+            spec.destination.unlink()
+        return
+    payload = data_path.read_bytes()
+    spec.destination.parent.mkdir(parents=True, exist_ok=True)
+    localio.write_bytes_atomic(spec.destination, payload)
+    meta = localio.read_json_dict(meta_path) or {}
+    mode = meta.get("mode")
+    if isinstance(mode, int):
+        os.chmod(spec.destination, mode)
+
+
+def _index_for(op_dir: Path, spec: MutationSpec) -> int:
+    journal = _read_journal(op_dir)
+    for item in journal.get("mutations", []):
+        if Path(item["destination"]) == spec.destination:
+            return int(item["index"])
+    raise ProjectionError("before-image index missing")
+
+
+def _capture_before(before_dir: Path, index: int, spec: MutationSpec) -> None:
+    meta: dict[str, Any] = {"mode": None, "absent": spec.expected_before == ABSENT}
+    if spec.expected_before == ABSENT:
+        (before_dir / f"{index}.absent").write_text("absent\n", encoding="utf-8")
+    else:
+        (before_dir / f"{index}.bin").write_bytes(spec.destination.read_bytes())
+        meta["mode"] = spec.destination.stat().st_mode & 0o777
+    localio.write_json(before_dir / f"{index}.meta.json", meta)
+
+
+def _stage_bytes(staged_dir: Path, index: int, spec: MutationSpec) -> None:
+    if spec.staged_bytes is None:
+        (staged_dir / f"{index}.absent").write_text("absent\n", encoding="utf-8")
+        return
+    (staged_dir / f"{index}.bin").write_bytes(spec.staged_bytes)
+
+
+def _run_validators(plan: Plan, ordered: tuple[MutationSpec, ...]) -> tuple[dict[str, Any], ...]:
+    staged = {index: spec.staged_bytes for index, spec in enumerate(ordered)}
+    results: list[dict[str, Any]] = []
+    for validator in plan.validators:
+        validator(plan, staged)
+        results.append({"name": getattr(validator, "__name__", "validator"), "status": "ok"})
+    return tuple(results)
+
+
+def _journal_payload(
+    plan: Plan,
+    ordered: tuple[MutationSpec, ...],
+    *,
+    status: str,
+    committed_indexes: list[int],
+) -> dict[str, Any]:
+    return {
+        "schema": JOURNAL_SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "operation_id": plan.operation_id,
+        "projector": plan.projector,
+        "source_fingerprint": plan.source_fingerprint,
+        "status": status,
+        "committed_indexes": list(committed_indexes),
+        "mutations": [
+            {
+                "index": index,
+                "destination": spec.destination.as_posix(),
+                "display_path": spec.display_path,
+                "mutation": spec.mutation,
+                "expected_before": spec.expected_before,
+                "desired_after": spec.desired_after,
+                "mode": spec.mode,
+            }
+            for index, spec in enumerate(ordered)
+        ],
+    }
+
+
+def _write_journal(op_dir: Path, payload: dict[str, Any]) -> None:
+    localio.write_json(op_dir / "journal.json", payload)
+    try:
+        os.chmod(op_dir / "journal.json", 0o600)
+    except OSError:
+        pass
+
+
+def _read_journal(op_dir: Path) -> dict[str, Any]:
+    payload = localio.read_json_dict(op_dir / "journal.json")
+    if payload is None:
+        raise ProjectionError("projection journal missing or invalid")
+    return payload
+
+
+def _mutations_from_journal(journal: Mapping[str, Any]) -> tuple[MutationSpec, ...]:
+    specs: list[MutationSpec] = []
+    for item in journal.get("mutations", []):
+        specs.append(
+            MutationSpec(
+                destination=Path(str(item["destination"])),
+                display_path=str(item.get("display_path") or ""),
+                mutation=item["mutation"],
+                expected_before=str(item["expected_before"]),
+                desired_after=str(item["desired_after"]),
+                mode=item.get("mode") if isinstance(item.get("mode"), int) else None,
+            )
+        )
+    return tuple(specs)
+
+
+def plan_from_journal(journal: Mapping[str, Any], mutations: tuple[MutationSpec, ...]) -> Plan:
+    return Plan(
+        operation_id=str(journal["operation_id"]),
+        projector=str(journal.get("projector") or "unknown"),
+        source_fingerprint=str(journal.get("source_fingerprint") or ""),
+        mutations=mutations,
+    )
+
+
+def _build_receipt(
+    plan: Plan,
+    *,
+    terminal_state: str,
+    validator_results: tuple[dict[str, Any], ...],
+) -> Receipt:
+    counts = {"create": 0, "replace": 0, "remove": 0}
+    destinations: list[dict[str, Any]] = []
+    for spec in plan.mutations:
+        counts[spec.mutation] = counts.get(spec.mutation, 0) + 1
+        destinations.append(
+            {
+                "display_path": spec.display_path,
+                "mutation": spec.mutation,
+                "before_digest": spec.expected_before,
+                "after_digest": spec.desired_after,
+            }
+        )
+    recovery_command = None
+    if terminal_state == "recovery-required":
+        recovery_command = f"brigade projection recover {plan.operation_id}"
+    return Receipt(
+        schema_version=SCHEMA_VERSION,
+        operation_id=plan.operation_id,
+        projector=plan.projector,
+        source_digest=plan.source_fingerprint,
+        destinations=tuple(destinations),
+        validator_results=validator_results,
+        mutation_counts=counts,
+        terminal_state=terminal_state,
+        recovery_command=recovery_command,
+    )
+
+
+def _persist_receipt(
+    op_dir: Path,
+    receipt: Receipt,
+    *,
+    journal_update: dict[str, Any],
+    keep_before: bool = False,
+) -> None:
+    payload = receipt.to_dict()
+    localio.write_json(op_dir / "receipt.json", payload)
+    try:
+        os.chmod(op_dir / "receipt.json", 0o600)
+    except OSError:
+        pass
+    _write_journal(op_dir, journal_update)
+    if receipt.terminal_state == "committed" and not keep_before:
+        shutil.rmtree(op_dir / "before", ignore_errors=True)
+        shutil.rmtree(op_dir / "staged", ignore_errors=True)
+
+
+def _receipt_from_file(op_dir: Path) -> Receipt:
+    payload = localio.read_json_dict(op_dir / "receipt.json")
+    if payload is None:
+        raise ProjectionError("projection receipt missing")
+    return Receipt(
+        schema_version=int(payload.get("schema_version") or SCHEMA_VERSION),
+        operation_id=str(payload["operation_id"]),
+        projector=str(payload.get("projector") or ""),
+        source_digest=str(payload.get("source_digest") or ""),
+        destinations=tuple(payload.get("destinations") or ()),
+        validator_results=tuple(payload.get("validator_results") or ()),
+        mutation_counts=dict(payload.get("mutation_counts") or {}),
+        terminal_state=str(payload["terminal_state"]),
+        recovery_command=payload.get("recovery_command"),
+    )
+
+
+def _assert_no_overlap(target: Path, destinations: set[Path], *, exclude: str) -> None:
+    incoming = {_physical(path) for path in destinations}
+    for item in unfinished_operations(target):
+        if item.operation_id == exclude:
+            continue
+        existing = {_physical(path) for path in item.destinations}
+        if incoming & existing:
+            raise OverlapBlockedError(f"unfinished projection {item.operation_id} overlaps the planned destination set")
+
+
+def _validate_mutation_bytes(spec: MutationSpec) -> None:
+    if spec.mutation in {"create", "replace"}:
+        if spec.staged_bytes is None:
+            raise PlanError("staged bytes required")
+        if content_digest(spec.staged_bytes) != spec.desired_after:
+            raise PlanError("desired after-state digest does not match staged bytes")
+    elif spec.mutation == "remove":
+        if spec.desired_after != ABSENT:
+            raise PlanError("remove must desire absence")
+    else:
+        raise PlanError("unsupported mutation type")
+
+
+def _reject_symlink_and_type(path: Path, kind: MutationKind) -> None:
+    try:
+        status = os.lstat(path)
+    except FileNotFoundError:
+        if kind != "create":
+            raise PlanError("destination is absent") from None
+        _reject_parent_symlink(path)
+        return
+    if stat.S_ISLNK(status.st_mode):
+        raise PlanError("unsafe symlink destination")
+    if stat.S_ISDIR(status.st_mode) and kind != "replace":
+        # Directory destinations are invalid as file mutations; parent-child
+        # checks still run first when another dest lives underneath.
+        raise PlanError("unsupported file type")
+    if not stat.S_ISREG(status.st_mode) and not stat.S_ISDIR(status.st_mode):
+        raise PlanError("unsupported file type")
+    if stat.S_ISDIR(status.st_mode):
+        return
+    _reject_parent_symlink(path)
+
+
+def _reject_parent_symlink(path: Path) -> None:
+    parent = path.parent
+    try:
+        status = os.lstat(parent)
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(status.st_mode):
+        raise PlanError("unsafe symlink destination")
+
+
+def _parent_child(left: Path, right: Path) -> bool:
+    left_parts = left.parts
+    right_parts = right.parts
+    if left_parts == right_parts:
+        return False
+    return left_parts == right_parts[: len(left_parts)] or right_parts == left_parts[: len(right_parts)]
+
+
+def _physical(path: Path) -> Path:
+    path = path.expanduser()
+    parent = path.parent.resolve()
+    return parent / path.name
+
+
+def _live_digest(path: Path) -> str:
+    try:
+        status = os.lstat(path)
+    except FileNotFoundError:
+        return ABSENT
+    if stat.S_ISLNK(status.st_mode):
+        raise PlanError("unsafe symlink destination")
+    if not stat.S_ISREG(status.st_mode):
+        raise PlanError("unsupported file type")
+    return content_digest(path.read_bytes())
+
+
+def _recover_digest(path: Path) -> str:
+    try:
+        status = os.lstat(path)
+    except FileNotFoundError:
+        return ABSENT
+    if stat.S_ISLNK(status.st_mode) or not stat.S_ISREG(status.st_mode):
+        return f"unexpected:{status.st_mode}"
+    return content_digest(path.read_bytes())
+
+
+def _redact_text(text: str) -> str:
+    home = str(Path.home().expanduser().resolve())
+    redacted = text.replace(home, "~")
+    if home != str(Path.home()):
+        redacted = redacted.replace(str(Path.home()), "~")
+    return _HOME_TOKEN_RE.sub("[redacted]", redacted)

--- a/src/brigade/projection/kernel.py
+++ b/src/brigade/projection/kernel.py
@@ -205,7 +205,9 @@ def build_plan(
     physical: list[tuple[MutationSpec, Path]] = []
     seen: dict[str, Path] = {}
     for spec in specs:
-        dest = _physical(spec.destination if spec.destination.is_absolute() else target / spec.destination)
+        requested = spec.destination if spec.destination.is_absolute() else target / spec.destination
+        _reject_parent_symlink(requested)
+        dest = _physical(requested)
         key = dest.as_posix()
         if key in seen:
             raise PlanError("duplicate destination")
@@ -287,8 +289,20 @@ def recover(operation_id: str, *, target: Path, force: bool = False) -> Receipt:
                 f"destination {spec.display_path} changed after the failed operation; pass --force to restore anyway"
             )
     _write_journal(op_dir, {**journal, "status": "restoring"})
-    for spec in reversed(mutations):
-        _restore_one(op_dir, spec)
+    try:
+        for spec in reversed(mutations):
+            _restore_one(op_dir, spec)
+    except OSError:
+        receipt = _build_receipt(
+            plan_from_journal(journal, mutations), terminal_state="recovery-required", validator_results=()
+        )
+        _persist_receipt(
+            op_dir,
+            receipt,
+            journal_update={**journal, "status": "recovery-required"},
+            keep_before=True,
+        )
+        return receipt
     receipt = _build_receipt(plan_from_journal(journal, mutations), terminal_state="restored", validator_results=())
     _persist_receipt(op_dir, receipt, journal_update={**journal, "status": "restored", "committed_indexes": []})
     return receipt
@@ -660,12 +674,15 @@ def _reject_symlink_and_type(path: Path, kind: MutationKind) -> None:
 
 def _reject_parent_symlink(path: Path) -> None:
     parent = path.parent
-    try:
-        status = os.lstat(parent)
-    except FileNotFoundError:
-        return
-    if stat.S_ISLNK(status.st_mode):
-        raise PlanError("unsafe symlink destination")
+    while parent != parent.parent:
+        try:
+            status = os.lstat(parent)
+        except FileNotFoundError:
+            parent = parent.parent
+            continue
+        if stat.S_ISLNK(status.st_mode):
+            raise PlanError("unsafe symlink destination")
+        parent = parent.parent
 
 
 def _parent_child(left: Path, right: Path) -> bool:

--- a/src/brigade/projection_cmd.py
+++ b/src/brigade/projection_cmd.py
@@ -1,0 +1,27 @@
+"""brigade projection recover command."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from .projection.kernel import DestinationChangedError, ProjectionError, recover as recover_operation
+
+
+def recover(operation_id: str, *, target: Path, force: bool, json_output: bool) -> int:
+    try:
+        receipt = recover_operation(operation_id, target=target, force=force)
+    except (DestinationChangedError, ProjectionError) as exc:
+        print(exc.diagnostic, file=sys.stderr)
+        return 2
+    payload = receipt.to_dict()
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        line = f"{payload['terminal_state']} {payload['operation_id']}"
+        command = payload.get("recovery_command")
+        if command:
+            line = f"{line}\n{command}"
+        print(line)
+    return 0

--- a/tests/test_projection_cli.py
+++ b/tests/test_projection_cli.py
@@ -1,0 +1,59 @@
+"""CLI for brigade projection recover (issue #910)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import cli
+from brigade.projection import kernel as projection
+from brigade.projection.fixture import mixed_workspace
+
+
+def test_projection_recover_cli_restores_and_prints_json(tmp_path: Path, capsys) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    projection.execute(
+        plan,
+        target=workspace,
+        inject=projection.FailureInjector(boundary="commit:1:after", restore_boundary="restore:0:before"),
+    )
+    code = cli.main(["projection", "recover", plan.operation_id, "--target", str(workspace), "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["terminal_state"] == "restored"
+    assert payload["operation_id"] == plan.operation_id
+    assert not (workspace / "a-create.txt").exists()
+    assert (workspace / "c-remove.txt").is_file()
+
+
+def test_projection_recover_cli_force_after_drift(tmp_path: Path, capsys) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    projection.execute(
+        plan,
+        target=workspace,
+        inject=projection.FailureInjector(boundary="commit:1:after", restore_boundary="restore:0:before"),
+    )
+    (workspace / "a-create.txt").write_bytes(b"user-edited\n")
+    code = cli.main(["projection", "recover", plan.operation_id, "--target", str(workspace), "--json"])
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "changed" in err.lower() or "drift" in err.lower()
+    code = cli.main(
+        [
+            "projection",
+            "recover",
+            plan.operation_id,
+            "--target",
+            str(workspace),
+            "--force",
+            "--json",
+        ]
+    )
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["terminal_state"] == "restored"
+
+
+def test_projection_command_is_grouped() -> None:
+    names = [name for _, names in cli.COMMAND_GROUPS for name in names]
+    assert "projection" in names

--- a/tests/test_projection_conformance.py
+++ b/tests/test_projection_conformance.py
@@ -1,0 +1,32 @@
+"""Reusable projection conformance fixture (issue #910)."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from brigade.projection import fixture, kernel
+
+
+def test_conformance_fixture_does_not_import_command_modules() -> None:
+    source = inspect.getsource(fixture)
+    assert "brigade.cli" not in source
+    assert "projection_cmd" not in source
+    assert "mcp" not in source
+    assert "harness_profile" not in source
+    assert "skills_cmd" not in source
+
+
+def test_conformance_fixture_mixed_operation_and_injected_failure(tmp_path: Path) -> None:
+    report = fixture.run_conformance(tmp_path)
+    assert report["committed"] is True
+    assert report["restored_after_inject"] is True
+    assert report["boundaries"] == [
+        "commit:0:before",
+        "commit:0:after",
+        "commit:1:before",
+        "commit:1:after",
+        "commit:2:before",
+        "commit:2:after",
+    ]
+    assert kernel.DEPENDENCY_DECISION["implementation"] == "native"

--- a/tests/test_projection_kernel.py
+++ b/tests/test_projection_kernel.py
@@ -86,6 +86,24 @@ def test_restore_failure_returns_recovery_required_and_recover_is_idempotent(tmp
     assert _snapshot(workspace) == before
 
 
+def test_manual_recovery_failure_keeps_recovery_material(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    projection.execute(
+        plan,
+        target=workspace,
+        inject=projection.FailureInjector(boundary="commit:1:after", restore_boundary="restore:0:before"),
+    )
+
+    def boom(*_args, **_kwargs):
+        raise OSError("restore failed")
+
+    monkeypatch.setattr(projection.localio, "write_bytes_atomic", boom)
+    receipt = projection.recover(plan.operation_id, target=workspace)
+    assert receipt.terminal_state == "recovery-required"
+    assert receipt.recovery_command == f"brigade projection recover {plan.operation_id}"
+    assert (projection.operation_dir(workspace, plan.operation_id) / "before").is_dir()
+
+
 def test_destination_drift_between_plan_and_prepare_fails_closed(tmp_path: Path) -> None:
     workspace, plan = mixed_workspace(tmp_path)
     before = _snapshot(workspace)
@@ -135,6 +153,27 @@ def test_plan_rejects_symlink_duplicate_and_parent_child(tmp_path: Path) -> None
                     expected_before=_digest(b"ok\n"),
                     desired_after=_digest(b"new\n"),
                     staged_bytes=b"new\n",
+                )
+            ],
+            target=workspace,
+        )
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    directory_link = workspace / "directory-link"
+    directory_link.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(projection.PlanError, match="symlink"):
+        projection.build_plan(
+            operation_id="op-parent-symlink",
+            projector="fixture",
+            source_fingerprint="src",
+            mutations=[
+                projection.mutation(
+                    destination=directory_link / "outside.txt",
+                    mutation="create",
+                    expected_before=projection.ABSENT,
+                    desired_after=_digest(b"new\\n"),
+                    staged_bytes=b"new\\n",
                 )
             ],
             target=workspace,

--- a/tests/test_projection_kernel.py
+++ b/tests/test_projection_kernel.py
@@ -1,0 +1,316 @@
+"""Projection transaction kernel (issue #910)."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade.projection import kernel as projection
+from brigade.projection.fixture import mixed_workspace
+
+
+def _digest(data: bytes | None) -> str:
+    if data is None:
+        return projection.ABSENT
+    return hashlib.sha256(data).hexdigest()
+
+
+def _snapshot(root: Path) -> dict[str, tuple[str, int | None]]:
+    records: dict[str, tuple[str, int | None]] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_dir() or ".brigade" in path.parts:
+            continue
+        rel = path.relative_to(root).as_posix()
+        records[rel] = (_digest(path.read_bytes()), path.stat().st_mode & 0o777)
+    return records
+
+
+def test_mixed_plan_commits_create_replace_and_remove(tmp_path: Path) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    receipt = projection.execute(plan, target=workspace)
+    assert receipt.terminal_state == "committed"
+    assert (workspace / "a-create.txt").read_bytes() == b"created\n"
+    assert (workspace / "b-replace.txt").read_bytes() == b"new\n"
+    assert not (workspace / "c-remove.txt").exists()
+    op_dir = projection.operation_dir(workspace, plan.operation_id)
+    assert not (op_dir / "before").exists()
+    assert (op_dir / "receipt.json").is_file()
+    payload = json.loads((op_dir / "receipt.json").read_text())
+    assert payload["terminal_state"] == "committed"
+    assert payload["recovery_command"] is None
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "commit:0:before",
+        "commit:0:after",
+        "commit:1:before",
+        "commit:1:after",
+        "commit:2:before",
+        "commit:2:after",
+    ],
+)
+def test_injected_failure_at_each_mutation_boundary_restores(tmp_path: Path, boundary: str) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    before = _snapshot(workspace)
+    receipt = projection.execute(
+        plan,
+        target=workspace,
+        inject=projection.FailureInjector(boundary=boundary),
+    )
+    assert receipt.terminal_state == "restored"
+    assert _snapshot(workspace) == before
+    assert receipt.recovery_command is None
+
+
+def test_restore_failure_returns_recovery_required_and_recover_is_idempotent(tmp_path: Path) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    before = _snapshot(workspace)
+    receipt = projection.execute(
+        plan,
+        target=workspace,
+        inject=projection.FailureInjector(boundary="commit:1:after", restore_boundary="restore:0:before"),
+    )
+    assert receipt.terminal_state == "recovery-required"
+    assert receipt.recovery_command == f"brigade projection recover {plan.operation_id}"
+    first = projection.recover(plan.operation_id, target=workspace)
+    assert first.terminal_state == "restored"
+    assert _snapshot(workspace) == before
+    second = projection.recover(plan.operation_id, target=workspace)
+    assert second.terminal_state == "restored"
+    assert _snapshot(workspace) == before
+
+
+def test_destination_drift_between_plan_and_prepare_fails_closed(tmp_path: Path) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    before = _snapshot(workspace)
+    (workspace / "b-replace.txt").write_bytes(b"drifted\n")
+    with pytest.raises(projection.DriftError):
+        projection.execute(plan, target=workspace)
+    assert (workspace / "b-replace.txt").read_bytes() == b"drifted\n"
+    assert not (workspace / "a-create.txt").exists()
+    assert (workspace / "c-remove.txt").exists()
+    assert not projection.operation_dir(workspace, plan.operation_id).exists()
+    assert _snapshot(workspace)["c-remove.txt"] == before["c-remove.txt"]
+
+
+def test_crash_state_restart_detects_and_recovers(tmp_path: Path) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    before = _snapshot(workspace)
+    projection.write_crash_fixture(plan, target=workspace, committed_count=1)
+    unfinished = projection.unfinished_operations(workspace)
+    assert len(unfinished) == 1
+    assert unfinished[0].operation_id == plan.operation_id
+    assert unfinished[0].status in {"committing", "recovery-required"}
+    receipt = projection.recover(plan.operation_id, target=workspace)
+    assert receipt.terminal_state == "restored"
+    assert _snapshot(workspace) == before
+
+
+def test_plan_rejects_symlink_duplicate_and_parent_child(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "file.txt"
+    target.write_bytes(b"ok\n")
+    link = workspace / "link.txt"
+    link.symlink_to(target)
+    nested = workspace / "dir"
+    nested.mkdir()
+    (nested / "child.txt").write_bytes(b"child\n")
+
+    with pytest.raises(projection.PlanError, match="symlink"):
+        projection.build_plan(
+            operation_id="op-symlink",
+            projector="fixture",
+            source_fingerprint="src",
+            mutations=[
+                projection.mutation(
+                    destination=link,
+                    mutation="replace",
+                    expected_before=_digest(b"ok\n"),
+                    desired_after=_digest(b"new\n"),
+                    staged_bytes=b"new\n",
+                )
+            ],
+            target=workspace,
+        )
+
+    with pytest.raises(projection.PlanError, match="duplicate"):
+        projection.build_plan(
+            operation_id="op-dup",
+            projector="fixture",
+            source_fingerprint="src",
+            mutations=[
+                projection.mutation(
+                    destination=target,
+                    mutation="replace",
+                    expected_before=_digest(b"ok\n"),
+                    desired_after=_digest(b"a\n"),
+                    staged_bytes=b"a\n",
+                ),
+                projection.mutation(
+                    destination=target,
+                    mutation="replace",
+                    expected_before=_digest(b"ok\n"),
+                    desired_after=_digest(b"b\n"),
+                    staged_bytes=b"b\n",
+                ),
+            ],
+            target=workspace,
+        )
+
+    with pytest.raises(projection.PlanError, match="parent-child"):
+        projection.build_plan(
+            operation_id="op-nested",
+            projector="fixture",
+            source_fingerprint="src",
+            mutations=[
+                projection.mutation(
+                    destination=nested,
+                    mutation="replace",
+                    expected_before=_digest(b"unused"),
+                    desired_after=_digest(b"x"),
+                    staged_bytes=b"x",
+                ),
+                projection.mutation(
+                    destination=nested / "child.txt",
+                    mutation="replace",
+                    expected_before=_digest(b"child\n"),
+                    desired_after=_digest(b"y\n"),
+                    staged_bytes=b"y\n",
+                ),
+            ],
+            target=workspace,
+        )
+
+
+def test_permission_and_disk_write_failures_restore(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    before = _snapshot(workspace)
+
+    def boom_permission(*_args, **_kwargs):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(projection.localio, "write_bytes_atomic", boom_permission)
+    receipt = projection.execute(plan, target=workspace)
+    assert receipt.terminal_state == "restored"
+    assert _snapshot(workspace) == before
+
+    def boom_disk(*_args, **_kwargs):
+        raise OSError(errno.ENOSPC, "no space")
+
+    monkeypatch.setattr(projection.localio, "write_bytes_atomic", boom_disk)
+    receipt = projection.execute(plan, target=workspace)
+    assert receipt.terminal_state == "restored"
+    assert _snapshot(workspace) == before
+
+
+def test_unfinished_recovery_blocks_only_overlapping_destinations(tmp_path: Path) -> None:
+    workspace, blocked_plan = mixed_workspace(tmp_path / "shared")
+    projection.execute(
+        blocked_plan,
+        target=workspace,
+        inject=projection.FailureInjector(boundary="commit:1:after", restore_boundary="restore:0:before"),
+    )
+    overlapping = projection.build_plan(
+        operation_id="op-overlap",
+        projector="fixture",
+        source_fingerprint="src-2",
+        mutations=[
+            projection.mutation(
+                destination=workspace / "b-replace.txt",
+                mutation="replace",
+                expected_before=_digest(b"old\n"),
+                desired_after=_digest(b"other\n"),
+                staged_bytes=b"other\n",
+            )
+        ],
+        target=workspace,
+    )
+    with pytest.raises(projection.OverlapBlockedError):
+        projection.execute(overlapping, target=workspace)
+
+    other = workspace / "other.txt"
+    other.write_bytes(b"keep\n")
+    disjoint = projection.build_plan(
+        operation_id="op-disjoint",
+        projector="fixture",
+        source_fingerprint="src-3",
+        mutations=[
+            projection.mutation(
+                destination=other,
+                mutation="replace",
+                expected_before=_digest(b"keep\n"),
+                desired_after=_digest(b"changed\n"),
+                staged_bytes=b"changed\n",
+            )
+        ],
+        target=workspace,
+    )
+    receipt = projection.execute(disjoint, target=workspace)
+    assert receipt.terminal_state == "committed"
+    assert other.read_bytes() == b"changed\n"
+
+
+def test_receipt_redacts_paths_secrets_and_omits_contents(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home" / "operator"
+    home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    workspace = home / "proj"
+    workspace.mkdir()
+    secret = b"Authorization: Bearer tok_live_secret_value\n"
+    dest = workspace / "owned.txt"
+    dest.write_bytes(b"before\n")
+    plan = projection.build_plan(
+        operation_id="op-private",
+        projector="fixture",
+        source_fingerprint="src",
+        mutations=[
+            projection.mutation(
+                destination=dest,
+                display_path=str(dest),
+                mutation="replace",
+                expected_before=_digest(b"before\n"),
+                desired_after=_digest(secret),
+                staged_bytes=secret,
+            )
+        ],
+        target=workspace,
+    )
+    receipt = projection.execute(plan, target=workspace)
+    payload = receipt.to_dict()
+    rendered = json.dumps(payload)
+    assert str(home) not in rendered
+    assert "tok_live_secret_value" not in rendered
+    assert "Authorization" not in rendered
+    assert secret.decode() not in rendered
+    assert payload["destinations"][0]["display_path"] == "owned.txt"
+    assert payload["schema_version"] == projection.SCHEMA_VERSION
+    assert payload["operation_id"] == "op-private"
+    assert payload["projector"] == "fixture"
+
+
+def test_recover_refuses_post_failure_destination_drift_without_force(tmp_path: Path) -> None:
+    workspace, plan = mixed_workspace(tmp_path)
+    projection.execute(
+        plan,
+        target=workspace,
+        inject=projection.FailureInjector(boundary="commit:1:after", restore_boundary="restore:0:before"),
+    )
+    (workspace / "a-create.txt").write_bytes(b"user-edited\n")
+    with pytest.raises(projection.DestinationChangedError):
+        projection.recover(plan.operation_id, target=workspace)
+    forced = projection.recover(plan.operation_id, target=workspace, force=True)
+    assert forced.terminal_state == "restored"
+    assert not (workspace / "a-create.txt").exists()
+
+
+def test_dependency_decision_is_native_stdlib() -> None:
+    assert projection.DEPENDENCY_DECISION["implementation"] == "native"
+    assert projection.DEPENDENCY_DECISION["runtime_package"] is None


### PR DESCRIPTION
## Summary

- Adds an internal projection transaction kernel so a multi-file plan either commits every mutation or restores every destination to its captured before-image.
- Journals, before-images, and redacted receipts live under `.brigade/projection/operations/<operation-id>/`. Successful commits delete before-images after the receipt is durable. Failed and interrupted operations keep recovery material.
- Exposes `brigade projection recover <operation-id>` (`--force` when a destination changed after the failed operation). Native stdlib implementation; no runtime package admitted. No production projector is migrated in this PR.

Closes #910.

## Why

Individual atomic writes do not protect a group of files. A later write failure can leave earlier destinations changed while ownership state or receipts still describe the previous state. #911 (MCP sync), #912 (harness profiles), and #913 (skills sync) depend on this kernel.

## Contract

- Plan validation rejects duplicate destinations, parent-child collisions, unsafe symlinks, unsupported file types, and live state that does not match the expected before-state.
- Destination drift between plan and prepare fails closed with no journal.
- Unfinished recovery blocks only overlapping destination sets.
- Receipts (`brigade.projection.receipt.v1`) carry schema version, operation id, projector, source digest, safe destination labels, before/after digests, validator results, mutation counts, terminal state, and a recovery command when needed. They omit projected contents, secrets, and raw home paths.
- Reusable conformance fixture: `brigade.projection.fixture` (no command-module imports).

## Dependency decision

Native standard-library implementation. `DEPENDENCY_DECISION` in `brigade.projection.kernel` records `implementation=native` and `runtime_package=None`. A runtime package may replace part of this only if #910's admission gate is filled in on the issue.

## Test plan

- [x] RED then GREEN via `brigade work verify run` (receipt `20260814-011400-work-verify-d41605`): 32 passed on `tests/test_projection_kernel.py`, `tests/test_projection_conformance.py`, `tests/test_projection_cli.py`, `tests/test_cli_help.py`
- [x] ruff check, ruff format --check, and mypy on the new modules (receipts `20260814-011241-work-verify-4d62c3`, `20260814-011533-work-verify-78318e`, `20260814-011342-work-verify-ae456b`)
- [ ] CI `./scripts/verify` on this PR (full local suite not run here; focused receipts only)
- [ ] Windows behavior is the same stdlib `lstat`/`os.replace` path; no native Windows run in this change

## Skipped sub-items

None. Two-attempt skip rule was not used.

