### PR TITLE
fix(center): omit unverified marker when lane has no requested model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   independent `reviewer` or `reviewer_codex` seat. (#920)
 
 ### Fixed
+- Center Research provider table no longer labels absent model seats as `- (unverified)`; only named models carry the unverified marker. (#961)
 - Quarantined items stay quarantined when a pending injection scan comes back clean, so a labeled quarantine cannot be released to untrusted and become content-eligible. Reviewed and verified items keep every consumer surface untrusted already has, including `context`. `brigade receipts verify` reports `verify-pending` (and does not append a local verified event) when the MiseLedger trust notify fails. Provenance-event JSONL now appends and fsyncs instead of rewriting the whole file. (#587)
 - Corrupt or future-version `.brigade/work/tasks.json` ledgers now fail
   closed on every `brigade work` surface (and other commands that read the

--- a/src/brigade/center_cmd/dashboard/views/research.py
+++ b/src/brigade/center_cmd/dashboard/views/research.py
@@ -298,11 +298,12 @@ def _doctor_css(status: str) -> str:
 
 def _lane_model_text(lane: Mapping[str, Any]) -> str:
     requested = lane.get("requested_model")
-    label = str(requested) if isinstance(requested, str) and requested else "-"
+    if not isinstance(requested, str) or not requested:
+        return "-"
     attestation = lane.get("model_attestation")
     if attestation != "verified":
-        return f"{label} (unverified)"
-    return label
+        return f"{requested} (unverified)"
+    return requested
 
 
 def _lane_fallback_text(lane: Mapping[str, Any]) -> str:

--- a/tests/test_center_research_view.py
+++ b/tests/test_center_research_view.py
@@ -257,7 +257,41 @@ def test_render_provider_health_shows_fallback_and_unverified_model() -> None:
     assert "gemini-browser" in page
     assert "luna (ok)" in page
     assert "gemini-web (unverified)" in page
+    assert "- (unverified)" not in page
     assert "Providers are degraded but usable." in page
+
+
+def test_lane_model_text_absent_model_skips_unverified_marker() -> None:
+    """Provider table: no requested_model is '-' alone, not '- (unverified)'."""
+    lane = {"requested_model": None, "model_attestation": "unverified"}
+    assert research._lane_model_text(lane) == "-"
+
+
+def test_lane_model_text_unverified_model_keeps_marker() -> None:
+    lane = {"requested_model": "gemini-web", "model_attestation": "unverified"}
+    assert research._lane_model_text(lane) == "gemini-web (unverified)"
+
+
+def test_render_provider_table_absent_model_column_is_bare_placeholder() -> None:
+    doctor = _doctor_payload(
+        lanes=[
+            {
+                "capability": "review",
+                "seat": "luna",
+                "status": "warn",
+                "auth_status": "unknown",
+                "requested_model": None,
+                "model_attestation": "unverified",
+                "detail": "probe skipped",
+            }
+        ]
+    )
+    page = research.render(
+        {"status": _status_payload([]), "doctor": doctor, "selected_run": ""},
+        "nonce",
+    )
+    assert "- (unverified)" not in page
+    assert "gemini-web (unverified)" not in page
 
 
 def test_render_recent_list_labels_legacy_missing_audit_and_fallback() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Center Research provider health table showed `- (unverified)` when a lane had no `requested_model`, which read like a model label rather than an absent one. Only named models now carry the unverified marker.

Fixes #961

## Type of change

- [x] Bug fix

## Checklist

- [x] Targeted `pytest -q tests/test_center_research_view.py -k "lane_model or provider_health or provider_table"` passes locally (4 passed)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR
- [x] No new runtime dependencies
- [x] Conventional commit messages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00f1216a-76a6-43bf-9b91-7afbe54c4328?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00f1216a-76a6-43bf-9b91-7afbe54c4328&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

