### PR TITLE
feat: surface Bootstrap Doctor lifecycle lint

### DIFF
--- a/docs/phase-bootstrap-doctor-lint-integration.md
+++ b/docs/phase-bootstrap-doctor-lint-integration.md
@@ -1,0 +1,51 @@
+# Bootstrap Doctor lifecycle lint integration
+
+Date: 2026-08-17
+Status: Approved for implementation
+
+## Goal
+
+Expose Bootstrap Doctor's deterministic lifecycle lint through Brigade's managed-tool doctor checks without turning operator-owned OpenClaw state into a Brigade workspace failure.
+
+## Contract
+
+- Run `bootstrap-doctor status --json` and `bootstrap-doctor lint --json` as separate probes.
+- Preserve the existing status result.
+- Report the lint probe as a separate managed-tool check.
+- Treat clean lint output as `OK`.
+- Treat lifecycle findings as advisory `WARN`, including Bootstrap Doctor findings whose own severity is `error`.
+- Treat a missing lint command, nonzero exit, malformed JSON, or an invalid payload as `WARN` with an upgrade or diagnostic message. These conditions must not raise from Brigade doctor.
+- Include warning and error counts plus the first stable finding ID in the lint summary when findings exist.
+- Keep invocation deterministic and side-effect free.
+
+## Managed surfaces
+
+The Bootstrap Doctor manifest advertises these surfaces:
+
+- `summary-json`: `bootstrap-doctor status --json`
+- `doctor-json`: `bootstrap-doctor lint --json`
+- `verify-exit`: `bootstrap-doctor lint --json`
+
+## Tests first
+
+Add focused coverage in `tests/test_managed.py` for:
+
+- clean status plus clean lint;
+- lint warnings and errors mapped to Brigade `WARN`;
+- malformed or unavailable lint mapped to `WARN`;
+- deterministic status-then-lint command order;
+- stable finding ID and severity counts in the lint summary;
+- updated managed-tool surface metadata.
+
+Observe the focused test fail before changing implementation, then make the smallest change in `src/brigade/managed.py` that satisfies the contract.
+
+## Verification
+
+Run focused managed-tool tests and the repository verification script through `brigade work verify run`. Because this worktree reuses the base repository virtualenv, set `PYTHONPATH` to this worktree's `src` directory so subprocesses import the isolated branch.
+
+## Out of scope
+
+- Mutating or repairing OpenClaw workspaces.
+- Converting Bootstrap Doctor lifecycle findings into Brigade `FAIL`.
+- Installing or upgrading Bootstrap Doctor automatically.
+- Adding model-route policy linting.

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -116,23 +116,111 @@ def _apply_snapshot(tool: ManagedTool, contract: dict[str, Any]) -> ManagedTool:
 # advisory: labeled operator-scoped and never FAIL a workspace doctor run.
 
 
+def _nonneg_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+_BOOTSTRAP_LINT_CHECK_IDS = frozenset(
+    {
+        "bootstrap-after-setup",
+        "orphan-workspace",
+        "configured-placeholder",
+        "memory-contradicts-fresh",
+        "inactive-context-content",
+        "dangling-agent-reference",
+        "duplicate-context",
+    }
+)
+_BOOTSTRAP_LINT_SEVERITIES = frozenset({"error", "warning"})
+
+
+def _first_stable_check_id(findings: list[object]) -> Optional[str]:
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        check_id = finding.get("check_id")
+        if isinstance(check_id, str) and check_id in _BOOTSTRAP_LINT_CHECK_IDS:
+            return check_id
+    return None
+
+
+def _lint_findings_valid(findings: list[object]) -> bool:
+    for finding in findings:
+        if not isinstance(finding, dict):
+            return False
+        check_id = finding.get("check_id")
+        if not isinstance(check_id, str) or check_id not in _BOOTSTRAP_LINT_CHECK_IDS:
+            return False
+        if finding.get("severity") not in _BOOTSTRAP_LINT_SEVERITIES:
+            return False
+    return True
+
+
+def _lint_severity_counts(findings: list[object]) -> tuple[int, int]:
+    errors = sum(1 for finding in findings if isinstance(finding, dict) and finding.get("severity") == "error")
+    warnings = sum(1 for finding in findings if isinstance(finding, dict) and finding.get("severity") == "warning")
+    return errors, warnings
+
+
+def _bootstrap_doctor_lint_missing(result: proc.Result) -> bool:
+    blob = f"{result.stdout}\n{result.stderr}".lower()
+    return "invalid choice" in blob or "unrecognized arguments" in blob
+
+
+def _bootstrap_doctor_lint_row(result: proc.Result) -> CheckResult:
+    name = "bootstrap-doctor (operator lifecycle)"
+    data = result.json()
+    if data is None:
+        if _bootstrap_doctor_lint_missing(result):
+            return (WARN, name, "installed but lint is unavailable; upgrade bootstrap-doctor")
+        return (WARN, name, f"installed but lint output unreadable (exit {result.code})")
+    if not isinstance(data, dict):
+        return (WARN, name, f"unexpected lint output (exit {result.code})")
+    findings = data.get("findings")
+    error_count = data.get("error_count")
+    warning_count = data.get("warning_count")
+    if not isinstance(findings, list) or not _nonneg_int(error_count) or not _nonneg_int(warning_count):
+        return (WARN, name, "installed but lint payload is invalid")
+    if not _lint_findings_valid(findings):
+        return (WARN, name, "installed but lint payload is invalid")
+    actual_errors, actual_warnings = _lint_severity_counts(findings)
+    clean = error_count == 0 and warning_count == 0 and not findings
+    if clean:
+        if result.code != 0:
+            return (WARN, name, f"installed but lint exited {result.code}")
+        return (OK, name, "0 error(s), 0 warning(s)")
+    if actual_errors != error_count or actual_warnings != warning_count:
+        return (WARN, name, "installed but lint payload is inconsistent")
+    detail = f"{error_count} error(s), {warning_count} warning(s)"
+    check_id = _first_stable_check_id(findings)
+    if check_id is not None:
+        detail = f"{detail}, {check_id}"
+    return (WARN, name, detail)
+
+
 def _bootstrap_doctor_doctor(ctx: DoctorContext) -> List[CheckResult]:
     name = "bootstrap-doctor (operator files)"
