### PR TITLE
fix(memory): make the Obsidian projection browsable on a real corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recover <operation-id>`. Refs #911.
 
 ### Changed
+- `brigade memory project-vault` produces a browsable vault on a real corpus.
+  Notes take their title from the card's leading heading when frontmatter has
+  no `title`, instead of the filename slug, and that heading is no longer
+  repeated in the body. Related links are ranked and capped at 12 per note, so
+  a large shared category no longer forms a complete graph. Maps that would
+  cover every note are omitted, and canvas nodes lay out in a grid rather than
+  one row. On a 1,254-card corpus this took the canvas from 83,586 edges and
+  11.3 MB to a bounded graph. (#888)
 - Center Memory Operations Cards now shows corpus size, a chip cloud, compact
   expandable rows, and 30-row paging. Handoffs is a sibling tab on that page;
   `/view/handoffs` redirects there. Snapshot polling reloads the page so

--- a/docs/memory-operations.md
+++ b/docs/memory-operations.md
@@ -40,6 +40,42 @@ The identity audit is read-only. It reports explicit card ids versus path fallba
 
 The crawl command projects memory into the evidence log only when the installed engine advertises `memory-projection.v1`. It accepts `--dry-run`, `--json`, `--rebuild`, and a positive `--limit`. It rejects the broader `--full` scan. Completed scans may tombstone missing projection rows. Failed or interrupted scans preserve the last completed projection and mark it stale instead of deleting it. Evidence projection status also appears inside Memory Operations inventory rows when evidence artifacts are present or missing.
 
+## Obsidian vault projection
+
+```bash
+brigade memory project-vault --target . --vault /path/to/vault
+brigade memory project-vault --target . --vault /path/to/vault --json
+```
+
+One-way projection of canonical memory into a `Brigade Memory/` subfolder of an operator-supplied vault: one note per store item with care-state frontmatter and tags, category and harness maps, and a topology canvas. Writes go through the projection transaction kernel, so a failed run restores the vault. A manual edit inside the projection is untrusted data: Brigade preserves it, writes a conflict copy, and reports drift instead of merging.
+
+Note titles come from a card's leading heading when its frontmatter has no `title`, falling back to the inventory title. Related links are ranked (explicit refs, then shared tags, then shared category) and capped per note, so a large shared category does not turn into a complete graph. A map that would cover every note is omitted. The vault path stays out of topology output as `redacted:operator-vault`.
+
+Rerunning is idempotent: unchanged notes produce no mutation.
+
+### Where memory flows
+
+```mermaid
+flowchart LR
+    subgraph AGENTS [" agent sessions "]
+        H["harness handoff inboxes"]
+    end
+    subgraph BRIGADE [" canonical memory "]
+        CANON["cards · rules · TOOLS.md<br/>USER.md · .learnings"]
+    end
+    subgraph VAULT [" operator vault "]
+        PROJ["Brigade Memory/<br/>generated, one-way"]
+        OWNED["operator-authored notes"]
+    end
+
+    H -->|"handoff ingest"| CANON
+    CANON -->|"memory recall · search · serve-mcp"| AGENTS
+    CANON -->|"memory project-vault"| PROJ
+    OWNED -.->|"no read path yet"| CANON
+```
+
+Brigade writes into a vault and does not read back from one. Retrieval from operator-authored vault notes is tracked in [#943](https://github.com/escoffier-labs/brigade/issues/943); writing agent-proposed notes back into a vault is tracked in [#945](https://github.com/escoffier-labs/brigade/issues/945). Until those land, a vault is a projection target, not a memory source.
+
 ## Care
 
 Care remains a separate mutating/planning family:

--- a/src/brigade/obsidian_vault.py
+++ b/src/brigade/obsidian_vault.py
@@ -17,6 +17,11 @@ from .projection import kernel
 
 PROJECTOR = "obsidian-vault"
 PROJECTION_FOLDER = "Brigade Memory"
+MAX_RELATED = 12
+CANVAS_COLUMNS = 24
+_REFERENCE_WEIGHT = 1_000
+_CANVAS_COLUMN_WIDTH = 260
+_CANVAS_ROW_HEIGHT = 140
 LEDGER_DIR = ".brigade/memory-vault"
 LEDGER_SCHEMA = "brigade.obsidian-vault.ledger.v1"
 _BEARER_RE = re.compile(r"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+")
@@ -224,8 +229,8 @@ def _render_projection(target: Path, *, root: Path, prior_files: dict[str, str])
     rendered: dict[str, bytes] = {}
     for record in records:
         rendered[record["path"]] = _render_note(record, links[record["id"]])
-    _render_maps(rendered, "category", "Categories", _groups(records, "category"))
-    _render_maps(rendered, "harness", "Harnesses", _groups(records, "source_harness"))
+    _render_maps(rendered, "category", "Categories", _groups(records, "category"), total=len(records))
+    _render_maps(rendered, "harness", "Harnesses", _groups(records, "source_harness"), total=len(records))
     rendered["Brigade Memory.canvas"] = _render_canvas(target, records, links)
     return rendered
 
@@ -254,14 +259,35 @@ def _record(target: Path, item: dict[str, Any]) -> dict[str, Any]:
     else:
         stable_id = str(item["id"])
         aliases = ()
+    title = str(item["title"])
+    body = _without_frontmatter(text)
+    heading, remainder = _leading_heading(body)
+    if heading and not str(frontmatter.get("title") or "").strip():
+        # Without a frontmatter title the inventory falls back to the filename slug,
+        # so the card's own heading is the better name for a human-browsable vault.
+        title, body = heading, remainder
+    elif heading and heading.casefold() == title.casefold():
+        body = remainder
     return {
         "id": stable_id,
         "aliases": aliases,
         "item": item,
-        "title": str(item["title"]),
-        "body": _without_frontmatter(text),
+        "title": title,
+        "body": body,
         "references": _references(frontmatter),
     }
+
+
+def _leading_heading(body: str) -> tuple[str, str]:
+    """Split a leading `# Heading` off the body; the projection renders its own title heading."""
+    lines = body.split("\n")
+    for index, line in enumerate(lines):
+        if not line.strip():
+            continue
+        if not line.startswith("# "):
+            return "", body
+        return line[2:].strip(), "\n".join(lines[index + 1 :]).lstrip("\n")
+    return "", body
 
 
 def _assign_paths(records: list[dict[str, Any]]) -> None:
