### PR TITLE
fix(test): derace graphtrail stale-baseline verify timeout test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   independent `reviewer` or `reviewer_codex` seat. (#920)
 
 ### Fixed
+- The graphtrail stale-baseline verify test no longer races wall-clock sync delays
+  against a tight subprocess timeout on loaded CI runners; sync timeout is injected
+  deterministically so the stale-graph assertion is reliable on Python 3.12. (#954)
 - Quarantined items stay quarantined when a pending injection scan comes back clean, so a labeled quarantine cannot be released to untrusted and become content-eligible. Reviewed and verified items keep every consumer surface untrusted already has, including `context`. `brigade receipts verify` reports `verify-pending` (and does not append a local verified event) when the MiseLedger trust notify fails. Provenance-event JSONL now appends and fsyncs instead of rewriting the whole file. (#587)
 - Corrupt or future-version `.brigade/work/tasks.json` ledgers now fail
   closed on every `brigade work` surface (and other commands that read the

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2337,6 +2337,7 @@ def test_work_verify_graphtrail_delta_preexisting_db_timeout_uses_stale_baseline
     _seed_graphtrail_db(tmp_path)
     graphtrail = _write_fake_graphtrail(tmp_path, sync_delay_seconds=0.2)
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+    _derace_graphtrail_sync_timing(monkeypatch, graphtrail, time_out_sync_call=1)
 
     assert (
         work_cmd.verify_run(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

`test_work_verify_graphtrail_delta_preexisting_db_timeout_uses_stale_baseline` intermittently failed on Python 3.12 with `KeyError: 'stale_graph_used'` because it relied on a wall-clock race between a 0.2s fake graphtrail sync delay and a 0.05s subprocess timeout. On fast or loaded CI runners the sync could finish before the cap, so the stale-baseline path never ran.

This applies the existing `_derace_graphtrail_sync_timing` helper (already used by neighboring graphtrail timeout tests) to inject a deterministic sync timeout on the first sync call while backup of the pre-existing database still succeeds.

Fixes #954

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] Targeted pytest passes locally (`test_work_verify_graphtrail_delta_preexisting_db_timeout_uses_stale_baseline`, 5 consecutive runs)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages, no AI co-authorship trailers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c85bea34-b89e-4911-878d-07514eb2e0c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c85bea34-b89e-4911-878d-07514eb2e0c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