-    r = proc.run(["bootstrap-doctor", "status", "--json"])
+    r = proc.run(["bootstrap-doctor", "status", "--json"], timeout=30.0)
     data = r.json()
     if data is None:
-        return [(WARN, name, f"installed but unwired or errored (exit {r.code})")]
-    if not isinstance(data, dict):
-        return [(WARN, name, f"unexpected status output (exit {r.code})")]
-    rows_value = data.get("rows", [])
-    rows = rows_value if isinstance(rows_value, list) else []
-    bad = [row for row in rows if isinstance(row, dict) and row.get("severity") in ("hard", "missing", "unreadable")]
-    soft = [row for row in rows if isinstance(row, dict) and row.get("severity") == "soft"]
-    if bad:
-        return [(WARN, name, f"{len(bad)} file(s) over hard limit / missing (advisory)")]
-    if soft:
-        return [(WARN, name, f"{len(soft)} file(s) in soft band")]
-    return [(OK, name, f"{len(rows)} bootstrap file(s) within limits")]
+        status_row: CheckResult = (WARN, name, f"installed but unwired or errored (exit {r.code})")
+    elif not isinstance(data, dict):
+        status_row = (WARN, name, f"unexpected status output (exit {r.code})")
+    else:
+        rows_value = data.get("rows", [])
+        rows = rows_value if isinstance(rows_value, list) else []
+        bad = [
+            row for row in rows if isinstance(row, dict) and row.get("severity") in ("hard", "missing", "unreadable")
+        ]
+        soft = [row for row in rows if isinstance(row, dict) and row.get("severity") == "soft"]
+        if bad:
+            status_row = (WARN, name, f"{len(bad)} file(s) over hard limit / missing (advisory)")
+        elif soft:
+            status_row = (WARN, name, f"{len(soft)} file(s) in soft band")
+        else:
+            status_row = (OK, name, f"{len(rows)} bootstrap file(s) within limits")
+    lint = proc.run(["bootstrap-doctor", "lint", "--json"], timeout=30.0)
+    return [status_row, _bootstrap_doctor_lint_row(lint)]
 
 
 def _token_glace_doctor(ctx: DoctorContext) -> List[CheckResult]:
