### PR TITLE
feat(center): densify memory inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recover <operation-id>`. Refs #911.
 
 ### Changed
+- Center Memory Operations Cards now shows corpus size, a chip cloud, compact
+  expandable rows, and 30-row paging. Handoffs is a sibling tab on that page;
+  `/view/handoffs` redirects there. Snapshot polling reloads the page so
+  nonce-scoped assets stay valid. (#903)
 - The shipped review-heavy `reviewer_flash` preset now uses Gemini 3.7 Flash Low
   on Antigravity. Security-sensitive or cross-file decisions still route to the
   independent `reviewer` or `reviewer_codex` seat. (#920)

--- a/src/brigade/center_cmd/dashboard/render.py
+++ b/src/brigade/center_cmd/dashboard/render.py
@@ -164,21 +164,7 @@ table.data-table th {{
     return;
   }}
   setInterval(function () {{
-    fetch(location.pathname + location.search, {{
-      cache: "no-store",
-      headers: {{ Accept: "text/html" }}
-    }}).then(function (res) {{
-      if (!res.ok) throw new Error("poll");
-      return res.text();
-    }}).then(function (html) {{
-      var doc = new DOMParser().parseFromString(html, "text/html");
-      var nextMain = doc.querySelector("main.dashboard-main");
-      var curMain = document.querySelector("main.dashboard-main");
-      if (!nextMain || !curMain) throw new Error("missing main");
-      curMain.innerHTML = nextMain.innerHTML;
-    }}).catch(function () {{
-      location.reload();
-    }});
+    location.reload();
   }}, pollMs);
 }})();
 document.addEventListener("input", function (e) {{

--- a/src/brigade/center_cmd/dashboard/views/__init__.py
+++ b/src/brigade/center_cmd/dashboard/views/__init__.py
@@ -19,7 +19,6 @@ from brigade.center_cmd.dashboard import render
 from brigade.center_cmd.dashboard.views import (
     agent_activity,
     code_graph,
-    handoff_inbox,
     memory_operations,
     outcome_rank,
     run_timeline,
@@ -29,7 +28,6 @@ from brigade.center_cmd.dashboard.views import (
 
 _VIEW_MODULES: tuple[ModuleType, ...] = (
     status_grid,
-    handoff_inbox,
     memory_operations,
     outcome_rank,
     run_timeline,

--- a/src/brigade/center_cmd/dashboard/views/memory_operations.py
+++ b/src/brigade/center_cmd/dashboard/views/memory_operations.py
@@ -11,19 +11,22 @@ Operator-facing copy uses plain language; raw node/edge/receipt ids stay in
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
 from typing import Any
 
 from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
+from brigade.center_cmd.dashboard.views import handoff_inbox
 
 NAME = "memory"
 TITLE = "Memory Operations"
 ORDER = 3
 
 _INVENTORY_LIMIT = 500
-_CLIENT_PAGE_SIZE = 50
+_CLIENT_PAGE_SIZE = 30
 _TAG_CHIP_LIMIT = 5
+_TOKEN_ESTIMATE_BYTES = 4
 
 # Status palette (dataviz reserved): always paired with icon + word, never color alone.
 _STATUS_GOOD = "#0ca30c"
@@ -70,27 +73,32 @@ _FLAG_PLAIN = {
 def fetch(target: Path) -> dict:
     topology = data.run_json(target, ["memory", "topology"])
     inventory = _fetch_inventory(target)
-    return {"topology": topology, "inventory": inventory}
+    handoffs = data.run_json(target, ["handoff", "lint"])
+    return {"topology": topology, "inventory": inventory, "handoffs": handoffs}
 
 
 def render(payload: dict, nonce: str) -> str:
     topology = payload.get("topology") if isinstance(payload.get("topology"), dict) else {}
     inventory = payload.get("inventory") if isinstance(payload.get("inventory"), dict) else {}
+    handoffs = payload.get("handoffs") if isinstance(payload.get("handoffs"), dict) else {}
 
     parts = [
         _stylesheet(nonce),
         _mode_tabs(),
         (
             '<div id="mo-topology" class="mo-panel" data-mo-panel="topology" '
-            'role="tabpanel" aria-labelledby="mo-tab-topology">'
+            'role="tabpanel" aria-labelledby="mo-tab-topology" hidden>'
         ),
         _render_topology(topology, inventory),
         "</div>",
-        (
-            '<div id="mo-inventory" class="mo-panel" data-mo-panel="inventory" '
-            'role="tabpanel" aria-labelledby="mo-tab-inventory">'
-        ),
+        ('<div id="mo-cards" class="mo-panel" data-mo-panel="cards" role="tabpanel" aria-labelledby="mo-tab-cards">'),
         _render_inventory(inventory),
+        "</div>",
+        (
+            '<div id="mo-handoffs" class="mo-panel" data-mo-panel="handoffs" '
+            'role="tabpanel" aria-labelledby="mo-tab-handoffs" hidden>'
+        ),
+        handoff_inbox.render(handoffs, nonce),
         "</div>",
         _script(nonce),
     ]
@@ -103,6 +111,7 @@ def _fetch_inventory(target: Path) -> dict:
     seen_offsets: set[int] = set()
     last_error: str | None = None
     contract_total: int | None = None
+    master_index: dict[str, Any] | None = None
     partial = False
     partial_reason: str | None = None
 
@@ -138,6 +147,9 @@ def _fetch_inventory(target: Path) -> dict:
                 if isinstance(item, dict):
                     items.append(item)
 
+        if master_index is None and isinstance(page.get("master_index"), dict):
+            master_index = page["master_index"]
+
         pagination = page.get("pagination") if isinstance(page.get("pagination"), dict) else {}
         total_val = pagination.get("total")
         if isinstance(total_val, int):
@@ -160,6 +172,8 @@ def _fetch_inventory(target: Path) -> dict:
     result: dict[str, Any] = {
         "items": items,
     }
+    if master_index is not None:
+        result["master_index"] = master_index
     if isinstance(contract_total, int):
         result["contract_total"] = contract_total
         result["total"] = contract_total
@@ -190,11 +204,14 @@ def _mode_tabs() -> str:
     return (
         '<div class="mo-modes" role="tablist" aria-label="' + html.esc("Memory Operations modes") + '">'
         '<a href="#mo-topology" id="mo-tab-topology" class="mo-mode" role="tab" '
-        'data-mo-mode="topology" aria-selected="true" aria-controls="mo-topology" '
-        'tabindex="0">' + html.esc("Topology") + "</a>"
-        '<a href="#mo-inventory" id="mo-tab-inventory" class="mo-mode" role="tab" '
-        'data-mo-mode="inventory" aria-selected="false" aria-controls="mo-inventory" '
-        'tabindex="-1">' + html.esc("Inventory") + "</a>"
+        'data-mo-mode="topology" aria-selected="false" aria-controls="mo-topology" '
+        'tabindex="-1">' + html.esc("Topology") + "</a>"
+        '<a href="#mo-cards" id="mo-tab-cards" class="mo-mode" role="tab" '
+        'data-mo-mode="cards" aria-selected="true" aria-controls="mo-cards" '
+        'tabindex="0">' + html.esc("Cards") + "</a>"
+        '<a href="#mo-handoffs" id="mo-tab-handoffs" class="mo-mode" role="tab" '
+        'data-mo-mode="handoffs" aria-selected="false" aria-controls="mo-handoffs" '
+        'tabindex="-1">' + html.esc("Handoffs") + "</a>"
         "</div>"
     )
 
@@ -1142,6 +1159,195 @@ def _inventory_row(item: dict, columns: list[dict[str, Any]]) -> list[str]:
     return [values[col["key"]] for col in columns]
 
 
+def _render_inventory(inventory: dict) -> str:
+    """Render the card index as a compact, browsable memory corpus."""
+    if inventory.get("error"):
+        return html.error_panel("Cards", str(inventory["error"]))
+    items = [item for item in inventory.get("items", []) if isinstance(item, dict)]
+    if not items:
+        return html.panel(html.esc("Cards"), f"<p>{html.esc('Nothing here.')}</p>")
+
+    card_items = [item for item in items if item.get("store_type") == "card"]
+    corpus_items = card_items or items
+    warning = inventory.get("warning")
+    body = [
+        _corpus_stats(corpus_items),
+        _master_index_row(inventory.get("master_index")),
+        _card_filter_cloud(corpus_items),
+    ]
+    if warning:
+        body.append(f'<p class="error">{html.esc(warning)}</p>')
+    body.append(_card_sections(corpus_items))
+    body.append(_card_pager(len(corpus_items), inventory))
+    return html.panel(html.esc("Cards"), "".join(body))
+
+
+def _corpus_stats(items: list[dict[str, Any]]) -> str:
+    card_count = len(items)
+    category_count = len({str(item["category"]).strip() for item in items if item.get("category")})
+    total_bytes = sum(_item_size_bytes(item) for item in items)
+    token_estimate = (total_bytes + _TOKEN_ESTIMATE_BYTES - 1) // _TOKEN_ESTIMATE_BYTES
+    return (
+        '<div class="mo-corpus-stats" aria-label="Memory corpus statistics">'
+        f'<span class="mo-stat-chip">{html.esc(f"{card_count} cards")}</span>'
+        f'<span class="mo-stat-chip">{html.esc(f"{category_count} categories")}</span>'
+        f'<span class="mo-stat-chip">{html.esc(f"~{token_estimate:,} tokens")}</span>'
+        "</div>"
+    )
+
+
+def _item_size_bytes(item: dict[str, Any]) -> int:
+    value = item.get("size_bytes")
+    return value if isinstance(value, int) and value >= 0 else 0
+
+
+def _master_index_row(raw: object) -> str:
+    info = raw if isinstance(raw, dict) else {}
+    path = _display(info.get("canonical_path") or "MEMORY.md")
+    size = _format_size(info.get("size_bytes"))
+    return (
+        '<details class="mo-master-index">'
+        '<summary><span class="mo-row-title">' + html.esc(path) + "</span>"
+        '<span class="mo-row-kind">' + html.esc("Master index") + "</span>"
+        '<span class="mo-row-age">' + html.esc(size) + "</span></summary>"
+        '<div class="mo-card-detail"><p>'
+        + html.esc("The repository index maps the memory corpus without duplicating card content here.")
+        + "</p></div></details>"
+    )
+
+
+def _filter_counts(items: list[dict[str, Any]]) -> tuple[dict[str, int], dict[str, int]]:
+    categories: dict[str, int] = {}
+    tags: dict[str, int] = {}
+    for item in items:
+        category = str(item.get("category") or "Uncategorized").strip() or "Uncategorized"
+        categories[category] = categories.get(category, 0) + 1
+        raw_tags = item.get("tags")
+        if isinstance(raw_tags, list):
+            for raw_tag in raw_tags:
+                tag = str(raw_tag or "").strip()
+                if tag:
+                    tags[tag] = tags.get(tag, 0) + 1
+    return categories, tags
+
+
+def _card_filter_cloud(items: list[dict[str, Any]]) -> str:
+    categories, tags = _filter_counts(items)
+
+    def chip(kind: str, value: str, count: int, *, active: bool = False) -> str:
+        return (
+            f'<button type="button" class="mo-filter-chip" data-mo-filter-chip="{html.esc(kind)}" '
+            f'data-mo-filter-value="{html.esc(value)}" aria-pressed="{str(active).lower()}">'
+            f"{html.esc(f'{value} ({count})')}</button>"
+        )
+
+    category_chips = [chip("all", "All", len(items), active=True)]
+    category_chips.extend(
+        chip("category", label, count) for label, count in sorted(categories.items(), key=lambda x: x[0].casefold())
+    )
+    tag_chips = [chip("tag", label, count) for label, count in sorted(tags.items(), key=lambda x: x[0].casefold())]
+    return (
+        '<div class="mo-card-search"><label>'
+        + html.esc("Search cards")
+        + ' <input type="search" data-mo-filter-text placeholder="Search cards" aria-label="Search cards"></label></div>'
+        '<div class="mo-filter-cloud" aria-label="Card categories">' + "".join(category_chips) + "</div>"
+        '<div class="mo-filter-cloud mo-tag-cloud" aria-label="Card tags">' + "".join(tag_chips) + "</div>"
+    )
+
+
+def _card_sections(items: list[dict[str, Any]]) -> str:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        category = str(item.get("category") or "Uncategorized").strip() or "Uncategorized"
+        grouped.setdefault(category, []).append(item)
+    sections: list[str] = []
+    for category in sorted(grouped, key=str.casefold):
+        cards = sorted(grouped[category], key=lambda item: str(item.get("title") or "").casefold())
+        rows = "".join(_card_row(item) for item in cards)
+        sections.append(
+            '<section class="mo-category-section" data-mo-category-section="1">'
+            f"<h3>{html.esc(f'{category.upper()} ({len(cards)})')}</h3>{rows}</section>"
+        )
+    return '<div class="mo-card-sections">' + "".join(sections) + "</div>"
+
+
+def _card_row(item: dict[str, Any]) -> str:
+    tags = (
+        [str(tag) for tag in item.get("tags", []) if tag not in (None, "")]
+        if isinstance(item.get("tags"), list)
+        else []
+    )
+    tags_json = json.dumps(tags, separators=(",", ":"))
+    category = str(item.get("category") or "Uncategorized").strip() or "Uncategorized"
+    age = _human_age(item.get("updated_at") or item.get("created_at"))
+    tag_html = _tag_chips(tags)
+    detail = _card_detail(item)
+    return (
+        f'<details class="mo-card-row" data-mo-row="1" data-mo-category="{html.esc(category)}" '
+        f'data-mo-tags="{html.esc(tags_json)}">'
+        '<summary><span class="mo-row-title">'
+        + html.esc(_display(item.get("title")))
+        + "</span>"
+        + tag_html
+        + f'<time class="mo-row-age">{html.esc(age)}</time></summary>{detail}</details>'
+    )
+
+
+def _card_detail(item: dict[str, Any]) -> str:
+    fields = (
+        ("Path", _display(item.get("canonical_path"))),
+        ("Size", _format_size(item.get("size_bytes"))),
+        ("Type", _display(item.get("store_type"))),
+        ("Freshness", _display(item.get("freshness"))),
+        ("Reviewed", _display(item.get("last_reviewed"))),
+        ("Evidence", _display(item.get("evidence_state"))),
+        ("Source", _display(item.get("source_harness"))),
+        ("Workflow", _display(item.get("owning_workflow"))),
+    )
+    rows = "".join(f"<dt>{html.esc(label)}</dt><dd>{html.esc(value)}</dd>" for label, value in fields)
+    mutation = _mutation_text(item)
+    card_id = _display(item.get("id"))
+    return (
+        '<div class="mo-card-detail"><dl>' + rows + "</dl>"
+        '<details class="mo-debug"><summary>' + html.esc("Record details") + "</summary>"
+        f"<code>{html.esc(f'id={card_id}; {mutation}')}</code></details></div>"
+    )
+
+
+def _format_size(value: object) -> str:
+    if not isinstance(value, int) or value < 0:
+        return "-"
+    if value < 1024:
+        return f"{value} B"
+    return f"{value / 1024:.1f}".rstrip("0").rstrip(".") + " KiB"
+
+
+def _human_age(value: object, *, today: date | None = None) -> str:
+    if not isinstance(value, str):
+        return "-"
+    try:
+        when = date.fromisoformat(value[:10])
+    except ValueError:
+        return "-"
+    days = max(0, ((today or date.today()) - when).days)
+    if days < 7:
+        return "today" if days == 0 else f"{days}d"
+    if days < 365:
+        return f"{days // 7}w"
+    return f"{days // 365}y"
+
+
+def _card_pager(loaded: int, inventory: dict) -> str:
+    total = inventory.get("contract_total") if inventory.get("partial") else inventory.get("total")
+    total_attr = total if isinstance(total, int) else loaded
+    return (
+        f'<div class="mo-pager" data-mo-page-size="{_CLIENT_PAGE_SIZE}" data-mo-total="{html.esc(total_attr)}">'
+        f'<button type="button" data-mo-page="prev" disabled>{html.esc("Prior")}</button>'
+        f"<span data-mo-page-status>{html.esc('Page 1')}</span>"
+        f'<button type="button" data-mo-page="next">{html.esc("Next")}</button></div>'
+    )
+
+
 def _stylesheet(nonce: str) -> str:
     return f"""<style nonce="{html.esc(nonce)}">
 .mo-modes {{
@@ -1334,6 +1540,132 @@ def _stylesheet(nonce: str) -> str:
   overflow: hidden;
   vertical-align: middle;
 }}
+.mo-corpus-stats,
+.mo-filter-cloud {{
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}}
+.mo-corpus-stats {{
+  margin: 0 0 0.75rem;
+}}
+.mo-stat-chip,
+.mo-filter-chip {{
+  border: 1px solid {_BORDER};
+  border-radius: 999px;
+  background: {_SURFACE};
+  color: {_TEXT_PRIMARY};
+  font: inherit;
+  font-size: 0.78rem;
+  line-height: 1.2;
+  padding: 0.28rem 0.55rem;
+}}
+.mo-stat-chip {{
+  font-weight: 600;
+}}
+.mo-filter-chip {{
+  cursor: pointer;
+}}
+.mo-filter-chip[aria-pressed="true"] {{
+  background: #0066cc;
+  border-color: #0066cc;
+  color: #fff;
+}}
+.mo-filter-chip:focus {{
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}}
+.mo-tag-cloud {{
+  margin-top: 0.35rem;
+}}
+.mo-card-search {{
+  margin: 0 0 0.55rem;
+}}
+.mo-card-search input {{
+  font: inherit;
+  min-width: 16rem;
+  padding: 0.25rem 0.4rem;
+  border: 1px solid #666;
+  border-radius: 0.2rem;
+  background: #fff;
+  color: {_TEXT_PRIMARY};
+}}
+.mo-master-index,
+.mo-card-row {{
+  border: 1px solid {_BORDER};
+  border-radius: 0.28rem;
+  background: {_SURFACE};
+}}
+.mo-master-index {{
+  margin: 0 0 0.75rem;
+}}
+.mo-master-index summary,
+.mo-card-row summary {{
+  display: flex;
+  align-items: center;
+  min-height: 1.8rem;
+  gap: 0.5rem;
+  padding: 0.22rem 0.55rem;
+  cursor: pointer;
+}}
+.mo-row-title {{
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: {_TEXT_PRIMARY};
+}}
+.mo-row-kind,
+.mo-row-age {{
+  flex: 0 0 auto;
+  color: {_TEXT_SECONDARY};
+  font-size: 0.78rem;
+  white-space: nowrap;
+}}
+.mo-card-sections {{
+  margin-top: 0.75rem;
+}}
+.mo-category-section {{
+  margin: 0 0 0.7rem;
+}}
+.mo-category-section h3 {{
+  margin: 0 0 0.28rem;
+  color: {_TEXT_SECONDARY};
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+}}
+.mo-card-row {{
+  display: block;
+  margin: 0 0 0.2rem;
+}}
+.mo-card-row .mo-tags {{
+  flex: 0 1 auto;
+  max-width: min(38vw, 24rem);
+}}
+.mo-card-detail {{
+  border-top: 1px solid {_BORDER};
+  padding: 0.5rem 0.75rem;
+  color: {_TEXT_SECONDARY};
+  font-size: 0.86rem;
+}}
+.mo-card-detail p {{
+  margin: 0;
+}}
+.mo-card-detail dl {{
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.22rem 0.75rem;
+  margin: 0;
+}}
+.mo-card-detail dt {{
+  font-weight: 600;
+}}
+.mo-card-detail dd {{
+  margin: 0;
+  overflow-wrap: anywhere;
+}}
 .mo-tag {{
   display: inline-block;
   padding: 0.1rem 0.4rem;
@@ -1374,6 +1706,18 @@ def _stylesheet(nonce: str) -> str:
   .mo-filters input[type="search"] {{
     min-width: 100%;
   }}
+  .mo-card-search input {{
+    min-width: 100%;
+  }}
+  .mo-card-row summary {{
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }}
+  .mo-card-row .mo-tags {{
+    order: 3;
+    width: 100%;
+    max-width: 100%;
+  }}
 }}
 </style>
 <noscript><style nonce="{html.esc(nonce)}">
@@ -1412,6 +1756,12 @@ def _script(nonce: str) -> str:
     if (pageDir) {{
       e.preventDefault();
       shiftPage(pageDir);
+      return;
+    }}
+    var chipKind = t.getAttribute("data-mo-filter-chip");
+    if (chipKind) {{
+      e.preventDefault();
+      selectChip(t);
     }}
   }});
 
@@ -1447,16 +1797,22 @@ def _script(nonce: str) -> str:
 
   var pageIndex = 0;
 
+  function selectChip(chip) {{
+    var chips = document.querySelectorAll("[data-mo-filter-chip]");
+    for (var i = 0; i < chips.length; i++) {{
+      chips[i].setAttribute("aria-pressed", chips[i] === chip ? "true" : "false");
+    }}
+    applyInventory();
+  }}
+
   function rowMatches(row) {{
-    var filters = document.querySelectorAll("[data-mo-filter]");
-    var span = row.querySelector("span[data-mo-store_type], td span");
-    for (var i = 0; i < filters.length; i++) {{
-      var sel = filters[i];
-      var key = sel.getAttribute("data-mo-filter");
-      var wanted = (sel.value || "").toLowerCase();
-      if (!wanted) continue;
-      if (key === "tag") {{
-        var rawTags = span && span.getAttribute ? (span.getAttribute("data-mo-tags") || "[]") : "[]";
+    var active = document.querySelector('[data-mo-filter-chip][aria-pressed="true"]');
+    if (active) {{
+      var kind = active.getAttribute("data-mo-filter-chip");
+      var wanted = (active.getAttribute("data-mo-filter-value") || "").toLowerCase();
+      if (kind === "category" && (row.getAttribute("data-mo-category") || "").toLowerCase() !== wanted) return false;
+      if (kind === "tag") {{
+        var rawTags = row.getAttribute("data-mo-tags") || "[]";
         var parsed = [];
         try {{ parsed = JSON.parse(rawTags); }} catch (err) {{ parsed = []; }}
         var found = false;
@@ -1464,14 +1820,6 @@ def _script(nonce: str) -> str:
           if (String(parsed[t]).toLowerCase() === wanted) {{ found = true; break; }}
         }}
         if (!found) return false;
-        continue;
-      }}
-      var actual = "";
-      if (span && span.getAttribute) {{
-        actual = (span.getAttribute("data-mo-" + key) || "").toLowerCase();
-      }}
-      if (actual !== wanted) {{
-        return false;
       }}
     }}
     var textInput = document.querySelector("[data-mo-filter-text]");
@@ -1498,7 +1846,7 @@ def _script(nonce: str) -> str:
     var pager = document.querySelector(".mo-pager");
     if (!pager) return;
     var size = parseInt(pager.getAttribute("data-mo-page-size") || "50", 10);
-    var rows = document.querySelectorAll("tr[data-mo-row]");
+    var rows = document.querySelectorAll("[data-mo-row]");
     var matched = [];
     for (var i = 0; i < rows.length; i++) {{
       if (rowMatches(rows[i])) matched.push(rows[i]);
@@ -1514,6 +1862,15 @@ def _script(nonce: str) -> str:
     for (var m = 0; m < matched.length; m++) {{
       matched[m].hidden = !(m >= start && m < end);
     }}
+    var sections = document.querySelectorAll("[data-mo-category-section]");
+    for (var s = 0; s < sections.length; s++) {{
+      var sectionRows = sections[s].querySelectorAll("[data-mo-row]");
+      var hasVisible = false;
+      for (var q = 0; q < sectionRows.length; q++) {{
+        if (!sectionRows[q].hidden) {{ hasVisible = true; break; }}
+      }}
+      sections[s].hidden = !hasVisible;
+    }}
     var status = pager.querySelector("[data-mo-page-status]");
     if (status) {{
       status.textContent = "Page " + (pageIndex + 1) + " of " + pages +
@@ -1525,7 +1882,9 @@ def _script(nonce: str) -> str:
     if (next) next.disabled = pageIndex >= pages - 1;
   }}
 
-  selectMode("topology");
+  var initialMode = (window.location.hash || "").replace("#mo-", "");
+  if (initialMode !== "topology" && initialMode !== "cards" && initialMode !== "handoffs") initialMode = "cards";
+  selectMode(initialMode);
   renderPage();
 }})();
 </script>"""

--- a/src/brigade/center_cmd/serve.py
+++ b/src/brigade/center_cmd/serve.py
@@ -21,6 +21,7 @@ from brigade.center_cmd.dashboard.views import all_views, render_nav, view_by_na
 _DEFAULT_PORT = 8765
 _VIEW_PREFIX = "/view/"
 _LEGACY_VIEW_REDIRECTS = {
+    "handoffs": "/view/memory#handoffs",
     "graph": "/view/work#ready",
     "waves": "/view/work#ready",
     "claims": "/view/work#claims",

--- a/src/brigade/memory_operations.py
+++ b/src/brigade/memory_operations.py
@@ -231,6 +231,7 @@ def inventory_payload(
         "schema": {"name": INVENTORY_SCHEMA_NAME, "version": INVENTORY_SCHEMA_VERSION},
         "target": ".",
         "generated_at": utc_now_iso_z(),
+        "master_index": _master_index_payload(target),
         "pagination": {
             "offset": offset,
             "limit": limit,
@@ -1524,6 +1525,7 @@ def _inventory_item_from_source(
         "id": f"{store_type}:{canonical_path}",
         "title": title,
         "canonical_path": canonical_path,
+        "size_bytes": _safe_file_size(path),
         "logical_destination": STORE_LOGICAL[store_type],
         "store_type": store_type,
         "category": category,
@@ -1541,6 +1543,25 @@ def _inventory_item_from_source(
         "last_mutation": _inventory_last_mutation(meta),
         "care": _care_for_path(canonical_path, care_index),
     }
+
+
+def _master_index_payload(target: Path) -> dict[str, Any] | None:
+    """Return stat-only metadata for the optional top-level MEMORY.md index."""
+    path = target / "MEMORY.md"
+    if path.is_symlink() or not path.is_file() or _canonical_relpath(target, path) is None:
+        return None
+    size_bytes = _safe_file_size(path)
+    if size_bytes is None:
+        return None
+    return {"canonical_path": "MEMORY.md", "size_bytes": size_bytes}
+
+
+def _safe_file_size(path: Path) -> int | None:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return None
+    return size if isinstance(size, int) and size >= 0 else None
 
 
 def _split_inline_tag_sequence(value: str) -> list[str] | None:

--- a/tests/test_center_dashboard.py
+++ b/tests/test_center_dashboard.py
@@ -154,6 +154,14 @@ def test_folded_work_routes_redirect_to_work_anchors(dashboard_server, legacy, l
     assert f"Location: {location}" in headers
 
 
+def test_handoffs_route_redirects_to_memory_handoffs_tab(dashboard_server):
+    host, port = dashboard_server.server_address
+    response = _raw_request(dashboard_server, f"{host}:{port}", path="/view/handoffs")
+    assert _status_code(response) == "301"
+    headers, _body = _headers_and_body(response)
+    assert "Location: /view/memory#handoffs" in headers
+
+
 def test_work_view_browser_check_answers_operator_questions(dashboard_server, monkeypatch):
     from brigade.center_cmd.dashboard.views import work as work_view
 
@@ -535,7 +543,7 @@ def _stub_memory_ops_json(monkeypatch, *, topology=None, inventory_pages=None):
     return calls
 
 
-def test_memory_operations_replaces_cards_and_uses_only_topology_inventory_contracts(monkeypatch, tmp_target):
+def test_memory_operations_replaces_cards_and_uses_only_contracts(monkeypatch, tmp_target):
     names = [module.NAME for module in all_views()]
     titles = [module.TITLE for module in all_views()]
     assert "cards" not in names
@@ -547,7 +555,11 @@ def test_memory_operations_replaces_cards_and_uses_only_topology_inventory_contr
     calls = _stub_memory_ops_json(monkeypatch)
     payload = view.fetch(tmp_target)
     assert isinstance(payload, dict)
-    assert {tuple(call[:2]) for call in calls} <= {("memory", "topology"), ("memory", "inventory")}
+    assert {tuple(call[:2]) for call in calls} <= {
+        ("memory", "topology"),
+        ("memory", "inventory"),
+        ("handoff", "lint"),
+    }
     assert ("memory", "topology") in {tuple(call[:2]) for call in calls}
     assert ("memory", "inventory") in {tuple(call[:2]) for call in calls}
     assert all("search" not in call for call in calls)
@@ -646,9 +658,116 @@ def test_memory_operations_renders_topology_health_ownership_and_inventory_field
     assert "stale" in html
     assert "refresh" in html.lower()
     assert "Topology" in html
-    assert "Inventory" in html
+    assert "Cards" in html
     assert 'data-mo-mode="topology"' in html
-    assert 'data-mo-mode="inventory"' in html
+    assert 'data-mo-mode="cards"' in html
+    assert 'data-mo-mode="handoffs"' in html
+
+
+def test_memory_operations_cards_density_matches_inventory_contract(monkeypatch, tmp_target):
+    inventory_pages = [
+        {
+            "master_index": {"canonical_path": "MEMORY.md", "size_bytes": 2048},
+            "items": [
+                _inventory_item(
+                    0,
+                    title="Architecture card",
+                    category="architecture",
+                    tags=["system", "design"],
+                    updated_at="2026-08-11",
+                    size_bytes=401,
+                ),
+                _inventory_item(
+                    1,
+                    title="Workflow card",
+                    category="workflow",
+                    tags=["system", "run"],
+                    updated_at="2026-07-03",
+                    size_bytes=800,
+                ),
+            ],
+            "pagination": {
+                "offset": 0,
+                "limit": 500,
+                "total": 2,
+                "returned": 2,
+                "has_more": False,
+                "next_offset": None,
+            },
+        }
+    ]
+    _stub_memory_ops_json(monkeypatch, inventory_pages=inventory_pages)
+    view = view_by_name("memory")
+    assert view is not None
+
+    rendered = view.render(view.fetch(tmp_target), nonce="density")
+
+    assert 'data-mo-mode="cards"' in rendered
+    assert 'data-mo-mode="handoffs"' in rendered
+    assert 'data-mo-mode="cards" aria-selected="true"' in rendered
+    assert 'data-mo-panel="topology" role="tabpanel" aria-labelledby="mo-tab-topology" hidden' in rendered
+    assert 'class="mo-corpus-stats"' in rendered
+    assert "2 cards" in rendered
+    assert "2 categories" in rendered
+    assert "~301 tokens" in rendered
+    assert 'class="mo-master-index"' in rendered
+    assert "MEMORY.md" in rendered and "2 KiB" in rendered
+    assert 'class="mo-filter-chip"' in rendered
+    assert "architecture (1)" in rendered
+    assert "system (2)" in rendered
+    assert "<select" not in rendered
+    assert 'class="mo-category-section"' in rendered
+    assert "ARCHITECTURE (1)" in rendered
+    assert 'class="mo-card-row"' in rendered
+    assert 'class="mo-card-detail"' in rendered
+    assert ">3d<" in rendered
+    assert "0h ago" not in rendered
+
+
+def test_memory_operations_humanizes_card_age():
+    from datetime import date
+
+    from brigade.center_cmd.dashboard.views import memory_operations
+
+    assert memory_operations._human_age("2026-08-11", today=date(2026, 8, 14)) == "3d"
+    assert memory_operations._human_age("2026-07-03", today=date(2026, 8, 14)) == "6w"
+
+
+def test_memory_view_browser_check_shows_dense_cards_and_handoffs(dashboard_server, monkeypatch):
+    from brigade.center_cmd.dashboard.views import memory_operations
+
+    def fake_fetch(target):
+        del target
+        return {
+            "topology": _topology_payload(),
+            "inventory": {
+                "items": [
+                    _inventory_item(
+                        0,
+                        title="Browser density card",
+                        category="workflow",
+                        tags=["browser", "memory"],
+                        size_bytes=480,
+                        updated_at="2026-08-11",
+                    )
+                ],
+                "total": 1,
+                "master_index": {"canonical_path": "MEMORY.md", "size_bytes": 1024},
+            },
+            "handoffs": {"count": 0, "results": []},
+        }
+
+    monkeypatch.setattr(memory_operations, "fetch", fake_fetch)
+    host, port = dashboard_server.server_address
+    response = _raw_request(dashboard_server, f"{host}:{port}", path="/view/memory")
+    assert _status_code(response) == "200"
+    _headers, body = _headers_and_body(response)
+    assert 'data-mo-mode="cards"' in body
+    assert 'data-mo-mode="handoffs"' in body
+    assert 'class="mo-corpus-stats"' in body
+    assert 'class="mo-master-index"' in body
+    assert 'class="mo-card-row"' in body
+    assert "Browser density card" in body
 
 
 def test_memory_operations_escapes_hostile_labels_and_has_no_inline_handlers(monkeypatch, tmp_target):

--- a/tests/test_center_page_load.py
+++ b/tests/test_center_page_load.py
@@ -173,8 +173,10 @@ def test_collect_does_not_live_probe_cloud_providers(tmp_path, monkeypatch):
 def test_settled_page_polls_snapshot_every_15s_without_cache_bust():
     html = render.page("Agent Activity - Brigade Center", "test-nonce", "<nav></nav>", "<p>body</p>", reload_ms=15000)
     assert "15000" in html
-    assert "fetch(" in html
-    assert "location.pathname" in html
+    # Reloading lets every snapshot issue a matching nonce for page-specific
+    # inline assets. Replacing main.innerHTML leaves those assets inert.
+    assert "location.reload()" in html
+    assert "fetch(" not in html
     assert "Date.now()" not in html
     assert "_=" not in html.split("<script", 1)[1]
 

--- a/tests/test_center_serve.py
+++ b/tests/test_center_serve.py
@@ -6,6 +6,7 @@ import time
 import pytest
 
 from brigade.center_cmd.serve import _make_server, serve, validate_bind_security
+from brigade.center_cmd.dashboard import render
 
 
 _FAKE_TOKEN = "fake-token-placeholder"
@@ -210,6 +211,15 @@ def test_bound_host_does_not_match_a_different_port(no_token_server):
     host, port = no_token_server.server_address
     response = _raw_request(no_token_server, f"{host}:{port + 1}")
     assert _status_code(response) == "403"
+
+
+def test_dashboard_refresh_reloads_nonce_scoped_view_scripts():
+    page = render.page("Center", "nonce", "", "", reload_ms=1000)
+    refresh = page.split("setInterval(function ()", 1)[1].split("</script>", 1)[0]
+
+    assert "location.reload();" in refresh
+    assert "fetch(" not in refresh
+    assert "curMain.innerHTML" not in page
 
 
 def test_missing_host_header_is_rejected(no_token_server):

--- a/tests/test_dashboard_memory_operations.py
+++ b/tests/test_dashboard_memory_operations.py
@@ -85,19 +85,17 @@ def test_render_mode_tabs_and_inventory_fields():
     fragment = memory_operations.render(payload, "unused-nonce")
 
     assert 'data-mo-mode="topology"' in fragment
-    assert 'data-mo-mode="inventory"' in fragment
+    assert 'data-mo-mode="cards"' in fragment
+    assert 'data-mo-mode="handoffs"' in fragment
     assert "Care scan" in fragment or "care scan" in fragment.lower()
     assert "Fixture Alpha Card" in fragment
     assert "memory/cards/fixture-alpha.md" in fragment
     assert 'class="mo-tag"' in fragment
     assert "alpha" in fragment and "fixture" in fragment
-    assert "2026-05-01" in fragment
-    assert "2026-12-01" in fragment
-    assert "<th>Title</th>" in fragment
-    assert "<th>Freshness</th>" in fragment
-    assert "<th>Evidence</th>" in fragment
-    # Id column is folded into the Title cell expander, not a standalone header.
-    assert "<th>Id</th>" not in fragment
+    assert 'class="mo-stat-chip"' in fragment
+    assert 'class="mo-filter-chip"' in fragment
+    assert 'class="mo-card-row"' in fragment
+    assert "<th>" not in fragment
 
 
 def test_render_summary_strip_and_pipeline_svg():
@@ -279,7 +277,7 @@ def test_render_inventory_tag_chips_hide_empty_columns_and_fold_id():
     assert "+1 more" in fragment or "+2 more" in fragment or "more" in fragment.lower()
     assert "<th>Id</th>" not in fragment
     assert "card:memory/cards/chip-row.md" in fragment  # still reachable via expander/details
-    assert "Created/Updated not tracked" in fragment or "not tracked" in fragment.lower()
+    assert 'class="mo-row-age">-</time>' in fragment
     assert "<th>Created</th>" not in fragment
     assert "<th>Updated</th>" not in fragment
 
@@ -429,13 +427,17 @@ def test_mode_tabs_expose_aria_and_js_disabled_anchors():
     )
     assert "ARIAROW_sentinel" in fragment
     assert 'id="mo-tab-topology"' in fragment
-    assert 'id="mo-tab-inventory"' in fragment
+    assert 'id="mo-tab-cards"' in fragment
+    assert 'id="mo-tab-handoffs"' in fragment
     assert 'aria-labelledby="mo-tab-topology"' in fragment
-    assert 'aria-labelledby="mo-tab-inventory"' in fragment
+    assert 'aria-labelledby="mo-tab-cards"' in fragment
+    assert 'aria-labelledby="mo-tab-handoffs"' in fragment
     assert 'aria-controls="mo-topology"' in fragment
-    assert 'aria-controls="mo-inventory"' in fragment
+    assert 'aria-controls="mo-cards"' in fragment
+    assert 'aria-controls="mo-handoffs"' in fragment
     assert 'href="#mo-topology"' in fragment
-    assert 'href="#mo-inventory"' in fragment
+    assert 'href="#mo-cards"' in fragment
+    assert 'href="#mo-handoffs"' in fragment
     assert 'tabindex="0"' in fragment
     assert 'tabindex="-1"' in fragment
     # Pagination/filter controls stay delegated + nonced (no inline handlers).
@@ -480,7 +482,7 @@ def test_inventory_pager_structure_exposes_second_page_item_and_prior_next():
     )
     assert "PAGEITEM_0000_SENTINEL" in fragment
     assert "PAGEITEM_0050_SENTINEL" in fragment
-    assert 'data-mo-page-size="50"' in fragment
+    assert 'data-mo-page-size="30"' in fragment
     assert 'data-mo-page="prev"' in fragment
     assert 'data-mo-page="next"' in fragment
     assert "data-mo-page-status" in fragment

--- a/tests/test_memory_inventory_cmd.py
+++ b/tests/test_memory_inventory_cmd.py
@@ -15,6 +15,7 @@ ITEM_FIELDS = {
     "id",
     "title",
     "canonical_path",
+    "size_bytes",
     "logical_destination",
     "store_type",
     "category",
@@ -238,6 +239,22 @@ def test_memory_inventory_schema_pagination_and_item_fields(tmp_path, capsys):
         },
     }
     assert set(item["care"]) == {"issues", "queued_action"}
+
+
+def test_memory_inventory_exposes_sizes_and_master_index_without_card_bodies(tmp_path, capsys):
+    _write_card(tmp_path, "memory/cards/sized.md", title="Sized", body="A compact card body.")
+    master_index = tmp_path / "MEMORY.md"
+    master_index.write_text("# Memory\n\n- [Sized](memory/cards/sized.md)\n", encoding="utf-8")
+
+    payload = _payload(tmp_path, capsys)
+
+    item = next(item for item in payload["items"] if item["canonical_path"] == "memory/cards/sized.md")
+    assert item["size_bytes"] == (tmp_path / "memory/cards/sized.md").stat().st_size
+    assert payload["master_index"] == {
+        "canonical_path": "MEMORY.md",
+        "size_bytes": master_index.stat().st_size,
+    }
+    assert "A compact card body." not in json.dumps(payload)
 
 
 def test_memory_inventory_includes_non_card_canonical_stores_and_filters(tmp_path, capsys):


### PR DESCRIPTION
Fixes #903.

## Summary
- Adds stat-only inventory sizing and master-index metadata, then computes the Cards corpus token budget.
- Replaces sparse inventory controls with a chip cloud, category sections, compact expandable card rows, and 30-row paging.
- Makes Handoffs a Memory Operations sibling tab, preserves Topology, and redirects `/view/handoffs`.
- Reloads Center snapshots so nonce-scoped page assets remain active after refresh.

## Screenshots
Before: operator-accepted ops-deck reference from #903.
After: browser check exercised the Cards default, chip filter, compact inline details, and Handoffs tab against a synthetic inventory fixture.

## Validation
- `./scripts/verify` via Brigade receipt `20260814-140315-work-verify-bad2dd`: 7406 passed, 3 skipped.
- Browser route check for `/view/memory` and legacy Handoffs redirect.
- Memory Handoff lint receipt `20260814-140355-work-verify-006fb8`.