### PR TITLE
fix(work): fail-closed work-graph hardening (recovered branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrupt or future-version `.brigade/work/tasks.json` ledgers now fail
   closed on every `brigade work` surface (and other commands that read the
   ledger) with `error: ...` and exit 2, instead of parsing as empty or
-  dumping a traceback. Unknown hand-edited edge types are preserved on
+  dumping a traceback. The work-store measurement harness
+  (`scripts/measure_work_store.py`, protocol 4) now reports
+  `schema_version_policy.future_version_rejected: true` with a clean
+  exit-2 error and untouched ledger bytes; it no longer treats future
+  versions as coerced. Unknown hand-edited edge types are preserved on
   rewrite and surfaced via `work ready` (`unknown_type_count`) and a
   `work doctor` WARN. `work import promote --all` returns 2 when any
   import fails. (#948)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   independent `reviewer` or `reviewer_codex` seat. (#920)
 
 ### Fixed
+- Corrupt or future-version `.brigade/work/tasks.json` ledgers now fail
+  closed on every `brigade work` surface (and other commands that read the
+  ledger) with `error: ...` and exit 2, instead of parsing as empty or
+  dumping a traceback. Unknown hand-edited edge types are preserved on
+  rewrite and surfaced via `work ready` (`unknown_type_count`) and a
+  `work doctor` WARN. `work import promote --all` returns 2 when any
+  import fails. (#948)
 - Bare `brigade care status` now discovers target-scoped per-entry
   registrations instead of scoring the atomic five-entry default. A target
   with no discovered units reports `missing`. Systemd status also reports

--- a/scripts/measure_work_store.py
+++ b/scripts/measure_work_store.py
@@ -17,11 +17,14 @@ Protocol defaults match the #846 scoping comment: 10 warmups and 100 measured
 trials, nearest-rank p50/p95, two-claimer barrier race requiring one success
 and one exit 13, and pass/fail gates for #737/#738 anchors where exercised.
 R3 retains the residual no-listener cells: same-actor rejection, guards/empty-filter,
-restart recovery, schema coercion observation, branch/config backup restore,
+restart recovery, fail-closed future-version rejection, branch/config backup restore,
 install footprint, cold-start/backup timing, resource samples, and observed
 metrics-state plus deleted-secret/history checks. Latency remains descriptive
 (no absolute service level). Numbers are never fabricated: cells are
 ``measured``, ``blocked``, or ``unavailable``.
+Protocol 4 inverts ``schema_version_policy``: a future ledger version must be
+rejected cleanly (exit 2, bytes untouched) instead of coerced to the current
+schema.
 
 Standard library plus the in-repo ``brigade`` package only.
 """
@@ -59,10 +62,11 @@ from brigade.work_cmd import ledger as ledger_mod
 ISSUE = 846
 SLICE = "R3"
 KIND = "work-store-characterization"
-PROTOCOL_VERSION = 3
+PROTOCOL_VERSION = 4
 TIMEBOX_NOTE = (
-    "R3 bounded repair: correct the SQLite release characterization while "
-    "retaining the accepted no-listener scope and residual cells. Dolt shapes "
+    "R3 bounded repair plus protocol 4: schema_version_policy records "
+    "fail-closed rejection of future ledger versions (clean error, exit 2, "
+    "bytes untouched) instead of ensure_ledger_edges coercion. Dolt shapes "
     "stay optional characterization candidates "
     "and must not enter Brigade runtime dependencies. Server listeners, TLS, "
     "and permission cells that need a listener remain blocked pending separate "
@@ -1059,35 +1063,76 @@ def _json_restart_recovery(root: Path, ledger: dict[str, Any]) -> dict[str, Any]
 
 
 def _json_schema_version_policy(root: Path, ledger: dict[str, Any]) -> dict[str, Any]:
-    """Observe current ledger version coercion (no production schema change)."""
+    """Observe fail-closed rejection of future ledger versions (no schema bump)."""
     future = _clone_ledger(ledger)
     future["version"] = edges_mod.TASK_LEDGER_VERSION + 100
+    future["future_field"] = {"keep": True}
     past = _clone_ledger(ledger)
     past["version"] = 1
     future_target = _json_load_target(root, future, with_git=False)
     past_target = _json_load_target(root, past, with_git=False)
     try:
-        future_on_disk = json.loads(work_helpers._tasks_path(future_target).read_text(encoding="utf-8"))
+        future_path = work_helpers._tasks_path(future_target)
+        before_bytes = future_path.read_bytes()
+        future_on_disk = json.loads(before_bytes.decode("utf-8"))
         past_on_disk = json.loads(work_helpers._tasks_path(past_target).read_text(encoding="utf-8"))
-        future_loaded = ledger_mod._read_task_ledger(future_target)
+
+        future_error: dict[str, Any] | None = None
+        future_version_after_read = None
+        try:
+            future_loaded = ledger_mod._read_task_ledger(future_target)
+            future_version_after_read = future_loaded.get("version")
+        except ledger_mod.TaskLedgerError as exc:
+            future_error = exc.as_dict()
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            cli_rc = work_cmd.tasks(target=future_target, json_output=True)
+        after_bytes = future_path.read_bytes()
+        cli_out = stdout.getvalue()
+        cli_err = stderr.getvalue()
+        try:
+            cli_payload = json.loads(cli_out) if cli_out.strip() else None
+        except json.JSONDecodeError:
+            cli_payload = None
+
         past_loaded = ledger_mod._read_task_ledger(past_target)
-        future_version_after_read = future_loaded.get("version")
         past_version_after_read = past_loaded.get("version")
-        future_coerced = future_version_after_read == edges_mod.TASK_LEDGER_VERSION
         past_coerced = past_version_after_read == edges_mod.TASK_LEDGER_VERSION
+        bytes_unchanged = after_bytes == before_bytes
+        rejected = (
+            future_error is not None
+            and future_error.get("reason") == ledger_mod.REASON_UNSUPPORTED_LEDGER_VERSION
+            and int(future_error.get("exit_code") or 0) == 2
+            and future_version_after_read is None
+        )
+        clean_error = (
+            cli_rc == 2
+            and "Traceback" not in cli_err
+            and isinstance(cli_payload, dict)
+            and cli_payload.get("reason") == ledger_mod.REASON_UNSUPPORTED_LEDGER_VERSION
+            and int(cli_payload.get("exit_code") or 0) == 2
+        )
+        extra_field_kept = future_on_disk.get("future_field") == {"keep": True}
         return {
             "status": "measured",
             "expected_version": edges_mod.TASK_LEDGER_VERSION,
             "future_version_written": future_on_disk.get("version"),
             "future_version_after_read": future_version_after_read,
-            "future_version_rejected": False,
-            "future_version_coerced_on_read": future_coerced,
+            "future_version_rejected": rejected,
+            "future_version_coerced_on_read": False,
+            "future_version_bytes_unchanged": bytes_unchanged,
+            "future_version_reason": None if future_error is None else future_error.get("reason"),
+            "future_version_exit_code": None if future_error is None else future_error.get("exit_code"),
+            "future_version_cli_exit_code": cli_rc,
+            "future_version_clean_error": clean_error,
             "downgrade_version_written": past_on_disk.get("version"),
             "downgrade_version_after_read": past_version_after_read,
             "downgrade_rejected": False,
             "downgrade_coerced_on_read": past_coerced,
-            "observed_policy": "ensure_ledger_edges_coerces_version_to_current",
-            "pass": future_coerced and past_coerced,
+            "observed_policy": "fail_closed_unsupported_ledger_version",
+            "pass": rejected and bytes_unchanged and clean_error and extra_field_kept and past_coerced,
         }
     finally:
         shutil.rmtree(future_target, ignore_errors=True)
@@ -1535,6 +1580,20 @@ def _sqlite_load(path: Path, ledger: dict[str, Any]) -> None:
         conn.close()
 
 
+def _sqlite_logical_digest(path: Path) -> str:
+    """Digest logical sqlite rows so WAL header churn is not a false write."""
+    conn = _sqlite_connect(path)
+    try:
+        payload = {
+            "meta": list(conn.execute("SELECT key, value FROM meta ORDER BY key")),
+            "tasks": list(conn.execute("SELECT id, payload FROM tasks ORDER BY id")),
+            "edges": list(conn.execute("SELECT id, payload FROM edges ORDER BY id")),
+        }
+    finally:
+        conn.close()
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
 def _sqlite_export_ledger(path: Path) -> dict[str, Any]:
     conn = _sqlite_connect(path)
     try:
@@ -1546,6 +1605,16 @@ def _sqlite_export_ledger(path: Path) -> dict[str, Any]:
             edges.append(json.loads(row[0]))
         version_row = conn.execute("SELECT value FROM meta WHERE key='version'").fetchone()
         version = int(version_row[0]) if version_row else edges_mod.TASK_LEDGER_VERSION
+        if version > edges_mod.TASK_LEDGER_VERSION:
+            raise ledger_mod.TaskLedgerError(
+                f"task ledger version {version} is newer than supported {edges_mod.TASK_LEDGER_VERSION}: {path}",
+                reason=ledger_mod.REASON_UNSUPPORTED_LEDGER_VERSION,
+                details={
+                    "path": str(path),
+                    "version": version,
+                    "supported": edges_mod.TASK_LEDGER_VERSION,
+                },
+            )
         ledger = {"version": version, "tasks": tasks, "edges": edges}
         edges_mod.ensure_ledger_edges(ledger)
         return ledger
@@ -2054,11 +2123,15 @@ def _sqlite_schema_version_policy(root: Path, ledger: dict[str, Any]) -> dict[st
         past["version"] = 1
         _sqlite_load(future_path, future)
         _sqlite_load(past_path, past)
-        # Adapter stores meta.version as written; export returns stored int.
-        future_export = _sqlite_export_ledger(future_path)
+        before_digest = _sqlite_logical_digest(future_path)
+        future_error: dict[str, Any] | None = None
+        future_export: dict[str, Any] | None = None
+        try:
+            future_export = _sqlite_export_ledger(future_path)
+        except ledger_mod.TaskLedgerError as exc:
+            future_error = exc.as_dict()
+        after_digest = _sqlite_logical_digest(future_path)
         past_export = _sqlite_export_ledger(past_path)
-        # After export, ensure_ledger_edges coerces for graph use.
-        future_coerced = future_export.get("version") == edges_mod.TASK_LEDGER_VERSION
         past_coerced = past_export.get("version") == edges_mod.TASK_LEDGER_VERSION
         conn = _sqlite_connect(future_path)
         try:
@@ -2070,19 +2143,37 @@ def _sqlite_schema_version_policy(root: Path, ledger: dict[str, Any]) -> dict[st
             past_meta = conn.execute("SELECT value FROM meta WHERE key='version'").fetchone()[0]
         finally:
             conn.close()
+        bytes_unchanged = after_digest == before_digest
+        rejected = (
+            future_error is not None
+            and future_error.get("reason") == ledger_mod.REASON_UNSUPPORTED_LEDGER_VERSION
+            and int(future_error.get("exit_code") or 0) == 2
+            and future_export is None
+        )
+        clean_error = rejected and "Traceback" not in str(future_error.get("error") if future_error else "")
         return {
             "status": "measured",
             "expected_version": edges_mod.TASK_LEDGER_VERSION,
             "future_version_written": int(future_meta),
-            "future_version_after_export": future_export.get("version"),
-            "future_version_rejected": False,
-            "future_version_coerced_on_export": future_coerced,
+            "future_version_after_export": None if future_export is None else future_export.get("version"),
+            "future_version_rejected": rejected,
+            "future_version_coerced_on_export": False,
+            "future_version_bytes_unchanged": bytes_unchanged,
+            "future_version_reason": None if future_error is None else future_error.get("reason"),
+            "future_version_exit_code": None if future_error is None else future_error.get("exit_code"),
+            "future_version_clean_error": clean_error,
             "downgrade_version_written": int(past_meta),
             "downgrade_version_after_export": past_export.get("version"),
             "downgrade_rejected": False,
             "downgrade_coerced_on_export": past_coerced,
-            "observed_policy": "adapter_meta_preserves_written_version_export_coerces_via_ensure_ledger_edges",
-            "pass": future_coerced and past_coerced and int(future_meta) == edges_mod.TASK_LEDGER_VERSION + 100,
+            "observed_policy": "fail_closed_unsupported_ledger_version",
+            "pass": (
+                rejected
+                and bytes_unchanged
+                and clean_error
+                and past_coerced
+                and int(future_meta) == edges_mod.TASK_LEDGER_VERSION + 100
+            ),
         }
     finally:
         for path in (future_path, past_path):

--- a/src/brigade/cli/context.py
+++ b/src/brigade/cli/context.py
@@ -48,6 +48,12 @@ def register(sub: argparse._SubParsersAction) -> None:
 
 
 def dispatch(args) -> int:
+    from ..work_cmd.ledger import guard_task_ledger_dispatch
+
+    return guard_task_ledger_dispatch(args, _dispatch_impl)
+
+
+def _dispatch_impl(args) -> int:
     from .. import context_cmd
 
     if args.context_command == "plan":

--- a/src/brigade/cli/handoff.py
+++ b/src/brigade/cli/handoff.py
@@ -260,6 +260,12 @@ def register(sub: argparse._SubParsersAction) -> None:
 
 
 def dispatch(args) -> int:
+    from ..work_cmd.ledger import guard_task_ledger_dispatch
+
+    return guard_task_ledger_dispatch(args, _dispatch_impl)
+
+
+def _dispatch_impl(args) -> int:
     from .. import handoff_cmd
 
     if args.handoff_command == "sources":

--- a/src/brigade/cli/operator.py
+++ b/src/brigade/cli/operator.py
@@ -362,6 +362,12 @@ def register(sub: argparse._SubParsersAction) -> None:
 
 
 def dispatch(args) -> int:
+    from ..work_cmd.ledger import guard_task_ledger_dispatch
+
+    return guard_task_ledger_dispatch(args, _dispatch_impl)
+
+
+def _dispatch_impl(args) -> int:
     from .. import operator_cmd
 
     if args.operator_command == "guide":

--- a/src/brigade/cli/repos.py
+++ b/src/brigade/cli/repos.py
@@ -621,6 +621,12 @@ def register(sub: argparse._SubParsersAction) -> None:
 
 
 def dispatch(args) -> int:
+    from ..work_cmd.ledger import guard_task_ledger_dispatch
+
+    return guard_task_ledger_dispatch(args, _dispatch_impl)
+
+
+def _dispatch_impl(args) -> int:
     from .. import repos_cmd
 
     if args.repos_command == "init":

--- a/src/brigade/cli/work/dispatching.py
+++ b/src/brigade/cli/work/dispatching.py
@@ -18,6 +18,12 @@ globals().update({name: value for name, value in vars(_family_base).items() if n
 
 
 def dispatch(args) -> int:
+    from ...work_cmd.ledger import guard_task_ledger_dispatch
+
+    return guard_task_ledger_dispatch(args, _dispatch_impl)
+
+
+def _dispatch_impl(args) -> int:
     from ... import work_cmd
 
     if args.work_command == "status":

--- a/src/brigade/cli/work/registration.py
+++ b/src/brigade/cli/work/registration.py
@@ -944,7 +944,9 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
     )
     p_work_import_promote.add_argument(
-        "--all", action="store_true", help="Promote all pending imports matching filters."
+        "--all",
+        action="store_true",
+        help="Promote all pending imports matching filters. Exits 2 if any import fails.",
     )
     p_work_import_promote.add_argument(
         "--kind",

--- a/src/brigade/operator_cmd/migration.py
+++ b/src/brigade/operator_cmd/migration.py
@@ -309,6 +309,8 @@ def _operator_migration_task_summary(target: Path) -> dict[str, Any]:
     }
     try:
         ledger = work_cmd._read_task_ledger(target)
+    except work_cmd.TaskLedgerError:
+        raise
     except Exception:
         ledger = {"tasks": []}
     pending = []

--- a/src/brigade/work_cmd/__init__.py
+++ b/src/brigade/work_cmd/__init__.py
@@ -77,6 +77,7 @@ from .helpers import (  # noqa: F401
     _write_json,
 )
 from .ledger import (  # noqa: F401
+    TaskLedgerError,
     _read_task_ledger,
     _write_task_ledger,
     _read_imports,

--- a/src/brigade/work_cmd/edges.py
+++ b/src/brigade/work_cmd/edges.py
@@ -78,6 +78,8 @@ class ReadinessResult:
     cycles: list[dict[str, Any]]
     orphans: list[dict[str, Any]]
     parents: list[str]
+    unknown_type_count: int = 0
+    unknown_types: tuple[str, ...] = ()
 
     def as_dict(self, *, explain: bool = False) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -87,6 +89,8 @@ class ReadinessResult:
             "cycle_count": len(self.cycles),
             "orphan_count": len(self.orphans),
             "parent_ids": list(self.parents),
+            "unknown_type_count": self.unknown_type_count,
+            "unknown_types": list(self.unknown_types),
         }
         if explain:
             payload["blocked"] = list(self.blocked)
@@ -463,12 +467,16 @@ def resolve_readiness(ledger: dict[str, Any]) -> ReadinessResult:
         unique_orphans.append(item)
     unique_orphans.sort(key=lambda item: (str(item.get("id") or ""), tuple(item.get("via") or ())))
 
+    unknown_edges = [edge for edge in edges if edge["type"] not in EDGE_TYPES]
+    unknown_types = tuple(sorted({edge["type"] for edge in unknown_edges}))
     return ReadinessResult(
         ready=ready,
         blocked=blocked,
         cycles=cycles,
         orphans=unique_orphans,
         parents=parents,
+        unknown_type_count=len(unknown_edges),
+        unknown_types=unknown_types,
     )
 
 

--- a/src/brigade/work_cmd/edges.py
+++ b/src/brigade/work_cmd/edges.py
@@ -119,7 +119,10 @@ def _normalize_edge_record(raw: object, *, require_id: bool = False) -> dict[str
         return None
     if not isinstance(target, str) or not target.strip():
         return None
-    if not isinstance(edge_type, str) or edge_type.strip() not in EDGE_TYPES:
+    # Preserve hand-edited unknown types across rewrite; mutation APIs still
+    # validate via ``_normalize_edge_type``. Unknown types never participate in
+    # readiness or cycle detection (see ``READINESS_EDGE_TYPES``).
+    if not isinstance(edge_type, str) or not edge_type.strip():
         return None
     edge: dict[str, Any] = {
         "source": source.strip(),

--- a/src/brigade/work_cmd/footprint.py
+++ b/src/brigade/work_cmd/footprint.py
@@ -28,14 +28,40 @@ PHASE_PREDICTED = "predicted"
 PHASE_REFINED = "refined"
 PHASE_RECONCILED = "reconciled"
 FOOTPRINT_PHASES = (PHASE_PREDICTED, PHASE_REFINED, PHASE_RECONCILED)
+# Bound hostile / hand-edited footprint lists so a single task cannot balloon
+# the ledger. Spike-validated workloads stay well under this.
+MAX_FOOTPRINT_ENTRIES = 512
 
 _PATH_TOKEN = re.compile(r"(?P<path>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+|[A-Za-z0-9_.-]+\.[A-Za-z0-9]+)")
+
+
+def is_safe_footprint_path(value: str) -> bool:
+    """Return True when ``value`` is a repo-relative path without traversal."""
+    text = value.strip()
+    if not text:
+        return False
+    if text.startswith("/") or text.startswith("\\"):
+        return False
+    # Windows drive / UNC
+    if len(text) >= 2 and text[1] == ":":
+        return False
+    if text.startswith("\\\\") or text.startswith("//"):
+        return False
+    normalized = text.replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    parts = [part for part in normalized.split("/") if part not in ("", ".")]
+    if not parts:
+        return False
+    if any(part == ".." for part in parts):
+        return False
+    return True
 
 
 def normalize_footprint(raw: object, *, phase: str | None = None) -> dict[str, Any]:
     """Return a footprint object with the spike-validated core fields."""
     data = raw if isinstance(raw, dict) else {}
-    files = _unique_strings(data.get("files"))
+    files = [path for path in _unique_strings(data.get("files")) if is_safe_footprint_path(path)]
     symbol_ids = _unique_strings(data.get("symbol_ids") if "symbol_ids" in data else data.get("symbols"))
     snapshot_hash = data.get("snapshot_hash")
     if snapshot_hash is None:
@@ -100,7 +126,7 @@ def symbols_from_metadata(metadata: dict[str, Any] | None) -> list[str]:
 def files_from_metadata(metadata: dict[str, Any] | None) -> list[str]:
     if not isinstance(metadata, dict):
         return []
-    return _unique_strings(metadata.get("files"))
+    return [path for path in _unique_strings(metadata.get("files")) if is_safe_footprint_path(path)]
 
 
 def predict_footprint(
@@ -186,10 +212,11 @@ def reconcile_footprint(
     delta: dict[str, Any] | None,
     *,
     prior: dict[str, Any] | None = None,
+    target: Path | None = None,
 ) -> dict[str, Any]:
     """Reconciled footprint at completion by joining a verify graph delta."""
     prior_norm = normalize_footprint(prior) if prior is not None else None
-    payload = _delta_payload(delta)
+    payload = _delta_payload(delta, target=target)
     files = _files_from_delta(payload)
     symbols = _symbols_from_delta(payload)
     snapshot_hash = _snapshot_hash_from_delta(payload)
@@ -302,11 +329,13 @@ def _unique_strings(value: object) -> list[str]:
             continue
         seen.add(text)
         result.append(text)
+        if len(result) >= MAX_FOOTPRINT_ENTRIES:
+            break
     return result
 
 
 def _path_tokens(text: str) -> list[str]:
-    return [match.group("path") for match in _PATH_TOKEN.finditer(text)]
+    return [match.group("path") for match in _PATH_TOKEN.finditer(text) if is_safe_footprint_path(match.group("path"))]
 
 
 def _files_from_impact_payload(payload: dict[str, Any]) -> list[str]:
@@ -324,7 +353,7 @@ def _files_from_impact_payload(payload: dict[str, Any]) -> list[str]:
                 file_value = item.get(file_key)
                 if isinstance(file_value, str) and file_value.strip():
                     files.append(file_value.strip())
-    return _unique_strings(files)
+    return [path for path in _unique_strings(files) if is_safe_footprint_path(path)]
 
 
 def _symbols_from_impact_payload(payload: dict[str, Any]) -> list[str]:
@@ -346,13 +375,25 @@ def _symbols_from_impact_payload(payload: dict[str, Any]) -> list[str]:
     return _unique_strings(symbols)
 
 
-def _delta_payload(delta: dict[str, Any] | None) -> dict[str, Any]:
+def _delta_payload(delta: dict[str, Any] | None, *, target: Path | None = None) -> dict[str, Any]:
     if not isinstance(delta, dict):
         return {}
     # Prefer an on-disk sidecar when present so join sees the full payload.
+    # Sidecar reads are confined to ``target`` when provided so a hostile
+    # receipt cannot exfiltrate arbitrary host files into the footprint.
     sidecar = delta.get("sidecar_path")
     if isinstance(sidecar, str) and sidecar.strip():
-        path = Path(sidecar)
+        path = Path(sidecar.strip())
+        if target is not None:
+            try:
+                resolved = path.expanduser().resolve(strict=False)
+                root = target.expanduser().resolve(strict=False)
+            except OSError:
+                return delta
+            try:
+                resolved.relative_to(root)
+            except ValueError:
+                return delta
         if path.is_file():
             try:
                 loaded = json.loads(path.read_text())
@@ -387,7 +428,7 @@ def _files_from_delta(payload: dict[str, Any]) -> list[str]:
             path = node.get("file_path") or node.get("path")
             if isinstance(path, str) and path.strip():
                 files.append(path.strip())
-    return _unique_strings(files)
+    return [path for path in _unique_strings(files) if is_safe_footprint_path(path)]
 
 
 def _symbols_from_delta(payload: dict[str, Any]) -> list[str]:

--- a/src/brigade/work_cmd/imports.py
+++ b/src/brigade/work_cmd/imports.py
@@ -9,6 +9,7 @@ from typing import Any
 from .. import evidence_brief, scrub
 from ..untrusted import scan_untrusted, wrap_untrusted
 from . import constants, helpers, ledger as ledger_mod
+from . import edges as edges_mod
 from . import scanners as scanners_mod
 from . import services as services_mod
 
@@ -935,25 +936,36 @@ def import_promote(
             )
         }
         promoted: list[tuple[dict[str, Any], dict[str, Any], bool]] = []
+        failed: list[tuple[dict[str, Any], Exception]] = []
         for item in imports:
             if item.get("id") not in wanted_ids:
                 continue
             text = str(item.get("text") or "").strip()
             if not text:
                 continue
-            task, created = ledger_mod._mark_import_promoted(target, item)
+            try:
+                task, created = ledger_mod._mark_import_promoted(target, item)
+            except (edges_mod.EdgeError, ledger_mod.TaskLedgerError) as exc:
+                failed.append((item, exc))
+                continue
             promoted.append((item, task, created))
         ledger_mod._write_imports(target, imports)
         created_count = len([item for item in promoted if item[2]])
         print(f"promoted: {len(promoted)}")
         print(f"created: {created_count}")
         print(f"existing: {len(promoted) - created_count}")
+        if failed:
+            print(f"failed: {len(failed)}")
         for item, task, created in promoted:
             status = "created" if created else "existing"
             print(
                 f"- {item.get('id')} -> {task['id']} [{status} acceptance={len(ledger_mod._task_acceptance(task))}] "
                 f"{helpers._short(str(task.get('text', '')))}"
             )
+        for item, exc in failed:
+            print(f"- {item.get('id')} failed: {exc}", file=sys.stderr)
+        if failed and not promoted:
+            return 2
         return 0
     if not import_id:
         print("error: import id is required unless --all is passed", file=sys.stderr)
@@ -972,7 +984,14 @@ def import_promote(
     if not text:
         print(f"error: import has no text: {import_id}", file=sys.stderr)
         return 2
-    task, created = ledger_mod._mark_import_promoted(target, item)
+    try:
+        task, created = ledger_mod._mark_import_promoted(target, item)
+    except edges_mod.EdgeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except ledger_mod.TaskLedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     ledger_mod._write_imports(target, imports)
     print(f"import: {item.get('id')}")
     print(f"status: {item.get('status')}")

--- a/src/brigade/work_cmd/imports.py
+++ b/src/brigade/work_cmd/imports.py
@@ -964,7 +964,7 @@ def import_promote(
             )
         for item, exc in failed:
             print(f"- {item.get('id')} failed: {exc}", file=sys.stderr)
-        if failed and not promoted:
+        if failed:
             return 2
         return 0
     if not import_id:

--- a/src/brigade/work_cmd/ledger.py
+++ b/src/brigade/work_cmd/ledger.py
@@ -52,16 +52,89 @@ def _task_ledger_lock(target: Path) -> Iterator[None]:
         runguard._release_lock(path, ownership)
 
 
+REASON_CORRUPT_LEDGER = "corrupt_ledger"
+REASON_UNSUPPORTED_LEDGER_VERSION = "unsupported_ledger_version"
+
+
+class TaskLedgerError(ValueError):
+    """Fail-closed read/parse failure for ``.brigade/work/tasks.json``."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: str,
+        details: dict[str, Any] | None = None,
+        exit_code: int = 2,
+    ):
+        super().__init__(message)
+        self.reason = reason
+        self.details = details or {}
+        self.exit_code = exit_code
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {"error": str(self), "reason": self.reason, "exit_code": self.exit_code}
+        payload.update(self.details)
+        return payload
+
+
 def _read_task_ledger(target: Path) -> dict[str, Any]:
     path = helpers._tasks_path(target)
     if not path.exists():
         return {"version": edges_mod.TASK_LEDGER_VERSION, "tasks": [], "edges": []}
     try:
-        payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return {"version": edges_mod.TASK_LEDGER_VERSION, "tasks": [], "edges": []}
+        raw = path.read_text()
+    except OSError as exc:
+        raise TaskLedgerError(
+            f"task ledger is unreadable: {path}",
+            reason=REASON_CORRUPT_LEDGER,
+            details={"path": str(path), "error": str(exc)},
+        ) from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise TaskLedgerError(
+            f"task ledger is corrupt (invalid JSON): {path}",
+            reason=REASON_CORRUPT_LEDGER,
+            details={"path": str(path), "error": str(exc)},
+        ) from exc
     if not isinstance(payload, dict):
-        return {"version": edges_mod.TASK_LEDGER_VERSION, "tasks": [], "edges": []}
+        raise TaskLedgerError(
+            f"task ledger is corrupt (root must be an object): {path}",
+            reason=REASON_CORRUPT_LEDGER,
+            details={"path": str(path)},
+        )
+    version = payload.get("version", 1)
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise TaskLedgerError(
+            f"task ledger has invalid version {version!r}: {path}",
+            reason=REASON_UNSUPPORTED_LEDGER_VERSION,
+            details={
+                "path": str(path),
+                "version": version,
+                "supported": edges_mod.TASK_LEDGER_VERSION,
+            },
+        )
+    if version > edges_mod.TASK_LEDGER_VERSION:
+        raise TaskLedgerError(
+            f"task ledger version {version} is newer than supported {edges_mod.TASK_LEDGER_VERSION}: {path}",
+            reason=REASON_UNSUPPORTED_LEDGER_VERSION,
+            details={
+                "path": str(path),
+                "version": version,
+                "supported": edges_mod.TASK_LEDGER_VERSION,
+            },
+        )
+    if version < 1:
+        raise TaskLedgerError(
+            f"task ledger has invalid version {version}: {path}",
+            reason=REASON_UNSUPPORTED_LEDGER_VERSION,
+            details={
+                "path": str(path),
+                "version": version,
+                "supported": edges_mod.TASK_LEDGER_VERSION,
+            },
+        )
     tasks = payload.get("tasks")
     if not isinstance(tasks, list):
         payload["tasks"] = []

--- a/src/brigade/work_cmd/ledger.py
+++ b/src/brigade/work_cmd/ledger.py
@@ -78,6 +78,23 @@ class TaskLedgerError(ValueError):
         return payload
 
 
+def emit_task_ledger_error(exc: TaskLedgerError, *, json_output: bool = False) -> int:
+    """Print a ``TaskLedgerError`` with the same contract as ``task_add`` (rc=2)."""
+    if json_output:
+        print(json.dumps(exc.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(f"error: {exc}", file=sys.stderr)
+    return int(exc.exit_code)
+
+
+def guard_task_ledger_dispatch(args: Any, impl: Callable[[Any], int]) -> int:
+    """Catch ``TaskLedgerError`` from a CLI dispatch implementation."""
+    try:
+        return impl(args)
+    except TaskLedgerError as exc:
+        return emit_task_ledger_error(exc, json_output=bool(getattr(args, "json", False)))
+
+
 def _read_task_ledger(target: Path) -> dict[str, Any]:
     path = helpers._tasks_path(target)
     if not path.exists():

--- a/src/brigade/work_cmd/session/run_status.py
+++ b/src/brigade/work_cmd/session/run_status.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 from ... import dogfood_cmd, localio
 from ...install import apply_gitignore
 from .. import constants, helpers, ledger as ledger_mod, config as config_mod, services as services_mod
-from .. import scanners as scanners_mod, reviews as reviews_mod
+from .. import scanners as scanners_mod, reviews as reviews_mod, edges as edges_mod
 
 from . import lifecycle as _family_base
 
@@ -489,7 +489,28 @@ def doctor(*, target: Path) -> int:
     else:
         helpers._doctor_line(constants.OK, "active_session", "none")
 
-    pending_tasks = ledger_mod._pending_tasks(effective_target)
+    try:
+        ledger = ledger_mod._read_task_ledger(effective_target)
+        pending_tasks = ledger_mod._pending_tasks(effective_target)
+    except ledger_mod.TaskLedgerError as exc:
+        failures += 1
+        helpers._doctor_line(constants.FAIL, "task_ledger", exc)
+        ledger = None
+        pending_tasks = []
+    else:
+        helpers._doctor_line(constants.OK, "task_ledger", helpers._tasks_path(effective_target))
+        unknown_edges = [
+            edge for edge in edges_mod.normalize_edges(ledger.get("edges")) if edge["type"] not in edges_mod.EDGE_TYPES
+        ]
+        if unknown_edges:
+            types = ", ".join(sorted({edge["type"] for edge in unknown_edges}))
+            helpers._doctor_line(
+                constants.WARN,
+                "unknown_edge_types",
+                f"{len(unknown_edges)} inert edge(s) with unknown type: {types}",
+            )
+        else:
+            helpers._doctor_line(constants.OK, "unknown_edge_types", "none")
     missing_acceptance = [task for task in pending_tasks if not ledger_mod._task_acceptance(task)]
     if missing_acceptance:
         sample = ", ".join(str(task.get("id")) for task in missing_acceptance[:5])
@@ -503,7 +524,10 @@ def doctor(*, target: Path) -> int:
             constants.OK, "task_acceptance", "pending tasks have acceptance criteria or no tasks are pending"
         )
 
-    plan_coverage = ledger_mod._plan_coverage_payload(effective_target)
+    if ledger is None:
+        plan_coverage = {"significant_without_plan": 0, "task_ids": []}
+    else:
+        plan_coverage = ledger_mod._plan_coverage_payload(effective_target)
     if plan_coverage["significant_without_plan"] > 0:
         plan_sample = ", ".join(plan_coverage["task_ids"][:5])
         helpers._doctor_line(

--- a/src/brigade/work_cmd/session/run_status.py
+++ b/src/brigade/work_cmd/session/run_status.py
@@ -242,7 +242,7 @@ def run(
                 delta = footprint_mod.receipt_graph_delta(receipt)
                 footprint_mod.set_task_footprint(
                     task,
-                    footprint_mod.reconcile_footprint(delta, prior=footprint_mod.task_footprint(task)),
+                    footprint_mod.reconcile_footprint(delta, prior=footprint_mod.task_footprint(task), target=target),
                 )
                 ledger_mod._write_task_ledger(target, ledger)
     if dogfood_rc == 0 and queue_next:

--- a/src/brigade/work_cmd/session/task_ops.py
+++ b/src/brigade/work_cmd/session/task_ops.py
@@ -27,7 +27,10 @@ def tasks(*, target: Path, all_tasks: bool = False, json_output: bool = False) -
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    ledger = ledger_mod._read_task_ledger(target)
+    try:
+        ledger = ledger_mod._read_task_ledger(target)
+    except ledger_mod.TaskLedgerError as exc:
+        return _emit_ledger_error(exc, json_output=json_output)
     task_items = [task for task in ledger["tasks"] if isinstance(task, dict)]
     task_items.sort(key=ledger_mod._task_sort_key)
     if not all_tasks:
@@ -778,6 +781,8 @@ def ready(
                 explain=explain,
                 parallel_safe=parallel_safe,
             )
+        except ledger_mod.TaskLedgerError as exc:
+            return _emit_ledger_error(exc, json_output=json_output)
         except campaign_mod.CampaignError as exc:
             if json_output:
                 print(json.dumps(exc.as_dict(), indent=2, sort_keys=True))
@@ -791,7 +796,10 @@ def ready(
                     print(f"dangling_endpoints: {len(dangling)}", file=sys.stderr)
             return int(exc.exit_code)
     else:
-        payload = ledger_mod._readiness_payload(target, explain=explain, parallel_safe=parallel_safe)
+        try:
+            payload = ledger_mod._readiness_payload(target, explain=explain, parallel_safe=parallel_safe)
+        except ledger_mod.TaskLedgerError as exc:
+            return _emit_ledger_error(exc, json_output=json_output)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -803,6 +811,11 @@ def ready(
     print(f"ready: {payload['ready_count']}")
     print(f"blocked: {payload['blocked_count']}")
     print(f"cycles: {payload['cycle_count']}")
+    unknown_type_count = int(payload.get("unknown_type_count") or 0)
+    if unknown_type_count:
+        unknown_types = ",".join(str(item) for item in payload.get("unknown_types") or [])
+        suffix = f" ({unknown_types})" if unknown_types else ""
+        print(f"unknown_type_count: {unknown_type_count}{suffix}")
     if parallel_safe:
         print(f"waves: {payload.get('wave_count', 0)}")
         print(f"partition_mode: {payload.get('partition_mode')}")
@@ -986,11 +999,7 @@ def _emit_claim_error(exc: Exception, *, json_output: bool) -> int:
 
 
 def _emit_ledger_error(exc: ledger_mod.TaskLedgerError, *, json_output: bool) -> int:
-    if json_output:
-        print(json.dumps(exc.as_dict(), indent=2, sort_keys=True))
-    else:
-        print(f"error: {exc}", file=sys.stderr)
-    return int(exc.exit_code)
+    return ledger_mod.emit_task_ledger_error(exc, json_output=json_output)
 
 
 def claim(
@@ -1077,6 +1086,8 @@ def release(
         )
     except ClaimError as exc:
         return _emit_claim_error(exc, json_output=json_output)
+    except ledger_mod.TaskLedgerError as exc:
+        return _emit_ledger_error(exc, json_output=json_output)
     if json_output:
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0

--- a/src/brigade/work_cmd/session/task_ops.py
+++ b/src/brigade/work_cmd/session/task_ops.py
@@ -124,6 +124,8 @@ def task_add(
             return 2
         try:
             result = ledger_mod._apply_graph_plan(target, plan, dry_run=dry_run)
+        except ledger_mod.TaskLedgerError as exc:
+            return _emit_ledger_error(exc, json_output=json_output)
         except (edges_mod.EdgeError, ValueError) as exc:
             print(f"error: {exc}", file=sys.stderr)
             if json_output and isinstance(exc, edges_mod.EdgeError):
@@ -233,6 +235,8 @@ def task_add(
         if json_output:
             print(json.dumps(exc.as_dict(), indent=2, sort_keys=True))
         return 2
+    except ledger_mod.TaskLedgerError as exc:
+        return _emit_ledger_error(exc, json_output=json_output)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -873,6 +877,8 @@ def task_edge_add(
         else:
             print(f"error: {exc}", file=sys.stderr)
         return 2
+    except ledger_mod.TaskLedgerError as exc:
+        return _emit_ledger_error(exc, json_output=json_output)
     payload = {"edge": edge, "created": created}
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -979,6 +985,14 @@ def _emit_claim_error(exc: Exception, *, json_output: bool) -> int:
     raise exc
 
 
+def _emit_ledger_error(exc: ledger_mod.TaskLedgerError, *, json_output: bool) -> int:
+    if json_output:
+        print(json.dumps(exc.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(f"error: {exc}", file=sys.stderr)
+    return int(exc.exit_code)
+
+
 def claim(
     *,
     target: Path,
@@ -1017,6 +1031,8 @@ def claim(
         )
     except ClaimError as exc:
         return _emit_claim_error(exc, json_output=json_output)
+    except ledger_mod.TaskLedgerError as exc:
+        return _emit_ledger_error(exc, json_output=json_output)
     if json_output:
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0

--- a/src/brigade/work_cmd/session/task_ops.py
+++ b/src/brigade/work_cmd/session/task_ops.py
@@ -713,7 +713,7 @@ def task_done(*, target: Path, task_id: str, force: bool = False, json_output: b
         delta = footprint_mod.receipt_graph_delta(receipt)
         footprint_mod.set_task_footprint(
             task,
-            footprint_mod.reconcile_footprint(delta, prior=footprint_mod.task_footprint(task)),
+            footprint_mod.reconcile_footprint(delta, prior=footprint_mod.task_footprint(task), target=target),
         )
         side_effects = edges_mod.close_side_effects(ledger, resolved_id)
         ledger_mod._write_task_ledger(target, ledger)

--- a/tests/test_work_cmd_work_graph_hardening.py
+++ b/tests/test_work_cmd_work_graph_hardening.py
@@ -1,0 +1,769 @@
+"""Adversarial hardening for work-graph surfaces (#783 edges, #796 footprints, #797 claim).
+
+These tests intentionally go beyond the happy-path coverage the feature PRs shipped:
+N-way claim races, kill-mid-write / truncated ledger, hand-edited tasks.json,
+cycle injection through every mutation path, hostile footprint payloads, and
+ledger version mismatches.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from brigade import work_cmd
+from brigade.work_cmd import claiming as claim_mod
+from brigade.work_cmd import edges as edges_mod
+from brigade.work_cmd import footprint as footprint_mod
+
+from tests.work_cmd_test_helpers import _init_git_repo
+
+
+def _add(target: Path, text: str, **kwargs):
+    task, created = work_cmd._add_task(target, text, **kwargs)
+    assert created
+    return task
+
+
+def _tasks_path(target: Path) -> Path:
+    return target / ".brigade" / "work" / "tasks.json"
+
+
+def _write_raw_ledger(target: Path, payload: dict) -> None:
+    path = _tasks_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _seed_task_dict(task_id: str, text: str) -> dict:
+    return {
+        "id": task_id,
+        "text": text,
+        "status": "pending",
+        "source": "manual",
+        "type": "task",
+        "priority": "normal",
+        "acceptance": [],
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Concurrent claim races beyond the happy pair
+# ---------------------------------------------------------------------------
+
+
+def test_n_way_concurrent_claim_exactly_one_winner(tmp_path, monkeypatch):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 15, 0, 0, tzinfo=timezone.utc),
+    )
+    task = _add(tmp_path, "N-way race target")
+    n = 8
+    barrier = threading.Barrier(n)
+    results: list[tuple[str, int, str]] = []
+    lock = threading.Lock()
+
+    def worker(idx: int) -> None:
+        actor = f"lane-{idx}"
+        claim_id = f"claim-{idx}"
+        barrier.wait(timeout=15)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "brigade",
+                "work",
+                "claim",
+                task["id"],
+                "--actor",
+                actor,
+                "--claim-id",
+                claim_id,
+                "--target",
+                str(tmp_path),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        with lock:
+            results.append((actor, proc.returncode, proc.stdout))
+
+    with ThreadPoolExecutor(max_workers=n) as executor:
+        futures = [executor.submit(worker, i) for i in range(n)]
+        for future in futures:
+            future.result(timeout=60)
+
+    assert len(results) == n
+    winners = [item for item in results if item[1] == 0]
+    losers = [item for item in results if item[1] == 13]
+    assert len(winners) == 1, f"expected exactly one winner, got {[(a, c) for a, c, _ in results]}"
+    assert len(losers) == n - 1
+    winner_payload = json.loads(winners[0][2])
+    assert winner_payload["created"] is True
+    for _actor, _code, stdout in losers:
+        payload = json.loads(stdout)
+        assert payload["reason"] == claim_mod.REASON_ALREADY_CLAIMED
+        assert payload["holder"] == winners[0][0]
+
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    stored = next(item for item in ledger["tasks"] if item["id"] == task["id"])
+    assert stored["assignee"] == winners[0][0]
+    assert stored["claim"]["claim_id"] == f"claim-{winners[0][0].split('-', 1)[1]}"
+
+
+def test_n_way_claim_next_assigns_distinct_ready_tasks(tmp_path, monkeypatch):
+    _init_git_repo(tmp_path)
+    clock = {"n": 0}
+
+    def _now():
+        clock["n"] += 1
+        return datetime(2026, 8, 9, 15, 0, clock["n"], tzinfo=timezone.utc)
+
+    monkeypatch.setattr(work_cmd.helpers, "_now", _now)
+    tasks = [_add(tmp_path, f"Ready pool {i}", priority="normal") for i in range(5)]
+    n = 5
+    barrier = threading.Barrier(n)
+    results: list[tuple[int, str]] = []
+    lock = threading.Lock()
+
+    def worker(idx: int) -> None:
+        barrier.wait(timeout=15)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "brigade",
+                "work",
+                "claim",
+                "--next",
+                "--actor",
+                f"lane-{idx}",
+                "--claim-id",
+                f"next-{idx}",
+                "--target",
+                str(tmp_path),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        with lock:
+            results.append((proc.returncode, proc.stdout))
+
+    with ThreadPoolExecutor(max_workers=n) as executor:
+        futures = [executor.submit(worker, i) for i in range(n)]
+        for future in futures:
+            future.result(timeout=60)
+
+    successes = [json.loads(out) for code, out in results if code == 0]
+    assert len(successes) == 5
+    claimed_ids = {item["task_id"] for item in successes}
+    assert claimed_ids == {task["id"] for task in tasks}
+
+
+def test_kill_mid_atomic_write_preserves_prior_ledger(tmp_path, monkeypatch):
+    """Simulate a crash before os.replace: the on-disk ledger must stay intact."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 15, 30, 0, tzinfo=timezone.utc),
+    )
+    task = _add(tmp_path, "Must survive crash")
+    path = _tasks_path(tmp_path)
+    before = path.read_text()
+    assert task["id"] in before
+
+    real_replace = os.replace
+
+    def boom_before_replace(src, dst):
+        raise OSError("simulated kill mid-write before replace")
+
+    monkeypatch.setattr(os, "replace", boom_before_replace)
+    with pytest.raises(OSError, match="simulated kill"):
+        work_cmd._write_task_ledger(
+            tmp_path,
+            {
+                "version": 2,
+                "tasks": [],
+                "edges": [],
+            },
+        )
+    monkeypatch.setattr(os, "replace", real_replace)
+    assert path.read_text() == before
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    assert any(item.get("id") == task["id"] for item in ledger["tasks"])
+
+
+# ---------------------------------------------------------------------------
+# Malformed / hand-edited tasks.json
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_tasks_json_must_not_be_wiped_by_mutation(tmp_path):
+    """Hand-truncated or corrupt tasks.json must fail closed — never empty-and-rewrite."""
+    _init_git_repo(tmp_path)
+    path = _tasks_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    good = {
+        "version": 2,
+        "tasks": [_seed_task_dict("keep-important", "Keep this work")],
+        "edges": [],
+    }
+    raw = json.dumps(good, indent=2) + "\n"
+    # Truncate mid-object so JSON is invalid but the task id is still on disk.
+    path.write_text(raw[: len(raw) // 2])
+    assert "keep-important" in path.read_text()
+
+    with pytest.raises(Exception) as excinfo:
+        work_cmd._add_task(tmp_path, "New after corrupt")
+    message = str(excinfo.value).casefold()
+    assert "corrupt" in message or "invalid" in message or "json" in message
+
+    # Original (corrupt) bytes must still be present — no silent empty rewrite.
+    on_disk = path.read_text()
+    assert "keep-important" in on_disk
+    assert "New after corrupt" not in on_disk
+
+
+def test_truncated_tasks_json_blocks_claim_and_edge_mutations(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    path = _tasks_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    good = {
+        "version": 2,
+        "tasks": [_seed_task_dict("still-here", "Still here")],
+        "edges": [],
+    }
+    path.write_text(json.dumps(good)[:-12])
+
+    rc = work_cmd.claim(
+        target=tmp_path,
+        task_id="still-here",
+        actor="lane-a",
+        claim_id="c1",
+        json_output=True,
+    )
+    assert rc == 2
+    first = capsys.readouterr()
+    captured = (first.out + first.err).casefold()
+    # Prefer an explicit corrupt-ledger signal over "task not found" on an empty parse.
+    assert "corrupt" in captured or "invalid" in captured or "json" in captured
+    assert "still-here" in path.read_text()
+
+    rc = work_cmd.task_edge_add(
+        target=tmp_path,
+        edge_type="blocks",
+        source="still-here",
+        target_id="still-here",
+        json_output=True,
+    )
+    assert rc == 2
+    assert "still-here" in path.read_text()
+    # Ensure we did not materialize an empty healthy ledger.
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(path.read_text())
+
+
+def test_hand_edited_unknown_edge_type_is_preserved_across_rewrite(tmp_path):
+    _init_git_repo(tmp_path)
+    a = _add(tmp_path, "Task A")
+    b = _add(tmp_path, "Task B")
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    ledger["edges"].append(
+        {
+            "id": "edge-hand-unknown",
+            "source": a["id"],
+            "target": b["id"],
+            "type": "depends-on",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+    # Bypass ensure_ledger_edges normalization by writing raw JSON.
+    _write_raw_ledger(tmp_path, ledger)
+
+    # A benign rewrite (edge list) must not silently drop the hand-edited type.
+    c = _add(tmp_path, "Task C")
+    rewritten = json.loads(_tasks_path(tmp_path).read_text())
+    types = {edge.get("type") for edge in rewritten.get("edges", [])}
+    assert "depends-on" in types
+    assert c["id"] in {task["id"] for task in rewritten["tasks"]}
+
+
+def test_hand_edited_self_edge_surfaces_as_cycle_not_ready(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    task = _add(tmp_path, "Self edged")
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    ledger["edges"] = [
+        {
+            "id": "edge-self",
+            "source": task["id"],
+            "target": task["id"],
+            "type": "blocks",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    ]
+    _write_raw_ledger(tmp_path, ledger)
+
+    assert work_cmd.ready(target=tmp_path, explain=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cycle_count"] >= 1
+    assert task["id"] not in {item["id"] for item in payload["ready"]}
+    blocked = next(item for item in payload["blocked"] if item["id"] == task["id"])
+    assert blocked["reason"] == edges_mod.REASON_DEPENDENCY_CYCLE
+
+
+def test_hand_edited_dangling_edge_target_does_not_gate_or_crash(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    consumer = _add(tmp_path, "Dangling consumer")
+    parent = _add(tmp_path, "Parent of missing child")
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    ledger["edges"] = [
+        {
+            "id": "edge-dangling",
+            "source": "missing-blocker",
+            "target": consumer["id"],
+            "type": "blocks",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        },
+        {
+            "id": "edge-dangling-pc",
+            "source": parent["id"],
+            "target": "missing-child",
+            "type": "parent-child",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        },
+    ]
+    _write_raw_ledger(tmp_path, ledger)
+    assert work_cmd.ready(target=tmp_path, explain=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    # Orphan blocker source must not gate the consumer.
+    assert payload["orphan_count"] >= 1
+    assert consumer["id"] in {item["id"] for item in payload["ready"]}
+    # Parent-of-missing is still a parent node, so not startable.
+    assert parent["id"] not in {item["id"] for item in payload["ready"]}
+
+
+# ---------------------------------------------------------------------------
+# Cycle attempts through every mutation path
+# ---------------------------------------------------------------------------
+
+
+def test_cycle_rejected_via_deps_closing_existing_chain(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    clock = {"n": 0}
+
+    def _now():
+        clock["n"] += 1
+        return datetime(2026, 8, 9, 16, 0, clock["n"], tzinfo=timezone.utc)
+
+    monkeypatch.setattr(work_cmd.helpers, "_now", _now)
+    a = _add(tmp_path, "A")
+    b = _add(tmp_path, "B")
+    assert work_cmd.task_edge_add(target=tmp_path, edge_type="blocks", source=a["id"], target_id=b["id"]) == 0
+    capsys.readouterr()
+    # C with blocks:B (B blocks C), then edge C→A would cycle; close via --deps on a
+    # reverse edge by adding a task that proposes blocking A while A already
+    # transitively blocks it — use graph for multi-edge, and deps for the
+    # single-edge close against an existing reverse.
+    # Direct: add edge B→A via a new task's deps is impossible (deps only make
+    # others block the new task). Close the cycle with edge add (already covered)
+    # and with import promote / graph below. Here: parent-child + blocks mix via deps.
+    assert (
+        work_cmd.task_add(
+            target=tmp_path,
+            text="Child under A",
+            deps=[f"parent-child:{a['id']}"],
+        )
+        == 0
+    )
+    child_id = capsys.readouterr().out.split("task: ", 1)[1].splitlines()[0]
+    # Child blocks A would form parent-child + blocks cycle (A→child, child→A).
+    assert (
+        work_cmd.task_edge_add(
+            target=tmp_path,
+            edge_type="blocks",
+            source=child_id,
+            target_id=a["id"],
+            json_output=True,
+        )
+        == 2
+    )
+    assert json.loads(capsys.readouterr().out)["reason"] == edges_mod.REASON_DEPENDENCY_CYCLE
+
+
+def test_cycle_rejected_via_graph_against_existing_ledger_edges(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 16, 10, 0, tzinfo=timezone.utc),
+    )
+    existing = _add(tmp_path, "Existing hub")
+    # Plan creates node X that blocks existing via... graph edges only reference
+    # plan-local keys. After materialization, add an edge from new node back.
+    # Instead: seed ledger edge existing→will-be-filled by applying graph that
+    # creates a node then we edge-add. Better: graph that alone is acyclic but
+    # combined with existing edges cycles.
+    # Seed: existing blocks phantom key? Can't. Seed edge after graph:
+    plan = {
+        "nodes": [{"key": "x", "text": "Graph X"}, {"key": "y", "text": "Graph Y"}],
+        "edges": [{"source": "x", "target": "y", "type": "blocks"}],
+    }
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps(plan))
+    assert work_cmd.task_add(target=tmp_path, graph=plan_path, json_output=True) == 0
+    applied = json.loads(capsys.readouterr().out)
+    x_id = applied["key_map"]["x"]
+    # existing → x already? Add existing blocks x, then x blocks existing via edge.
+    assert work_cmd.task_edge_add(target=tmp_path, edge_type="blocks", source=existing["id"], target_id=x_id) == 0
+    capsys.readouterr()
+    assert (
+        work_cmd.task_edge_add(
+            target=tmp_path,
+            edge_type="blocks",
+            source=x_id,
+            target_id=existing["id"],
+            json_output=True,
+        )
+        == 2
+    )
+    assert json.loads(capsys.readouterr().out)["reason"] == edges_mod.REASON_DEPENDENCY_CYCLE
+
+
+def test_cycle_via_import_promote_proposed_edges_fails_closed(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 16, 20, 0, tzinfo=timezone.utc),
+    )
+    a = _add(tmp_path, "Upstream A")
+    b = _add(tmp_path, "Downstream B")
+    assert work_cmd.task_edge_add(target=tmp_path, edge_type="blocks", source=a["id"], target_id=b["id"]) == 0
+    capsys.readouterr()
+    assert work_cmd.import_add(target=tmp_path, text="Cycle bait import", kind="task", source="manual") == 0
+    capsys.readouterr()
+    imports = work_cmd._read_imports(tmp_path)
+    imports[0]["metadata"] = {
+        "proposed_edges": [{"type": "blocks", "source": b["id"], "target": a["id"]}],
+    }
+    work_cmd._write_imports(tmp_path, imports)
+    before_count = len(work_cmd._read_task_ledger(tmp_path)["tasks"])
+    # Must not traceback; must refuse the promote and leave ledger/import intact.
+    rc = work_cmd.import_promote(target=tmp_path, import_id=imports[0]["id"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    combined = (captured.out + captured.err).casefold()
+    assert "cycle" in combined or "dependency" in combined
+    assert len(work_cmd._read_task_ledger(tmp_path)["tasks"]) == before_count
+    assert work_cmd._read_imports(tmp_path)[0]["status"] == "pending"
+
+
+def test_cycle_via_deps_unknown_type_rejected(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    upstream = _add(tmp_path, "Upstream")
+    rc = work_cmd.task_add(
+        target=tmp_path,
+        text="Bad deps type",
+        deps=[f"depends-on:{upstream['id']}"],
+        json_output=True,
+    )
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "unknown edge type" in (captured.out + captured.err).casefold() or "depends-on" in (
+        captured.out + captured.err
+    )
+
+
+def test_parent_child_bidirectional_cycle_rejected(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 16, 30, 0, tzinfo=timezone.utc),
+    )
+    a = _add(tmp_path, "Parent A")
+    b = _add(tmp_path, "Parent B")
+    assert work_cmd.task_edge_add(target=tmp_path, edge_type="parent-child", source=a["id"], target_id=b["id"]) == 0
+    capsys.readouterr()
+    assert (
+        work_cmd.task_edge_add(
+            target=tmp_path,
+            edge_type="parent-child",
+            source=b["id"],
+            target_id=a["id"],
+            json_output=True,
+        )
+        == 2
+    )
+    assert json.loads(capsys.readouterr().out)["reason"] == edges_mod.REASON_DEPENDENCY_CYCLE
+
+
+# ---------------------------------------------------------------------------
+# Footprint hostility
+# ---------------------------------------------------------------------------
+
+
+def test_footprint_caps_huge_file_and_symbol_lists():
+    huge_files = [f"src/mod_{i}.py" for i in range(50_000)]
+    huge_symbols = [f"pkg.sym_{i}" for i in range(50_000)]
+    normalized = footprint_mod.normalize_footprint(
+        {"files": huge_files, "symbol_ids": huge_symbols},
+        phase="predicted",
+    )
+    assert len(normalized["files"]) <= footprint_mod.MAX_FOOTPRINT_ENTRIES
+    assert len(normalized["symbol_ids"]) <= footprint_mod.MAX_FOOTPRINT_ENTRIES
+
+
+def test_footprint_rejects_path_traversal_and_absolute_paths(tmp_path):
+    _init_git_repo(tmp_path)
+    task = _add(tmp_path, "Hostile paths")
+    rc = work_cmd.task_claim(
+        target=tmp_path,
+        task_id=task["id"],
+        actor="lane-a",
+        files=[
+            "../../etc/passwd",
+            "/etc/shadow",
+            "src/ok.py",
+            "..\\windows\\system32\\config",
+            "docs/../secrets/key.pem",
+        ],
+        from_plan=False,
+        json_output=True,
+    )
+    assert rc == 0
+    # Re-read — only safe relative paths may be stored.
+    stored, _ = work_cmd._find_task(tmp_path, task["id"])
+    files = stored["metadata"]["footprint"]["files"]
+    assert files == ["src/ok.py"]
+    for bad in ("../", "/etc/", "windows\\system32", "secrets/key"):
+        assert not any(bad in item or item.startswith("/") for item in files)
+
+
+def test_footprint_sidecar_path_cannot_read_outside_target(tmp_path):
+    _init_git_repo(tmp_path)
+    outside = tmp_path.parent / "outside-secret.json"
+    outside.write_text(
+        json.dumps(
+            {
+                "files": ["leaked.py"],
+                "changed_symbols": ["leaked.sym"],
+                "snapshot_hash": "evil",
+            }
+        )
+    )
+    try:
+        prior = footprint_mod.normalize_footprint(
+            {"files": ["safe.py"], "symbol_ids": ["safe.sym"], "snapshot_hash": "safe"},
+            phase="refined",
+        )
+        reconciled = footprint_mod.reconcile_footprint(
+            {"sidecar_path": str(outside)},
+            prior=prior,
+            target=tmp_path,
+        )
+        # Must not join the outside sidecar; fall back to prior.
+        assert reconciled["files"] == ["safe.py"]
+        assert reconciled["symbol_ids"] == ["safe.sym"]
+        assert reconciled["snapshot_hash"] == "safe"
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+def test_footprint_sidecar_inside_target_still_joins(tmp_path):
+    _init_git_repo(tmp_path)
+    sidecar = tmp_path / ".brigade" / "work" / "verify-delta.json"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "files": ["src/joined.py"],
+                "changed_symbols": ["pkg.joined"],
+                "snapshot_hash": "inside",
+            }
+        )
+    )
+    reconciled = footprint_mod.reconcile_footprint(
+        {"sidecar_path": str(sidecar)},
+        target=tmp_path,
+    )
+    assert reconciled["files"] == ["src/joined.py"]
+    assert reconciled["symbol_ids"] == ["pkg.joined"]
+    assert reconciled["snapshot_hash"] == "inside"
+
+
+# ---------------------------------------------------------------------------
+# Ledger version mismatches
+# ---------------------------------------------------------------------------
+
+
+def test_future_ledger_version_rejects_mutation_without_clobber(tmp_path):
+    _init_git_repo(tmp_path)
+    path = _tasks_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 99,
+        "tasks": [_seed_task_dict("future-1", "From the future")],
+        "edges": [],
+        "future_field": {"keep": True},
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    before = path.read_text()
+
+    with pytest.raises(Exception) as excinfo:
+        work_cmd._add_task(tmp_path, "Must not write")
+    assert "version" in str(excinfo.value).casefold()
+    assert path.read_text() == before
+
+    rc = work_cmd.claim(target=tmp_path, task_id="future-1", actor="lane-a", claim_id="c1")
+    assert rc != 0
+    assert path.read_text() == before
+
+
+def test_non_integer_ledger_version_rejects(tmp_path):
+    _init_git_repo(tmp_path)
+    path = _tasks_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": "two",
+                "tasks": [_seed_task_dict("v-str", "String version")],
+                "edges": [],
+            }
+        )
+        + "\n"
+    )
+    with pytest.raises(Exception) as excinfo:
+        work_cmd._read_task_ledger(tmp_path)
+    assert "version" in str(excinfo.value).casefold()
+
+
+def test_legacy_v1_still_migrates_on_read(tmp_path):
+    _init_git_repo(tmp_path)
+    path = _tasks_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "tasks": [_seed_task_dict("legacy-ok", "Legacy pending")],
+            }
+        )
+    )
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    assert ledger["version"] == 2
+    assert ledger["edges"] == []
+    assert ledger["tasks"][0]["id"] == "legacy-ok"
+
+
+# ---------------------------------------------------------------------------
+# Dual claim surface: task claim must not bypass CAS
+# ---------------------------------------------------------------------------
+
+
+def test_task_claim_cannot_steal_cas_holder(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 17, 0, 0, tzinfo=timezone.utc),
+    )
+    task = _add(tmp_path, "CAS held")
+    assert work_cmd.claim(target=tmp_path, task_id=task["id"], actor="lane-a", claim_id="c1", json_output=True) == 0
+    capsys.readouterr()
+
+    rc = work_cmd.task_claim(
+        target=tmp_path,
+        task_id=task["id"],
+        actor="lane-b",
+        files=["src/a.py"],
+        from_plan=False,
+        json_output=True,
+    )
+    assert rc == 13
+    payload = json.loads(capsys.readouterr().out)
+    assert payload.get("reason") == claim_mod.REASON_ALREADY_CLAIMED
+    stored, _ = work_cmd._find_task(tmp_path, task["id"])
+    assert stored["assignee"] == "lane-a"
+    assert stored["claim"]["actor"] == "lane-a"
+    assert stored["claim"]["claim_id"] == "c1"
+
+
+def test_task_claim_writes_releasable_claim_record(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 17, 10, 0, tzinfo=timezone.utc),
+    )
+    task = _add(tmp_path, "Footprint claim needs CAS record")
+    assert (
+        work_cmd.task_claim(
+            target=tmp_path,
+            task_id=task["id"],
+            actor="lane-a",
+            files=["src/a.py"],
+            from_plan=False,
+            json_output=True,
+        )
+        == 0
+    )
+    claimed = json.loads(capsys.readouterr().out)
+    assert claimed["status"] == "in_progress"
+    stored, _ = work_cmd._find_task(tmp_path, task["id"])
+    assert isinstance(stored.get("claim"), dict)
+    assert stored["claim"]["actor"] == "lane-a"
+    assert stored["claim"]["claim_id"]
+
+    assert work_cmd.release(target=tmp_path, actor=["lane-a"], json_output=True) == 0
+    released = json.loads(capsys.readouterr().out)
+    assert released["released_count"] == 1
+    stored, _ = work_cmd._find_task(tmp_path, task["id"])
+    assert stored["status"] == "pending"
+    assert "claim" not in stored
+
+
+def test_task_claim_idempotent_for_same_actor_refines_footprint(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 17, 20, 0, tzinfo=timezone.utc),
+    )
+    task = _add(tmp_path, "Same actor refine")
+    assert work_cmd.claim(target=tmp_path, task_id=task["id"], actor="lane-a", claim_id="hold", json_output=True) == 0
+    capsys.readouterr()
+    assert (
+        work_cmd.task_claim(
+            target=tmp_path,
+            task_id=task["id"],
+            actor="lane-a",
+            files=["src/refined.py"],
+            from_plan=False,
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["footprint"]["files"] == ["src/refined.py"]
+    stored, _ = work_cmd._find_task(tmp_path, task["id"])
+    assert stored["claim"]["claim_id"] == "hold"
+    assert stored["assignee"] == "lane-a"

--- a/tests/test_work_cmd_work_graph_hardening.py
+++ b/tests/test_work_cmd_work_graph_hardening.py
@@ -656,6 +656,153 @@ def test_non_integer_ledger_version_rejects(tmp_path):
     assert "version" in str(excinfo.value).casefold()
 
 
+def _write_corrupt_ledger(target: Path) -> Path:
+    path = _tasks_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"version": 2, "tasks": [')
+    return path
+
+
+def _write_unsupported_ledger(target: Path) -> Path:
+    path = _tasks_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 99,
+        "tasks": [_seed_task_dict("future-1", "From the future")],
+        "edges": [],
+        "future_field": {"keep": True},
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    return path
+
+
+def _run_read_surface(command: str, target: Path) -> int:
+    if command == "tasks":
+        return work_cmd.tasks(target=target, json_output=True)
+    if command == "ready":
+        return work_cmd.ready(target=target, json_output=True)
+    if command == "release":
+        return work_cmd.release(target=target, actor=["lane-a"], json_output=True)
+    raise AssertionError(f"unknown read surface: {command}")
+
+
+@pytest.mark.parametrize("command", ["tasks", "ready", "release"])
+@pytest.mark.parametrize("kind", ["corrupt", "unsupported"])
+def test_read_surfaces_fail_closed_on_bad_ledger(tmp_path, capsys, command, kind):
+    _init_git_repo(tmp_path)
+    path = _write_corrupt_ledger(tmp_path) if kind == "corrupt" else _write_unsupported_ledger(tmp_path)
+    before = path.read_text()
+    expected_reason = "corrupt_ledger" if kind == "corrupt" else "unsupported_ledger_version"
+    needle = "corrupt" if kind == "corrupt" else "version"
+
+    rc = _run_read_surface(command, tmp_path)
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.err
+    payload = json.loads(captured.out)
+    assert payload["reason"] == expected_reason
+    assert payload["exit_code"] == 2
+    assert needle in (captured.out + captured.err).casefold()
+    assert path.read_text() == before
+
+
+def test_work_dispatch_catches_ledger_error_for_unwired_show(tmp_path):
+    _init_git_repo(tmp_path)
+    path = _write_corrupt_ledger(tmp_path)
+    before = path.read_text()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "brigade",
+            "work",
+            "task",
+            "show",
+            "future-1",
+            "--target",
+            str(tmp_path),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "Traceback" not in proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["reason"] == "corrupt_ledger"
+    assert payload["exit_code"] == 2
+    assert path.read_text() == before
+
+
+def test_unknown_edge_type_surfaces_in_ready_and_doctor(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    a = _add(tmp_path, "Task A")
+    b = _add(tmp_path, "Task B")
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    ledger["edges"].append(
+        {
+            "id": "edge-hand-unknown",
+            "source": a["id"],
+            "target": b["id"],
+            "type": "dependson",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+    _write_raw_ledger(tmp_path, ledger)
+
+    assert work_cmd.ready(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unknown_type_count"] == 1
+    assert payload["unknown_types"] == ["dependson"]
+
+    assert work_cmd.ready(target=tmp_path) == 0
+    text = capsys.readouterr().out
+    assert "unknown_type_count: 1" in text
+    assert "dependson" in text
+
+    work_cmd.doctor(target=tmp_path)
+    doctor_out = capsys.readouterr().out
+    assert "unknown_edge_types" in doctor_out
+    assert "dependson" in doctor_out
+
+
+def test_import_promote_all_partial_failure_is_nonzero(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 16, 30, 0, tzinfo=timezone.utc),
+    )
+    a = _add(tmp_path, "Upstream A")
+    b = _add(tmp_path, "Downstream B")
+    assert work_cmd.task_edge_add(target=tmp_path, edge_type="blocks", source=a["id"], target_id=b["id"]) == 0
+    assert work_cmd.import_add(target=tmp_path, text="Healthy import", kind="task", source="manual") == 0
+    assert work_cmd.import_add(target=tmp_path, text="Cycle bait import", kind="task", source="manual") == 0
+    capsys.readouterr()
+    imports = work_cmd._read_imports(tmp_path)
+    cycle_item = next(item for item in imports if item["text"] == "Cycle bait import")
+    cycle_item["metadata"] = {
+        "proposed_edges": [{"type": "blocks", "source": b["id"], "target": a["id"]}],
+    }
+    work_cmd._write_imports(tmp_path, imports)
+    before_count = len(work_cmd._read_task_ledger(tmp_path)["tasks"])
+
+    rc = work_cmd.import_promote(target=tmp_path, all_matching=True)
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "promoted: 1" in captured.out
+    assert "failed: 1" in captured.out
+    assert (
+        "cycle" in (captured.out + captured.err).casefold() or "dependency" in (captured.out + captured.err).casefold()
+    )
+    after = work_cmd._read_task_ledger(tmp_path)
+    assert len(after["tasks"]) == before_count + 1
+    remaining = [item for item in work_cmd._read_imports(tmp_path) if item.get("status") == "pending"]
+    assert len(remaining) == 1
+    assert remaining[0]["text"] == "Cycle bait import"
+
+
 def test_legacy_v1_still_migrates_on_read(tmp_path):
     _init_git_repo(tmp_path)
     path = _tasks_path(tmp_path)

--- a/tests/test_work_store_measurement.py
+++ b/tests/test_work_store_measurement.py
@@ -77,7 +77,7 @@ def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
     )
     assert report["issue"] == 846
     assert report["slice"] == "R3"
-    assert report["protocol_version"] == 3
+    assert report["protocol_version"] == 4
     assert report["kind"] == "work-store-characterization"
     assert report["anonymous_metrics"] == "disabled_in_harness"
     assert {"environment", "fixtures", "results", "decision", "capability_notes"} <= set(report)
@@ -107,7 +107,19 @@ def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
         assert result["restart_recovery"]["status"] == "measured"
         assert result["restart_recovery"]["pass"] is True
         assert result["schema_version_policy"]["status"] == "measured"
-        assert result["schema_version_policy"]["future_version_rejected"] is False
+        # Protocol 4: fail-closed. The v102 probe must reject, not coerce.
+        assert result["schema_version_policy"]["future_version_rejected"] is True
+        assert result["schema_version_policy"]["future_version_bytes_unchanged"] is True
+        assert result["schema_version_policy"]["future_version_reason"] == "unsupported_ledger_version"
+        assert result["schema_version_policy"]["future_version_exit_code"] == 2
+        assert result["schema_version_policy"]["future_version_clean_error"] is True
+        assert result["schema_version_policy"]["observed_policy"] == "fail_closed_unsupported_ledger_version"
+        assert result["schema_version_policy"]["pass"] is True
+        assert result["schema_version_policy"]["downgrade_rejected"] is False
+        downgrade_key = (
+            "downgrade_coerced_on_read" if result["shape"] == "json_ledger" else "downgrade_coerced_on_export"
+        )
+        assert result["schema_version_policy"][downgrade_key] is True
         assert result["backup_restore"]["status"] == "measured"
         assert result["backup_restore"]["pass"] is True
         assert isinstance(result["backup_restore"]["backup_time_ns"], int)
@@ -124,6 +136,10 @@ def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
         assert result["claim_race"]["exit_13_count"] == 1
 
     json_result = next(item for item in report["results"] if item["shape"] == "json_ledger")
+    assert json_result["schema_version_policy"]["future_version_after_read"] is None
+    assert json_result["schema_version_policy"]["future_version_coerced_on_read"] is False
+    assert json_result["schema_version_policy"]["future_version_cli_exit_code"] == 2
+    assert json_result["schema_version_policy"]["future_version_written"] == 102
     assert json_result["guard_and_empty_filter"]["status"] == "measured"
     assert json_result["guard_and_empty_filter"]["pass"] is True
     assert json_result["guard_and_empty_filter"]["if_actor_mismatch"]["pass"] is True
@@ -147,6 +163,9 @@ def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
     assert git_history["synthetic_tracked_history"]["deleted_secret_retained_in_history"] is True
     assert git_history["pass"] is True
     sqlite_result = next(item for item in report["results"] if item["shape"] == "sqlite_wal")
+    assert sqlite_result["schema_version_policy"]["future_version_after_export"] is None
+    assert sqlite_result["schema_version_policy"]["future_version_coerced_on_export"] is False
+    assert sqlite_result["schema_version_policy"]["future_version_written"] == 102
     assert sqlite_result["guard_and_empty_filter"]["status"] == "measured"
     assert sqlite_result["guard_and_empty_filter"]["pass"] is True
     assert sqlite_result["guard_and_empty_filter"]["claim_cleanup"] == {"item_revision": 2, "pass": True}
@@ -162,6 +181,35 @@ def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
     assert sqlite_result["secret_history_handling"]["git_history"]["status"] == "unavailable"
     assert "scanned_store_path" in sqlite_result["metrics_state"]
     assert sqlite_result["metrics_state"]["metrics_artifacts"] == []
+
+
+def test_schema_version_policy_rejects_future_version_cleanly(tmp_path):
+    """v102 probe records fail-closed rejection: clean error, rc=2, lossless."""
+    module = _load_module()
+    ledger = module.build_fixture("chain_50")
+    json_policy = module._json_schema_version_policy(tmp_path, ledger)
+    assert json_policy["pass"] is True
+    assert json_policy["future_version_rejected"] is True
+    assert json_policy["future_version_written"] == 102
+    assert json_policy["future_version_after_read"] is None
+    assert json_policy["future_version_coerced_on_read"] is False
+    assert json_policy["future_version_bytes_unchanged"] is True
+    assert json_policy["future_version_reason"] == "unsupported_ledger_version"
+    assert json_policy["future_version_exit_code"] == 2
+    assert json_policy["future_version_cli_exit_code"] == 2
+    assert json_policy["future_version_clean_error"] is True
+    assert json_policy["downgrade_coerced_on_read"] is True
+    sqlite_policy = module._sqlite_schema_version_policy(tmp_path, ledger)
+    assert sqlite_policy["pass"] is True
+    assert sqlite_policy["future_version_rejected"] is True
+    assert sqlite_policy["future_version_written"] == 102
+    assert sqlite_policy["future_version_after_export"] is None
+    assert sqlite_policy["future_version_coerced_on_export"] is False
+    assert sqlite_policy["future_version_bytes_unchanged"] is True
+    assert sqlite_policy["future_version_reason"] == "unsupported_ledger_version"
+    assert sqlite_policy["future_version_exit_code"] == 2
+    assert sqlite_policy["future_version_clean_error"] is True
+    assert sqlite_policy["downgrade_coerced_on_export"] is True
 
 
 def test_sqlite_metrics_restores_env_and_scans_store(tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Recover the unfinished work-graph hardening campaign from `cursor/brigade-work-graph-hardening-5764` onto current main. Corrupt or future-version `tasks.json` no longer parses as an empty ledger (which let the next mutation wipe recoverable work). Hand-edited unknown edge types survive rewrite, import promote fails closed on cycle-forming proposed edges, and footprint lists/sidecar reads are capped and confined to the workspace target.

The previous campaign ended without a PR. This branch replays only the work main still lacked.

## Recovered from `cursor/brigade-work-graph-hardening-5764`

- Fail-closed task-ledger reads: `TaskLedgerError` with reasons `corrupt_ledger` and `unsupported_ledger_version`
- Preserve hand-edited unknown edge types across `normalize_edges` rewrite
- Catch `EdgeError` / `TaskLedgerError` on `import_promote` (exit 2, import stays pending)
- Footprint size cap (`MAX_FOOTPRINT_ENTRIES = 512`), drop traversal/absolute paths, confine reconcile `sidecar_path` reads to `--target`
- `tests/test_work_cmd_work_graph_hardening.py` (769-line adversarial suite)

## Dropped as already-landed

- `fix(work): bind task claim to CAS claim records` (commit `81085625` on the old branch) already merged via [PR #857](https://github.com/escoffier-labs/brigade/pull/857) / #856, including the follow-up that adopts legacy `in_progress` rows without `--actor`. Not replayed.
- The recovered suite still asserts the dual-surface CAS behavior against current main (`task_claim` cannot steal a live holder; pending claims write a releasable record; same-actor refine keeps `claim_id`).

## Reconciliation with main (~90 commits ahead of the old branch point)

- Replayed onto current main rather than a raw rebase: `ledger.py`, `task_ops.py`, `footprint.py`, and `imports.py` all moved substantially.
- `TaskLedgerError` subclasses `ValueError`. Current `task_add` already has a `ValueError` handler, so the ledger handler is registered first; otherwise JSON `as_dict()` payloads would never emit.
- `#857` already owns `task_claim` CAS binding (and omitted the old branch's `TaskLedgerError` helpers). This PR adds those helpers only, and passes `target=` into `reconcile_footprint` from `task_done` / run completion.
- `ensure_ledger_edges` still stamps `version = 2` after a successful read, so legacy v1 migrates in memory; future versions are rejected before that call.
- Campaign member ledgers already fail closed via their own reader; left untouched.

## Policy inversion: future ledger versions now fail closed

This is a deliberate contract change, not a broken fixture to patch around. CI on `test (3.11)` failed in `tests/test_work_store_measurement.py` because that harness still encoded the old tolerate-future-versions policy. Targeted `test_work_cmd_*` suites missed it (K3 review F4).

**Old contract (measurement protocol 3):** `scripts/measure_work_store.py` wrote a v102 ledger (`TASK_LEDGER_VERSION + 100`) and asserted `schema_version_policy.future_version_rejected is False`. `_read_task_ledger` plus `ensure_ledger_edges` coerced the in-memory version to 2. That was the documented tolerate/coerce policy.

**Why fail-closed replaces it:** Silent-empty or coerced reads of corrupt / future ledgers are how recoverable work gets wiped. The next mutation rewrites `tasks.json` from the empty or downgraded parse. K3 review F1 is the same rationale: hostile ledger state must fail gracefully (`error: ...` / `reason=unsupported_ledger_version` / rc=2) with on-disk bytes untouched, not parse as empty or silently downgrade.

**What moved (the v102 probe was not deleted):** Protocol 4 still writes version 102 and still measures the store's reaction. The cell now requires clean rejection and lossless reporting:

- `future_version_rejected` is `True` (was `False` — assertion inverted because the measured policy inverted)
- `protocol_version` is `4` (was `3` — pass criteria and report fields for this cell changed)
- `observed_policy` is `fail_closed_unsupported_ledger_version` (was `ensure_ledger_edges_coerces_version_to_current` / the sqlite coerce string — those names encoded the old expectation)
- New required proofs: `future_version_reason=unsupported_ledger_version`, `future_version_exit_code=2`, `future_version_bytes_unchanged=true`, `future_version_clean_error=true` (JSON also records `future_version_cli_exit_code=2` and `future_version_after_read=null`)
- Legacy v1 is unchanged: `downgrade_rejected` stays `False`; v1 still migrates in memory

The sqlite characterization adapter now raises `TaskLedgerError` on a future `meta.version` instead of coercing via `ensure_ledger_edges`. Losslessness there is a logical row digest (WAL header churn is not a write).

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] `pytest -q` passes locally (7726 passed, 5 skipped, 68 subtests passed in 38:18)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages

## Targeted tests

```
python -m pytest tests/test_work_store_measurement.py -q
# 20 passed in 33.62s

python -m pytest tests/test_work_cmd_work_graph_hardening.py \
  tests/test_work_cmd_ledger.py tests/test_work_cmd_edges.py \
  tests/test_work_cmd_footprint.py tests/test_work_cmd_claim.py \
  tests/test_work_cmd_imports.py tests/test_work_cmd_facade.py -q
# 241 passed in 16.42s

python -m pytest -q
# 7726 passed, 5 skipped, 68 subtests passed in 2298.53s (0:38:18)
```

261 targeted tests passed, including the four CI failures. Full suite green locally. Temp-dir smoke: truncated `tasks.json` returns `reason=corrupt_ledger` and is not rewritten; a v99/v102 ledger returns `reason=unsupported_ledger_version` and keeps extra fields.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-538f21d3-f9ef-4e8b-99d6-5c2433822785?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-538f21d3-f9ef-4e8b-99d6-5c2433822785&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

