### PR TITLE
feat(memory): project canonical memory into an Obsidian vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `brigade memory project-vault` writes a one-way Obsidian projection of
+  canonical memory into an existing vault: care-state frontmatter and tags,
+  wikilinks, category/harness maps, and a topology canvas. Vault writes use
+  the projection kernel, preserve manual edits via conflict copies, and keep
+  the operator vault path out of public status. (#888)
 - `--run-budget PATH` accepts one `brigade.run_budget.v1` JSON declaration on
   `brigade run`, dogfood, and model-trial starts. Brigade persists the supplied
   declaration in the run and plan receipts without mapping `timeout_seconds`

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -38,7 +38,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade init`: 1 command path(s)
 - `brigade learn` (extras): 13 command path(s)
 - `brigade mcp`: 14 command path(s)
-- `brigade memory`: 17 command path(s)
+- `brigade memory`: 18 command path(s)
 - `brigade model`: 7 command path(s)
 - `brigade notifications` (extras): 4 command path(s)
 - `brigade openclaw-fragments` (extras): 1 command path(s)
@@ -254,6 +254,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade memory init-git`
 - `brigade memory inventory`
 - `brigade memory lint`
+- `brigade memory project-vault`
 - `brigade memory recall`
 - `brigade memory search`
 - `brigade memory serve-mcp`

--- a/src/brigade/cli/memory.py
+++ b/src/brigade/cli/memory.py
@@ -154,6 +154,17 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Filter by owning workflow (repeatable; OR; case-insensitive).",
     )
     p_memory_inventory.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_memory_project_vault = memory_sub.add_parser(
+        "project-vault",
+        help="Project canonical memory one-way into an Obsidian vault subfolder.",
+    )
+    p_memory_project_vault.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace with canonical memory."
+    )
+    p_memory_project_vault.add_argument("--vault", type=Path, required=True, help="Existing Obsidian vault directory.")
+    p_memory_project_vault.add_argument(
+        "--json", action="store_true", help="Print machine-readable projection receipt."
+    )
     p_memory_search = memory_sub.add_parser("search", help="Keyword-search local memory cards.")
     p_memory_search.add_argument("query", help="Search terms (matched against title, tags, summary, and body).")
     p_memory_search.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to search.")
@@ -274,6 +285,10 @@ def dispatch(args) -> int:
             source_harness=args.source_harness,
             owning_workflow=args.owning_workflow,
         )
