### PR TITLE
fix(work): release scanner run authority on proof publication failure

### DIFF
--- a/src/brigade/work_cmd/scanners.py
+++ b/src/brigade/work_cmd/scanners.py
@@ -2032,145 +2032,149 @@ def _scanners_run_payload(
     before_counts = _scanner_import_counts(target)
     runs: list[dict[str, Any]] = []
     contexts: list[tuple[dict[str, Any], dict[str, Any]]] = []
-    for scanner in selected:
-        try:
-            before_raw = _scanner_inbox_bytes(target)
-            before_imports = _scanner_inbox_imports(target)
-        except OSError:
-            before_raw = b""
-            before_imports = []
-        before_ids = {
-            str(item.get("id")) for item in before_imports if isinstance(item, dict) and isinstance(item.get("id"), str)
-        }
-        run = _scanner_run_one(target, scanner, force=force)
-        _register_scanner_run_proof(scanner, run)
-        stamped_ids = _scanner_stamp_new_imports(
-            target=target,
-            scanner=scanner,
-            run=run,
-            before_ids=before_ids,
-            before_imports=before_imports,
-            before_raw=before_raw,
-        )
-        run["provenance_imports_stamped"] = len(stamped_ids)
-        if stamped_ids:
-            run["stamped_import_ids"] = stamped_ids
-        _write_scanner_run_receipt(run)
-        runs.append(run)
-        contexts.append((scanner, run))
-    ingest_errors: list[str] = []
-    ingest_payloads: list[tuple[dict[str, Any], dict[str, Any], Path, list[dict[str, Any]]]] = []
-    if ingest_output:
-        for scanner, run in contexts:
-            if run.get("status") != "completed":
-                continue
-            path, records, errors = _scanner_validate_import_output(target, scanner)
-            if errors:
-                ingest_errors.extend(errors)
-                continue
-            if path is not None:
-                ingest_payloads.append(
-                    (
-                        scanner,
-                        run,
-                        path,
-                        _scanner_enrich_import_records(target=target, scanner=scanner, run=run, records=records),
-                    )
-                )
-        if ingest_errors:
-            after_counts = _scanner_import_counts(target)
-            payload = {
-                "target": str(target),
-                "runs_root": str(helpers._scanner_runs_root(target)),
-                "selected": len(selected),
-                "completed": len([run for run in runs if run.get("status") == "completed"]),
-                "failed": len([run for run in runs if run.get("status") != "completed"]),
-                "skipped": [
-                    {"scanner_id": item["scanner"].get("id"), "reason": item["reason"]}
-                    for item in skipped
-                    if isinstance(item.get("scanner"), dict)
-                ],
-                "imports_before": before_counts,
-                "imports_after": after_counts,
-                "ingest_output": True,
-                "ingest_errors": ingest_errors,
-                "runs": runs,
-            }
-            for run in runs:
-                _release_scanner_run_directory_authority(run)
-            return payload, 2
-        for scanner, run, path, records in ingest_payloads:
-            scanner_source = str(scanner.get("source") or "scanner").strip() or "scanner"
+    try:
+        for scanner in selected:
             try:
-                existing_imports = _scanner_inbox_imports(target)
+                before_raw = _scanner_inbox_bytes(target)
+                before_imports = _scanner_inbox_imports(target)
             except OSError:
+                before_raw = b""
+                before_imports = []
+            before_ids = {
+                str(item.get("id"))
+                for item in before_imports
+                if isinstance(item, dict) and isinstance(item.get("id"), str)
+            }
+            run = _scanner_run_one(target, scanner, force=force)
+            _register_scanner_run_proof(scanner, run)
+            stamped_ids = _scanner_stamp_new_imports(
+                target=target,
+                scanner=scanner,
+                run=run,
+                before_ids=before_ids,
+                before_imports=before_imports,
+                before_raw=before_raw,
+            )
+            run["provenance_imports_stamped"] = len(stamped_ids)
+            if stamped_ids:
+                run["stamped_import_ids"] = stamped_ids
+            _write_scanner_run_receipt(run)
+            runs.append(run)
+            contexts.append((scanner, run))
+        ingest_errors: list[str] = []
+        ingest_payloads: list[tuple[dict[str, Any], dict[str, Any], Path, list[dict[str, Any]]]] = []
+        if ingest_output:
+            for scanner, run in contexts:
+                if run.get("status") != "completed":
+                    continue
+                path, records, errors = _scanner_validate_import_output(target, scanner)
+                if errors:
+                    ingest_errors.extend(errors)
+                    continue
+                if path is not None:
+                    ingest_payloads.append(
+                        (
+                            scanner,
+                            run,
+                            path,
+                            _scanner_enrich_import_records(target=target, scanner=scanner, run=run, records=records),
+                        )
+                    )
+            if ingest_errors:
+                after_counts = _scanner_import_counts(target)
+                payload = {
+                    "target": str(target),
+                    "runs_root": str(helpers._scanner_runs_root(target)),
+                    "selected": len(selected),
+                    "completed": len([run for run in runs if run.get("status") == "completed"]),
+                    "failed": len([run for run in runs if run.get("status") != "completed"]),
+                    "skipped": [
+                        {"scanner_id": item["scanner"].get("id"), "reason": item["reason"]}
+                        for item in skipped
+                        if isinstance(item.get("scanner"), dict)
+                    ],
+                    "imports_before": before_counts,
+                    "imports_after": after_counts,
+                    "ingest_output": True,
+                    "ingest_errors": ingest_errors,
+                    "runs": runs,
+                }
+                return payload, 2
+            for scanner, run, path, records in ingest_payloads:
+                scanner_source = str(scanner.get("source") or "scanner").strip() or "scanner"
+                try:
+                    existing_imports = _scanner_inbox_imports(target)
+                except OSError:
+                    run["ingest_output"] = {
+                        "path": str(path),
+                        "created": 0,
+                        "skipped": 0,
+                        "dismissed": 0,
+                        "rejected": len(records),
+                        "rejection_reasons": {"inbox_persistence_failed": len(records)},
+                        "records": len(records),
+                        "created_import_ids": [],
+                        "skipped_source_fingerprints": [],
+                        "dismissed_source_fingerprints": [],
+                    }
+                    _write_scanner_run_receipt(run)
+                    continue
+                imported, skipped_records, skipped_dismissed, rejected = ledger_mod._append_import_records(
+                    target,
+                    records,
+                    provenance_source=scanner_source,
+                    contain_provenance_errors=True,
+                    migrate_untrusted_identities=True,
+                    preserve_existing_raw=lambda data: _append_scanner_inbox_bytes(target, data),
+                    restore_existing_raw=lambda data, exists: _restore_scanner_inbox_bytes(target, data, exists),
+                    existing_imports=existing_imports,
+                )
+                if _scanner_run_proof(scanner, run) is not None:
+                    for item in imported:
+                        _record_scanner_import_proof(scanner, run, item)
                 run["ingest_output"] = {
                     "path": str(path),
-                    "created": 0,
-                    "skipped": 0,
-                    "dismissed": 0,
-                    "rejected": len(records),
-                    "rejection_reasons": {"inbox_persistence_failed": len(records)},
+                    "created": len(imported),
+                    "skipped": len(skipped_records),
+                    "dismissed": len(skipped_dismissed),
+                    "rejected": len(rejected),
+                    "rejection_reasons": {rejected[0]: len(rejected)} if rejected else {},
                     "records": len(records),
-                    "created_import_ids": [],
-                    "skipped_source_fingerprints": [],
-                    "dismissed_source_fingerprints": [],
+                    "created_import_ids": [str(item.get("id")) for item in imported if isinstance(item.get("id"), str)],
+                    "skipped_source_fingerprints": [
+                        fingerprint
+                        for record in skipped_records
+                        if (fingerprint := ledger_mod._import_fingerprint(record))
+                    ],
+                    "dismissed_source_fingerprints": [
+                        fingerprint
+                        for record in skipped_dismissed
+                        if (fingerprint := ledger_mod._import_fingerprint(record))
+                    ],
                 }
                 _write_scanner_run_receipt(run)
-                continue
-            imported, skipped_records, skipped_dismissed, rejected = ledger_mod._append_import_records(
-                target,
-                records,
-                provenance_source=scanner_source,
-                contain_provenance_errors=True,
-                migrate_untrusted_identities=True,
-                preserve_existing_raw=lambda data: _append_scanner_inbox_bytes(target, data),
-                restore_existing_raw=lambda data, exists: _restore_scanner_inbox_bytes(target, data, exists),
-                existing_imports=existing_imports,
-            )
-            if _scanner_run_proof(scanner, run) is not None:
-                for item in imported:
-                    _record_scanner_import_proof(scanner, run, item)
-            run["ingest_output"] = {
-                "path": str(path),
-                "created": len(imported),
-                "skipped": len(skipped_records),
-                "dismissed": len(skipped_dismissed),
-                "rejected": len(rejected),
-                "rejection_reasons": {rejected[0]: len(rejected)} if rejected else {},
-                "records": len(records),
-                "created_import_ids": [str(item.get("id")) for item in imported if isinstance(item.get("id"), str)],
-                "skipped_source_fingerprints": [
-                    fingerprint for record in skipped_records if (fingerprint := ledger_mod._import_fingerprint(record))
-                ],
-                "dismissed_source_fingerprints": [
-                    fingerprint
-                    for record in skipped_dismissed
-                    if (fingerprint := ledger_mod._import_fingerprint(record))
-                ],
-            }
-            _write_scanner_run_receipt(run)
-    after_counts = _scanner_import_counts(target)
-    payload = {
-        "target": str(target),
-        "runs_root": str(helpers._scanner_runs_root(target)),
-        "selected": len(selected),
-        "completed": len([run for run in runs if run.get("status") == "completed"]),
-        "failed": len([run for run in runs if run.get("status") != "completed"]),
-        "skipped": [
-            {"scanner_id": item["scanner"].get("id"), "reason": item["reason"]}
-            for item in skipped
-            if isinstance(item.get("scanner"), dict)
-        ],
-        "imports_before": before_counts,
-        "imports_after": after_counts,
-        "ingest_output": ingest_output,
-        "ingest_errors": ingest_errors,
-        "runs": runs,
-    }
-    for run in runs:
-        _release_scanner_run_directory_authority(run)
-    return payload, 0 if payload["failed"] == 0 else 1
+        after_counts = _scanner_import_counts(target)
+        payload = {
+            "target": str(target),
+            "runs_root": str(helpers._scanner_runs_root(target)),
+            "selected": len(selected),
+            "completed": len([run for run in runs if run.get("status") == "completed"]),
+            "failed": len([run for run in runs if run.get("status") != "completed"]),
+            "skipped": [
+                {"scanner_id": item["scanner"].get("id"), "reason": item["reason"]}
+                for item in skipped
+                if isinstance(item.get("scanner"), dict)
+            ],
+            "imports_before": before_counts,
+            "imports_after": after_counts,
+            "ingest_output": ingest_output,
+            "ingest_errors": ingest_errors,
+            "runs": runs,
+        }
+        return payload, 0 if payload["failed"] == 0 else 1
+    finally:
+        for run in runs:
+            _release_scanner_run_directory_authority(run)
 
 
 def scanners_run(

--- a/tests/test_work_cmd_scanners.py
+++ b/tests/test_work_cmd_scanners.py
@@ -719,6 +719,74 @@ conflict_window = "02:00-02:10"
     assert metadata["scanner_output_path_snapshot"]["exists"] is True
 
 
+def test_scanners_run_releases_directory_authority_when_import_publication_raises(tmp_path, monkeypatch):
+    from brigade.work_cmd import scanners as scanners_mod
+
+    _init_git_repo(tmp_path)
+    script = tmp_path / "scanner.py"
+    script.write_text(
+        """
+import json
+from pathlib import Path
+
+path = Path.cwd() / ".brigade" / "scanner-imports.jsonl"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({"kind": "task", "source": "repo-scan", "text": "Review generated finding"}) + "\\n")
+"""
+    )
+    config = tmp_path / ".brigade" / "scanners.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        f"""
+[[scanner]]
+id = "repo-scan"
+source = "repo-scan"
+command = "{sys.executable} {script}"
+cadence = "daily@02:00"
+enabled = true
+timeout = 30
+output_path = ".brigade/scanner-imports.jsonl"
+import_path = ".brigade/scanner-imports.jsonl"
+import_format = "jsonl"
+conflict_window = "02:00-02:10"
+"""
+    )
+
+    prior_keys = set(scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES)
+    captured_keys: list[int] = []
+    captured_fds: list[tuple[int, int]] = []
+
+    def fail_publication(*_args: object, **_kwargs: object) -> None:
+        authorities = scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES
+        retained = {key: authority for key, authority in authorities.items() if key not in prior_keys}
+        assert retained, "expected retained scanner-run directory authority"
+        for key, authority in retained.items():
+            captured_keys.append(key)
+            captured_fds.append((authority.root, authority.directory))
+            os.fstat(authority.root)
+            os.fstat(authority.directory)
+        raise RuntimeError("forced import proof publication failure")
+
+    monkeypatch.setattr(scanners_mod.ledger_mod, "_append_import_records", fail_publication)
+
+    with pytest.raises(RuntimeError, match="forced import proof publication failure"):
+        scanners_mod._scanners_run_payload(target=tmp_path, scanner_id="repo-scan", ingest_output=True)
+
+    assert captured_keys
+    assert captured_fds
+    remaining = scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES
+    assert set(remaining) == prior_keys
+    for key in captured_keys:
+        assert key not in remaining
+    for root, directory in captured_fds:
+        with pytest.raises(OSError) as raised:
+            os.fstat(root)
+        assert raised.value.errno == errno.EBADF
+        with pytest.raises(OSError) as raised:
+            os.fstat(directory)
+        assert raised.value.errno == errno.EBADF
+
+
 def test_work_scanners_ingest_output_sanitizes_hostile_records_and_owns_identity(tmp_path, capsys):
     _init_git_repo(tmp_path)
     script = tmp_path / "scanner.py"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

`--ingest-output` could leave scanner-run directory descriptors open when import proof publication or a later receipt rewrite raised. `_scanners_run_payload` now releases every retained run authority from a `finally` that covers ingestion, receipt rewrites, and proof publication failures.

Fixes #883

Follow-up to #871. Rebased on current `main` after #932.

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] Targeted `python -m pytest tests/test_work_cmd_scanners.py -q` passes locally (99 passed)
- [x] Added or updated tests covering the change
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages

Internal descriptor-release fix; no user-visible changelog entry. In-house commit includes the allowed Cursor agent trailer.

## Test plan

- Regression `test_scanners_run_releases_directory_authority_when_import_publication_raises` forces `_append_import_records` to raise and asserts the captured run-root/run-leaf descriptors are `EBADF` and the authority-map entry is gone.
- Full scanner module: `python -m pytest tests/test_work_cmd_scanners.py -q` → 99 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96cb81ed-84ef-4294-b3c5-db91f9b36e86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96cb81ed-84ef-4294-b3c5-db91f9b36e86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

