### PR TITLE
test(hooks): isolate pre-push fixture updates

### DIFF
--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -91,12 +91,20 @@ def _git_env(repo: Path) -> dict:
         "GIT_COMMITTER_EMAIL": "t@example.com",
         "HOME": str(repo),
         "XDG_CONFIG_HOME": str(repo / ".config"),
+        # The embedded CLI starts a detached update refresh unless it is opted
+        # out. It inherits this test's temporary HOME, so letting it run can
+        # race TemporaryDirectory cleanup by creating .cache/brigade late.
+        "BRIGADE_NO_UPDATE_CHECK": "1",
     }
     # Put the editable-install brigade on PATH so the hook's `brigade` and
     # `brigade guard git` invocations resolve to this checkout.
     if _VENV_BIN.is_dir():
         env["PATH"] = f"{_VENV_BIN}:{env.get('PATH', '')}"
     return env
+
+
+def test_pre_push_hook_fixture_disables_background_update_checks(tmp_path: Path) -> None:
+    assert _git_env(tmp_path)["BRIGADE_NO_UPDATE_CHECK"] == "1"
 
 
 def _git(repo: Path, *args: str, check: bool = True) -> str:


### PR DESCRIPTION
## Summary
- disable passive update refreshes for pre-push hook fixture subprocesses
- pin the fixture contract with a regression test

## Root cause
The fixture sets `HOME` to its temporary repository. A nested `brigade` command could start a detached update-refresh process that then created `$HOME/.cache/brigade` after `TemporaryDirectory` began cleanup.

## Verification
- `brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_pre_push_hook.py" --capture brigade-work` - 12 consecutive passes
- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work` - 7383 passed, 3 skipped