### PR TITLE
feat(run): accept explicit budget declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `--run-budget PATH` accepts one `brigade.run_budget.v1` JSON declaration on
+  `brigade run`, dogfood, and model-trial starts. Brigade persists the supplied
+  declaration in the run and plan receipts without mapping `timeout_seconds`
+  into a run budget. Budget cancellation receipts now carry bounded per-seat or
+  per-transport outcomes and the observed work that may still be active. (#885,
+  #886)
 - `brigade mcp sync --write` commits selected native configs and MCP ownership
   state through the projection transaction kernel. A failed write restores the
   selected destinations; unfinished operations are visible through `brigade

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -366,7 +366,7 @@ projector; the coordinator applies terminal policy via `run.failed` /
 | `run_budget.reservation_denied` | `dimension`, `mode`, `declared`, `used`, `remaining`, `request_id`, `reason_class` | Emitted before new work starts |
 | `run_budget.exhausted` | `dimension`, `mode`, `declared`, `used`, `remaining`, `reason_class` | Enforceable ceiling reached |
 | `run_budget.cancel_requested` | `request_id`, `reason_class`, `transport_capability`, `dimension` | Best-effort cancel request |
-| `run_budget.cancelled` | `request_id`, `reason_class`, `transport_capability`, `transport_result`, `active_remaining`, `dimension` | Cancel receipt; names work that could not be interrupted |
+| `run_budget.cancelled` | `request_id`, `reason_class`, `transport_capability`, `transport_result`, `active_remaining`, `active_seats`, `outcomes`, `dimension` | Cancel receipt with bounded per-seat or per-transport outcomes and observed work that may remain active |
 | `run_budget.usage_reconciled` | `dimension`, `mode`, `usage_source`, `estimated_used`, `provider_used`, `used`, `request_id`, `reason_class` | Estimated and provider values stay distinct |
 
 Enforceable dimensions: `wall_clock_seconds`, `worker_dispatch_count`.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -247,8 +247,9 @@ It is intentionally bounded: two orchestrator calls plus the worker calls in the
 
 Hard run-budget ceilings (`wall_clock_seconds`, `worker_dispatch_count`) apply
 only when a run persists `run_budget` or `verification_contract.budget` (#593).
-Ordinary `brigade run`, dogfood, and model-trial starts without those
-declarations stay unbounded for backward compatibility; per-agent
+Operators can supply a versioned JSON declaration with `--run-budget PATH` on
+`brigade run`, dogfood, and model-trial run or resume commands. Starts without
+that file stay unbounded for backward compatibility. Per-agent
 `timeout_seconds` is not a run-budget declaration. Aggregate and split token
 budgets on a verification contract stay observed-only. Model, tool, token, and
 cost dimensions require an adapter-owned enforcement boundary. External

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2761,6 +2761,55 @@ def _build_budget_coordinator(
     return coordinator
 
 
+def _observed_budget_cancellation(
+    process_registry: proc.ProcessRegistry,
+    control_registry: run_control.LiveTurnRegistry | None,
+    active_seats: tuple[str, ...],
+) -> run_budget.CancellationReport:
+    """Cancel both transports and preserve only observed per-seat state."""
+    outcomes: list[run_budget.CancelOutcome] = []
+    active: list[str] = []
+    represented: set[str] = set()
+    if control_registry is not None:
+        interrupted, still_active = control_registry.interrupt_observed(active_seats)
+        outcomes.extend(run_budget.CancelOutcome(seat, "interrupt", result) for seat, result in interrupted)
+        represented.update(seat for seat, _result in interrupted)
+        represented.update(still_active)
+        active.extend(still_active)
+
+    try:
+        observed_processes = process_registry.cancel()
+    except Exception:
+        unobserved = tuple(seat for seat in active_seats if seat not in represented)
+        outcomes.extend(run_budget.CancelOutcome(seat, "process_cancel", "error") for seat in unobserved)
+        active.extend(unobserved)
+        return run_budget.CancellationReport(
+            outcomes=tuple(outcomes),
+            active_seats=tuple(dict.fromkeys(active)),
+        )
+
+    process_results: dict[str, str] = {}
+    priority = {"interrupted": 0, "still_active": 1, "error": 2}
+    for process in observed_processes:
+        seat = process.seat or "process"
+        existing = process_results.get(seat)
+        if existing is None or priority[process.result] > priority[existing]:
+            process_results[seat] = process.result
+    for seat, result in process_results.items():
+        outcomes.append(run_budget.CancelOutcome(seat, "process_cancel", result))
+        represented.add(seat)
+        if result in {"still_active", "error"}:
+            active.append(seat)
+
+    for seat in active_seats:
+        if seat not in represented:
+            outcomes.append(run_budget.CancelOutcome(seat, "none", "unsupported"))
+    return run_budget.CancellationReport(
+        outcomes=tuple(outcomes),
+        active_seats=tuple(dict.fromkeys(active)),
+    )
+
+
 def record_approval_pause(output_dir: Path, approval_reference: Mapping[str, Any]) -> None:
     """Commit an approval wait and refresh its compatibility snapshot.
 
@@ -3135,6 +3184,8 @@ def record_run_start(
     field survives a startup failure.
     """
 
+    if run_budget_payload is not None:
+        run_budget_payload = run_budget.validate_explicit_declaration(run_budget_payload)
     output_dir = output_dir.expanduser().resolve()
     started_at = started_at or datetime.now(timezone.utc)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -3584,6 +3635,8 @@ def run(
     verification_contract_payload: Mapping[str, Any] | None = None,
     run_budget_payload: Mapping[str, Any] | None = None,
 ) -> int:
+    if run_budget_payload is not None:
+        run_budget_payload = run_budget.validate_explicit_declaration(run_budget_payload)
     started_at = datetime.now(timezone.utc)
     process_registry = proc.ProcessRegistry()
     transport_for_payload = codex_transport or roster.codex_transport
@@ -4071,6 +4124,16 @@ def run(
                 contract_for_plan = dict(run_raw["verification_contract"])
         if isinstance(contract_for_plan, Mapping):
             plan_doc["verification_contract"] = dict(contract_for_plan)
+        budget_for_plan = run_budget_payload
+        if budget_for_plan is None:
+            try:
+                run_raw = json.loads((output_dir / "run.json").read_text())
+            except (OSError, json.JSONDecodeError):
+                run_raw = None
+            if isinstance(run_raw, dict) and isinstance(run_raw.get("run_budget"), dict):
+                budget_for_plan = dict(run_raw["run_budget"])
+        if isinstance(budget_for_plan, Mapping):
+            plan_doc["run_budget"] = dict(budget_for_plan)
         _write_json(output_dir / "plan.json", plan_doc)
 
     if cwd is not None and output_dir is not None:
@@ -4104,6 +4167,10 @@ def run(
             plan_doc["verification_contract"] = dict(prior_plan["verification_contract"])
         elif isinstance(verification_contract_payload, Mapping):
             plan_doc["verification_contract"] = dict(verification_contract_payload)
+        if isinstance(prior_plan, dict) and isinstance(prior_plan.get("run_budget"), dict):
+            plan_doc["run_budget"] = dict(prior_plan["run_budget"])
+        elif isinstance(run_budget_payload, Mapping):
+            plan_doc["run_budget"] = dict(run_budget_payload)
         _write_json(output_dir / "plan.json", plan_doc)
         if plan_attempts is not None:
             attempts_payload = {"attempts": plan_attempts or []}
@@ -4298,14 +4365,9 @@ def run(
 
     budget_coordinator: run_budget.BudgetCoordinator | None = None
 
-    def _budget_cancel_fn() -> tuple[str, int]:
-        """Best-effort cancel of in-flight worker processes for budget/policy stops."""
-        if process_registry is None:
-            return "unsupported", len(active_seats)
-        process_registry.cancel()
-        # Cancellation is best effort; transports that cannot interrupt leave
-        # active_remaining as the count of seats that may still finish.
-        return "partial", max(0, len(active_seats) - 1)
+    def _budget_cancel_fn() -> run_budget.CancellationReport:
+        """Record observed per-seat interruption state without raw transport data."""
+        return _observed_budget_cancellation(process_registry, control_registry, active_seats)
 
     def _append_budget_event(event_type: str, payload: Mapping[str, Any], idempotency_key: str) -> Any:
         assert output_dir is not None
@@ -4357,7 +4419,7 @@ def run(
                 budget_coordinator.request_cancel(
                     request_id="opcancel:live-ctrl-c",
                     reason_class="operator_cancel",
-                    transport_capability="process_cancel" if process_registry is not None else "none",
+                    transport_capability="mixed",
                     dimension="wall_clock_seconds",
                     cancel_fn=_budget_cancel_fn,
                 )
@@ -4409,7 +4471,7 @@ def run(
                     budget_coordinator.request_cancel(
                         request_id=f"budgetcancel:{exc.dimension}",
                         reason_class="budget_cancel",
-                        transport_capability="process_cancel" if process_registry is not None else "none",
+                        transport_capability="mixed",
                         dimension=exc.dimension,
                         cancel_fn=_budget_cancel_fn,
                     )

--- a/src/brigade/cli/dogfood.py
+++ b/src/brigade/cli/dogfood.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from typing import Any
 from pathlib import Path
 
 from ..dogfood_cmd import DEFAULT_TIMEOUT_SECONDS
@@ -39,11 +40,17 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Use Codex's native read-only sandbox instead of the dogfood trusted-workspace default.",
     )
     p_dogfood.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Per-agent timeout.")
+    p_dogfood.add_argument(
+        "--run-budget",
+        type=Path,
+        default=None,
+        help="Path to a brigade.run_budget.v1 JSON declaration for this dogfood run.",
+    )
     p_dogfood.set_defaults(func=dispatch)
 
 
 def dispatch(args) -> int:
-    from .. import dogfood_cmd
+    from .. import dogfood_cmd, run_budget
 
     dogfood_args = list(args.dogfood_args)
     if dogfood_args and dogfood_args[0] == "init":
@@ -77,14 +84,26 @@ def dispatch(args) -> int:
             return 2
         return dogfood_cmd.next_step(target=args.target)
     task = " ".join(dogfood_args) if dogfood_args else None
+    run_budget_payload = None
+    if args.run_budget is not None:
+        try:
+            run_budget_payload = run_budget.load_declaration_file(args.run_budget)
+        except run_budget.BudgetCompatibilityError as exc:
+            print(f"error: invalid run budget declaration: {exc}", file=sys.stderr)
+            return 2
+    run_kwargs: dict[str, Any] = {
+        "target": args.target,
+        "output_dir": args.output_dir,
+        "handoff": not args.no_handoff,
+        "handoff_inbox": args.handoff_inbox,
+        "agent_cli": args.agent_cli,
+        "inspect": not args.no_inspect,
+        "native_read_only_sandbox": args.native_read_only_sandbox,
+        "timeout_seconds": args.timeout_seconds,
+    }
+    if run_budget_payload is not None:
+        run_kwargs["run_budget_payload"] = run_budget_payload
     return dogfood_cmd.run(
         task,
-        target=args.target,
-        output_dir=args.output_dir,
-        handoff=not args.no_handoff,
-        handoff_inbox=args.handoff_inbox,
-        agent_cli=args.agent_cli,
-        inspect=not args.no_inspect,
-        native_read_only_sandbox=args.native_read_only_sandbox,
-        timeout_seconds=args.timeout_seconds,
+        **run_kwargs,
     )

--- a/src/brigade/cli/model.py
+++ b/src/brigade/cli/model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Any
 
 
 def register(sub: argparse._SubParsersAction) -> None:
@@ -58,6 +59,12 @@ def register(sub: argparse._SubParsersAction) -> None:
             help="Roster path. Uses normal workspace/worktree-parent/user fallback.",
         )
         parser.add_argument("--output-dir", type=Path, default=None, help="Trial artifact directory.")
+        parser.add_argument(
+            "--run-budget",
+            type=Path,
+            default=None,
+            help="Path to a brigade.run_budget.v1 JSON declaration for each trial cell.",
+        )
         parser.set_defaults(func=_dispatch_trial)
     for command in ("show", "summary"):
         parser = trial_sub.add_parser(command, help=f"{command.title()} trial artifacts.")
@@ -87,7 +94,7 @@ def _dispatch_trial(args) -> int:
     import json
     import sys
 
-    from .. import model_trials
+    from .. import model_trials, run_budget
     from .. import roster as roster_mod
 
     if args.trial_command in {"show", "summary"}:
@@ -105,21 +112,27 @@ def _dispatch_trial(args) -> int:
 
     target = args.target.expanduser().resolve()
     try:
+        run_budget_payload = run_budget.load_declaration_file(args.run_budget) if args.run_budget is not None else None
         roster_path = roster_mod.resolve_roster_path(target, args.roster)
         roster = roster_mod.load_roster(roster_path)
         manifest = model_trials.load_manifest(args.manifest)
         output_dir = args.output_dir or target / ".brigade" / "evals" / manifest["name"]
         plan, cells = model_trials.build_plan(args.manifest, roster, output_dir)
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, ValueError, run_budget.BudgetCompatibilityError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     if args.trial_command == "plan":
         print(json.dumps(plan, indent=2, sort_keys=True))
         return 0
+    execute_kwargs: dict[str, Any] = {
+        "workspace": target,
+        "output_dir": output_dir,
+        "resume": args.trial_command == "resume",
+    }
+    if run_budget_payload is not None:
+        execute_kwargs["run_budget_payload"] = run_budget_payload
     return model_trials.execute(
         args.manifest,
         roster,
-        workspace=target,
-        output_dir=output_dir,
-        resume=args.trial_command == "resume",
+        **execute_kwargs,
     )

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -9,7 +9,7 @@ import time
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from subprocess import DEVNULL, STDOUT, Popen
-from typing import Callable, Iterator
+from typing import Any, Callable, Iterator, Mapping
 
 
 _DETACH_START_TIMEOUT_SECONDS = 30.0
@@ -255,6 +255,12 @@ def register(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Directory for run artifacts. Defaults to .brigade/runs/<id> under --cwd.",
     )
+    p_run.add_argument(
+        "--run-budget",
+        type=Path,
+        default=None,
+        help="Path to a brigade.run_budget.v1 JSON declaration persisted with this run.",
+    )
     p_run.add_argument("--no-artifacts", action="store_true", help="Do not write run artifacts.")
     p_run.add_argument(
         "--handoff",
@@ -291,6 +297,7 @@ def _resolved_scheduler(args, roster) -> str:
 
 def dispatch(args) -> int:
     from .. import aboyeur as aboyeur_mod
+    from .. import run_budget
     from .. import runguard
     from .. import roster as roster_mod
     from ..route_catalog import validate_overrides
@@ -321,6 +328,16 @@ def dispatch(args) -> int:
     if args.inspect and args.no_artifacts:
         print("error: --inspect cannot be used with --no-artifacts", file=sys.stderr)
         return 2
+    if args.run_budget is not None and args.no_artifacts:
+        print("error: --run-budget requires run artifacts so the declaration can be persisted", file=sys.stderr)
+        return 2
+    run_budget_payload = None
+    if args.run_budget is not None:
+        try:
+            run_budget_payload = run_budget.load_declaration_file(args.run_budget)
+        except run_budget.BudgetCompatibilityError as exc:
+            print(f"error: invalid run budget declaration: {exc}", file=sys.stderr)
+            return 2
     if args.worktree and args.no_artifacts:
         print(
             "error: --worktree cannot be used with --no-artifacts; "
@@ -440,6 +457,7 @@ def dispatch(args) -> int:
             roster_resolution=roster_resolution,
             roster=loaded_roster,
             output_dir=output_dir,
+            run_budget_payload=run_budget_payload,
         )
 
     worktree_cwd = None
@@ -451,17 +469,22 @@ def dispatch(args) -> int:
             lifecycle.enter_context(_terminalize_escaped_run(output_dir, seat=lifecycle_seat))
             lifecycle.enter_context(aboyeur_mod.terminal_sigterm_handler(output_dir, seat=lifecycle_seat))
             if output_dir is not None:
+                start_kwargs: dict[str, Any] = {
+                    "task": args.task,
+                    "cwd": run_cwd,
+                    "roster": loaded_roster,
+                    "read_only": args.read_only,
+                    "worker": args.worker,
+                    "dry_run": args.dry_run,
+                    "lock_workspace": run_cwd,
+                    "codex_transport": args.codex_transport or loaded_roster.codex_transport,
+                    "scheduler": _resolved_scheduler(args, loaded_roster),
+                }
+                if run_budget_payload is not None:
+                    start_kwargs["run_budget_payload"] = run_budget_payload
                 aboyeur_mod.record_run_start(
                     output_dir,
-                    task=args.task,
-                    cwd=run_cwd,
-                    roster=loaded_roster,
-                    read_only=args.read_only,
-                    worker=args.worker,
-                    dry_run=args.dry_run,
-                    lock_workspace=run_cwd,
-                    codex_transport=args.codex_transport or loaded_roster.codex_transport,
-                    scheduler=_resolved_scheduler(args, loaded_roster),
+                    **start_kwargs,
                 )
             if output_dir is not None and (advisory or output_warnings):
                 from .. import localio
@@ -487,7 +510,7 @@ def dispatch(args) -> int:
                 effective_cwd = runguard.create_detached_worktree(run_cwd, worktree_cwd)
                 keep_worktree = True
                 print(f"worktree: {effective_cwd}", file=sys.stderr)
-            run_kwargs = {
+            run_kwargs: dict[str, Any] = {
                 "dry_run": args.dry_run,
                 "show_plan": args.show_plan,
                 "verbose": args.verbose,
@@ -497,6 +520,8 @@ def dispatch(args) -> int:
                 "read_only": args.read_only,
                 "sandbox": effective_sandbox,
             }
+            if run_budget_payload is not None:
+                run_kwargs["run_budget_payload"] = run_budget_payload
             if args.worktree and any(agent.transport == "acpx" for agent in loaded_roster.agents.values()):
                 run_kwargs["authorized_writable_worktree"] = True
             if args.worktree:
@@ -683,7 +708,9 @@ def dispatch(args) -> int:
     return rc
 
 
-def _dispatch_detached(args, *, run_cwd: Path, roster_resolution, roster, output_dir: Path) -> int:
+def _dispatch_detached(
+    args, *, run_cwd: Path, roster_resolution, roster, output_dir: Path, run_budget_payload: Mapping[str, Any] | None
+) -> int:
     from .. import aboyeur as aboyeur_mod
     from .. import proc as proc_mod
 
@@ -714,14 +741,19 @@ def _dispatch_detached(args, *, run_cwd: Path, roster_resolution, roster, output
                     should_record=lambda: not child_handoff,
                 )
             )
+            start_kwargs: dict[str, Any] = {
+                "task": args.task,
+                "cwd": run_cwd,
+                "roster": roster,
+                "read_only": args.read_only,
+                "worker": args.worker,
+                "scheduler": _resolved_scheduler(args, roster),
+            }
+            if run_budget_payload is not None:
+                start_kwargs["run_budget_payload"] = run_budget_payload
             aboyeur_mod.record_run_start(
                 output_dir,
-                task=args.task,
-                cwd=run_cwd,
-                roster=roster,
-                read_only=args.read_only,
-                worker=args.worker,
-                scheduler=_resolved_scheduler(args, roster),
+                **start_kwargs,
             )
             initial_receipt = (output_dir / "run.json").read_bytes()
             log_path = output_dir / "detached.log"
@@ -872,6 +904,8 @@ def _detached_child_argv(args, *, run_cwd: Path, roster_resolution, output_dir: 
         argv.append("--handoff")
     if args.handoff_inbox is not None:
         argv.extend(["--handoff-inbox", str(args.handoff_inbox.expanduser().resolve())])
+    if args.run_budget is not None:
+        argv.extend(["--run-budget", str(args.run_budget.expanduser().resolve())])
     return argv
 
 

--- a/src/brigade/dogfood_cmd.py
+++ b/src/brigade/dogfood_cmd.py
@@ -9,9 +9,9 @@ import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
-from . import aboyeur, localio, runguard, toml_compat
+from . import aboyeur, localio, run_budget, runguard, toml_compat
 from . import agents
 from . import runs_cmd
 from .roster import Agent, Roster
@@ -472,7 +472,14 @@ def run(
     inspect: bool = True,
     native_read_only_sandbox: bool = False,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    run_budget_payload: Mapping[str, Any] | None = None,
 ) -> int:
+    if run_budget_payload is not None:
+        try:
+            run_budget_payload = run_budget.validate_explicit_declaration(run_budget_payload)
+        except run_budget.BudgetCompatibilityError as exc:
+            print(f"error: invalid run budget declaration: {exc}", file=sys.stderr)
+            return 2
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
@@ -529,24 +536,34 @@ def run(
     run_task = task or DEFAULT_TASK
     roster = _dogfood_roster(effective_timeout, effective_agent_cli)
     try:
+        start_kwargs: dict[str, Any] = {
+            "task": run_task,
+            "cwd": effective_target,
+            "roster": roster,
+            "read_only": True,
+            "lock_workspace": effective_target,
+        }
+        if run_budget_payload is not None:
+            start_kwargs["run_budget_payload"] = run_budget_payload
         aboyeur.record_run_start(
             chosen_output_dir,
-            task=run_task,
-            cwd=effective_target,
-            roster=roster,
-            read_only=True,
-            lock_workspace=effective_target,
+            **start_kwargs,
         )
         with runguard.run_lock(effective_target, run_dir=chosen_output_dir):
+            run_kwargs: dict[str, Any] = {
+                "show_plan": True,
+                "cwd": effective_target,
+                "output_dir": chosen_output_dir,
+                "handoff_inbox": chosen_handoff_inbox,
+                "read_only": True,
+                "sandbox": "read-only" if effective_native else None,
+            }
+            if run_budget_payload is not None:
+                run_kwargs["run_budget_payload"] = run_budget_payload
             rc = aboyeur.run(
                 run_task,
                 roster,
-                show_plan=True,
-                cwd=effective_target,
-                output_dir=chosen_output_dir,
-                handoff_inbox=chosen_handoff_inbox,
-                read_only=True,
-                sandbox="read-only" if effective_native else None,
+                **run_kwargs,
             )
     except runguard.RunGuardError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/src/brigade/model_trials.py
+++ b/src/brigade/model_trials.py
@@ -11,9 +11,9 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
-from . import aboyeur, localio, runguard
+from . import aboyeur, localio, run_budget, runguard
 from .roster import Roster
 
 MANIFEST_SCHEMA = "brigade.eval_manifest.v1"
@@ -629,7 +629,14 @@ def execute(
     workspace: Path,
     output_dir: Path,
     resume: bool,
+    run_budget_payload: Mapping[str, Any] | None = None,
 ) -> int:
+    if run_budget_payload is not None:
+        try:
+            run_budget_payload = run_budget.validate_explicit_declaration(run_budget_payload)
+        except run_budget.BudgetCompatibilityError as exc:
+            print(f"error: invalid run budget declaration: {exc}", file=sys.stderr)
+            return 2
     workspace = workspace.expanduser().resolve()
     output_dir = output_dir.expanduser().resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -689,26 +696,36 @@ def execute(
                 return 2
         try:
             read_only = cell.execution_mode == "read-only"
+            start_kwargs: dict[str, Any] = {
+                "task": cell.prompt,
+                "cwd": cell_workspace,
+                "roster": roster,
+                "read_only": read_only,
+                "worker": cell.seat,
+                "lock_workspace": workspace,
+            }
+            if run_budget_payload is not None:
+                start_kwargs["run_budget_payload"] = run_budget_payload
             aboyeur.record_run_start(
                 run_dir,
-                task=cell.prompt,
-                cwd=cell_workspace,
-                roster=roster,
-                read_only=read_only,
-                worker=cell.seat,
-                lock_workspace=workspace,
+                **start_kwargs,
             )
             with runguard.run_lock(workspace, run_dir=run_dir):
+                run_kwargs: dict[str, Any] = {
+                    "worker": cell.seat,
+                    "cwd": cell_workspace,
+                    "output_dir": run_dir,
+                    "route_enabled": False,
+                    "read_only": read_only,
+                    "authorized_writable_worktree": cell.execution_mode == "writable-worktree",
+                    "lock_workspace": workspace,
+                }
+                if run_budget_payload is not None:
+                    run_kwargs["run_budget_payload"] = run_budget_payload
                 rc = aboyeur.run(
                     cell.prompt,
                     roster,
-                    worker=cell.seat,
-                    cwd=cell_workspace,
-                    output_dir=run_dir,
-                    route_enabled=False,
-                    read_only=read_only,
-                    authorized_writable_worktree=cell.execution_mode == "writable-worktree",
-                    lock_workspace=workspace,
+                    **run_kwargs,
                 )
             try:
                 text = (run_dir / "final.txt").read_text()

--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -37,13 +37,13 @@ class ProcessRegistry:
         self._terminate_grace = terminate_grace
         self._kill_grace = kill_grace
         self._lock = threading.Lock()
-        self._processes: set[subprocess.Popen[bytes]] = set()
+        self._processes: dict[subprocess.Popen[bytes], str | None] = {}
         self._canceled = False
 
-    def register(self, process: subprocess.Popen[bytes]) -> None:
+    def register(self, process: subprocess.Popen[bytes], *, seat: str | None = None) -> None:
         with self._lock:
             if not self._canceled:
-                self._processes.add(process)
+                self._processes[process] = seat
                 return
         _terminate_processes(
             (process,),
@@ -53,16 +53,26 @@ class ProcessRegistry:
 
     def unregister(self, process: subprocess.Popen[bytes]) -> None:
         with self._lock:
-            self._processes.discard(process)
+            self._processes.pop(process, None)
 
-    def cancel(self) -> None:
+    def for_seat(self, seat: str) -> _SeatProcessRegistry:
+        return _SeatProcessRegistry(self, seat)
+
+    def cancel(self) -> tuple[ProcessCancelOutcome, ...]:
         with self._lock:
             self._canceled = True
-            processes = tuple(self._processes)
-        _terminate_processes(
-            processes,
-            terminate_grace=self._terminate_grace,
-            kill_grace=self._kill_grace,
+            processes = tuple(self._processes.items())
+        try:
+            _terminate_processes(
+                tuple(process for process, _seat in processes),
+                terminate_grace=self._terminate_grace,
+                kill_grace=self._kill_grace,
+            )
+        except Exception:
+            return tuple(ProcessCancelOutcome(seat, "error") for _process, seat in processes)
+        return tuple(
+            ProcessCancelOutcome(seat, "interrupted" if process.poll() is not None else "still_active")
+            for process, seat in processes
         )
 
     def terminate(self, process: subprocess.Popen[bytes]) -> None:
@@ -71,6 +81,31 @@ class ProcessRegistry:
             terminate_grace=self._terminate_grace,
             kill_grace=self._kill_grace,
         )
+
+
+@dataclass(frozen=True)
+class ProcessCancelOutcome:
+    """Safe observed state after a cancellation request for one registered process."""
+
+    seat: str | None
+    result: str
+
+
+class _SeatProcessRegistry:
+    """Label process registrations with a Brigade seat without changing adapters."""
+
+    def __init__(self, parent: ProcessRegistry, seat: str) -> None:
+        self._parent = parent
+        self._seat = seat
+
+    def register(self, process: subprocess.Popen[bytes]) -> None:
+        self._parent.register(process, seat=self._seat)
+
+    def unregister(self, process: subprocess.Popen[bytes]) -> None:
+        self._parent.unregister(process)
+
+    def cancel(self) -> tuple[ProcessCancelOutcome, ...]:
+        return self._parent.cancel()
 
 
 def _signal_process_group(process: subprocess.Popen[bytes], sig: int) -> None:

--- a/src/brigade/run_budget.py
+++ b/src/brigade/run_budget.py
@@ -44,9 +44,11 @@ Standard library only. Brigade is zero-runtime-dependency.
 from __future__ import annotations
 
 import hashlib
+import json
 import threading
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
 from brigade import run_events
@@ -95,7 +97,7 @@ ALL_DIMENSIONS = ENFORCEABLE_DIMENSIONS | OBSERVED_DIMENSIONS
 
 BUDGET_MODES = frozenset({"enforceable", "observed"})
 USAGE_SOURCES = frozenset({"estimated", "provider_reconciled"})
-TRANSPORT_CAPABILITIES = frozenset({"interrupt", "process_cancel", "none"})
+TRANSPORT_CAPABILITIES = frozenset({"interrupt", "process_cancel", "none", "mixed"})
 TRANSPORT_RESULTS = frozenset(
     {
         "interrupted",
@@ -103,6 +105,8 @@ TRANSPORT_RESULTS = frozenset(
         "partial",
         "unsupported",
         "requested",
+        "still_active",
+        "error",
     }
 )
 REASON_CLASSES = frozenset(
@@ -165,6 +169,8 @@ RUN_BUDGET_EVENT_PAYLOADS: dict[str, frozenset[str]] = {
             "transport_capability",
             "transport_result",
             "active_remaining",
+            "active_seats",
+            "outcomes",
             "dimension",
         }
     ),
@@ -363,6 +369,46 @@ def parse_declaration(payload: Mapping[str, Any] | None) -> RunBudgetDeclaration
     )
 
 
+def load_declaration_file(path: Path) -> dict[str, Any]:
+    """Load one operator-supplied, versioned run-budget declaration file.
+
+    The parsed mapping is returned verbatim after strict validation so the exact
+    declaration can be persisted into every run artifact without synthesizing
+    defaults or changing it into a verification-contract budget.
+    """
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise BudgetCompatibilityError(
+            f"could not read run budget declaration: {exc}", code="schema_incompatible"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise BudgetCompatibilityError("run budget declaration is not valid JSON", code="schema_incompatible") from exc
+    return validate_explicit_declaration(payload)
+
+
+def validate_explicit_declaration(payload: object) -> dict[str, Any]:
+    """Validate a supplied declaration without filling in compatibility defaults."""
+    if not isinstance(payload, Mapping):
+        raise BudgetCompatibilityError("run budget declaration must be an object", code="schema_incompatible")
+    required = {"schema", "schema_version"}
+    missing = required - set(payload)
+    if missing:
+        raise BudgetCompatibilityError(
+            _bound(f"run budget declaration is missing required fields: {sorted(missing)}"),
+            code="schema_incompatible",
+        )
+    allowed = required | {"ceilings", "observed", "threshold_pct", "token_budget"}
+    unknown = set(payload) - allowed
+    if unknown:
+        raise BudgetCompatibilityError(
+            _bound(f"run budget declaration has unknown fields: {sorted(unknown)}"),
+            code="schema_incompatible",
+        )
+    parse_declaration(payload)
+    return dict(payload)
+
+
 def declaration_has_budget_content(declaration: RunBudgetDeclaration) -> bool:
     """True when a declaration carries at least one known budget field."""
     if declaration.wall_clock_seconds is not None or declaration.worker_dispatch_count is not None:
@@ -501,6 +547,39 @@ def declaration_from_verification_budget(budget: Mapping[str, Any] | None) -> Ru
 
 
 @dataclass(frozen=True)
+class CancelOutcome:
+    """Bounded, provider-safe cancellation observation for one seat or transport."""
+
+    seat: str
+    transport_capability: str
+    transport_result: str
+
+
+@dataclass(frozen=True)
+class CancellationReport:
+    """Observed cancellation state used to build one durable receipt."""
+
+    outcomes: tuple[CancelOutcome, ...]
+    active_seats: tuple[str, ...]
+
+    @property
+    def transport_capability(self) -> str:
+        capabilities = {outcome.transport_capability for outcome in self.outcomes}
+        return next(iter(capabilities)) if len(capabilities) == 1 else "mixed"
+
+    @property
+    def transport_result(self) -> str:
+        results = {outcome.transport_result for outcome in self.outcomes}
+        if not results:
+            return "unsupported"
+        if "error" in results:
+            return "error"
+        if self.active_seats:
+            return "partial" if "interrupted" in results else "still_active"
+        return "interrupted" if results == {"interrupted"} else "partial"
+
+
+@dataclass(frozen=True)
 class CancelReceipt:
     request_id: str
     reason_class: str
@@ -508,6 +587,8 @@ class CancelReceipt:
     transport_result: str
     active_remaining: int
     dimension: str
+    outcomes: tuple[CancelOutcome, ...] = ()
+    active_seats: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -554,6 +635,15 @@ class BudgetProjection:
                     "transport_result": receipt.transport_result,
                     "active_remaining": receipt.active_remaining,
                     "dimension": receipt.dimension,
+                    "outcomes": [
+                        {
+                            "seat": outcome.seat,
+                            "transport_capability": outcome.transport_capability,
+                            "transport_result": outcome.transport_result,
+                        }
+                        for outcome in receipt.outcomes
+                    ],
+                    "active_seats": list(receipt.active_seats),
                 }
                 for receipt in self.cancel_receipts
             ],
@@ -640,6 +730,24 @@ def project_budget_state(
             elif reason == "budget_cancel" and terminal_policy is None:
                 terminal_policy = "budget_exhausted"
         elif event_type == EVENT_CANCELLED:
+            raw_outcomes = payload.get("outcomes")
+            outcomes: tuple[CancelOutcome, ...] = ()
+            if isinstance(raw_outcomes, list):
+                outcomes = tuple(
+                    CancelOutcome(
+                        seat=str(item.get("seat") or ""),
+                        transport_capability=str(item.get("transport_capability") or "none"),
+                        transport_result=str(item.get("transport_result") or "unsupported"),
+                    )
+                    for item in raw_outcomes
+                    if isinstance(item, Mapping)
+                )
+            raw_active_seats = payload.get("active_seats")
+            active_seats = (
+                tuple(seat for seat in raw_active_seats if isinstance(seat, str))
+                if isinstance(raw_active_seats, list)
+                else ()
+            )
             receipt = CancelReceipt(
                 request_id=str(payload.get("request_id") or ""),
                 reason_class=str(payload.get("reason_class") or "budget_cancel"),
@@ -650,6 +758,8 @@ def project_budget_state(
                 and not isinstance(payload.get("active_remaining"), bool)
                 else 0,
                 dimension=str(payload.get("dimension") or ""),
+                outcomes=outcomes,
+                active_seats=active_seats,
             )
             cancels.append(receipt)
             if receipt.reason_class == "operator_cancel":
@@ -957,21 +1067,53 @@ def build_cancelled_event(
     transport_result: str,
     active_remaining: int,
     dimension: str,
+    outcomes: Sequence[CancelOutcome] = (),
+    active_seats: Sequence[str] = (),
 ) -> dict[str, Any]:
     if transport_result not in TRANSPORT_RESULTS:
         raise BudgetError("invalid transport_result", code="cancel_invalid")
     if not isinstance(active_remaining, int) or isinstance(active_remaining, bool) or active_remaining < 0:
         raise BudgetError("active_remaining must be a non-negative integer", code="cancel_invalid")
+    if (outcomes or active_seats) and active_remaining != len(active_seats):
+        raise BudgetError("active_remaining must equal the observed active seat set", code="cancel_invalid")
+    if len(outcomes) > 16 or len(active_seats) > 16:
+        raise BudgetError("cancel outcomes exceed the bounded receipt limit", code="cancel_invalid")
+    safe_outcomes = []
+    for outcome in outcomes:
+        if not isinstance(outcome, CancelOutcome):
+            raise BudgetError("cancel outcome is invalid", code="cancel_invalid")
+        if not outcome.seat or len(outcome.seat) > 80:
+            raise BudgetError("cancel outcome seat is invalid", code="cancel_invalid")
+        if outcome.transport_capability not in TRANSPORT_CAPABILITIES:
+            raise BudgetError("cancel outcome capability is invalid", code="cancel_invalid")
+        if outcome.transport_result not in TRANSPORT_RESULTS:
+            raise BudgetError("cancel outcome result is invalid", code="cancel_invalid")
+        safe_outcomes.append(
+            {
+                "seat": outcome.seat,
+                "transport_capability": outcome.transport_capability,
+                "transport_result": outcome.transport_result,
+            }
+        )
+    safe_active_seats = list(active_seats)
+    if len(set(safe_active_seats)) != len(safe_active_seats) or any(
+        not isinstance(seat, str) or not seat or len(seat) > 80 for seat in safe_active_seats
+    ):
+        raise BudgetError("active seat set is invalid", code="cancel_invalid")
+    payload: dict[str, Any] = {
+        "request_id": request_id,
+        "reason_class": reason_class,
+        "transport_capability": transport_capability,
+        "transport_result": transport_result,
+        "active_remaining": active_remaining,
+        "dimension": dimension,
+    }
+    if outcomes or active_seats:
+        payload["active_seats"] = safe_active_seats
+        payload["outcomes"] = safe_outcomes
     return {
         "event_type": EVENT_CANCELLED,
-        "payload": {
-            "request_id": request_id,
-            "reason_class": reason_class,
-            "transport_capability": transport_capability,
-            "transport_result": transport_result,
-            "active_remaining": active_remaining,
-            "dimension": dimension,
-        },
+        "payload": payload,
         "idempotency_key": _idempotency_key(EVENT_CANCELLED, request_id),
     }
 
@@ -1040,6 +1182,33 @@ def validate_run_budget_payload(event_type: str, payload: Mapping[str, Any]) -> 
         active = payload.get("active_remaining")
         if not isinstance(active, int) or isinstance(active, bool) or active < 0:
             raise run_events.CanonicalizationError("run_budget.cancelled active_remaining is invalid")
+        active_seats = payload.get("active_seats")
+        outcomes = payload.get("outcomes")
+        if active_seats is not None:
+            if not isinstance(active_seats, list) or len(active_seats) > 16 or active != len(active_seats):
+                raise run_events.CanonicalizationError("run_budget.cancelled active_seats is invalid")
+            if len(set(active_seats)) != len(active_seats) or any(
+                not isinstance(seat, str) or not seat or len(seat) > 80 for seat in active_seats
+            ):
+                raise run_events.CanonicalizationError("run_budget.cancelled active_seats is invalid")
+        if outcomes is not None:
+            if not isinstance(outcomes, list) or len(outcomes) > 16:
+                raise run_events.CanonicalizationError("run_budget.cancelled outcomes is invalid")
+            for outcome in outcomes:
+                if not isinstance(outcome, Mapping) or set(outcome) != {
+                    "seat",
+                    "transport_capability",
+                    "transport_result",
+                }:
+                    raise run_events.CanonicalizationError("run_budget.cancelled outcome is invalid")
+                if (
+                    not isinstance(outcome["seat"], str)
+                    or not outcome["seat"]
+                    or len(outcome["seat"]) > 80
+                    or outcome["transport_capability"] not in TRANSPORT_CAPABILITIES
+                    or outcome["transport_result"] not in TRANSPORT_RESULTS
+                ):
+                    raise run_events.CanonicalizationError("run_budget.cancelled outcome is invalid")
 
 
 AppendEvent = Callable[[str, Mapping[str, Any], str], Any]
@@ -1323,13 +1492,17 @@ class BudgetCoordinator:
         reason_class: str,
         transport_capability: str,
         dimension: str,
-        cancel_fn: Callable[[], tuple[str, int]] | None = None,
+        cancel_fn: Callable[[], CancellationReport | tuple[str, int]] | None = None,
     ) -> CancelReceipt:
         """Best-effort cancel of active work with durable cancel receipts.
 
-        ``cancel_fn`` returns ``(transport_result, active_remaining)``.
+        ``cancel_fn`` returns observations. The legacy tuple form remains
+        readable for callers that only have an aggregate transport result.
         """
         with self._lock:
+            for receipt in reversed(self._projection.cancel_receipts):
+                if receipt.request_id == request_id:
+                    return receipt
             requested = build_cancel_requested_event(
                 request_id=request_id,
                 reason_class=reason_class,
@@ -1339,8 +1512,17 @@ class BudgetCoordinator:
             self._commit([requested])
             transport_result = "unsupported"
             active_remaining = 0
+            outcomes: tuple[CancelOutcome, ...] = ()
+            active_seats: tuple[str, ...] = ()
             if cancel_fn is not None:
-                transport_result, active_remaining = cancel_fn()
+                observation = cancel_fn()
+                if isinstance(observation, CancellationReport):
+                    outcomes = observation.outcomes
+                    active_seats = observation.active_seats
+                    transport_result = observation.transport_result
+                    active_remaining = len(active_seats)
+                else:
+                    transport_result, active_remaining = observation
             cancelled = build_cancelled_event(
                 request_id=request_id,
                 reason_class=reason_class,
@@ -1348,6 +1530,8 @@ class BudgetCoordinator:
                 transport_result=transport_result,
                 active_remaining=active_remaining,
                 dimension=dimension,
+                outcomes=outcomes,
+                active_seats=active_seats,
             )
             self._commit([cancelled])
             return CancelReceipt(
@@ -1357,6 +1541,8 @@ class BudgetCoordinator:
                 transport_result=transport_result,
                 active_remaining=active_remaining,
                 dimension=dimension,
+                outcomes=outcomes,
+                active_seats=active_seats,
             )
 
     def reconcile_usage(

--- a/src/brigade/run_control.py
+++ b/src/brigade/run_control.py
@@ -131,6 +131,22 @@ class LiveTurnRegistry:
             interrupted.append(active.worker)
         return {"ok": True, "interrupted": len(interrupted), "workers": interrupted}
 
+    def interrupt_observed(self, workers: tuple[str, ...]) -> tuple[tuple[tuple[str, str], ...], tuple[str, ...]]:
+        """Request per-seat interruption and return bounded, provider-safe observations."""
+        outcomes: list[tuple[str, str]] = []
+        for worker in workers:
+            active = self._turns(worker)
+            if not active:
+                continue
+            try:
+                active[0].thread.interrupt(active[0].turn_id)
+            except Exception:
+                outcomes.append((worker, "error"))
+            else:
+                outcomes.append((worker, "interrupted"))
+        active_workers = tuple(active.worker for active in self._turns(None) if active.worker in workers)
+        return tuple(outcomes), active_workers
+
     def _require_worker(self, worker: str) -> ActiveTurn:
         with self._lock:
             active = self._active.get(worker)

--- a/src/brigade/run_events.py
+++ b/src/brigade/run_events.py
@@ -139,6 +139,8 @@ EVENT_TYPES: dict[str, frozenset[str]] = {
             "transport_capability",
             "transport_result",
             "active_remaining",
+            "active_seats",
+            "outcomes",
             "dimension",
         }
     ),

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -467,6 +467,7 @@ def dispatch(
         ) -> agents.AgentResult:
             assert selected_agent.cli is not None
             cli_ref = selected_agent.cli
+            seat_process_registry = process_registry.for_seat(selected_agent.name)
             if selected_agent.transport == "acpx":
                 from . import acpx_adapter
 
@@ -477,7 +478,7 @@ def dispatch(
                     "version": selected_agent.transport_version or "",
                     "read_only": effective_read_only,
                     "writable_worktree": authorized_writable_worktree,
-                    "process_registry": process_registry,
+                    "process_registry": seat_process_registry,
                 }
                 worker_env = _with_orchestrator_run_id(
                     dict(selected_agent.env) if selected_agent.env is not None else None
@@ -497,7 +498,7 @@ def dispatch(
                     reasoning=selected_agent.reasoning,
                     env=dict(selected_agent.env) if selected_agent.env is not None else None,
                     resume_session_id=resume_session_id,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             if selected_agent.env is not None:
                 # Env seats always dispatch through the direct CLI path. The
@@ -516,7 +517,7 @@ def dispatch(
                     cwd=cwd,
                     read_only=effective_read_only,
                     env=dict(selected_agent.env),
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                     **env_kwargs,
                 )
             if selected_agent.cli == "codex" and appserver is not None:
@@ -574,7 +575,7 @@ def dispatch(
                     timeout=timeout,
                     cwd=cwd,
                     read_only=effective_read_only,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is None:
                 return run_direct_agent(
@@ -584,7 +585,7 @@ def dispatch(
                     cwd=cwd,
                     read_only=effective_read_only,
                     sandbox=sandbox,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is None:
                 return run_direct_agent(
@@ -594,7 +595,7 @@ def dispatch(
                     cwd=cwd,
                     read_only=effective_read_only,
                     model=selected_agent.model,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             if sandbox is None and selected_agent.model is None and selected_agent.reasoning is not None:
                 return run_direct_agent(
@@ -604,7 +605,7 @@ def dispatch(
                     cwd=cwd,
                     read_only=effective_read_only,
                     reasoning=selected_agent.reasoning,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             if sandbox is not None and selected_agent.model is not None and selected_agent.reasoning is None:
                 return run_direct_agent(
@@ -615,7 +616,7 @@ def dispatch(
                     read_only=effective_read_only,
                     sandbox=sandbox,
                     model=selected_agent.model,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is not None:
                 return run_direct_agent(
@@ -626,7 +627,7 @@ def dispatch(
                     read_only=effective_read_only,
                     sandbox=sandbox,
                     reasoning=selected_agent.reasoning,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is not None:
                 return run_direct_agent(
@@ -637,7 +638,7 @@ def dispatch(
                     read_only=effective_read_only,
                     model=selected_agent.model,
                     reasoning=selected_agent.reasoning,
-                    process_registry=process_registry,
+                    process_registry=seat_process_registry,
                 )
             assert sandbox is not None
             assert selected_agent.model is not None
@@ -651,7 +652,7 @@ def dispatch(
                 sandbox=sandbox,
                 model=selected_agent.model,
                 reasoning=selected_agent.reasoning,
-                process_registry=process_registry,
+                process_registry=seat_process_registry,
             )
 
         def invoke(

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -124,6 +124,40 @@ def _model_roster():
     )
 
 
+def test_budget_cancellation_report_combines_appserver_and_process_observations():
+    class ControlRegistry:
+        def interrupt_observed(self, workers):
+            assert workers == ("appserver", "direct")
+            return (("appserver", "interrupted"),), ("appserver",)
+
+    class ProcessRegistry:
+        def cancel(self):
+            return (proc.ProcessCancelOutcome("direct", "interrupted"),)
+
+    report = aboyeur._observed_budget_cancellation(
+        ProcessRegistry(),
+        ControlRegistry(),
+        ("appserver", "direct"),
+    )
+
+    assert [(outcome.seat, outcome.transport_capability, outcome.transport_result) for outcome in report.outcomes] == [
+        ("appserver", "interrupt", "interrupted"),
+        ("direct", "process_cancel", "interrupted"),
+    ]
+    assert report.active_seats == ("appserver",)
+
+
+def test_budget_cancellation_report_does_not_invent_active_seats_without_processes():
+    class ProcessRegistry:
+        def cancel(self):
+            return ()
+
+    report = aboyeur._observed_budget_cancellation(ProcessRegistry(), None, ("direct",))
+
+    assert report.active_seats == ()
+    assert [(outcome.seat, outcome.transport_result) for outcome in report.outcomes] == [("direct", "unsupported")]
+
+
 def _grok_roster(*, fallback=False):
     seats = {
         "chef": Agent("chef", "codex", "plan and synthesize"),
@@ -1321,6 +1355,63 @@ def test_normal_run_persists_and_enforces_declared_dispatch_ceiling(monkeypatch,
     assert len(requested) == 1
     assert denied
     assert exhausted
+
+
+def test_explicit_run_budget_survives_run_start_and_plan_persistence(monkeypatch, tmp_path):
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    budget_payload = {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": 1,
+        "ceilings": {"worker_dispatch_count": 1},
+    }
+
+    def fake_run_agent(_cli_ref, prompt, **_kwargs):
+        if "Return exactly one JSON object" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"stage": 1, "worker": "coder", "task": "implement"}]}),
+                ok=True,
+            )
+        return agents.AgentResult(text="done", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    output_dir = tmp_path / "run"
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            cwd=tmp_path,
+            output_dir=output_dir,
+            route_enabled=False,
+            code_graph_enabled=False,
+            evidence_enabled=False,
+            run_budget_payload=budget_payload,
+        )
+        == 0
+    )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    plan = json.loads((output_dir / "plan.json").read_text())
+    assert run_meta["run_budget"] == budget_payload
+    assert plan["run_budget"] == budget_payload
+
+
+def test_direct_run_rejects_invalid_explicit_budget_before_planning(monkeypatch, tmp_path):
+    def planner_must_not_run(*_args, **_kwargs):
+        raise AssertionError("planner should not run for an invalid budget declaration")
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", planner_must_not_run)
+
+    with pytest.raises(aboyeur.run_budget.BudgetCompatibilityError):
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            cwd=tmp_path,
+            route_enabled=False,
+            code_graph_enabled=False,
+            evidence_enabled=False,
+            run_budget_payload={"ceilings": {"worker_dispatch_count": 1}},
+        )
 
 
 def test_undeclared_ordinary_run_invents_no_hard_ceiling(monkeypatch, tmp_path):

--- a/tests/test_dogfood_cmd.py
+++ b/tests/test_dogfood_cmd.py
@@ -472,6 +472,26 @@ def test_dogfood_ordinary_path_does_not_declare_run_budget(tmp_path, monkeypatch
     assert "run_budget_payload" not in run_kwargs[0]
 
 
+def test_dogfood_cli_forwards_explicit_budget_file(tmp_path, monkeypatch):
+    budget_path = tmp_path / "budget.json"
+    budget_payload = {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": 1,
+        "ceilings": {"worker_dispatch_count": 1},
+    }
+    _write_json(budget_path, budget_payload)
+    seen = {}
+
+    def fake_run(*_args, **kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(dogfood_cmd, "run", fake_run)
+
+    assert cli.main(["dogfood", "--target", str(tmp_path), "--run-budget", str(budget_path)]) == 0
+    assert seen["run_budget_payload"] == budget_payload
+
+
 def test_dogfood_latest_uses_configured_artifacts(tmp_path, monkeypatch):
     configured = tmp_path / "configured-runs"
     dogfood_cmd.init(target=tmp_path, artifacts_dir=configured)

--- a/tests/test_model_trials.py
+++ b/tests/test_model_trials.py
@@ -263,6 +263,52 @@ def test_model_trial_ordinary_path_does_not_declare_run_budget(tmp_path, monkeyp
     assert "run_budget_payload" not in run_kwargs[0]
 
 
+def test_model_trial_forwards_explicit_budget_payload(tmp_path, monkeypatch):
+    manifest = _manifest()
+    manifest["trials"] = 1
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(manifest))
+    root = tmp_path / "results"
+    budget_payload = {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": 1,
+        "ceilings": {"worker_dispatch_count": 1},
+    }
+    start_kwargs: list[dict] = []
+    run_kwargs: list[dict] = []
+
+    def fake_record_run_start(output_dir, **kwargs):
+        start_kwargs.append(dict(kwargs))
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "run.json").write_text(json.dumps({"status": "started"}))
+
+    def fake_run(_task, _roster, **kwargs):
+        run_kwargs.append(dict(kwargs))
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok", "duration_seconds": 0.5}))
+        return 0
+
+    monkeypatch.setattr(model_trials.aboyeur, "record_run_start", fake_record_run_start)
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    monkeypatch.setattr(model_trials.runguard, "run_lock", lambda *a, **k: nullcontext())
+
+    assert (
+        model_trials.execute(
+            manifest_path,
+            _roster(),
+            workspace=tmp_path,
+            output_dir=root,
+            resume=False,
+            run_budget_payload=budget_payload,
+        )
+        == 0
+    )
+    assert start_kwargs[0]["run_budget_payload"] == budget_payload
+    assert run_kwargs[0]["run_budget_payload"] == budget_payload
+
+
 def test_resume_does_not_skip_running_cells(tmp_path, monkeypatch):
     manifest_path = tmp_path / "eval.json"
     manifest_path.write_text(json.dumps(_manifest()))

--- a/tests/test_run_budget.py
+++ b/tests/test_run_budget.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -11,6 +12,14 @@ from brigade.receipt_schema import RUN_EVENT_SCHEMA, RUN_EVENT_SCHEMA_VERSION
 
 RUN_ID = "20260810-210000-budget593"
 RECORDED_AT = "2026-08-10T21:00:00.000000Z"
+
+
+def _declaration_payload() -> dict[str, object]:
+    return {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": 1,
+        "ceilings": {"wall_clock_seconds": 30, "worker_dispatch_count": 1},
+    }
 
 
 def _build_event(sequence: int, event_type: str, payload: dict, key: str, recorded_at: str, previous: str | None):
@@ -55,6 +64,72 @@ def test_run_budget_events_reject_raw_diagnostic_payload_keys():
         )
     assert "forbidden" in str(exc.value) or "unknown payload" in str(exc.value)
     assert len(str(exc.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_load_declaration_file_is_versioned_strict_and_canonical(tmp_path):
+    declaration_path = tmp_path / "budget.json"
+    declaration_path.write_text(json.dumps(_declaration_payload()))
+
+    assert run_budget.load_declaration_file(declaration_path) == _declaration_payload()
+
+    declaration_path.write_text(json.dumps({"schema": "brigade.run_budget.v1", "schema_version": True}))
+    with pytest.raises(run_budget.BudgetCompatibilityError):
+        run_budget.load_declaration_file(declaration_path)
+
+    declaration_path.write_text(json.dumps({"ceilings": {"unknown_dimension": 1}}))
+    with pytest.raises(run_budget.BudgetCompatibilityError):
+        run_budget.load_declaration_file(declaration_path)
+
+    for incomplete in (
+        {"schema_version": 1, "ceilings": {}},
+        {"schema": "brigade.run_budget.v1", "ceilings": {}},
+        {**_declaration_payload(), "unexpected": True},
+    ):
+        declaration_path.write_text(json.dumps(incomplete))
+        with pytest.raises(run_budget.BudgetCompatibilityError):
+            run_budget.load_declaration_file(declaration_path)
+
+
+def test_cancellation_report_preserves_mixed_seat_outcomes_and_replays_once():
+    declaration = run_budget.RunBudgetDeclaration(worker_dispatch_count=1)
+    calls = 0
+
+    def cancel() -> run_budget.CancellationReport:
+        nonlocal calls
+        calls += 1
+        return run_budget.CancellationReport(
+            outcomes=(
+                run_budget.CancelOutcome("coder", "interrupt", "interrupted"),
+                run_budget.CancelOutcome("reviewer", "none", "unsupported"),
+            ),
+            active_seats=("reviewer",),
+        )
+
+    coordinator = run_budget.BudgetCoordinator(declaration=declaration, append_event=lambda *_args: None)
+    receipt = coordinator.request_cancel(
+        request_id="mixed-cancel",
+        reason_class="budget_cancel",
+        transport_capability="mixed",
+        dimension="worker_dispatch_count",
+        cancel_fn=cancel,
+    )
+    replay = coordinator.request_cancel(
+        request_id="mixed-cancel",
+        reason_class="budget_cancel",
+        transport_capability="mixed",
+        dimension="worker_dispatch_count",
+        cancel_fn=lambda: (_ for _ in ()).throw(AssertionError("cancellation replayed")),
+    )
+
+    assert calls == 1
+    assert receipt == replay
+    assert receipt.transport_result == "partial"
+    assert receipt.active_remaining == 1
+    assert receipt.active_seats == ("reviewer",)
+    assert [(outcome.seat, outcome.transport_result) for outcome in receipt.outcomes] == [
+        ("coder", "interrupted"),
+        ("reviewer", "unsupported"),
+    ]
 
 
 def test_run_budget_events_are_status_neutral_in_projector():

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -158,6 +158,71 @@ role = "code"
     assert seen["fail_fast"] is True
 
 
+def test_run_cli_forwards_explicit_budget_file_before_dispatch(tmp_path, monkeypatch):
+    roster_path = tmp_path / "roster.toml"
+    roster_path.write_text('orchestrator = "chef"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    budget_path = tmp_path / "budget.json"
+    budget_payload = {
+        "schema": "brigade.run_budget.v1",
+        "schema_version": 1,
+        "ceilings": {"worker_dispatch_count": 1},
+    }
+    budget_path.write_text(json.dumps(budget_payload))
+    seen = {}
+
+    def fake_run(*_args, **kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    assert (
+        cli.main(
+            [
+                "run",
+                "do something",
+                "--roster",
+                str(roster_path),
+                "--cwd",
+                str(tmp_path),
+                "--output-dir",
+                str(tmp_path / "run"),
+                "--run-budget",
+                str(budget_path),
+            ]
+        )
+        == 0
+    )
+    assert seen["run_budget_payload"] == budget_payload
+
+
+def test_run_cli_rejects_invalid_budget_before_dispatch(tmp_path, monkeypatch, capsys):
+    roster_path = tmp_path / "roster.toml"
+    roster_path.write_text('orchestrator = "chef"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    budget_path = tmp_path / "budget.json"
+    budget_path.write_text(json.dumps({"schema": "brigade.run_budget.v1", "schema_version": True}))
+    monkeypatch.setattr(aboyeur, "run", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("dispatched")))
+
+    assert (
+        cli.main(
+            [
+                "run",
+                "do something",
+                "--roster",
+                str(roster_path),
+                "--cwd",
+                str(tmp_path),
+                "--output-dir",
+                str(tmp_path / "run"),
+                "--run-budget",
+                str(budget_path),
+            ]
+        )
+        == 2
+    )
+    assert "budget" in capsys.readouterr().err
+
+
 def test_run_cli_keep_going_sets_fail_fast_false(tmp_path, monkeypatch):
     roster_path = tmp_path / "roster.toml"
     roster_path.write_text(

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -481,6 +481,7 @@ def test_run_detach_child_argv_preserves_worker(tmp_path):
         wait=2.5,
         keep_going=False,
         scheduler="waves",
+        run_budget=None,
     )
     roster_resolution = roster_mod.RosterResolution(
         path=(tmp_path / "roster.toml").resolve(),
@@ -501,6 +502,46 @@ def test_run_detach_child_argv_preserves_worker(tmp_path):
     assert argv[argv.index("--wait") + 1] == "2.5"
     assert argv[argv.index("--resolved-roster-source") + 1] == "workspace"
     assert argv[argv.index("--resolved-roster-shadowed") + 1] == str(roster_resolution.shadowed[0])
+    assert "--run-budget" not in argv
+
+
+def test_run_detach_child_argv_forwards_run_budget(tmp_path):
+    budget_path = tmp_path / "budget.json"
+    budget_path.write_text("{}")
+    args = argparse.Namespace(
+        task="do work",
+        allow_dirty=False,
+        worktree=False,
+        show_plan=False,
+        verbose=False,
+        read_only=False,
+        no_code_graph=False,
+        no_evidence=False,
+        sandbox=None,
+        codex_transport=None,
+        handoff=False,
+        handoff_inbox=None,
+        worker="coder",
+        wait=2.5,
+        keep_going=False,
+        scheduler="waves",
+        run_budget=budget_path,
+    )
+    roster_resolution = roster_mod.RosterResolution(
+        path=(tmp_path / "roster.toml").resolve(),
+        source="workspace",
+        shadowed=((tmp_path / "user-roster.toml").resolve(),),
+    )
+    output_dir = tmp_path / "run"
+
+    argv = run_cli._detached_child_argv(
+        args,
+        run_cwd=tmp_path,
+        roster_resolution=roster_resolution,
+        output_dir=output_dir,
+    )
+
+    assert argv[argv.index("--run-budget") + 1] == str(budget_path.resolve())
 
 
 def _minimal_roster() -> roster_mod.Roster:


### PR DESCRIPTION
## Summary

- Adds `--run-budget PATH` to ordinary `brigade run`, dogfood, and model-trial run or resume paths.
- Requires explicit versioned declarations, preserves the supplied JSON in run and plan artifacts, and leaves undeclared runs unbounded.
- Records observed per-seat cancellation results across app-server and process transports, including work that may still be active.

## Verification

- `brigade work verify run --target . --argv-json ... --capture brigade-work`: 627 passed in 62.92s, receipt `20260814-134201-work-verify-1cbd35`.
- Review-fix RED/GREEN receipts: `20260814-133623-work-verify-581b89` failed as expected, then `20260814-133808-work-verify-e5270f` passed.
- `./scripts/verify` did not reach a final green state within the task's two-attempt limit. The first attempt lacked the linked worktree's virtual environment. The second passed Ruff checks and formatting, then MyPy reported typing errors that were corrected afterward. No third full-gate attempt was run.

The current head still needs a fresh `./scripts/verify` run before merge.

Closes #885
Closes #886
