### PR TITLE
fix(care): report per-entry systemd registrations in status_payload

### DIFF
--- a/src/brigade/care_cmd.py
+++ b/src/brigade/care_cmd.py
@@ -1325,9 +1325,13 @@ def status_payload(*, target: Path, home: Path | None = None) -> dict[str, Any]:
     Topology and other read-only consumers should use this instead of scraping
     crontab text or private markers. ``enabled`` is true when either backend has
     a Brigade care block installed for *target* (current, stale, or tampered).
+
+    Systemd discovery matches bare ``brigade care status``: when a target has
+    per-entry registrations (including the #762 memory-job inventory), report
+    those entries instead of treating the absent atomic CARE_ENTRIES set as a
+    missing install.
     """
     target = target.expanduser().resolve()
-    entries = [_entry_status(target, entry) for entry in CARE_ENTRIES]
     if _is_windows():
         return {
             "enabled": False,
@@ -1335,17 +1339,23 @@ def status_payload(*, target: Path, home: Path | None = None) -> dict[str, Any]:
                 "crontab": {"backend": "crontab", "status": "unsupported-backend", "error": None},
                 "systemd": {"backend": "systemd", "status": "unsupported-backend", "error": None},
             },
-            "entries": entries,
+            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
         }
     crontab = _crontab_backend_status(target=target, home=home)
-    systemd = _systemd_backend_status(target=target, home=home)
+    installed_systemd = _installed_systemd_entries(target=target, home=home)
+    systemd_entries = installed_systemd if installed_systemd else CARE_ENTRIES
+    systemd = _systemd_backend_status(target=target, home=home, entries=systemd_entries)
     crontab_enabled = _backend_is_installed(str(crontab.get("status"))) and bool(crontab.get("target_match"))
     systemd_enabled = _backend_is_installed(str(systemd.get("status"))) and bool(systemd.get("target_match"))
+    if installed_systemd:
+        selected_entries = installed_systemd
+    else:
+        selected_entries = CARE_ENTRIES
     return {
         "enabled": crontab_enabled or systemd_enabled,
         "target_match": bool(crontab.get("target_match")) or bool(systemd.get("target_match")),
         "backends": {"crontab": crontab, "systemd": systemd},
-        "entries": entries,
+        "entries": [_entry_status(target, entry) for entry in selected_entries],
     }
 
 

--- a/tests/test_care_cmd.py
+++ b/tests/test_care_cmd.py
@@ -180,6 +180,43 @@ def test_care_status_payload_reports_crontab_and_systemd_enabled(tmp_path, monke
     assert systemd_enabled["backends"]["systemd"]["status"] == "current"
 
 
+def test_care_status_payload_discovers_per_entry_memory_jobs(tmp_path, monkeypatch):
+    """#762 cutover installs MEMORY_JOB entries, not the atomic CARE_ENTRIES set.
+
+    Topology and Center read status_payload; if that helper still evaluates only
+    the default five recipes, a successful per-entry migration looks disabled.
+    """
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_cmd, "_read_crontab", lambda: ("", None))
+
+    assert (
+        care_cmd.install(
+            target=target,
+            backend="systemd",
+            home=home,
+            entry_ids=["handoff-ingest", "care-scan", "memory-closeout"],
+        )
+        == 0
+    )
+
+    payload = care_cmd.status_payload(target=target, home=home)
+    assert payload["enabled"] is True
+    assert payload["target_match"] is True
+    assert payload["backends"]["systemd"]["status"] == "current"
+    assert payload["backends"]["systemd"]["target_match"] is True
+    assert [entry["id"] for entry in payload["entries"]] == [
+        "handoff-ingest",
+        "care-scan",
+        "memory-closeout",
+    ]
+    for default_id in ("daily-care", "ingest-sweep", "nightly-ops"):
+        assert default_id not in {entry["id"] for entry in payload["entries"]}
+
+
 def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch):
     store = {"text": "# keep-me\n0 2 * * * /usr/bin/true\n"}
     before = store["text"]


### PR DESCRIPTION
Refs #762

Worked by the Brigade `grok` seat via `brigade-issue-pr`.

`status_payload` derived its systemd entries from the atomic `CARE_ENTRIES` set, so a target carrying per-entry registrations read as a missing install instead of the entries it actually has. Discovery now matches bare `brigade care status`.

## Verification

`tests/test_care_cmd.py` passes 45/45, captured through Brigade (receipt `20260815-204427-work-verify-dbddfd`). The full suite was **not** completed locally: it was still running after 12 minutes and was holding the worktree, so CI is the authoritative full-suite gate here. Do not merge on a red CI.

## Provenance note

This branch exists because of #935. The seat finished its work, then `brigade run` crashed on the missing `_SeatProcessRegistry.terminate`, so the dispatch reported failure while the child process survived and kept running unsupervised for 24 minutes. The output was recovered from the orphaned worktree and re-applied to a clean branch off the same base commit (463461e9). It is worth reviewing with that history in mind, though the change itself is coherent and self-consistent.