+    if args.memory_command == "project-vault":
+        from .. import obsidian_vault
+
+        return obsidian_vault.project(target=args.target, vault=args.vault, json_output=args.json)
     if args.memory_command == "care":
         if args.memory_care_command == "init":
             return memory_cmd.init(

--- a/src/brigade/memory_operations.py
+++ b/src/brigade/memory_operations.py
@@ -105,6 +105,7 @@ def topology_payload(target: Path) -> dict[str, Any]:
     _add_manual_refresh_node(nodes)
     _add_care_nodes(nodes, care_entries, care_enabled=care_enabled, care_health=care_health)
     _add_evidence_node(nodes, evidence)
+    _add_obsidian_vault_node(nodes, target)
 
     active_harnesses, config_malformed = _active_writer_harnesses(target, handoff_health)
     ingest_receipt = _normalize_receipt(_latest_ingest_receipt(draft_queue))
@@ -125,6 +126,7 @@ def topology_payload(target: Path) -> dict[str, Any]:
     _add_unknown_adapter_nodes(nodes, edges, target)
     _add_external_scheduler_node(nodes, target)
     _add_care_and_evidence_edges(nodes, edges, care_entries, evidence=evidence, target=target)
+    _add_obsidian_vault_edge(nodes, edges, target)
 
     health = _health_blocks(
         care_health=care_health,
@@ -604,6 +606,50 @@ def _add_evidence_node(nodes: dict[str, dict[str, Any]], evidence: dict[str, Any
         next_action="brigade evidence status",
     )
     nodes["stage:evidence_projection"]["counts"]["status"] = status
+
+
+def _add_obsidian_vault_node(nodes: dict[str, dict[str, Any]], target: Path) -> None:
+    """Expose the optional external vault as a derived, never-canonical node."""
+    try:
+        from . import obsidian_vault
+
+        status = obsidian_vault.status_payload(target)
+    except Exception:  # noqa: BLE001 - topology remains read-only and fail-open
+        status = None
+    if status is None:
+        return
+    nodes["derived:obsidian_vault"] = _node(
+        node_id="derived:obsidian_vault",
+        kind="derived",
+        label="Obsidian vault projection",
+        owner=str(status.get("owner") or BRIGADE_OWNER),
+        authority="derived_writer",
+        state="derived",
+        path=str(status.get("path") or "redacted:operator-vault"),
+        counts={"drift_count": status.get("drift_count")},
+        latest_run=status.get("latest_run"),
+        next_action="brigade memory project-vault --vault <path>",
+    )
+
+
+def _add_obsidian_vault_edge(nodes: dict[str, dict[str, Any]], edges: list[dict[str, Any]], target: Path) -> None:
+    if "derived:obsidian_vault" not in nodes:
+        return
+    node = nodes["derived:obsidian_vault"]
+    latest_run = node.get("latest_run")
+    receipt = _normalize_receipt(latest_run if isinstance(latest_run, dict) else None)
+    edges.append(
+        _edge(
+            edge_id="edge:canonical:obsidian_vault",
+            frm="canonical:cards",
+            to="derived:obsidian_vault",
+            flow="project",
+            authority="derived_writer",
+            writer_component="obsidian-vault",
+            latest_receipt=receipt,
+            enabled=True,
+        )
+    )
 
 
 def _active_writer_harnesses(target: Path, handoff_health: Any) -> tuple[list[tuple[str, str, bool, int, int]], bool]:

--- a/src/brigade/obsidian_vault.py
+++ b/src/brigade/obsidian_vault.py
@@ -20,6 +20,7 @@ PROJECTION_FOLDER = "Brigade Memory"
 LEDGER_DIR = ".brigade/memory-vault"
 LEDGER_SCHEMA = "brigade.obsidian-vault.ledger.v1"
 _BEARER_RE = re.compile(r"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+")
+_AUTHORIZATION_RE = re.compile(r"(?i)(\bauthorization\s*:\s*)[^\r\n]*")
 
 
 def project(*, target: Path, vault: Path, json_output: bool = False) -> int:
@@ -79,6 +80,13 @@ def _project_payload(*, target: Path, vault: Path) -> dict[str, Any]:
         expected = prior_files.get(relative)
         live = _digest(current)
         desired_digest = kernel.content_digest(content)
+        if _is_nonregular_destination(current):
+            drift.append(relative if expected is not None else f"untracked:{relative}")
+            conflict = _conflict_destination(relative, root=root, prior_files=prior_files)
+            current = root / conflict
+            relative = conflict
+            live = _digest(current)
+            expected = prior_files.get(relative)
         if expected is None and live != kernel.ABSENT:
             conflict = _conflict_destination(relative, root=root, prior_files=prior_files)
             current = root / conflict
@@ -196,7 +204,11 @@ def _project_payload(*, target: Path, vault: Path) -> dict[str, Any]:
         receipt["completed_at"] = ledger_receipt["completed_at"]
     return {
         "schema": "brigade.obsidian-vault.receipt.v1",
-        "written": sum(1 for item in receipt["destinations"] if item.get("mutation") != "remove"),
+        "written": (
+            sum(1 for item in receipt["destinations"] if item.get("mutation") != "remove")
+            if receipt["terminal_state"] == "committed"
+            else 0
+        ),
         "unchanged": unchanged,
         "drift": drift,
         "receipt": receipt,
@@ -212,10 +224,8 @@ def _render_projection(target: Path, *, root: Path, prior_files: dict[str, str])
     rendered: dict[str, bytes] = {}
     for record in records:
         rendered[record["path"]] = _render_note(record, links[record["id"]])
-    for category, members in _groups(records, "category").items():
-        rendered[f"Maps/Categories/{_safe_name(category)}.md"] = _render_map("category", category, members)
-    for harness, members in _groups(records, "source_harness").items():
-        rendered[f"Maps/Harnesses/{_safe_name(harness)}.md"] = _render_map("harness", harness, members)
+    _render_maps(rendered, "category", "Categories", _groups(records, "category"))
+    _render_maps(rendered, "harness", "Harnesses", _groups(records, "source_harness"))
     rendered["Brigade Memory.canvas"] = _render_canvas(target, records, links)
     return rendered
 
@@ -348,6 +358,25 @@ def _render_map(kind: str, name: str, members: list[dict[str, Any]]) -> bytes:
     return "\n".join(lines).encode()
 
 
+def _render_maps(rendered: dict[str, bytes], kind: str, folder: str, groups: dict[str, list[dict[str, Any]]]) -> None:
+    used: set[str] = set()
+    for name, members in groups.items():
+        stem = _unique_map_stem(name, used)
+        rendered[f"Maps/{folder}/{stem}.md"] = _render_map(kind, name, members)
+
+
+def _unique_map_stem(name: str, used: set[str]) -> str:
+    base = _safe_name(name)
+    candidate = base
+    attempt = 1
+    while candidate.lower() in used:
+        suffix = _sha256(name)[:8] if attempt == 1 else f"{_sha256(name)[:8]}-{attempt}"
+        candidate = f"{base}-{suffix}"
+        attempt += 1
+    used.add(candidate.lower())
+    return candidate
+
+
 def _render_canvas(target: Path, records: list[dict[str, Any]], links: dict[str, list[dict[str, Any]]]) -> bytes:
     topology = memory_operations.topology_payload(target)
     records_sorted = sorted(records, key=lambda item: item["id"])
@@ -425,7 +454,12 @@ def _groups(records: list[dict[str, Any]], field: str) -> dict[str, list[dict[st
 def _wikilink(record: dict[str, Any]) -> str:
     path = str(record.get("link_path") or record["path"])
     target = path.removesuffix(".md")
-    return f"[[{_redacted_scalar(target)}|{_redacted_scalar(record['title'])}]]"
+    return f"[[{_escape_wikilink(target)}|{_escape_wikilink(str(record['title']))}]]"
+
+
+def _escape_wikilink(value: str) -> str:
+    text = _redacted_scalar(value)
+    return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]").replace("|", "\\|")
 
 
 def _references(frontmatter: dict[str, Any]) -> list[str]:
@@ -499,6 +533,14 @@ def _digest(path: Path) -> str:
         return kernel.ABSENT
 
 
+def _exists_or_symlink(path: Path) -> bool:
+    return path.exists() or path.is_symlink()
+
+
+def _is_nonregular_destination(path: Path) -> bool:
+    return _exists_or_symlink(path) and (path.is_symlink() or not path.is_file())
+
+
 def _conflict_destination(relative: str, *, root: Path, prior_files: dict[str, str]) -> str:
     """Allocate a generated conflict path without treating vault contents as trusted."""
     attempt = 1
@@ -506,7 +548,9 @@ def _conflict_destination(relative: str, *, root: Path, prior_files: dict[str, s
         candidate = _conflict_path(relative, _sha256(relative), attempt=attempt)
         expected = prior_files.get(candidate)
         live = _digest(root / candidate)
-        if (expected is None and live == kernel.ABSENT) or (expected is not None and live == expected):
+        if (expected is None and not _exists_or_symlink(root / candidate)) or (
+            expected is not None and live == expected
+        ):
             return candidate
         attempt += 1
 
@@ -518,7 +562,7 @@ def _conflict_path(relative: str, digest: str, *, attempt: int = 1) -> str:
 
 
 def _safe_name(value: str) -> str:
-    cleaned = re.sub(r"[\\/:*?\"<>|]+", "-", _redacted_scalar(value)).strip(" .")
+    cleaned = re.sub(r"[\\/:*?\"<>|\[\]]+", "-", _redacted_scalar(value)).strip(" .")
     return cleaned or "untitled"
 
 
@@ -527,8 +571,10 @@ def _redacted_scalar(value: object) -> str:
 
 
 def _redact(value: str) -> str:
-    """Apply the content guard and the bounded bearer-token rule used by projections."""
-    return _BEARER_RE.sub(r"\1 [redacted]", redact_text(value))
+    """Apply the content guard and remove credentials from authorization headers."""
+    redacted = redact_text(value)
+    redacted = _AUTHORIZATION_RE.sub(r"\1[redacted]", redacted)
+    return _BEARER_RE.sub(r"\1 [redacted]", redacted)
 
 
 def _yaml(value: object) -> str:

--- a/src/brigade/obsidian_vault.py
+++ b/src/brigade/obsidian_vault.py
@@ -1,0 +1,561 @@
+"""One-way, transaction-backed projection of canonical memory into Obsidian."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from . import memory_cmd, memory_operations
+from .card_identity import card_identity
+from .guard import redact_text
+from .projection import kernel
+
+PROJECTOR = "obsidian-vault"
+PROJECTION_FOLDER = "Brigade Memory"
+LEDGER_DIR = ".brigade/memory-vault"
+LEDGER_SCHEMA = "brigade.obsidian-vault.ledger.v1"
+_BEARER_RE = re.compile(r"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+")
+
+
+def project(*, target: Path, vault: Path, json_output: bool = False) -> int:
+    """Project canonical memory to an operator-selected vault without reading it as content."""
+    target = target.expanduser().resolve()
+    vault = vault.expanduser().resolve()
+    if not target.is_dir():
+        return _error(f"--target is not a directory: {target}")
+    if not vault.is_dir():
+        return _error(f"--vault is not a directory: {vault}")
+
+    payload = _project_payload(target=target, vault=vault)
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            "memory vault projection: "
+            f"written={payload['written']} unchanged={payload['unchanged']} drift={len(payload['drift'])}"
+        )
+    return 0 if payload["receipt"]["terminal_state"] in {"committed", "unchanged"} else 1
+
+
+def status_payload(target: Path) -> dict[str, Any] | None:
+    """Return public, untrusted-data-safe status for the topology contract."""
+    target = target.expanduser().resolve()
+    ledgers = _ledgers(target)
+    if not ledgers:
+        return None
+    latest_path, ledger = max(ledgers, key=lambda item: item[0].stat().st_mtime_ns)
+    root_text = ledger.get("projection_root")
+    root = Path(root_text) if isinstance(root_text, str) else None
+    drift = _drift(root, _ledger_files(ledger)) if root is not None else ["ledger-invalid"]
+    receipt_value = ledger.get("receipt")
+    receipt: dict[str, Any] = receipt_value if isinstance(receipt_value, dict) else {}
+    return {
+        "status": "warn" if drift else "ok",
+        "owner": "brigade",
+        "path": "redacted:operator-vault",
+        "drift_count": len(drift),
+        "latest_run": _public_receipt(receipt),
+        "ledger": latest_path.name,
+    }
+
+
+def _project_payload(*, target: Path, vault: Path) -> dict[str, Any]:
+    root = vault / PROJECTION_FOLDER
+    ledger_path = _ledger_path(target, vault)
+    ledger = _read_ledger(ledger_path)
+    prior_files = _ledger_files(ledger)
+    desired = _render_projection(target, root=root, prior_files=prior_files)
+    drift = _drift(root, prior_files)
+    mutations: list[kernel.MutationSpec] = []
+    actual_files: dict[str, str] = dict(prior_files)
+
+    for relative, content in desired.items():
+        current = root / relative
+        expected = prior_files.get(relative)
+        live = _digest(current)
+        desired_digest = kernel.content_digest(content)
+        if expected is None and live != kernel.ABSENT:
+            conflict = _conflict_destination(relative, root=root, prior_files=prior_files)
+            current = root / conflict
+            relative = conflict
+            live = _digest(current)
+            expected = prior_files.get(relative)
+        if expected is not None and live != expected:
+            # A vault edit is untrusted data. Preserve it rather than merging or overwriting it.
+            drift.append(relative)
+            conflict = _conflict_destination(relative, root=root, prior_files=prior_files)
+            current = root / conflict
+            relative = conflict
+            live = _digest(current)
+            expected = prior_files.get(relative)
+        if expected == desired_digest and live == desired_digest:
+            actual_files[relative] = desired_digest
+            continue
+        if expected is None:
+            expected = live
+        if live != expected:
+            # A collision on a conflict copy is also untrusted. Leave it and report the drift.
+            drift.append(relative)
+            continue
+        mutations.append(
+            kernel.mutation(
+                destination=current,
+                mutation="create" if live == kernel.ABSENT else "replace",
+                expected_before=live,
+                desired_after=desired_digest,
+                staged_bytes=content,
+                display_path=f"vault/{PROJECTION_FOLDER}/{relative}",
+            )
+        )
+        actual_files[relative] = desired_digest
+
+    desired_paths = set(desired)
+    for relative, expected in prior_files.items():
+        if relative in desired_paths or relative in drift or ".conflict-" in relative:
+            continue
+        current = root / relative
+        if _digest(current) != expected:
+            drift.append(relative)
+            continue
+        mutations.append(
+            kernel.mutation(
+                destination=current,
+                mutation="remove",
+                expected_before=expected,
+                desired_after=kernel.ABSENT,
+                display_path=f"vault/{PROJECTION_FOLDER}/{relative}",
+            )
+        )
+        actual_files.pop(relative, None)
+
+    drift = sorted(set(drift))
+    unchanged = sum(
+        1 for relative, content in desired.items() if prior_files.get(relative) == kernel.content_digest(content)
+    )
+    if not mutations:
+        return {
+            "schema": "brigade.obsidian-vault.receipt.v1",
+            "written": 0,
+            "unchanged": unchanged,
+            "drift": drift,
+            "receipt": {
+                "terminal_state": "unchanged",
+                "mutation_counts": {"total": 0, "create": 0, "replace": 0, "remove": 0},
+            },
+        }
+
+    source_digest = _sha256(json.dumps({key: value.decode("utf-8") for key, value in desired.items()}, sort_keys=True))
+    operation_id = f"obsidian-vault-{source_digest[:16]}-{uuid.uuid4().hex[:12]}"
+    ledger_receipt = {
+        "operation_id": operation_id,
+        "terminal_state": "committed",
+        "completed_at": _utc_now(),
+    }
+    receipt_seed = {
+        "schema": LEDGER_SCHEMA,
+        "projection_root": str(root),
+        "files": actual_files,
+        "receipt": ledger_receipt,
+    }
+    # The ledger shares the same transaction as every vault note, map, and canvas.
+    receipt_bytes = json.dumps(receipt_seed, indent=2, sort_keys=True).encode() + b"\n"
+    ledger_live = _digest(ledger_path)
+    mutations.append(
+        kernel.mutation(
+            destination=ledger_path,
+            mutation="create" if ledger_live == kernel.ABSENT else "replace",
+            expected_before=ledger_live,
+            desired_after=kernel.content_digest(receipt_bytes),
+            staged_bytes=receipt_bytes,
+            display_path=".brigade/memory-vault/ledger.json",
+        )
+    )
+    try:
+        plan = kernel.build_plan(
+            operation_id=operation_id,
+            projector=PROJECTOR,
+            source_fingerprint=source_digest,
+            mutations=mutations,
+            target=target,
+        )
+        receipt = kernel.execute(plan, target=target).to_dict()
+    except kernel.ProjectionError as exc:
+        return {
+            "schema": "brigade.obsidian-vault.receipt.v1",
+            "written": 0,
+            "unchanged": unchanged,
+            "drift": drift,
+            "receipt": {"terminal_state": "failed", "diagnostic": exc.diagnostic, "mutation_counts": {"total": 0}},
+        }
+    if receipt["terminal_state"] == "committed":
+        receipt["completed_at"] = ledger_receipt["completed_at"]
+    return {
+        "schema": "brigade.obsidian-vault.receipt.v1",
+        "written": sum(1 for item in receipt["destinations"] if item.get("mutation") != "remove"),
+        "unchanged": unchanged,
+        "drift": drift,
+        "receipt": receipt,
+    }
+
+
+def _render_projection(target: Path, *, root: Path, prior_files: dict[str, str]) -> dict[str, bytes]:
+    inventory = _inventory(target)
+    records = [_record(target, item) for item in inventory]
+    _assign_paths(records)
+    _assign_link_paths(records, root=root, prior_files=prior_files)
+    links = _relationships(records)
+    rendered: dict[str, bytes] = {}
+    for record in records:
+        rendered[record["path"]] = _render_note(record, links[record["id"]])
+    for category, members in _groups(records, "category").items():
+        rendered[f"Maps/Categories/{_safe_name(category)}.md"] = _render_map("category", category, members)
+    for harness, members in _groups(records, "source_harness").items():
+        rendered[f"Maps/Harnesses/{_safe_name(harness)}.md"] = _render_map("harness", harness, members)
+    rendered["Brigade Memory.canvas"] = _render_canvas(target, records, links)
+    return rendered
+
+
+def _inventory(target: Path) -> list[dict[str, Any]]:
+    offset = 0
+    items: list[dict[str, Any]] = []
+    while True:
+        page = memory_operations.inventory_payload(target, offset=offset, limit=memory_operations.INVENTORY_MAX_LIMIT)
+        batch = page["items"]
+        items.extend(item for item in batch if isinstance(item, dict))
+        if not page["pagination"]["has_more"]:
+            return items
+        offset = int(page["pagination"]["next_offset"])
+
+
+def _record(target: Path, item: dict[str, Any]) -> dict[str, Any]:
+    rel = str(item["canonical_path"])
+    path = target / rel
+    text = path.read_text(encoding="utf-8", errors="replace")
+    frontmatter, _ = memory_cmd._parse_frontmatter(text)
+    stable_id = card_identity(frontmatter, rel).card_id if item.get("store_type") == "card" else str(item["id"])
+    return {
+        "id": stable_id,
+        "item": item,
+        "title": str(item["title"]),
+        "body": _without_frontmatter(text),
+        "references": _references(frontmatter),
+    }
+
+
+def _assign_paths(records: list[dict[str, Any]]) -> None:
+    used: set[str] = set()
+    folders = {"card": "Cards", "rule": "Rules", "tools": "Tools", "user": "User", "learning": "Learnings"}
+    for record in sorted(records, key=lambda item: (str(item["item"]["store_type"]), item["title"], item["id"])):
+        folder = folders[str(record["item"]["store_type"])]
+        base = _safe_name(record["title"])
+        candidate = f"{folder}/{base}.md"
+        if candidate.lower() in used:
+            candidate = f"{folder}/{base}-{_sha256(record['id'])[:8]}.md"
+        used.add(candidate.lower())
+        record["path"] = candidate
+
+
+def _assign_link_paths(records: list[dict[str, Any]], *, root: Path, prior_files: dict[str, str]) -> None:
+    """Link to a generated conflict copy when the canonical note's normal path drifted."""
+    for record in records:
+        path = str(record["path"])
+        expected = prior_files.get(path)
+        live = _digest(root / path)
+        if (expected is None and live != kernel.ABSENT) or (expected is not None and live != expected):
+            record["link_path"] = _conflict_destination(path, root=root, prior_files=prior_files)
+        else:
+            record["link_path"] = path
+
+
+def _relationships(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    by_source = {str(record["item"]["canonical_path"]): record for record in records}
+    result: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        related: dict[str, dict[str, Any]] = {}
+        item = record["item"]
+        tags = {str(tag).lower() for tag in item.get("tags") or []}
+        category = str(item.get("category") or "")
+        for other in records:
+            if other is record:
+                continue
+            other_item = other["item"]
+            if category and category == str(other_item.get("category") or ""):
+                related[other["id"]] = other
+                continue
+            if tags & {str(tag).lower() for tag in other_item.get("tags") or []}:
+                related[other["id"]] = other
+        for reference in record["references"]:
+            referenced = by_source.get(reference)
+            if referenced is not None and referenced is not record:
+                related[referenced["id"]] = referenced
+        result[record["id"]] = sorted(related.values(), key=lambda item: (item["title"], item["id"]))
+    return result
+
+
+def _render_note(record: dict[str, Any], related: list[dict[str, Any]]) -> bytes:
+    item = record["item"]
+    fresh_until = item.get("fresh_until")
+    care_state = str(item.get("freshness") or "missing")
+    tags = [str(tag) for tag in item.get("tags") or []]
+    tags.extend([f"care/{care_state}", f"harness/{item.get('source_harness') or 'unknown'}"])
+    if fresh_until:
+        tags.append(f"freshness/{fresh_until}")
+    tags = list(dict.fromkeys(_redacted_scalar(tag) for tag in tags if _redacted_scalar(tag)))
+    frontmatter = [
+        "---",
+        "generated: true",
+        f"canonical_id: {_yaml(record['id'])}",
+        f"canonical_path: {_yaml(item['canonical_path'])}",
+        f"title: {_yaml(record['title'])}",
+        f"store_type: {_yaml(item['store_type'])}",
+        f"category: {_yaml(item.get('category') or 'uncategorized')}",
+        f"care_state: {_yaml(care_state)}",
+        f"freshness: {_yaml(care_state)}",
+        f"freshness_date: {_yaml(fresh_until) if fresh_until else 'null'}",
+        f"review_state: {_yaml(item.get('review_state') or 'missing')}",
+        f"source_harness: {_yaml(item.get('source_harness') or 'unknown')}",
+        "tags:",
+        *[f"  - {_yaml(tag)}" for tag in tags],
+        "---",
+        "",
+        f"# {_redacted_scalar(record['title'])}",
+        "",
+        _redact(record["body"]),
+    ]
+    if related:
+        frontmatter.extend(["", "## Related", "", *[f"- {_wikilink(other)}" for other in related]])
+    return ("\n".join(frontmatter).rstrip() + "\n").encode()
+
+
+def _render_map(kind: str, name: str, members: list[dict[str, Any]]) -> bytes:
+    lines = [
+        "---",
+        "generated: true",
+        f"map_kind: {_yaml(kind)}",
+        f"map_value: {_yaml(name)}",
+        "---",
+        "",
+        f"# {kind.title()}: {_redacted_scalar(name)}",
+        "",
+        *[f"- {_wikilink(member)}" for member in members],
+        "",
+    ]
+    return "\n".join(lines).encode()
+
+
+def _render_canvas(target: Path, records: list[dict[str, Any]], links: dict[str, list[dict[str, Any]]]) -> bytes:
+    topology = memory_operations.topology_payload(target)
+    records_sorted = sorted(records, key=lambda item: item["id"])
+    nodes = [
+        {
+            "id": f"card-{_sha256(record['id'])[:16]}",
+            "type": "text",
+            "text": _redacted_scalar(record["title"]),
+            "x": index * 260,
+            "y": 0,
+            "width": 220,
+            "height": 80,
+        }
+        for index, record in enumerate(records_sorted)
+    ]
+    node_ids = {record["id"]: node["id"] for record, node in zip(records_sorted, nodes, strict=True)}
+    edges = []
+    seen: set[tuple[str, str]] = set()
+    for record in records:
+        for other in links[record["id"]]:
+            pair = tuple(sorted((record["id"], other["id"])))
+            if pair in seen:
+                continue
+            seen.add(pair)
+            edges.append(
+                {
+                    "id": f"edge-{_sha256(':'.join(pair))[:16]}",
+                    "fromNode": node_ids[pair[0]],
+                    "toNode": node_ids[pair[1]],
+                }
+            )
+    # The canvas is intentionally structural. Volatile receipts and this projection's
+    # own derived node are omitted so a no-change rerun has no canvas mutation.
+    topology_nodes = [
+        node
+        for node in topology["nodes"]
+        if isinstance(node, dict) and str(node.get("id") or "") != "derived:obsidian_vault"
+    ]
+    topology_ids: dict[str, str] = {}
+    for index, node in enumerate(sorted(topology_nodes, key=lambda item: str(item["id"]))):
+        original_id = str(node["id"])
+        canvas_id = f"topology:{original_id}"
+        topology_ids[original_id] = canvas_id
+        nodes.append(
+            {
+                "id": canvas_id,
+                "type": "text",
+                "text": _redacted_scalar(node.get("label") or original_id),
+                "x": index * 260,
+                "y": 180,
+                "width": 220,
+                "height": 80,
+            }
+        )
+    for edge in sorted(topology["edges"], key=lambda item: str(item.get("id") or "")):
+        if not isinstance(edge, dict):
+            continue
+        frm = topology_ids.get(str(edge.get("from") or ""))
+        to = topology_ids.get(str(edge.get("to") or ""))
+        if frm is not None and to is not None:
+            edges.append({"id": f"topology:{edge['id']}", "fromNode": frm, "toNode": to})
+    return (
+        json.dumps({"brigade_generated": True, "nodes": nodes, "edges": edges}, indent=2, sort_keys=True) + "\n"
+    ).encode()
+
+
+def _groups(records: list[dict[str, Any]], field: str) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        value = str(record["item"].get(field) or "uncategorized")
+        groups.setdefault(value, []).append(record)
+    return {key: sorted(value, key=lambda item: (item["title"], item["id"])) for key, value in sorted(groups.items())}
+
+
+def _wikilink(record: dict[str, Any]) -> str:
+    path = str(record.get("link_path") or record["path"])
+    target = path.removesuffix(".md")
+    return f"[[{_redacted_scalar(target)}|{_redacted_scalar(record['title'])}]]"
+
+
+def _references(frontmatter: dict[str, Any]) -> list[str]:
+    values: list[Any] = []
+    for key in ("references", "refs", "related", "links"):
+        value = frontmatter.get(key)
+        values.extend(value if isinstance(value, list) else [value])
+    found: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        candidate = value.strip().replace("\\", "/")
+        if candidate.endswith(".md") and not candidate.startswith(("/", "~", "..")) and candidate not in found:
+            found.append(candidate)
+    return found
+
+
+def _without_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    lines = text.splitlines(keepends=True)
+    for index, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            return "".join(lines[index + 1 :])
+    return text
+
+
+def _ledgers(target: Path) -> list[tuple[Path, dict[str, Any]]]:
+    root = target / LEDGER_DIR
+    if not root.is_dir():
+        return []
+    return [(path, payload) for path in root.glob("*.json") if (payload := _read_ledger(path))]
+
+
+def _ledger_path(target: Path, vault: Path) -> Path:
+    return target / LEDGER_DIR / f"{_sha256(str(vault))[:24]}.json"
+
+
+def _read_ledger(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) and payload.get("schema") == LEDGER_SCHEMA else {}
+
+
+def _ledger_files(ledger: dict[str, Any]) -> dict[str, str]:
+    files = ledger.get("files")
+    if not isinstance(files, dict):
+        return {}
+    return {
+        str(path): str(digest) for path, digest in files.items() if isinstance(path, str) and isinstance(digest, str)
+    }
+
+
+def _drift(root: Path | None, expected: dict[str, str]) -> list[str]:
+    if root is None:
+        return ["ledger-invalid"]
+    drift = [relative for relative, digest in expected.items() if _digest(root / relative) != digest]
+    if root.is_dir():
+        for path in root.rglob("*"):
+            if path.is_file() and path.relative_to(root).as_posix() not in expected:
+                drift.append(f"untracked:{path.relative_to(root).as_posix()}")
+    return sorted(set(drift))
+
+
+def _digest(path: Path) -> str:
+    try:
+        return kernel.content_digest(path.read_bytes()) if path.is_file() and not path.is_symlink() else kernel.ABSENT
+    except OSError:
+        return kernel.ABSENT
+
+
+def _conflict_destination(relative: str, *, root: Path, prior_files: dict[str, str]) -> str:
+    """Allocate a generated conflict path without treating vault contents as trusted."""
+    attempt = 1
+    while True:
+        candidate = _conflict_path(relative, _sha256(relative), attempt=attempt)
+        expected = prior_files.get(candidate)
+        live = _digest(root / candidate)
+        if (expected is None and live == kernel.ABSENT) or (expected is not None and live == expected):
+            return candidate
+        attempt += 1
+
+
+def _conflict_path(relative: str, digest: str, *, attempt: int = 1) -> str:
+    path = Path(relative)
+    suffix = digest[:8] if attempt == 1 else f"{digest[:8]}-{attempt}"
+    return (path.parent / f"{path.stem}.conflict-{suffix}{path.suffix}").as_posix()
+
+
+def _safe_name(value: str) -> str:
+    cleaned = re.sub(r"[\\/:*?\"<>|]+", "-", _redacted_scalar(value)).strip(" .")
+    return cleaned or "untitled"
+
+
+def _redacted_scalar(value: object) -> str:
+    return _redact(str(value)).replace("\r", " ").replace("\n", " ").strip()
+
+
+def _redact(value: str) -> str:
+    """Apply the content guard and the bounded bearer-token rule used by projections."""
+    return _BEARER_RE.sub(r"\1 [redacted]", redact_text(value))
+
+
+def _yaml(value: object) -> str:
+    text = _redacted_scalar(value)
+    return text if re.fullmatch(r"[A-Za-z0-9_./-]+", text) else json.dumps(text)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _public_receipt(receipt: dict[str, Any]) -> dict[str, Any] | None:
+    if not receipt:
+        return None
+    return {
+        "run_id": receipt.get("operation_id"),
+        "status": receipt.get("terminal_state"),
+        "completed_at": receipt.get("completed_at"),
+    }
+
+
+def _error(message: str) -> int:
+    import sys
+
+    print(f"error: {message}", file=sys.stderr)
+    return 2

--- a/tests/test_memory_vault_projection.py
+++ b/tests/test_memory_vault_projection.py
@@ -1,0 +1,179 @@
+"""Acceptance tests for the optional Obsidian vault projection (#888)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, obsidian_vault
+from brigade.projection import kernel
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    """A throwaway Obsidian vault, never an operator vault."""
+    path = tmp_path / "vault"
+    path.mkdir()
+    return path
+
+
+def _write_card(target: Path, name: str, *, title: str, body: str, tags: list[str]) -> None:
+    path = target / "memory" / "cards" / f"{name}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = {"alpha": "00000000000a", "beta": "00000000000b"}[name]
+    path.write_text(
+        "\n".join(
+            [
+                "---",
+                f"id: card-00000000-0000-4000-8000-{suffix}",
+                f"title: {title}",
+                "category: operations",
+                f"tags: {json.dumps(tags)}",
+                "fresh_until: 2099-01-01",
+                "last_reviewed: 2026-08-14",
+                "source_harness: codex",
+                'refs: ["memory/cards/beta.md"]' if name == "alpha" else "refs: []",
+                "---",
+                body,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _project(target: Path, vault: Path, capsys) -> dict:
+    assert cli.main(["memory", "project-vault", "--target", str(target), "--vault", str(vault), "--json"]) == 0
+    return json.loads(capsys.readouterr().out)
+
+
+def test_project_vault_is_linked_redacted_idempotent_and_reports_drift(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_card(
+        tmp_path,
+        "alpha",
+        title="Alpha",
+        tags=["operations", "shared"],
+        body="Use the canonical process. Authorization: Bearer should-not-escape.",
+    )
+    _write_card(tmp_path, "beta", title="Beta", tags=["operations", "shared"], body="Related guidance.")
+    (tmp_path / "rules").mkdir()
+    (tmp_path / "rules" / "retention.md").write_text("---\ntitle: Retention\n---\nKeep records.\n", encoding="utf-8")
+    (tmp_path / "TOOLS.md").write_text("---\ntitle: Tool Notes\n---\nUse approved tools.\n", encoding="utf-8")
+
+    first = _project(tmp_path, vault, capsys)
+
+    projection = vault / "Brigade Memory"
+    alpha = projection / "Cards" / "Alpha.md"
+    beta = projection / "Cards" / "Beta.md"
+    assert first["written"] > 0
+    assert alpha.is_file() and beta.is_file()
+    assert (projection / "Rules" / "Retention.md").is_file()
+    assert (projection / "Tools" / "Tool Notes.md").is_file()
+    text = alpha.read_text(encoding="utf-8")
+    assert "generated: true" in text
+    assert "care_state: fresh" in text
+    assert "freshness_date: 2099-01-01" in text
+    assert "source_harness: codex" in text
+    assert "care/fresh" in text and "harness/codex" in text
+    assert "[[Cards/Beta|Beta]]" in text
+    assert "should-not-escape" not in text
+    assert (projection / "Maps" / "Categories" / "operations.md").read_text(encoding="utf-8").count("[[") == 2
+    assert "generated: true" in (projection / "Maps" / "Harnesses" / "codex.md").read_text(encoding="utf-8")
+    canvas = json.loads((projection / "Brigade Memory.canvas").read_text(encoding="utf-8"))
+    assert canvas["nodes"] and canvas["edges"]
+    assert any(node["id"] == "topology:canonical:cards" for node in canvas["nodes"])
+    assert any(edge["id"] == "topology:edge:ingest:write:cards" for edge in canvas["edges"])
+
+    before = {path.relative_to(projection): path.stat().st_mtime_ns for path in projection.rglob("*") if path.is_file()}
+    second = _project(tmp_path, vault, capsys)
+    after = {path.relative_to(projection): path.stat().st_mtime_ns for path in projection.rglob("*") if path.is_file()}
+    assert second["written"] == 0
+    assert second["receipt"]["mutation_counts"]["total"] == 0
+    assert before == after
+
+    alpha.write_text(text + "\nmanual vault edit\n", encoding="utf-8")
+    drifted = _project(tmp_path, vault, capsys)
+    assert "Cards/Alpha.md" in drifted["drift"]
+    assert "manual vault edit" in alpha.read_text(encoding="utf-8")
+    beta_text = beta.read_text(encoding="utf-8")
+    assert "[[Cards/Alpha.conflict-" in beta_text
+
+    assert cli.main(["memory", "topology", "--target", str(tmp_path), "--json"]) == 0
+    topology = json.loads(capsys.readouterr().out)
+    node = next(item for item in topology["nodes"] if item["id"] == "derived:obsidian_vault")
+    assert node["owner"] == "brigade"
+    assert node["latest_run"] is not None
+
+
+def test_project_vault_restores_the_vault_when_a_transaction_fails(
+    tmp_path: Path, vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha", tags=["operations"], body="Canonical note.")
+    real_execute = obsidian_vault.kernel.execute
+
+    def fail_during_commit(plan, *, target):
+        return real_execute(plan, target=target, inject=kernel.FailureInjector(boundary="commit:2:before"))
+
+    monkeypatch.setattr(obsidian_vault.kernel, "execute", fail_during_commit)
+
+    result = obsidian_vault._project_payload(target=tmp_path, vault=vault)
+
+    assert result["receipt"]["terminal_state"] == "restored"
+    projection = vault / "Brigade Memory"
+    assert not [path for path in projection.rglob("*") if path.is_file()]
+    assert not list((tmp_path / ".brigade" / "memory-vault").glob("*.json"))
+
+
+def test_project_vault_writes_a_conflict_copy_without_clobbering_existing_vault_data(
+    tmp_path: Path, vault: Path, capsys
+) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha", tags=["operations"], body="Canonical note.")
+    existing = vault / "Brigade Memory" / "Cards" / "Alpha.md"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("operator-owned note\n", encoding="utf-8")
+
+    receipt = _project(tmp_path, vault, capsys)
+
+    assert "untracked:Cards/Alpha.md" in receipt["drift"]
+    assert existing.read_text(encoding="utf-8") == "operator-owned note\n"
+    assert list(existing.parent.glob("Alpha.conflict-*.md"))
+
+
+def test_project_vault_skips_a_manually_edited_conflict_copy_when_linking(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha", tags=["operations"], body="Canonical alpha.")
+    _write_card(tmp_path, "beta", title="Beta", tags=["operations"], body="Canonical beta.")
+    root = vault / "Brigade Memory" / "Cards"
+    root.mkdir(parents=True)
+    (root / "Alpha.md").write_text("operator-owned base\n", encoding="utf-8")
+    (root / "Alpha.conflict-ea62791a.md").write_text("operator-owned conflict\n", encoding="utf-8")
+
+    _project(tmp_path, vault, capsys)
+
+    beta = (root / "Beta.md").read_text(encoding="utf-8")
+    assert "[[Cards/Alpha.conflict-ea62791a-2|Alpha]]" in beta
+    assert (root / "Alpha.conflict-ea62791a.md").read_text(encoding="utf-8") == "operator-owned conflict\n"
+
+
+def test_project_vault_does_not_reuse_an_unfinished_transaction_journal(
+    tmp_path: Path, vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha", tags=["operations"], body="Canonical note.")
+    real_execute = obsidian_vault.kernel.execute
+    operation_ids: list[str] = []
+
+    def crash_before_first_write(plan, *, target):
+        operation_ids.append(plan.operation_id)
+        return real_execute(plan, target=target, inject=kernel.FailureInjector(crash_after=0))
+
+    monkeypatch.setattr(obsidian_vault.kernel, "execute", crash_before_first_write)
+    first = obsidian_vault._project_payload(target=tmp_path, vault=vault)
+    second = obsidian_vault._project_payload(target=tmp_path, vault=vault)
+
+    assert first["receipt"]["terminal_state"] == "recovery-required"
+    assert second["receipt"]["terminal_state"] == "failed"
+    assert len(operation_ids) == 2
+    assert operation_ids[0] != operation_ids[1]
+    assert kernel.operation_dir(tmp_path, operation_ids[0]).is_dir()
+    assert not kernel.operation_dir(tmp_path, operation_ids[1]).exists()

--- a/tests/test_memory_vault_projection.py
+++ b/tests/test_memory_vault_projection.py
@@ -19,7 +19,9 @@ def vault(tmp_path: Path) -> Path:
     return path
 
 
-def _write_card(target: Path, name: str, *, title: str, body: str, tags: list[str]) -> None:
+def _write_card(
+    target: Path, name: str, *, title: str, body: str, tags: list[str], category: str = "operations"
+) -> None:
     path = target / "memory" / "cards" / f"{name}.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     suffix = {"alpha": "00000000000a", "beta": "00000000000b"}[name]
@@ -29,7 +31,7 @@ def _write_card(target: Path, name: str, *, title: str, body: str, tags: list[st
                 "---",
                 f"id: card-00000000-0000-4000-8000-{suffix}",
                 f"title: {title}",
-                "category: operations",
+                f"category: {category}",
                 f"tags: {json.dumps(tags)}",
                 "fresh_until: 2099-01-01",
                 "last_reviewed: 2026-08-14",
@@ -107,6 +109,22 @@ def test_project_vault_is_linked_redacted_idempotent_and_reports_drift(tmp_path:
     assert node["latest_run"] is not None
 
 
+def test_project_vault_redacts_basic_authorization_credentials(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_card(
+        tmp_path,
+        "alpha",
+        title="Alpha",
+        tags=["operations"],
+        body="Authorization: Basic should-not-escape",
+    )
+
+    _project(tmp_path, vault, capsys)
+
+    text = (vault / "Brigade Memory" / "Cards" / "Alpha.md").read_text(encoding="utf-8")
+    assert "should-not-escape" not in text
+    assert "Authorization: [redacted]" in text
+
+
 def test_project_vault_restores_the_vault_when_a_transaction_fails(
     tmp_path: Path, vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -121,6 +139,7 @@ def test_project_vault_restores_the_vault_when_a_transaction_fails(
     result = obsidian_vault._project_payload(target=tmp_path, vault=vault)
 
     assert result["receipt"]["terminal_state"] == "restored"
+    assert result["written"] == 0
     projection = vault / "Brigade Memory"
     assert not [path for path in projection.rglob("*") if path.is_file()]
     assert not list((tmp_path / ".brigade" / "memory-vault").glob("*.json"))
@@ -139,6 +158,50 @@ def test_project_vault_writes_a_conflict_copy_without_clobbering_existing_vault_
     assert "untracked:Cards/Alpha.md" in receipt["drift"]
     assert existing.read_text(encoding="utf-8") == "operator-owned note\n"
     assert list(existing.parent.glob("Alpha.conflict-*.md"))
+
+
+def test_project_vault_preserves_directory_and_symlink_collisions(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha", tags=["operations"], body="Canonical alpha.")
+    _write_card(tmp_path, "beta", title="Beta", tags=["operations"], body="Canonical beta.")
+    root = vault / "Brigade Memory" / "Cards"
+    alpha = root / "Alpha.md"
+    beta = root / "Beta.md"
+    alpha.mkdir(parents=True)
+    operator_note = tmp_path / "operator-note.md"
+    operator_note.write_text("operator-owned note\n", encoding="utf-8")
+    beta.symlink_to(operator_note)
+
+    receipt = _project(tmp_path, vault, capsys)
+
+    assert "untracked:Cards/Alpha.md" in receipt["drift"]
+    assert "untracked:Cards/Beta.md" in receipt["drift"]
+    assert alpha.is_dir()
+    assert beta.is_symlink()
+    assert list(root.glob("Alpha.conflict-*.md"))
+    assert list(root.glob("Beta.conflict-*.md"))
+
+
+def test_project_vault_keeps_mocs_with_colliding_sanitized_names(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha", tags=["shared"], body="Alpha.", category="ops/a")
+    _write_card(tmp_path, "beta", title="Beta", tags=["shared"], body="Beta.", category="ops:a")
+
+    _project(tmp_path, vault, capsys)
+
+    maps = list((vault / "Brigade Memory" / "Maps" / "Categories").glob("ops-a*.md"))
+    assert len(maps) == 2
+    assert sorted(path.read_text(encoding="utf-8").count("[[") for path in maps) == [1, 1]
+
+
+def test_project_vault_escapes_wikilink_delimiters_in_titles(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha]]|Map", tags=["shared"], body="Alpha.")
+    _write_card(tmp_path, "beta", title="Beta", tags=["shared"], body="Beta.")
+
+    _project(tmp_path, vault, capsys)
+
+    root = vault / "Brigade Memory" / "Cards"
+    assert (root / "Alpha-Map.md").is_file()
+    beta = (root / "Beta.md").read_text(encoding="utf-8")
+    assert "[[Cards/Alpha-Map|Alpha\\]\\]\\|Map]]" in beta
 
 
 def test_project_vault_skips_a_manually_edited_conflict_copy_when_linking(tmp_path: Path, vault: Path, capsys) -> None:


### PR DESCRIPTION
Fixes #888

## What changed

- Adds `brigade memory project-vault` for a one-way projection of canonical memory into an existing Obsidian vault.
- Generated notes include care-state frontmatter and tags, plus wikilinks between related memory.
- Adds category and harness MOC notes, and a JSON Canvas built from the Brigade memory topology.
- Uses the projection kernel for transactional vault and ledger writes, detects vault drift, preserves manual edits through conflict copies, and redacts projected content.

## Verification

- `./scripts/verify` passed through Brigade after rebasing onto current `origin/main`: receipt `20260814-150608-work-verify-2a1012`.
- Focused regression receipts: `20260814-143021-work-verify-261f9c`, `20260814-143150-work-verify-5427bd`, `20260814-143218-work-verify-5cfed1`, `20260814-143305-work-verify-98f262`, and `20260814-145057-work-verify-71b580`.