@@ -431,8 +519,9 @@ _TOOLS: Tuple[ManagedTool, ...] = (
         wire=_noop_wire,
         doctor=_bootstrap_doctor_doctor,
         surfaces=(
-            _surface("doctor-json", ("bootstrap-doctor", "status", "--json"), timeout_seconds=30.0),
-            _surface("verify-exit", ("bootstrap-doctor", "status", "--json"), timeout_seconds=30.0),
+            _surface("summary-json", ("bootstrap-doctor", "status", "--json"), timeout_seconds=30.0),
+            _surface("doctor-json", ("bootstrap-doctor", "lint", "--json"), timeout_seconds=30.0),
+            _surface("verify-exit", ("bootstrap-doctor", "lint", "--json"), timeout_seconds=30.0),
         ),
     ),
     ManagedTool(

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -120,18 +120,16 @@ def _nonneg_int(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
-_BOOTSTRAP_LINT_CHECK_IDS = frozenset(
-    {
-        "bootstrap-after-setup",
-        "orphan-workspace",
-        "configured-placeholder",
-        "memory-contradicts-fresh",
-        "inactive-context-content",
-        "dangling-agent-reference",
-        "duplicate-context",
-    }
-)
-_BOOTSTRAP_LINT_SEVERITIES = frozenset({"error", "warning"})
+_BOOTSTRAP_LINT_EXPECTED_SEVERITY = {
+    "bootstrap-after-setup": "error",
+    "orphan-workspace": "warning",
+    "configured-placeholder": "warning",
+    "memory-contradicts-fresh": "error",
+    "inactive-context-content": "warning",
+    "dangling-agent-reference": "error",
+    "duplicate-context": "warning",
+}
+_BOOTSTRAP_LINT_CHECK_IDS = frozenset(_BOOTSTRAP_LINT_EXPECTED_SEVERITY)
 
 
 def _first_stable_check_id(findings: list[object]) -> Optional[str]:
@@ -151,7 +149,7 @@ def _lint_findings_valid(findings: list[object]) -> bool:
         check_id = finding.get("check_id")
         if not isinstance(check_id, str) or check_id not in _BOOTSTRAP_LINT_CHECK_IDS:
             return False
-        if finding.get("severity") not in _BOOTSTRAP_LINT_SEVERITIES:
+        if finding.get("severity") != _BOOTSTRAP_LINT_EXPECTED_SEVERITY[check_id]:
             return False
     return True
 
@@ -179,18 +177,29 @@ def _bootstrap_doctor_lint_row(result: proc.Result) -> CheckResult:
     findings = data.get("findings")
     error_count = data.get("error_count")
     warning_count = data.get("warning_count")
+    ok = data.get("ok")
     if not isinstance(findings, list) or not _nonneg_int(error_count) or not _nonneg_int(warning_count):
+        return (WARN, name, "installed but lint payload is invalid")
+    if "ok" not in data or not isinstance(ok, bool):
         return (WARN, name, "installed but lint payload is invalid")
     if not _lint_findings_valid(findings):
         return (WARN, name, "installed but lint payload is invalid")
     actual_errors, actual_warnings = _lint_severity_counts(findings)
-    clean = error_count == 0 and warning_count == 0 and not findings
-    if clean:
-        if result.code != 0:
-            return (WARN, name, f"installed but lint exited {result.code}")
-        return (OK, name, "0 error(s), 0 warning(s)")
     if actual_errors != error_count or actual_warnings != warning_count:
         return (WARN, name, "installed but lint payload is inconsistent")
+    clean = error_count == 0 and warning_count == 0 and not findings
+    if ok is not clean:
+        return (WARN, name, "installed but lint payload is inconsistent")
+    if error_count:
+        expected_code = 2
+    elif warning_count:
+        expected_code = 1
+    else:
+        expected_code = 0
+    if result.code != expected_code:
+        return (WARN, name, "installed but lint payload is inconsistent")
+    if clean:
+        return (OK, name, "0 error(s), 0 warning(s)")
     detail = f"{error_count} error(s), {warning_count} warning(s)"
     check_id = _first_stable_check_id(findings)
     if check_id is not None:

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -530,7 +530,7 @@ _TOOLS: Tuple[ManagedTool, ...] = (
         surfaces=(
             _surface("summary-json", ("bootstrap-doctor", "status", "--json"), timeout_seconds=30.0),
             _surface("doctor-json", ("bootstrap-doctor", "lint", "--json"), timeout_seconds=30.0),
-            _surface("verify-exit", ("bootstrap-doctor", "lint", "--json"), timeout_seconds=30.0),
+            _surface("verify-exit", ("bootstrap-doctor", "--version"), timeout_seconds=30.0),
         ),
     ),
     ManagedTool(

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -582,7 +582,7 @@ def test_bootstrap_doctor_declares_status_and_lint_surfaces():
     surfaces = {surface.kind: surface for surface in t.surfaces}
     assert surfaces["summary-json"].command == ("bootstrap-doctor", "status", "--json")
     assert surfaces["doctor-json"].command == ("bootstrap-doctor", "lint", "--json")
-    assert surfaces["verify-exit"].command == ("bootstrap-doctor", "lint", "--json")
+    assert surfaces["verify-exit"].command == ("bootstrap-doctor", "--version")
     for surface in surfaces.values():
         assert surface.read_only is True
         assert surface.timeout_seconds == 30.0

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -93,10 +93,10 @@ def test_bootstrap_doctor_lint_findings_map_to_warn_never_fail(monkeypatch):
         "warning_count": 1,
         "findings": [
             {
-                "check_id": "orphan-workspace",
+                "check_id": "bootstrap-after-setup",
                 "severity": "error",
                 "message": sentinel,
-                "path": "/tmp/orphan",
+                "path": "/tmp/setup",
             },
             {
                 "check_id": "inactive-context-content",
@@ -123,7 +123,7 @@ def test_bootstrap_doctor_lint_summary_includes_counts_and_first_check_id(monkey
         "error_count": 2,
         "warning_count": 1,
         "findings": [
-            {"check_id": "orphan-workspace", "severity": "error", "message": "hidden"},
+            {"check_id": "bootstrap-after-setup", "severity": "error", "message": "hidden"},
             {"check_id": "dangling-agent-reference", "severity": "error", "message": "hidden"},
             {"check_id": "inactive-context-content", "severity": "warning", "message": "hidden"},
         ],
@@ -135,19 +135,24 @@ def test_bootstrap_doctor_lint_summary_includes_counts_and_first_check_id(monkey
     detail = next(detail for status, name, detail in results if name == "bootstrap-doctor (operator lifecycle)")
     assert "2 error(s)" in detail
     assert "1 warning(s)" in detail
-    assert "orphan-workspace" in detail
+    assert "bootstrap-after-setup" in detail
     assert "dangling-agent-reference" not in detail
     assert "hidden" not in detail
 
 
-_KNOWN_BOOTSTRAP_LINT_CHECK_IDS = (
-    "bootstrap-after-setup",
-    "orphan-workspace",
-    "configured-placeholder",
-    "memory-contradicts-fresh",
-    "inactive-context-content",
-    "dangling-agent-reference",
-    "duplicate-context",
+_BOOTSTRAP_LINT_EXPECTED_SEVERITY = {
+    "bootstrap-after-setup": "error",
+    "orphan-workspace": "warning",
+    "configured-placeholder": "warning",
+    "memory-contradicts-fresh": "error",
+    "inactive-context-content": "warning",
+    "dangling-agent-reference": "error",
+    "duplicate-context": "warning",
+}
+_KNOWN_BOOTSTRAP_LINT_CHECK_IDS = tuple(_BOOTSTRAP_LINT_EXPECTED_SEVERITY)
+_GENERIC_LINT_LIFECYCLE_WARN = (
+    "installed but lint payload is invalid",
+    "installed but lint payload is inconsistent",
 )
 
 
@@ -155,16 +160,25 @@ def _lifecycle_row(results):
     return next(row for row in results if row[1] == "bootstrap-doctor (operator lifecycle)")
 
 
+def _assert_generic_lifecycle_warn(results, *secrets: str) -> None:
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "WARN"
+    assert detail in _GENERIC_LINT_LIFECYCLE_WARN
+    assert all(row_status != "FAIL" for row_status, _, _ in results)
+    for secret in secrets:
+        assert all(secret not in row_detail for _, _, row_detail in results)
+
+
 @pytest.mark.parametrize(
     "error_count, warning_count, findings",
     [
-        (3, 0, [{"check_id": "orphan-workspace", "severity": "error"}]),
+        (3, 0, [{"check_id": "bootstrap-after-setup", "severity": "error"}]),
         (0, 2, [{"check_id": "inactive-context-content", "severity": "warning"}]),
         (
             1,
             0,
             [
-                {"check_id": "orphan-workspace", "severity": "error"},
+                {"check_id": "bootstrap-after-setup", "severity": "error"},
                 {"check_id": "inactive-context-content", "severity": "warning"},
             ],
         ),
@@ -261,16 +275,18 @@ def test_bootstrap_doctor_lint_unknown_check_id_never_appears_in_detail(monkeypa
     assert all("/tmp/unknown" not in row_detail for _, _, row_detail in results)
 
 
-@pytest.mark.parametrize("check_id", _KNOWN_BOOTSTRAP_LINT_CHECK_IDS)
-def test_bootstrap_doctor_lint_accepts_known_check_ids(monkeypatch, check_id):
+@pytest.mark.parametrize("check_id,severity", list(_BOOTSTRAP_LINT_EXPECTED_SEVERITY.items()))
+def test_bootstrap_doctor_lint_accepts_known_check_ids(monkeypatch, check_id, severity):
+    error_count = 1 if severity == "error" else 0
+    warning_count = 0 if severity == "error" else 1
     payload = {
         "ok": False,
-        "error_count": 1,
-        "warning_count": 0,
+        "error_count": error_count,
+        "warning_count": warning_count,
         "findings": [
             {
                 "check_id": check_id,
-                "severity": "error",
+                "severity": severity,
                 "message": "hidden",
                 "path": "/tmp/known",
                 "agent_id": "agent-do-not-leak",
@@ -279,17 +295,239 @@ def test_bootstrap_doctor_lint_accepts_known_check_ids(monkeypatch, check_id):
     }
     results, _calls = _run_bootstrap_doctor(
         monkeypatch,
-        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr=""),
+        lint=managed.proc.Result(code=2 if error_count else 1, stdout=json.dumps(payload), stderr=""),
     )
     status, _name, detail = _lifecycle_row(results)
     assert status == "WARN"
-    assert "1 error(s)" in detail
-    assert "0 warning(s)" in detail
+    assert f"{error_count} error(s)" in detail
+    assert f"{warning_count} warning(s)" in detail
     assert check_id in detail
     assert "hidden" not in detail
     assert "agent-do-not-leak" not in detail
     assert "/tmp/known" not in detail
     assert all(row_status != "FAIL" for row_status, _, _ in results)
+
+
+@pytest.mark.parametrize("check_id,expected_severity", list(_BOOTSTRAP_LINT_EXPECTED_SEVERITY.items()))
+def test_bootstrap_doctor_lint_rejects_wrong_known_id_severity(monkeypatch, check_id, expected_severity):
+    sentinel = "do-not-leak-severity-message"
+    severity = "warning" if expected_severity == "error" else "error"
+    error_count = 1 if severity == "error" else 0
+    warning_count = 0 if severity == "error" else 1
+    payload = {
+        "ok": False,
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "findings": [
+            {
+                "check_id": check_id,
+                "severity": severity,
+                "message": sentinel,
+                "path": "/tmp/severity-mismatch",
+                "agent_id": "agent-do-not-leak",
+            }
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(
+            code=2 if error_count else 1,
+            stdout=json.dumps(payload),
+            stderr="hidden-stderr",
+        ),
+    )
+    _assert_generic_lifecycle_warn(
+        results,
+        sentinel,
+        "agent-do-not-leak",
+        "/tmp/severity-mismatch",
+        "hidden-stderr",
+        f"{error_count} error(s)",
+        check_id,
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"findings": [], "error_count": 0, "warning_count": 0},
+        {"ok": "true", "findings": [], "error_count": 0, "warning_count": 0},
+        {"ok": 1, "findings": [], "error_count": 0, "warning_count": 0},
+        {"ok": 0, "findings": [], "error_count": 0, "warning_count": 0},
+        {"ok": None, "findings": [], "error_count": 0, "warning_count": 0},
+    ],
+)
+def test_bootstrap_doctor_lint_rejects_missing_or_non_bool_ok(monkeypatch, payload):
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=0, stdout=json.dumps(payload), stderr="hidden-stderr"),
+    )
+    _assert_generic_lifecycle_warn(results, "hidden-stderr", "0 error(s)")
+
+
+@pytest.mark.parametrize(
+    "payload,code",
+    [
+        (
+            {
+                "ok": True,
+                "error_count": 0,
+                "warning_count": 1,
+                "findings": [{"check_id": "orphan-workspace", "severity": "warning", "message": "hidden"}],
+            },
+            1,
+        ),
+        (
+            {
+                "ok": False,
+                "error_count": 0,
+                "warning_count": 0,
+                "findings": [],
+            },
+            0,
+        ),
+        (
+            {
+                "ok": True,
+                "error_count": 1,
+                "warning_count": 0,
+                "findings": [{"check_id": "bootstrap-after-setup", "severity": "error", "message": "hidden"}],
+            },
+            2,
+        ),
+    ],
+)
+def test_bootstrap_doctor_lint_rejects_inconsistent_ok(monkeypatch, payload, code):
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=code, stdout=json.dumps(payload), stderr=""),
+    )
+    _assert_generic_lifecycle_warn(results, "hidden", "1 error(s)", "1 warning(s)")
+
+
+@pytest.mark.parametrize(
+    "payload,code",
+    [
+        ({"ok": True, "error_count": 0, "warning_count": 0, "findings": []}, 1),
+        ({"ok": True, "error_count": 0, "warning_count": 0, "findings": []}, 2),
+        (
+            {
+                "ok": False,
+                "error_count": 0,
+                "warning_count": 1,
+                "findings": [{"check_id": "orphan-workspace", "severity": "warning", "message": "hidden"}],
+            },
+            0,
+        ),
+        (
+            {
+                "ok": False,
+                "error_count": 0,
+                "warning_count": 1,
+                "findings": [{"check_id": "orphan-workspace", "severity": "warning", "message": "hidden"}],
+            },
+            2,
+        ),
+        (
+            {
+                "ok": False,
+                "error_count": 1,
+                "warning_count": 0,
+                "findings": [{"check_id": "bootstrap-after-setup", "severity": "error", "message": "hidden"}],
+            },
+            0,
+        ),
+        (
+            {
+                "ok": False,
+                "error_count": 1,
+                "warning_count": 0,
+                "findings": [{"check_id": "bootstrap-after-setup", "severity": "error", "message": "hidden"}],
+            },
+            1,
+        ),
+    ],
+)
+def test_bootstrap_doctor_lint_rejects_exit_mismatch(monkeypatch, payload, code):
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=code, stdout=json.dumps(payload), stderr="hidden-stderr"),
+    )
+    _assert_generic_lifecycle_warn(
+        results,
+        "hidden",
+        "hidden-stderr",
+        "orphan-workspace",
+        "bootstrap-after-setup",
+        f"exited {code}",
+    )
+
+
+def test_bootstrap_doctor_lint_accepts_clean_exit_0(monkeypatch):
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=0, stdout=_CLEAN_BOOTSTRAP_LINT, stderr=""),
+    )
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "OK"
+    assert detail == "0 error(s), 0 warning(s)"
+    assert all(row_status != "FAIL" for row_status, _, _ in results)
+
+
+def test_bootstrap_doctor_lint_accepts_warnings_only_exit_1(monkeypatch):
+    payload = {
+        "ok": False,
+        "error_count": 0,
+        "warning_count": 1,
+        "findings": [
+            {
+                "check_id": "orphan-workspace",
+                "severity": "warning",
+                "message": "hidden",
+                "path": "/tmp/orphan",
+                "agent_id": "agent-do-not-leak",
+            }
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=1, stdout=json.dumps(payload), stderr="hidden-stderr"),
+    )
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "WARN"
+    assert detail == "0 error(s), 1 warning(s), orphan-workspace"
+    assert all(row_status != "FAIL" for row_status, _, _ in results)
+    assert all("hidden" not in row_detail for _, _, row_detail in results)
+    assert all("agent-do-not-leak" not in row_detail for _, _, row_detail in results)
+    assert all("/tmp/orphan" not in row_detail for _, _, row_detail in results)
+
+
+def test_bootstrap_doctor_lint_accepts_errors_exit_2(monkeypatch):
+    payload = {
+        "ok": False,
+        "error_count": 1,
+        "warning_count": 0,
+        "findings": [
+            {
+                "check_id": "dangling-agent-reference",
+                "severity": "error",
+                "message": "hidden",
+                "path": "/tmp/dangling",
+                "agent_id": "agent-do-not-leak",
+            }
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr="hidden-stderr"),
+    )
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "WARN"
+    assert detail == "1 error(s), 0 warning(s), dangling-agent-reference"
+    assert all(row_status != "FAIL" for row_status, _, _ in results)
+    assert all("hidden" not in row_detail for _, _, row_detail in results)
+    assert all("agent-do-not-leak" not in row_detail for _, _, row_detail in results)
+    assert all("/tmp/dangling" not in row_detail for _, _, row_detail in results)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -459,7 +459,7 @@ def test_bootstrap_doctor_lint_rejects_exit_mismatch(monkeypatch, payload, code)
         "hidden-stderr",
         "orphan-workspace",
         "bootstrap-after-setup",
-        f"exited {code}",
+        f"exit {code}",
     )
 
 

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -40,6 +40,316 @@ def test_detect_uses_resolver(monkeypatch):
     assert t.detect() is True
 
 
+_CLEAN_BOOTSTRAP_STATUS = '{"rows": []}'
+_CLEAN_BOOTSTRAP_LINT = '{"ok": true, "findings": [], "error_count": 0, "warning_count": 0}'
+
+
+def _run_bootstrap_doctor(monkeypatch, *, lint, status_stdout=_CLEAN_BOOTSTRAP_STATUS):
+    t = managed.resolve("bootstrap-doctor")
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(list(args))
+        if args == ["bootstrap-doctor", "status", "--json"]:
+            return managed.proc.Result(code=0, stdout=status_stdout, stderr="")
+        if args == ["bootstrap-doctor", "lint", "--json"]:
+            return lint
+        raise AssertionError(f"unexpected argv: {args}")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    return t.doctor(ctx), calls
+
+
+def test_bootstrap_doctor_runs_status_then_lint(monkeypatch):
+    results, calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=0, stdout=_CLEAN_BOOTSTRAP_LINT, stderr=""),
+    )
+    assert calls == [
+        ["bootstrap-doctor", "status", "--json"],
+        ["bootstrap-doctor", "lint", "--json"],
+    ]
+    assert results  # doctor still returns rows after both probes
+
+
+def test_bootstrap_doctor_clean_status_and_clean_lint_return_two_ok_rows(monkeypatch):
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=0, stdout=_CLEAN_BOOTSTRAP_LINT, stderr=""),
+    )
+    assert [(status, name) for status, name, _detail in results] == [
+        ("OK", "bootstrap-doctor (operator files)"),
+        ("OK", "bootstrap-doctor (operator lifecycle)"),
+    ]
+    assert all(status != "FAIL" for status, _, _ in results)
+
+
+def test_bootstrap_doctor_lint_findings_map_to_warn_never_fail(monkeypatch):
+    sentinel = "do-not-leak-finding-message"
+    payload = {
+        "ok": False,
+        "error_count": 1,
+        "warning_count": 1,
+        "findings": [
+            {
+                "check_id": "orphan-workspace",
+                "severity": "error",
+                "message": sentinel,
+                "path": "/tmp/orphan",
+            },
+            {
+                "check_id": "inactive-context-content",
+                "severity": "warning",
+                "message": sentinel,
+                "path": "/tmp/inactive",
+            },
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr=sentinel),
+    )
+    lint_rows = [row for row in results if row[1] == "bootstrap-doctor (operator lifecycle)"]
+    assert lint_rows
+    assert all(status == "WARN" for status, _, _ in lint_rows)
+    assert all(status != "FAIL" for status, _, _ in results)
+    assert all(sentinel not in detail for _, _, detail in results)
+
+
+def test_bootstrap_doctor_lint_summary_includes_counts_and_first_check_id(monkeypatch):
+    payload = {
+        "ok": False,
+        "error_count": 2,
+        "warning_count": 1,
+        "findings": [
+            {"check_id": "orphan-workspace", "severity": "error", "message": "hidden"},
+            {"check_id": "dangling-agent-reference", "severity": "error", "message": "hidden"},
+            {"check_id": "inactive-context-content", "severity": "warning", "message": "hidden"},
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr=""),
+    )
+    detail = next(detail for status, name, detail in results if name == "bootstrap-doctor (operator lifecycle)")
+    assert "2 error(s)" in detail
+    assert "1 warning(s)" in detail
+    assert "orphan-workspace" in detail
+    assert "dangling-agent-reference" not in detail
+    assert "hidden" not in detail
+
+
+_KNOWN_BOOTSTRAP_LINT_CHECK_IDS = (
+    "bootstrap-after-setup",
+    "orphan-workspace",
+    "configured-placeholder",
+    "memory-contradicts-fresh",
+    "inactive-context-content",
+    "dangling-agent-reference",
+    "duplicate-context",
+)
+
+
+def _lifecycle_row(results):
+    return next(row for row in results if row[1] == "bootstrap-doctor (operator lifecycle)")
+
+
+@pytest.mark.parametrize(
+    "error_count, warning_count, findings",
+    [
+        (3, 0, [{"check_id": "orphan-workspace", "severity": "error"}]),
+        (0, 2, [{"check_id": "inactive-context-content", "severity": "warning"}]),
+        (
+            1,
+            0,
+            [
+                {"check_id": "orphan-workspace", "severity": "error"},
+                {"check_id": "inactive-context-content", "severity": "warning"},
+            ],
+        ),
+    ],
+)
+def test_bootstrap_doctor_lint_counts_must_match_finding_severities(monkeypatch, error_count, warning_count, findings):
+    sentinel = "do-not-leak-mismatch-message"
+    payload = {
+        "ok": False,
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "findings": [
+            {**finding, "message": sentinel, "path": "/tmp/mismatch", "agent_id": "agent-do-not-leak"}
+            for finding in findings
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr=""),
+    )
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "WARN"
+    assert detail == "installed but lint payload is inconsistent"
+    assert all(row_status != "FAIL" for row_status, _, _ in results)
+    assert all(f"{error_count} error(s)" not in row_detail for _, _, row_detail in results)
+    assert all(sentinel not in row_detail for _, _, row_detail in results)
+    assert all("agent-do-not-leak" not in row_detail for _, _, row_detail in results)
+    assert all("/tmp/mismatch" not in row_detail for _, _, row_detail in results)
+
+
+@pytest.mark.parametrize(
+    "findings",
+    [
+        [{"check_id": "invented-check-id-do-not-leak", "severity": "error"}],
+        ["not-a-finding-dict"],
+        [{"severity": "error"}],
+        [{"check_id": "orphan-workspace"}],
+        [{"check_id": "orphan-workspace", "severity": "info"}],
+        [{"check_id": "", "severity": "error"}],
+        [{"check_id": 1, "severity": "error"}],
+        [
+            {"check_id": "orphan-workspace", "severity": "error"},
+            {"check_id": "invented-check-id-do-not-leak", "severity": "warning"},
+        ],
+    ],
+)
+def test_bootstrap_doctor_lint_rejects_unknown_or_malformed_findings(monkeypatch, findings):
+    payload = {
+        "ok": False,
+        "error_count": 1,
+        "warning_count": 0,
+        "findings": findings,
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr=""),
+    )
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "WARN"
+    assert detail == "installed but lint payload is invalid"
+    assert all(row_status != "FAIL" for row_status, _, _ in results)
+    assert all("invented-check-id-do-not-leak" not in row_detail for _, _, row_detail in results)
+    assert all("not-a-finding-dict" not in row_detail for _, _, row_detail in results)
+    assert all("1 error(s)" not in row_detail for _, _, row_detail in results)
+
+
+def test_bootstrap_doctor_lint_unknown_check_id_never_appears_in_detail(monkeypatch):
+    unknown = "invented-check-id-do-not-leak"
+    payload = {
+        "ok": False,
+        "error_count": 1,
+        "warning_count": 0,
+        "findings": [
+            {
+                "check_id": unknown,
+                "severity": "error",
+                "message": "hidden-message",
+                "path": "/tmp/unknown",
+                "agent_id": "agent-do-not-leak",
+            }
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr="hidden-stderr"),
+    )
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "WARN"
+    assert detail == "installed but lint payload is invalid"
+    assert all(unknown not in row_detail for _, _, row_detail in results)
+    assert all("hidden-message" not in row_detail for _, _, row_detail in results)
+    assert all("hidden-stderr" not in row_detail for _, _, row_detail in results)
+    assert all("agent-do-not-leak" not in row_detail for _, _, row_detail in results)
+    assert all("/tmp/unknown" not in row_detail for _, _, row_detail in results)
+
+
+@pytest.mark.parametrize("check_id", _KNOWN_BOOTSTRAP_LINT_CHECK_IDS)
+def test_bootstrap_doctor_lint_accepts_known_check_ids(monkeypatch, check_id):
+    payload = {
+        "ok": False,
+        "error_count": 1,
+        "warning_count": 0,
+        "findings": [
+            {
+                "check_id": check_id,
+                "severity": "error",
+                "message": "hidden",
+                "path": "/tmp/known",
+                "agent_id": "agent-do-not-leak",
+            }
+        ],
+    }
+    results, _calls = _run_bootstrap_doctor(
+        monkeypatch,
+        lint=managed.proc.Result(code=2, stdout=json.dumps(payload), stderr=""),
+    )
+    status, _name, detail = _lifecycle_row(results)
+    assert status == "WARN"
+    assert "1 error(s)" in detail
+    assert "0 warning(s)" in detail
+    assert check_id in detail
+    assert "hidden" not in detail
+    assert "agent-do-not-leak" not in detail
+    assert "/tmp/known" not in detail
+    assert all(row_status != "FAIL" for row_status, _, _ in results)
+
+
+@pytest.mark.parametrize(
+    "lint",
+    [
+        managed.proc.Result(code=0, stdout="not-json-at-all", stderr="kaboom-do-not-leak"),
+        managed.proc.Result(
+            code=0,
+            stdout='{"ok": true, "findings": {}, "error_count": 0, "warning_count": 0}',
+            stderr="",
+        ),
+        managed.proc.Result(
+            code=0,
+            stdout='{"ok": true, "findings": [], "error_count": true, "warning_count": 0}',
+            stderr="",
+        ),
+        managed.proc.Result(
+            code=0,
+            stdout='{"ok": true, "findings": [], "error_count": 0, "warning_count": -1}',
+            stderr="",
+        ),
+        managed.proc.Result(
+            code=0,
+            stdout='{"ok": true, "findings": [], "error_count": 1, "warning_count": 0}',
+            stderr="",
+        ),
+        managed.proc.Result(
+            code=2,
+            stdout="",
+            stderr="usage: bootstrap-doctor [-h] {status,apply}\nerror: invalid choice: 'lint'",
+        ),
+        managed.proc.Result(code=2, stdout="", stderr="openclaw.json unreadable"),
+    ],
+)
+def test_bootstrap_doctor_lint_degrades_to_warn_without_raising(monkeypatch, lint):
+    results, calls = _run_bootstrap_doctor(monkeypatch, lint=lint)
+    assert calls == [
+        ["bootstrap-doctor", "status", "--json"],
+        ["bootstrap-doctor", "lint", "--json"],
+    ]
+    lint_rows = [row for row in results if row[1] == "bootstrap-doctor (operator lifecycle)"]
+    assert lint_rows
+    assert all(status == "WARN" for status, _, _ in lint_rows)
+    assert all(status != "FAIL" for status, _, _ in results)
+    assert all("kaboom-do-not-leak" not in detail for _, _, detail in results)
+    assert all("openclaw.json unreadable" not in detail for _, _, detail in results)
+    assert all("invalid choice" not in detail for _, _, detail in results)
+
+
+def test_bootstrap_doctor_declares_status_and_lint_surfaces():
+    t = managed.resolve("bootstrap-doctor")
+    surfaces = {surface.kind: surface for surface in t.surfaces}
+    assert surfaces["summary-json"].command == ("bootstrap-doctor", "status", "--json")
+    assert surfaces["doctor-json"].command == ("bootstrap-doctor", "lint", "--json")
+    assert surfaces["verify-exit"].command == ("bootstrap-doctor", "lint", "--json")
+    for surface in surfaces.values():
+        assert surface.read_only is True
+        assert surface.timeout_seconds == 30.0
+
+
 def test_memory_doctor_no_longer_external_managed_tool():
     # Folded into brigade.memory_doctor / brigade memory status|lint|compact.
     assert managed.resolve("memory-doctor") is None


