### PR TITLE
docs(code-graph): cite Brigade setup as standalone install replacement

### DIFF
--- a/engines/code-graph/README.md
+++ b/engines/code-graph/README.md
@@ -31,7 +31,9 @@
 
 ## Install
 
-Install GraphTrail and `graphtrail-mcp` through Brigade's verified managed manifest:
+Install GraphTrail and `graphtrail-mcp` through Brigade's verified managed manifest.
+`brigade setup` is the distribution replacement for every standalone install path
+per [`docs/phase-4a-compatibility-and-archive.md`](../../docs/phase-4a-compatibility-and-archive.md):
 
 ```bash
 brigade setup


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #365

## What and why

Completes the Phase 4B README slice for issue #365. The archived `cargo install` / `escoffier-labs/graphtrail` install guidance was removed in #611; this PR adds an explicit cross-reference to the Phase 4A compatibility policy so the README states that `brigade setup` replaces every standalone install path.

`engines/code-graph/content/announcements/` is untouched (historical record). The remaining unchecked #365 items (miseledger#43 straggler, crates.io deprecation directive) are out of scope.

## Verification

- `cargo +1.85.0 test --test repository_contract` — 11 passed
- `python -m pytest tests/test_managed.py::test_graphtrail_declares_verified_brigade_install_and_bounded_context_contract -q` — 1 passed

## Type of change

- [x] Docs

## Checklist

- [x] Targeted tests pass locally
- [x] No personal details or secrets
- [x] No new runtime dependencies
- [x] Conventional commit message
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cd324a9-c998-4d2c-ad3b-e82bc86979e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cd324a9-c998-4d2c-ad3b-e82bc86979e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

