### PR TITLE
feat(mcp): commit native configs and ownership as one transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `brigade mcp sync --write` commits selected native configs and MCP ownership
+  state through the projection transaction kernel. A failed write restores the
+  selected destinations; unfinished operations are visible through `brigade
+  mcp status` and `brigade mcp doctor`, and can be recovered with `brigade mcp
+  recover <operation-id>`. Refs #911.
+
 ### Changed
 - The shipped review-heavy `reviewer_flash` preset now uses Gemini 3.7 Flash Low
   on Antigravity. Security-sensitive or cross-file decisions still route to the

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -37,7 +37,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade ingest`: 1 command path(s)
 - `brigade init`: 1 command path(s)
 - `brigade learn` (extras): 13 command path(s)
-- `brigade mcp`: 12 command path(s)
+- `brigade mcp`: 14 command path(s)
 - `brigade memory`: 17 command path(s)
 - `brigade model`: 7 command path(s)
 - `brigade notifications` (extras): 4 command path(s)
@@ -238,6 +238,8 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade mcp pi-bridge install`
 - `brigade mcp pi-bridge uninstall`
 - `brigade mcp plan`
+- `brigade mcp recover`
+- `brigade mcp status`
 - `brigade mcp sync`
 - `brigade mcp verify`
 - `brigade memory care backfill`

--- a/src/brigade/cli/mcp.py
+++ b/src/brigade/cli/mcp.py
@@ -55,6 +55,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_plan.add_argument("--user-scope", action="store_true", help="Include user-scoped targets (e.g. antigravity).")
     p_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
+    p_status = mcp_sub.add_parser("status", help="Show unfinished MCP projection recovery.")
+    _target(p_status)
+    p_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
     p_sync = mcp_sub.add_parser("sync", help="Merge the catalog into each tool's config (dry-run unless --write).")
     _target(p_sync)
     p_sync.add_argument("--name", default=None, help="Sync a single server.")
@@ -91,6 +95,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_doctor = mcp_sub.add_parser("doctor", help="Validate the canonical catalog and report gaps.")
     _target(p_doctor)
     p_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    p_recover = mcp_sub.add_parser("recover", help="Restore destinations from an unfinished MCP projection.")
+    _target(p_recover)
+    p_recover.add_argument("operation_id", help="Projection operation id to recover.")
+    p_recover.add_argument("--force", action="store_true", help="Recover even if a destination changed after failure.")
+    p_recover.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
     p_import = mcp_sub.add_parser("import", help="Read an existing tool's MCP config into the canonical catalog.")
     _target(p_import)
@@ -185,6 +195,8 @@ def dispatch(args) -> int:
             user_scope=args.user_scope,
             json_output=args.json,
         )
+    if args.mcp_command == "status":
+        return mcp_cmd.status(target=args.target, json_output=args.json)
     if args.mcp_command == "sync":
         return mcp_cmd.sync(
             target=args.target,
@@ -211,6 +223,10 @@ def dispatch(args) -> int:
         )
     if args.mcp_command == "doctor":
         return mcp_cmd.doctor(target=args.target, json_output=args.json)
+    if args.mcp_command == "recover":
+        return mcp_cmd.recover_operation(
+            target=args.target, operation_id=args.operation_id, force=args.force, json_output=args.json
+        )
     if args.mcp_command == "import":
         return mcp_cmd.import_servers(
             target=args.target,

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -726,6 +726,15 @@ def mcp_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     unsupported = sorted(h for h in ctx.harnesses if h not in mcp_adapters.ADAPTERS and h != "this-repo")
     if unsupported:
         results.append((INFO, "mcp: targets", f"no MCP adapter for: {', '.join(unsupported)}"))
+    for record in mcp_cmd._recovery_records(ctx.target):
+        command = record.get("recovery_command") or f"brigade mcp recover {record.get('operation_id')}"
+        results.append(
+            (
+                WARN,
+                "mcp: recovery",
+                f"{record.get('operation_id')}; run `{command}`",
+            )
+        )
     return results
 
 

--- a/src/brigade/mcp_cmd.py
+++ b/src/brigade/mcp_cmd.py
@@ -10,14 +10,18 @@ unless ``--force``); orphans are removed only with ``--prune`` and only when sti
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import json
 import math
 import subprocess
 import sys
+import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from . import localio, mcp_adapters, mcp_runtime
+from . import localio, mcp_adapters, mcp_runtime, projection
 from .mcp_adapters import ADAPTERS, MCP_TARGETS, CanonicalServer
 from .render import emit as _emit
 