### PR DESCRIPTION
## Summary

- Run `bootstrap-doctor lint --json` after the existing operator-file status probe.
- Expose a separate operator lifecycle row across Brigade doctor surfaces.
- Validate known check IDs, fixed severities, exact counts, the `ok` flag, and exit status before trusting the payload.
- Keep lifecycle findings advisory and avoid exposing finding messages, paths, agent IDs, stderr, or unknown IDs.

## Why

The existing Bootstrap Doctor integration reports context-file size. It cannot identify stale first-run state, completed workspaces that retain `BOOTSTRAP.md`, or dangling agent references.

## Verification

- `./scripts/verify`: 7,788 passed, 3 skipped, 68 subtests passed, 83.61% coverage.
- Post-rewrite focused suite: 55 passed.
- Public-content guard passed for the tracked tree and branch history.
- Live integration smoke: lifecycle row reports 0 errors and 0 warnings.

## Compatibility

Older Bootstrap Doctor installations without `lint` produce an advisory upgrade warning. Lifecycle findings remain warnings in Brigade and do not become hard failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `bootstrap-doctor` with lint checks alongside status checks.
  * Reports clear lint findings, severities, counts, and validation results.
  * Distinguishes status summaries from lint diagnostics and verification results.

* **Bug Fixes**
  * Detects inconsistent, malformed, or unavailable lint responses.
  * Validates check identifiers, exit codes, and overall success indicators.
  * Gracefully degrades to warnings when lint information cannot be verified.
  * Sanitizes diagnostic details shown in doctor output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->