@@ -290,6 +316,11 @@ def _assign_link_paths(records: list[dict[str, Any]], *, root: Path, prior_files
 
 
 def _relationships(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Rank each note's neighbours and keep the strongest few.
+
+    Every pair sharing a category used to become related, so one 221-card category
+    alone contributed ~24,000 edges. Ranking keeps the useful links and bounds the graph.
+    """
     # Dual-read index: canonical paths, stable card IDs, and legacy aliases all resolve.
     # A key claimed by two different records is ambiguous (#867); mark it unresolvable
     # instead of letting the last writer silently win and mis-link.
@@ -311,7 +342,7 @@ def _relationships(records: list[dict[str, Any]]) -> dict[str, list[dict[str, An
             claim(str(alias), record)
     result: dict[str, list[dict[str, Any]]] = {}
     for record in records:
-        related: dict[str, dict[str, Any]] = {}
+        scored: dict[str, tuple[int, dict[str, Any]]] = {}
         item = record["item"]
         tags = {str(tag).lower() for tag in item.get("tags") or []}
         category = str(item.get("category") or "")
@@ -319,16 +350,19 @@ def _relationships(records: list[dict[str, Any]]) -> dict[str, list[dict[str, An
             if other is record:
                 continue
             other_item = other["item"]
-            if category and category == str(other_item.get("category") or ""):
-                related[other["id"]] = other
+            shared = len(tags & {str(tag).lower() for tag in other_item.get("tags") or []})
+            same_category = bool(category) and category == str(other_item.get("category") or "")
+            if not shared and not same_category:
                 continue
-            if tags & {str(tag).lower() for tag in other_item.get("tags") or []}:
-                related[other["id"]] = other
+            scored[other["id"]] = (shared * 2 + (1 if same_category else 0), other)
         for reference in record["references"]:
             referenced = by_source.get(reference)
             if referenced is not None and referenced is not record:
-                related[referenced["id"]] = referenced
-        result[record["id"]] = sorted(related.values(), key=lambda item: (item["title"], item["id"]))
+                # An explicit ref is the strongest signal and always survives the cap.
+                scored[referenced["id"]] = (_REFERENCE_WEIGHT, referenced)
+        ranked = sorted(scored.values(), key=lambda entry: (-entry[0], entry[1]["title"], entry[1]["id"]))
+        kept = [other for _, other in ranked[:MAX_RELATED]]
+        result[record["id"]] = sorted(kept, key=lambda other: (other["title"], other["id"]))
     return result
 
 
@@ -385,9 +419,15 @@ def _render_map(kind: str, name: str, members: list[dict[str, Any]]) -> bytes:
     return "\n".join(lines).encode()
 
 
-def _render_maps(rendered: dict[str, bytes], kind: str, folder: str, groups: dict[str, list[dict[str, Any]]]) -> None:
+def _render_maps(
+    rendered: dict[str, bytes], kind: str, folder: str, groups: dict[str, list[dict[str, Any]]], *, total: int
+) -> None:
     used: set[str] = set()
     for name, members in groups.items():
+        # A map holding every note groups nothing. Cards without `source_harness` used to
+        # collapse into one "unknown" map listing the entire corpus.
+        if len(members) >= total:
+            continue
         stem = _unique_map_stem(name, used)
         rendered[f"Maps/{folder}/{stem}.md"] = _render_map(kind, name, members)
 
@@ -412,13 +452,15 @@ def _render_canvas(target: Path, records: list[dict[str, Any]], links: dict[str,
             "id": f"card-{_sha256(record['id'])[:16]}",
             "type": "text",
             "text": _redacted_scalar(record["title"]),
-            "x": index * 260,
-            "y": 0,
+            "x": (index % CANVAS_COLUMNS) * _CANVAS_COLUMN_WIDTH,
+            "y": (index // CANVAS_COLUMNS) * _CANVAS_ROW_HEIGHT,
             "width": 220,
             "height": 80,
         }
         for index, record in enumerate(records_sorted)
     ]
+    # Topology sits below the note grid instead of overlapping row two.
+    topology_row = ((len(records_sorted) + CANVAS_COLUMNS - 1) // CANVAS_COLUMNS) * _CANVAS_ROW_HEIGHT + 180
     node_ids = {record["id"]: node["id"] for record, node in zip(records_sorted, nodes, strict=True)}
     edges = []
     seen: set[tuple[str, str]] = set()
@@ -452,8 +494,8 @@ def _render_canvas(target: Path, records: list[dict[str, Any]], links: dict[str,
                 "id": canvas_id,
                 "type": "text",
                 "text": _redacted_scalar(node.get("label") or original_id),
-                "x": index * 260,
-                "y": 180,
+                "x": (index % CANVAS_COLUMNS) * _CANVAS_COLUMN_WIDTH,
+                "y": topology_row + (index // CANVAS_COLUMNS) * _CANVAS_ROW_HEIGHT,
                 "width": 220,
                 "height": 80,
             }

--- a/tests/test_memory_vault_projection.py
+++ b/tests/test_memory_vault_projection.py
@@ -46,6 +46,29 @@ def _write_card(
     )
 
 
+def _write_cards(target: Path, count: int, *, category: str, tags: list[str]) -> None:
+    """Write `count` sibling cards that all share one category, the shape that blew up the canvas."""
+    root = target / "memory" / "cards"
+    root.mkdir(parents=True, exist_ok=True)
+    for index in range(count):
+        (root / f"bulk-{index:03d}.md").write_text(
+            "\n".join(
+                [
+                    "---",
+                    f"id: card-00000000-0000-4000-8000-{index:012d}",
+                    f"title: Bulk {index:03d}",
+                    f"category: {category}",
+                    f"tags: {json.dumps(tags)}",
+                    "refs: []",
+                    "---",
+                    f"Bulk body {index:03d}.",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+
 def _project(target: Path, vault: Path, capsys) -> dict:
     assert cli.main(["memory", "project-vault", "--target", str(target), "--vault", str(vault), "--json"]) == 0
     return json.loads(capsys.readouterr().out)
@@ -217,6 +240,86 @@ def test_project_vault_skips_a_manually_edited_conflict_copy_when_linking(tmp_pa
     beta = (root / "Beta.md").read_text(encoding="utf-8")
     assert "[[Cards/Alpha.conflict-ea62791a-2|Alpha]]" in beta
     assert (root / "Alpha.conflict-ea62791a.md").read_text(encoding="utf-8") == "operator-owned conflict\n"
+
+
+def test_project_vault_titles_a_note_from_its_leading_heading(tmp_path: Path, vault: Path, capsys) -> None:
+    """Cards without a frontmatter title fall back to their slug, which reads badly in a vault."""
+    path = tmp_path / "memory" / "cards" / "rocinante-gateway-beta-worktree-steering.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "---\nid: card-00000000-0000-4000-8000-00000000000c\ncategory: operations\ntags: []\n---\n"
+        "# Rocinante gateway from a worktree\n\nSteer the beta from a worktree.\n",
+        encoding="utf-8",
+    )
+
+    _project(tmp_path, vault, capsys)
+
+    note = vault / "Brigade Memory" / "Cards" / "Rocinante gateway from a worktree.md"
+    assert note.is_file()
+    text = note.read_text(encoding="utf-8")
+    assert 'title: "Rocinante gateway from a worktree"' in text
+    assert text.count("# Rocinante gateway from a worktree") == 1
+    # Provenance still points at the slug file the card actually lives in.
+    assert "canonical_path: " in text and "rocinante-gateway-beta-worktree-steering.md" in text
+
+
+def test_project_vault_keeps_an_explicit_frontmatter_title_over_the_body_heading(
+    tmp_path: Path, vault: Path, capsys
+) -> None:
+    """An explicit title is operator intent; a differing body heading stays part of the body."""
+    _write_card(
+        tmp_path,
+        "alpha",
+        title="Solomon jobs and profile cheatsheet",
+        tags=["shared"],
+        body="# Targeted resume variants\n\nPick the lane.",
+    )
+
+    _project(tmp_path, vault, capsys)
+
+    text = (vault / "Brigade Memory" / "Cards" / "Solomon jobs and profile cheatsheet.md").read_text(encoding="utf-8")
+    assert "# Solomon jobs and profile cheatsheet" in text
+    assert "# Targeted resume variants" in text
+
+
+def test_project_vault_caps_related_links_and_canvas_edges(tmp_path: Path, vault: Path, capsys) -> None:
+    """Same-category cards used to form a complete graph, so 1,254 notes produced 83,586 edges."""
+    _write_cards(tmp_path, 30, category="workflow", tags=["shared"])
+
+    _project(tmp_path, vault, capsys)
+
+    projection = vault / "Brigade Memory"
+    for note in (projection / "Cards").glob("Bulk *.md"):
+        assert note.read_text(encoding="utf-8").count("[[") <= obsidian_vault.MAX_RELATED
+    canvas = json.loads((projection / "Brigade Memory.canvas").read_text(encoding="utf-8"))
+    card_edges = [edge for edge in canvas["edges"] if not str(edge["id"]).startswith("topology:")]
+    assert card_edges
+    assert len(card_edges) <= 30 * obsidian_vault.MAX_RELATED
+    assert len(card_edges) < 30 * 29 // 2  # not the complete graph the cap replaced
+
+
+def test_project_vault_omits_a_map_that_covers_every_note(tmp_path: Path, vault: Path, capsys) -> None:
+    """A map listing every note groups nothing; the harness map was one 1,254-entry file."""
+    _write_cards(tmp_path, 3, category="workflow", tags=["shared"])
+
+    _project(tmp_path, vault, capsys)
+
+    projection = vault / "Brigade Memory"
+    assert not list((projection / "Maps" / "Harnesses").glob("*.md"))
+    assert not list((projection / "Maps" / "Categories").glob("*.md"))
+
+
+def test_project_vault_lays_out_canvas_notes_in_a_grid(tmp_path: Path, vault: Path, capsys) -> None:
+    """A single row put 1,254 nodes across roughly 345,000 pixels of canvas."""
+    _write_cards(tmp_path, 30, category="workflow", tags=["shared"])
+
+    _project(tmp_path, vault, capsys)
+
+    canvas = json.loads((vault / "Brigade Memory" / "Brigade Memory.canvas").read_text(encoding="utf-8"))
+    card_nodes = [node for node in canvas["nodes"] if str(node["id"]).startswith("card-")]
+    assert len(card_nodes) == 30
+    assert len({node["y"] for node in card_nodes}) > 1
+    assert max(node["x"] for node in card_nodes) < 30 * 260
 
 
 def test_project_vault_does_not_reuse_an_unfinished_transaction_journal(


### PR DESCRIPTION
## What

`brigade memory project-vault` (#888, #930) was correct but not browsable at real scale. Running it against a 1,254-card corpus produced:

- an 11.3 MB canvas with **83,586 edges**
- **687 notes named by filename slug**, with the card's real title sitting in its body heading right below
- a `Maps/Harnesses/unknown.md` listing every note, because cards carry no `source_harness`
- canvas nodes in a single row roughly 345,000 pixels wide

Same corpus after this change: **10,373 edges, 1.6 MB**, human-titled notes, no degenerate map.

## Changes

| Fix | Where |
| --- | --- |
| Title a note from its leading heading when frontmatter has no `title`, and strip that heading from the body | `_record`, `_leading_heading` |
| Rank related notes and cap at `MAX_RELATED = 12` | `_relationships` |
| Omit a map whose members are every note | `_render_maps` |
| Grid canvas layout, topology below the note grid | `_render_canvas` |

On titles: the inventory falls back to the filename slug when a card has no frontmatter `title`, which is fine for an index and bad for a vault someone reads. An explicit frontmatter title still wins, and a body heading that differs from it stays as content. Four cards in the test corpus depend on that.

On ranking: every pair sharing a category used to become related, unconditionally. One 221-card category contributed roughly 24,000 pairs on its own. Explicit refs outrank shared tags, which outrank a shared category, and refs always survive the cap.

## Tests

Five tests, each written to fail first:

- `test_project_vault_titles_a_note_from_its_leading_heading`
- `test_project_vault_keeps_an_explicit_frontmatter_title_over_the_body_heading`
- `test_project_vault_caps_related_links_and_canvas_edges`
- `test_project_vault_omits_a_map_that_covers_every_note`
- `test_project_vault_lays_out_canvas_notes_in_a_grid`

`./scripts/verify`: 7,689 passed, 3 skipped, coverage 83.55% against the 78% floor.

## Docs

Adds an `## Obsidian vault projection` section to `docs/memory-operations.md` with a mermaid flowchart of where memory actually flows. The diagram shows the read path from an operator vault as a dashed, absent edge, pointing at #943 and #945.

## Rebased onto #934

Originally this PR carried a follow-up warning: it renames notes whose titles previously came from the filename slug, and projected notes had no `aliases` frontmatter, so Obsidian could not resolve links across the rename. #934 landed that fix, and this branch is now rebased on top of it. The rename hazard is handled upstream and the warning no longer applies.

Both conflicts were in functions the two changes share, and both were resolved by layering rather than choosing:

- `_record`: #934's `identity` / `stable_id` / `aliases` block is kept whole, with the title-and-body derivation appended below it.
- `_relationships`: #934's dual-read `claim()` index builder is kept verbatim, including the ambiguity marking, with the ranking loop layered on top.

The interaction worth naming: #934 marks a dual-read key claimed by two records as `None` rather than last-writer-wins. The ranking loop reads refs through `by_source.get(reference)` and guards on `is not None`, so an ambiguous key yields no link and no score. `_REFERENCE_WEIGHT` only ever applies to refs that resolved unambiguously, so the cap cannot evict a real ref in favour of a tag match, and cannot resurrect a neutralized one.

`_references` and `_render_note` are untouched here, so #934's ID normalization and `aliases:` emission carry through unmodified. All four of its regression tests pass unchanged.

`./scripts/verify` on the rebased branch: 7,705 passed, 3 skipped, exit 0.

Refs #888. Related: #931, #934, #943, #945.