@@ -729,7 +733,77 @@ def verify(
     return _emit(payload, json_output, lines, rc)
 
 
-def sync(
+@dataclass
+class McpSyncPlan:
+    target: Path
+    harnesses: list[str]
+    items: list[dict[str, Any]]
+    notes: list[str]
+    exposures: list[dict[str, Any]]
+    gated: set[str]
+    gate_error: str | None
+    gate_declined: bool
+    projection: Any | None
+    source_catalog: str
+    destination_files: list[str]
+    errors: list[str] = field(default_factory=list)
+    native_write_paths: list[Path] = field(default_factory=list)
+
+
+def _state_bytes(state: dict[str, Any]) -> bytes:
+    return (json.dumps(state, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _file_bytes(path: Path) -> bytes | None:
+    return path.read_bytes() if path.is_file() else None
+
+
+def _content_digest(data: bytes | None) -> str:
+    return projection.ABSENT if data is None else hashlib.sha256(data).hexdigest()
+
+
+def _mutation_for_path(
+    *,
+    dest: Path,
+    display_path: str,
+    before: bytes | None,
+    after: bytes | None,
+) -> Any | None:
+    if before == after:
+        return None
+    if before is None:
+        mutation_type = "create"
+    elif after is None:
+        mutation_type = "remove"
+    else:
+        mutation_type = "replace"
+    return projection.mutation(
+        destination=dest,
+        display_path=display_path,
+        mutation=mutation_type,
+        expected_before=_content_digest(before),
+        desired_after=_content_digest(after),
+        staged_bytes=after,
+    )
+
+
+def _recovery_records(target: Path) -> list[dict[str, Any]]:
+    records = []
+    for record in projection.unfinished_operations(target):
+        if not record.operation_id.startswith("mcp-"):
+            continue
+        records.append(
+            {
+                "operation_id": record.operation_id,
+                "terminal_state": "recovery-required",
+                "status": record.status,
+                "recovery_command": f"brigade mcp recover {record.operation_id}",
+            }
+        )
+    return records
+
+
+def build_sync_plan(
     *,
     target: Path,
     name: str | None = None,
@@ -741,25 +815,28 @@ def sync(
     user_scope: bool = False,
     allow_global_stdio: bool = False,
     interactive: bool | None = None,
-    verify_runtime: bool = False,
-    verify_timeout: float | None = None,
     json_output: bool = False,
-) -> int:
+) -> McpSyncPlan:
     target = target.expanduser().resolve()
-    if verify_runtime and not write:
-        message = "--verify requires --write"
-        return _emit({"errors": [message]}, json_output, [f"error: {message}"], 2)
-    timeout_error = _verify_timeout_error(verify_timeout, flag="--verify-timeout")
-    if timeout_error:
-        return _emit({"errors": [timeout_error]}, json_output, [f"error: {timeout_error}"], 2)
     servers, errors, _ = load_canonical(target)
+    notes: list[str] = []
     if errors:
-        return _emit({"errors": errors}, json_output, [f"error: {e}" for e in errors], 2)
+        return McpSyncPlan(
+            target=target,
+            harnesses=[],
+            items=[],
+            notes=[],
+            exposures=[],
+            gated=set(),
+            gate_error=None,
+            gate_declined=False,
+            projection=None,
+            source_catalog=str(canonical_path(target)),
+            destination_files=[],
+            errors=errors,
+        )
     harnesses, notes = active_targets(target, harness=harness, user_scope=user_scope)
-    state = _load_state(target)
-    all_items: list[dict[str, Any]] = []
-    files_written: list[str] = []
-
+    state = copy.deepcopy(_load_state(target))
     planned = [
         (h, _plan_for_harness(target, h, servers, state, force=force, prune=prune, adopt=adopt, name_filter=name))
         for h in harnesses
@@ -772,12 +849,6 @@ def sync(
         warning_lines = _stdio_exposure_lines(exposures)
         notes.extend(warning_lines)
         if write and not allow_global_stdio:
-            # A user-scoped stdio sync never completes silently: interactive runs
-            # confirm at the prompt, non-interactive runs need the explicit flag.
-            # Only the exposed user-scoped destinations gate; project-scoped
-            # harnesses in the same invocation still write. Callers that capture
-            # stdout (operator sync-mcp) pass `interactive` explicitly; the
-            # prompt stays on stderr so captured JSON is clean.
             is_interactive = interactive if interactive is not None else (not json_output and sys.stdin.isatty())
             if not is_interactive:
                 gated = {e["harness"] for e in exposures}
@@ -796,10 +867,13 @@ def sync(
                     gate_declined = True
                     notes.append("user-scoped stdio destinations skipped: not confirmed at the prompt")
 
+    all_items: list[dict[str, Any]] = []
+    mutations: list[Any] = []
+    native_write_paths: list[Path] = []
+    plan_errors: list[str] = []
+    desired_state = copy.deepcopy(state)
     for h, items in planned:
         if h in gated:
-            # Preserve the plan for visibility, but nothing in this destination
-            # is written and no ownership state changes.
             for item in items:
                 if item["action"] in ("create", "update", "remove"):
                     item["action"] = "skip"
@@ -810,10 +884,7 @@ def sync(
         all_items.extend(items)
         adapter = ADAPTERS[h]
         path = mcp_adapters.resolve_path(adapter, target)
-        owner_map = state.setdefault("ownership", {}).setdefault(h, {}).setdefault(adapter.path, {})
-        # The write set is built strictly from plan items: create/update/current servers are
-        # (re)written; conflict/foreign/orphan-skip servers are omitted so their live value in
-        # the file is preserved by the merge. This is what protects a user-edited server.
+        owner_map = desired_state.get("ownership", {}).get(h, {}).get(adapter.path)
         to_write: dict[str, dict[str, Any]] = {}
         to_remove: set[str] = set()
         changed = False
@@ -821,6 +892,8 @@ def sync(
             server_name = item["server"]
             action, status = item["action"], item["status"]
             if action in ("create", "update"):
+                if owner_map is None:
+                    owner_map = desired_state.setdefault("ownership", {}).setdefault(h, {}).setdefault(adapter.path, {})
                 to_write[server_name] = _project_server(target, h, servers[server_name])
                 owner_map[server_name] = {
                     "canonical_fingerprint": item["_canon_fp"],
@@ -829,51 +902,245 @@ def sync(
                 changed = True
             elif action == "remove":
                 to_remove.add(server_name)
-                owner_map.pop(server_name, None)
+                if owner_map is not None:
+                    owner_map.pop(server_name, None)
                 changed = True
             elif status == "current":
-                # Owned + matching (or reconciled after state loss): re-assert ownership and
-                # keep it present in the file. Identical content, so not a "change".
+                if owner_map is None:
+                    owner_map = desired_state.setdefault("ownership", {}).setdefault(h, {}).setdefault(adapter.path, {})
                 to_write[server_name] = _project_server(target, h, servers[server_name])
                 owner_map[server_name] = {
                     "canonical_fingerprint": item["_canon_fp"],
                     "projected_fingerprint": item["_proj_fp"],
                 }
-        if write and (changed or any(i.get("_reconciled") for i in items)):
+        if changed or any(i.get("_reconciled") for i in items):
             existing = path.read_text() if path.is_file() else None
             try:
                 new_text = adapter.write_file(existing, to_write, to_remove)
             except ValueError as exc:
-                message = f"{path}: {exc}"
-                return _emit({"errors": [message]}, json_output, [f"error: {message}"], 2)
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(new_text)
-            files_written.append(str(path))
+                plan_errors.append(f"{path}: {exc}")
+                continue
+            mutation = _mutation_for_path(
+                dest=path,
+                display_path=adapter.path,
+                before=_file_bytes(path),
+                after=new_text.encode("utf-8"),
+            )
+            if mutation is not None:
+                mutations.append(mutation)
+                native_write_paths.append(path)
 
-    if write:
-        _save_state(target, state)
-    counts = _counts(all_items)
-    source_catalog = str(canonical_path(target))
-    destination_files = [str(mcp_adapters.resolve_path(ADAPTERS[h], target)) for h in harnesses]
+    ownership_path = state_path(target)
+    if ownership_path.is_file() or desired_state != state:
+        ownership_mutation = _mutation_for_path(
+            dest=ownership_path,
+            display_path=STATE_REL,
+            before=_file_bytes(ownership_path),
+            after=_state_bytes(desired_state),
+        )
+        if ownership_mutation is not None:
+            mutations.append(ownership_mutation)
+
+    canon = canonical_path(target)
+    source_digest = localio.file_sha256(canon) if canon.is_file() else "missing"
+    projection_plan = (
+        projection.build_plan(
+            operation_id=f"mcp-{uuid.uuid4().hex}",
+            projector="mcp",
+            source_fingerprint=source_digest,
+            mutations=mutations,
+            target=target,
+        )
+        if mutations
+        else None
+    )
+    return McpSyncPlan(
+        target=target,
+        harnesses=harnesses,
+        items=all_items,
+        notes=notes,
+        exposures=exposures,
+        gated=gated,
+        gate_error=gate_error,
+        gate_declined=gate_declined,
+        projection=projection_plan,
+        source_catalog=str(canon),
+        destination_files=[str(mcp_adapters.resolve_path(ADAPTERS[h], target)) for h in harnesses],
+        errors=plan_errors,
+        native_write_paths=native_write_paths,
+    )
+
+
+def status(*, target: Path, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    recovery = _recovery_records(target)
     payload = {
         "target": str(target),
-        "source_catalog": source_catalog,
-        "destination_files": destination_files,
-        "harnesses": harnesses,
-        "wrote": write,
-        "files_written": files_written,
-        "notes": notes,
-        "stdio_exposures": exposures,
-        "items": _public_items(all_items),
-        "counts": counts,
+        "recovery": recovery,
+        "terminal_state": recovery[0]["terminal_state"] if recovery else "unchanged",
     }
+    lines = [f"brigade mcp status: {target}"]
+    if recovery:
+        for record in recovery:
+            lines.append(f"recovery-required: {record.get('operation_id')} ({record.get('recovery_command')})")
+    else:
+        lines.append("no unfinished projection recovery")
+    return _emit(payload, json_output, lines, 0)
+
+
+def recover_operation(*, target: Path, operation_id: str, force: bool = False, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    if not operation_id.startswith("mcp-"):
+        message = "MCP recovery requires an MCP operation id"
+        return _emit({"errors": [message]}, json_output, [f"error: {message}"], 2)
+    try:
+        receipt = projection.recover(operation_id, target=target, force=force)
+    except projection.ProjectionError as exc:
+        return _emit({"errors": [str(exc)]}, json_output, [f"error: {exc}"], 2)
+    payload = receipt.to_dict()
+    payload["recovery_command"] = f"brigade mcp recover {operation_id}" if receipt.recovery_command else None
+    lines = [f"brigade mcp recover {operation_id}: {receipt.terminal_state}"]
+    rc = 0 if receipt.terminal_state == "restored" else 2
+    return _emit(payload, json_output, lines, rc)
+
+
+def sync(
+    *,
+    target: Path,
+    name: str | None = None,
+    harness: str | None = None,
+    write: bool = False,
+    force: bool = False,
+    prune: bool = False,
+    adopt: bool = False,
+    user_scope: bool = False,
+    allow_global_stdio: bool = False,
+    interactive: bool | None = None,
+    verify_runtime: bool = False,
+    verify_timeout: float | None = None,
+    json_output: bool = False,
+    inject_failure: str | None = None,
+) -> int:
+    target = target.expanduser().resolve()
+    if verify_runtime and not write:
+        message = "--verify requires --write"
+        return _emit({"errors": [message]}, json_output, [f"error: {message}"], 2)
+    timeout_error = _verify_timeout_error(verify_timeout, flag="--verify-timeout")
+    if timeout_error:
+        return _emit({"errors": [timeout_error]}, json_output, [f"error: {timeout_error}"], 2)
+    planned = build_sync_plan(
+        target=target,
+        name=name,
+        harness=harness,
+        write=write,
+        force=force,
+        prune=prune,
+        adopt=adopt,
+        user_scope=user_scope,
+        allow_global_stdio=allow_global_stdio,
+        interactive=interactive,
+        json_output=json_output,
+    )
+    if planned.errors and not planned.items:
+        return _emit({"errors": planned.errors}, json_output, [f"error: {e}" for e in planned.errors], 2)
+    if planned.errors:
+        return _emit({"errors": planned.errors}, json_output, [f"error: {e}" for e in planned.errors], 2)
+
+    files_written: list[str] = []
+    terminal_state = "planned"
+    operation_id: str | None = planned.projection.operation_id if planned.projection else None
+    projection_view: dict[str, Any] = {
+        "operation_id": operation_id,
+        "projector": "mcp",
+        "terminal_state": terminal_state,
+        "destinations": [
+            {"display_path": mutation.display_path, "mutation": mutation.mutation}
+            for mutation in (planned.projection.mutations if planned.projection else ())
+        ],
+    }
+    if write and planned.projection:
+        try:
+            receipt = projection.execute(
+                planned.projection,
+                target=target,
+                inject=projection.FailureInjector(boundary=inject_failure),
+            )
+        except projection.OverlapBlockedError as exc:
+            message = str(exc)
+            return _emit(
+                {
+                    "target": str(target),
+                    "errors": [message],
+                    "operation_id": operation_id,
+                    "terminal_state": "recovery-required",
+                    "recovery": _recovery_records(target),
+                },
+                json_output,
+                [f"error: {message}"],
+                2,
+            )
+        except projection.DriftError as exc:
+            message = str(exc)
+            return _emit(
+                {"target": str(target), "errors": [message], "operation_id": operation_id, "terminal_state": "planned"},
+                json_output,
+                [f"error: {message}"],
+                2,
+            )
+        terminal_state = receipt.terminal_state
+        operation_id = receipt.operation_id
+        projection_view = receipt.to_dict()
+        if terminal_state == "committed":
+            files_written = [str(path) for path in planned.native_write_paths]
+        elif terminal_state in {"restored", "recovery-required"}:
+            payload = {
+                "target": str(target),
+                "source_catalog": planned.source_catalog,
+                "destination_files": planned.destination_files,
+                "harnesses": planned.harnesses,
+                "wrote": False,
+                "files_written": [],
+                "notes": planned.notes,
+                "stdio_exposures": planned.exposures,
+                "items": _public_items(planned.items),
+                "counts": _counts(planned.items),
+                "operation_id": operation_id,
+                "terminal_state": terminal_state,
+                "projection": projection_view,
+                "errors": [f"projection {terminal_state}"],
+            }
+            return _emit(payload, json_output, [f"error: projection {terminal_state}"], 2)
+
+    if write and planned.projection is None:
+        terminal_state = "unchanged"
+        operation_id = None
+        projection_view["terminal_state"] = terminal_state
+        projection_view["operation_id"] = None
+    counts = _counts(planned.items)
+    payload = {
+        "target": str(target),
+        "source_catalog": planned.source_catalog,
+        "destination_files": planned.destination_files,
+        "harnesses": planned.harnesses,
+        "wrote": write and terminal_state == "committed",
+        "files_written": files_written,
+        "notes": planned.notes,
+        "stdio_exposures": planned.exposures,
+        "items": _public_items(planned.items),
+        "counts": counts,
+        "operation_id": None if terminal_state == "unchanged" else operation_id,
+        "terminal_state": terminal_state if write else "planned",
+        "projection": projection_view,
+    }
+    if write and terminal_state == "unchanged":
+        payload["operation_id"] = None
+        payload["projection"] = projection_view
+    servers, _, _ = load_canonical(target)
     if write and verify_runtime:
-        # Gated destinations were not written and their stdio servers were not
-        # acknowledged; never select them for verification (which would spawn
-        # the very processes the gate refused to configure).
-        verifiable = [h for h in harnesses if h not in gated]
+        verifiable = [h for h in planned.harnesses if h not in planned.gated]
         selected = _servers_for_verification(servers, verifiable, name_filter=name) if verifiable else {}
         if selected:
+            state = _load_state(target)
             config_current = _config_current_by_name(target, servers, verifiable, state, name_filter=name)
             verification_payload, verify_rc = mcp_runtime.run_verification(
                 target,
@@ -894,25 +1161,23 @@ def sync(
         verify_rc = 0
 
     verb = "wrote" if write else "would"
-    lines = [f"brigade mcp sync ({'write' if write else 'dry-run'}): {target}", f"source: {source_catalog}"]
-    lines += [f"destination: {path}" for path in destination_files]
-    lines += [f"{i['harness']:<12} {i['server']:<20} {i['status']:<14} -> {i['action']}" for i in all_items]
+    lines = [f"brigade mcp sync ({'write' if write else 'dry-run'}): {target}", f"source: {planned.source_catalog}"]
+    lines += [f"destination: {path}" for path in planned.destination_files]
+    lines += [f"{i['harness']:<12} {i['server']:<20} {i['status']:<14} -> {i['action']}" for i in planned.items]
     lines += [f"{verb}: {f}" for f in files_written]
     if write and verify_runtime and payload.get("verification"):
         lines.append(f"verification receipt: {payload['verification']['receipt_path']}")
-    lines += notes
+    lines += planned.notes
     rc = 1 if counts["conflict"] else 0
     if verify_rc != 0:
         rc = verify_rc
-    # The gate outcome wins over conflict and verification codes: an
-    # unacknowledged user-scoped stdio write is the error being reported.
-    if gate_error:
-        payload["errors"] = [gate_error]
-        payload["stdio_gated"] = sorted(gated)
-        lines.append(f"error: {gate_error}")
+    if planned.gate_error:
+        payload["errors"] = [planned.gate_error]
+        payload["stdio_gated"] = sorted(planned.gated)
+        lines.append(f"error: {planned.gate_error}")
         rc = 2
-    elif gate_declined:
-        payload["stdio_gated"] = sorted(gated)
+    elif planned.gate_declined:
+        payload["stdio_gated"] = sorted(planned.gated)
         rc = 1
     return _emit(payload, json_output, lines, rc)
 
@@ -925,6 +1190,14 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
     for server in servers.values():
         for severity, message in mcp_adapters.validate_server(server):
             issues.append({"severity": severity, "message": message})
+    for record in _recovery_records(target):
+        command = record.get("recovery_command") or f"brigade mcp recover {record.get('operation_id')}"
+        issues.append(
+            {
+                "severity": "warn",
+                "message": f"projection recovery-required: {record.get('operation_id')}; run `{command}`",
+            }
+        )
     configured = _configured_harnesses(target)
     unsupported: list[str] = []
     if configured:

--- a/tests/test_mcp_projection.py
+++ b/tests/test_mcp_projection.py
@@ -1,0 +1,285 @@
+"""MCP sync transactional commit against the projection kernel (#911)."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from brigade import mcp_cmd, projection
+
+
+def _init(target: Path) -> None:
+    assert mcp_cmd.init(target=target, json_output=True) == 0
+
+
+def _add_github(target: Path) -> None:
+    assert (
+        mcp_cmd.add(
+            target=target,
+            name="github",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-github"],
+            env=["GITHUB_TOKEN=ref:GITHUB_TOKEN"],
+            timeout=60,
+            json_output=True,
+        )
+        == 0
+    )
+
+
+def _payload(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def _snapshot(paths: list[Path]) -> dict[str, bytes | None]:
+    return {str(path): path.read_bytes() if path.is_file() else None for path in paths}
+
+
+def test_sync_plan_includes_every_selected_destination_and_ownership(tmp_path: Path, capsys) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    (tmp_path / ".vscode").mkdir()
+    capsys.readouterr()
+    assert mcp_cmd.sync(target=tmp_path, json_output=True) == 0
+    payload = _payload(capsys)
+    labels = {item["display_path"] for item in payload["projection"]["destinations"]}
+    assert ".mcp.json" in labels
+    assert ".cursor/mcp.json" in labels
+    assert ".codex/config.toml" in labels
+    assert ".grok/config.toml" in labels
+    assert ".vscode/mcp.json" in labels
+    assert "opencode.json" in labels
+    assert ".brigade/mcp/state.json" in labels
+    assert payload["terminal_state"] == "planned"
+    assert payload["operation_id"]
+    assert payload["wrote"] is False
+    assert not (tmp_path / ".mcp.json").exists()
+    assert not (tmp_path / ".brigade/mcp/state.json").exists()
+
+
+def test_idempotent_sync_writes_nothing_and_creates_no_recovery(tmp_path: Path, capsys) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    assert mcp_cmd.sync(target=tmp_path, write=True, json_output=True) == 0
+    capsys.readouterr()
+    before_files = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+    assert mcp_cmd.sync(target=tmp_path, write=True, json_output=True) == 0
+    payload = _payload(capsys)
+    assert payload["terminal_state"] == "unchanged"
+    assert payload["files_written"] == []
+    assert payload["operation_id"] is None
+    assert projection.unfinished_operations(tmp_path) == []
+    after_files = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+    assert after_files == before_files
+
+
+def test_foreign_servers_remain_preserved(tmp_path: Path) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    target_file = tmp_path / ".mcp.json"
+    target_file.write_text(json.dumps({"mcpServers": {"local": {"command": "mylocal"}}}))
+    assert mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True) == 0
+    doc = json.loads(target_file.read_text())
+    assert doc["mcpServers"]["local"] == {"command": "mylocal"}
+    assert "github" in doc["mcpServers"]
+
+
+def test_user_edit_still_conflicts_unless_force(tmp_path: Path, capsys) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True)
+    target_file = tmp_path / ".mcp.json"
+    doc = json.loads(target_file.read_text())
+    doc["mcpServers"]["github"]["command"] = "edited-by-user"
+    target_file.write_text(json.dumps(doc))
+    capsys.readouterr()
+    assert mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True) == 1
+    payload = _payload(capsys)
+    assert any(item["status"] == "conflicted" for item in payload["items"])
+    assert json.loads(target_file.read_text())["mcpServers"]["github"]["command"] == "edited-by-user"
+    assert mcp_cmd.sync(target=tmp_path, harness="claude", write=True, force=True, json_output=True) == 0
+    assert json.loads(target_file.read_text())["mcpServers"]["github"]["command"] == "npx"
+
+
+def test_foreign_conflict_does_not_create_ownership_state(tmp_path: Path, capsys) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    target_file = tmp_path / ".mcp.json"
+    target_file.write_text(json.dumps({"mcpServers": {"github": {"command": "foreign"}}}))
+    before = target_file.read_bytes()
+    assert not mcp_cmd.state_path(tmp_path).exists()
+    capsys.readouterr()
+
+    assert mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True) == 1
+    payload = _payload(capsys)
+
+    assert payload["wrote"] is False
+    assert payload["terminal_state"] == "unchanged"
+    assert target_file.read_bytes() == before
+    assert not mcp_cmd.state_path(tmp_path).exists()
+
+
+def _claude_and_ownership(tmp_path: Path) -> list[Path]:
+    return [tmp_path / ".mcp.json", tmp_path / ".brigade" / "mcp" / "state.json"]
+
+
+def test_failure_before_and_after_each_destination_restores(tmp_path: Path) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"keep": {"command": "foreign"}}}))
+    before = _snapshot(_claude_and_ownership(tmp_path))
+    plan_payload = mcp_cmd.build_sync_plan(target=tmp_path, harness="claude")
+    assert plan_payload.projection is not None
+    points = [
+        f"commit:{index}:{boundary}"
+        for index, _mutation in enumerate(
+            sorted(plan_payload.projection.mutations, key=lambda item: item.destination.as_posix())
+        )
+        for boundary in ("before", "after")
+    ]
+    assert points
+    for point in points:
+        for path, data in before.items():
+            dest = Path(path)
+            if data is None:
+                dest.unlink(missing_ok=True)
+            else:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(data)
+        rc = mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True, inject_failure=point)
+        assert rc == 2
+        assert _snapshot(_claude_and_ownership(tmp_path)) == before
+
+
+def test_prune_rollback_restores_pruned_entry(tmp_path: Path) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    mcp_cmd.add(
+        target=tmp_path, name="docs", transport="http", url="https://example.com/v1", timeout=10, json_output=True
+    )
+    mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True)
+    servers, _, _ = mcp_cmd.load_canonical(tmp_path)
+    del servers["docs"]
+    mcp_cmd._write_canonical(tmp_path, servers)
+    live = json.loads((tmp_path / ".mcp.json").read_text())
+    assert "docs" in live["mcpServers"]
+    before = (tmp_path / ".mcp.json").read_bytes()
+    state_before = (tmp_path / ".brigade/mcp/state.json").read_bytes()
+    plan_payload = mcp_cmd.build_sync_plan(target=tmp_path, harness="claude", prune=True)
+    assert plan_payload.projection is not None
+    point = next(
+        f"commit:{index}:after"
+        for index, mutation in enumerate(
+            sorted(plan_payload.projection.mutations, key=lambda item: item.destination.as_posix())
+        )
+        if mutation.display_path == ".mcp.json"
+    )
+    rc = mcp_cmd.sync(target=tmp_path, harness="claude", write=True, prune=True, json_output=True, inject_failure=point)
+    assert rc == 2
+    assert (tmp_path / ".mcp.json").read_bytes() == before
+    assert (tmp_path / ".brigade/mcp/state.json").read_bytes() == state_before
+    assert "docs" in json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]
+
+
+def test_destination_drift_after_planning_fails_closed(tmp_path: Path, capsys) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True)
+    capsys.readouterr()
+    mcp_cmd.add(
+        target=tmp_path,
+        name="docs",
+        transport="http",
+        url="https://example.com/v1",
+        timeout=10,
+        json_output=True,
+    )
+    capsys.readouterr()
+    planned = mcp_cmd.build_sync_plan(target=tmp_path, harness="claude")
+    (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"drifted": {"command": "nope"}}}))
+    assert planned.projection is not None
+    with pytest.raises(projection.DriftError):
+        projection.execute(planned.projection, target=tmp_path)
+    assert json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"] == {"drifted": {"command": "nope"}}
+
+
+def test_recovery_output_uses_safe_labels_and_omits_secrets(tmp_path: Path, capsys) -> None:
+    _init(tmp_path)
+    mcp_cmd.add(
+        target=tmp_path,
+        name="github",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env=["GITHUB_TOKEN=literal:super-secret-token-value"],
+        timeout=60,
+        json_output=True,
+    )
+    capsys.readouterr()
+    assert mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True) == 0
+    payload = _payload(capsys)
+    rendered = json.dumps(payload)
+    assert "super-secret-token-value" not in rendered
+    assert str(tmp_path) not in json.dumps(payload.get("projection", {}))
+    for dest in payload["projection"]["destinations"]:
+        assert not dest["display_path"].startswith("/")
+        assert "/home/" not in dest["display_path"]
+
+
+def test_unfinished_recovery_surfaces_on_status_doctor_and_blocks_sync(tmp_path: Path, capsys) -> None:
+    _init(tmp_path)
+    _add_github(tmp_path)
+    mcp_cmd.sync(target=tmp_path, harness="claude", write=True, json_output=True)
+    capsys.readouterr()
+    planned = mcp_cmd.build_sync_plan(target=tmp_path, harness="cursor")
+    assert planned.projection is not None
+    projection.kernel.write_crash_fixture(planned.projection, target=tmp_path, committed_count=1)
+    capsys.readouterr()
+    assert mcp_cmd.status(target=tmp_path, json_output=True) == 0
+    status_payload = _payload(capsys)
+    assert status_payload["recovery"]
+    assert status_payload["recovery"][0]["terminal_state"] == "recovery-required"
+    assert mcp_cmd.doctor(target=tmp_path, json_output=True) == 0
+    doctor_payload = _payload(capsys)
+    assert any("recovery" in issue["message"] for issue in doctor_payload["issues"])
+    from brigade import doctor as doctor_mod
+
+    checks = doctor_mod.mcp_station_checks(doctor_mod.build_context(tmp_path))
+    assert any(name.startswith("mcp: recovery") for _, name, _ in checks)
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=tmp_path, harness="cursor", write=True, json_output=True)
+    assert rc == 2
+    blocked = _payload(capsys)
+    assert blocked["terminal_state"] == "recovery-required"
+    assert "errors" in blocked
+
+
+def test_mcp_recovery_ignores_other_projectors(tmp_path: Path, capsys) -> None:
+    destination = tmp_path / "generic.txt"
+    data = b"generic\n"
+    plan = projection.build_plan(
+        operation_id="generic-test",
+        projector="generic",
+        source_fingerprint="fixture",
+        target=tmp_path,
+        mutations=[
+            projection.mutation(
+                destination=destination,
+                display_path="generic.txt",
+                mutation="create",
+                expected_before=projection.ABSENT,
+                desired_after=hashlib.sha256(data).hexdigest(),
+                staged_bytes=data,
+            )
+        ],
+    )
+    assert (
+        projection.execute(plan, target=tmp_path, inject=projection.FailureInjector(crash_after=0)).terminal_state
+        == "recovery-required"
+    )
+
+    assert mcp_cmd.status(target=tmp_path, json_output=True) == 0
+    assert _payload(capsys)["recovery"] == []
+    assert mcp_cmd.recover_operation(target=tmp_path, operation_id="generic-test", json_output=True) == 2


### PR DESCRIPTION
## Summary
- `brigade mcp sync --write` now commits selected native configs and the MCP ownership sidecar as one projection transaction. A later write failure restores every destination to its pre-operation state.
- Dry-run is read-only and uses the same immutable plan as apply. JSON adds `operation_id` and `terminal_state` and keeps existing public fields.
- Unfinished overlapping recovery is visible from `brigade mcp status`, `brigade mcp doctor`, and the next mutating sync. Recover with `brigade mcp recover <operation-id>`.

## Review notes
- Issue #911 is blocked by #910. This PR includes a stdlib projection kernel matching the #910 contract so MCP can land. If #910 merges first, rebase and prefer that kernel.
- Recovery CLI is `brigade mcp recover` rather than `brigade projection recover`, to avoid a new top-level command that #910 owns.
- `inject_failure` is a test-only kwarg on `mcp_cmd.sync` / `projection.commit`, not a public CLI flag.

## Test plan
- [x] Focused: `pytest tests/test_projection_kernel.py tests/test_mcp_projection.py tests/test_mcp_cmd.py tests/test_mcp_runtime.py tests/test_mcp_integration.py`
- [x] Full suite via Brigade verify: 7382 passed, 3 skipped, coverage 83%
- [ ] Rebase onto #910 if that kernel lands first

Fixes #911

Made with [Cursor](https://cursor.com)