### PR TITLE
fix(memory): make vault related-link cap configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recover <operation-id>`. Refs #911.
 
 ### Changed
+- `brigade memory project-vault` accepts `--max-related` to tune the per-note
+  related-link cap (default 12). Explicit refs still outrank tag/category
+  matches but no longer claim to always survive the cap. (#966)
 - `brigade memory project-vault` produces a browsable vault on a real corpus.
   Notes take their title from the card's leading heading when frontmatter has
   no `title`, instead of the filename slug, and that heading is no longer

--- a/src/brigade/cli/memory.py
+++ b/src/brigade/cli/memory.py
@@ -163,6 +163,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_memory_project_vault.add_argument("--vault", type=Path, required=True, help="Existing Obsidian vault directory.")
     p_memory_project_vault.add_argument(
+        "--max-related",
+        type=int,
+        default=None,
+        help="Maximum ranked related links per note (default: 12).",
+    )
+    p_memory_project_vault.add_argument(
         "--json", action="store_true", help="Print machine-readable projection receipt."
     )
     p_memory_search = memory_sub.add_parser("search", help="Keyword-search local memory cards.")
@@ -288,7 +294,10 @@ def dispatch(args) -> int:
     if args.memory_command == "project-vault":
         from .. import obsidian_vault
 
-        return obsidian_vault.project(target=args.target, vault=args.vault, json_output=args.json)
+        max_related = obsidian_vault.DEFAULT_MAX_RELATED if args.max_related is None else args.max_related
+        return obsidian_vault.project(
+            target=args.target, vault=args.vault, json_output=args.json, max_related=max_related
+        )
     if args.memory_command == "care":
         if args.memory_care_command == "init":
             return memory_cmd.init(

--- a/src/brigade/obsidian_vault.py
+++ b/src/brigade/obsidian_vault.py
@@ -17,7 +17,8 @@ from .projection import kernel
 
 PROJECTOR = "obsidian-vault"
 PROJECTION_FOLDER = "Brigade Memory"
-MAX_RELATED = 12
+DEFAULT_MAX_RELATED = 12
+MAX_RELATED = DEFAULT_MAX_RELATED
 CANVAS_COLUMNS = 24
 _REFERENCE_WEIGHT = 1_000
 _CANVAS_COLUMN_WIDTH = 260
@@ -28,7 +29,7 @@ _BEARER_RE = re.compile(r"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+")
 _AUTHORIZATION_RE = re.compile(r"(?i)(\bauthorization\s*:\s*)[^\r\n]*")
 
 
-def project(*, target: Path, vault: Path, json_output: bool = False) -> int:
+def project(*, target: Path, vault: Path, json_output: bool = False, max_related: int = DEFAULT_MAX_RELATED) -> int:
     """Project canonical memory to an operator-selected vault without reading it as content."""
     target = target.expanduser().resolve()
     vault = vault.expanduser().resolve()
@@ -36,8 +37,10 @@ def project(*, target: Path, vault: Path, json_output: bool = False) -> int:
         return _error(f"--target is not a directory: {target}")
     if not vault.is_dir():
         return _error(f"--vault is not a directory: {vault}")
+    if max_related < 1:
+        return _error(f"--max-related must be at least 1, got {max_related}")
 
-    payload = _project_payload(target=target, vault=vault)
+    payload = _project_payload(target=target, vault=vault, max_related=max_related)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
@@ -70,12 +73,12 @@ def status_payload(target: Path) -> dict[str, Any] | None:
     }
 
 
-def _project_payload(*, target: Path, vault: Path) -> dict[str, Any]:
+def _project_payload(*, target: Path, vault: Path, max_related: int = DEFAULT_MAX_RELATED) -> dict[str, Any]:
     root = vault / PROJECTION_FOLDER
     ledger_path = _ledger_path(target, vault)
     ledger = _read_ledger(ledger_path)
     prior_files = _ledger_files(ledger)
-    desired = _render_projection(target, root=root, prior_files=prior_files)
+    desired = _render_projection(target, root=root, prior_files=prior_files, max_related=max_related)
     drift = _drift(root, prior_files)
     mutations: list[kernel.MutationSpec] = []
     actual_files: dict[str, str] = dict(prior_files)
@@ -220,12 +223,14 @@ def _project_payload(*, target: Path, vault: Path) -> dict[str, Any]:
     }
 
 
-def _render_projection(target: Path, *, root: Path, prior_files: dict[str, str]) -> dict[str, bytes]:
+def _render_projection(
+    target: Path, *, root: Path, prior_files: dict[str, str], max_related: int = DEFAULT_MAX_RELATED
+) -> dict[str, bytes]:
     inventory = _inventory(target)
     records = [_record(target, item) for item in inventory]
     _assign_paths(records)
     _assign_link_paths(records, root=root, prior_files=prior_files)
-    links = _relationships(records)
+    links = _relationships(records, max_related=max_related)
     rendered: dict[str, bytes] = {}
     for record in records:
         rendered[record["path"]] = _render_note(record, links[record["id"]])
@@ -315,7 +320,9 @@ def _assign_link_paths(records: list[dict[str, Any]], *, root: Path, prior_files
             record["link_path"] = path
 
 
-def _relationships(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+def _relationships(
+    records: list[dict[str, Any]], *, max_related: int = DEFAULT_MAX_RELATED
+) -> dict[str, list[dict[str, Any]]]:
     """Rank each note's neighbours and keep the strongest few.
 
     Every pair sharing a category used to become related, so one 221-card category
@@ -358,10 +365,10 @@ def _relationships(records: list[dict[str, Any]]) -> dict[str, list[dict[str, An
         for reference in record["references"]:
             referenced = by_source.get(reference)
             if referenced is not None and referenced is not record:
-                # An explicit ref is the strongest signal and always survives the cap.
+                # Explicit refs outrank tag/category matches, but the cap still applies.
                 scored[referenced["id"]] = (_REFERENCE_WEIGHT, referenced)
         ranked = sorted(scored.values(), key=lambda entry: (-entry[0], entry[1]["title"], entry[1]["id"]))
-        kept = [other for _, other in ranked[:MAX_RELATED]]
+        kept = [other for _, other in ranked[:max_related]]
         result[record["id"]] = sorted(kept, key=lambda other: (other["title"], other["id"]))
     return result
 
@@ -425,7 +432,8 @@ def _render_maps(
     used: set[str] = set()
     for name, members in groups.items():
         # A map holding every note groups nothing. Cards without `source_harness` used to
-        # collapse into one "unknown" map listing the entire corpus.
+        # collapse into one "unknown" map listing the entire corpus. With a single-note
+        # corpus, every group is the whole set, so no maps are emitted.
         if len(members) >= total:
             continue
         stem = _unique_map_stem(name, used)

--- a/tests/test_memory_vault_projection.py
+++ b/tests/test_memory_vault_projection.py
@@ -290,12 +290,98 @@ def test_project_vault_caps_related_links_and_canvas_edges(tmp_path: Path, vault
 
     projection = vault / "Brigade Memory"
     for note in (projection / "Cards").glob("Bulk *.md"):
-        assert note.read_text(encoding="utf-8").count("[[") <= obsidian_vault.MAX_RELATED
+        assert note.read_text(encoding="utf-8").count("[[") <= obsidian_vault.DEFAULT_MAX_RELATED
     canvas = json.loads((projection / "Brigade Memory.canvas").read_text(encoding="utf-8"))
     card_edges = [edge for edge in canvas["edges"] if not str(edge["id"]).startswith("topology:")]
     assert card_edges
-    assert len(card_edges) <= 30 * obsidian_vault.MAX_RELATED
+    assert len(card_edges) <= 30 * obsidian_vault.DEFAULT_MAX_RELATED
     assert len(card_edges) < 30 * 29 // 2  # not the complete graph the cap replaced
+
+
+def test_project_vault_honors_max_related_override(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_cards(tmp_path, 20, category="workflow", tags=["shared"])
+
+    assert (
+        cli.main(
+            [
+                "memory",
+                "project-vault",
+                "--target",
+                str(tmp_path),
+                "--vault",
+                str(vault),
+                "--max-related",
+                "5",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    projection = vault / "Brigade Memory"
+    for note in (projection / "Cards").glob("Bulk *.md"):
+        assert note.read_text(encoding="utf-8").count("[[") <= 5
+    canvas = json.loads((projection / "Brigade Memory.canvas").read_text(encoding="utf-8"))
+    card_edges = [edge for edge in canvas["edges"] if not str(edge["id"]).startswith("topology:")]
+    assert len(card_edges) <= 20 * 5
+
+
+def test_project_vault_rejects_non_positive_max_related(tmp_path: Path, vault: Path, capsys) -> None:
+    _write_card(tmp_path, "alpha", title="Alpha", tags=["operations"], body="Canonical note.")
+
+    assert (
+        cli.main(
+            [
+                "memory",
+                "project-vault",
+                "--target",
+                str(tmp_path),
+                "--vault",
+                str(vault),
+                "--max-related",
+                "0",
+            ]
+        )
+        == 2
+    )
+    assert "--max-related must be at least 1" in capsys.readouterr().err
+
+
+def test_project_vault_drops_explicit_refs_beyond_max_related(tmp_path: Path, vault: Path, capsys) -> None:
+    """Explicit refs outrank tag/category matches but still respect the cap."""
+    refs = [f"card-00000000-0000-4000-8000-{index:012d}" for index in range(1, 6)]
+    _write_ref_card(tmp_path, "hub", "000000000000", title="Hub", category="ops", refs=refs)
+    for index in range(1, 6):
+        _write_ref_card(
+            tmp_path,
+            f"target-{index}",
+            f"{index:012d}",
+            title=f"Target {index}",
+            category="ops",
+            refs=[],
+        )
+
+    assert (
+        cli.main(
+            [
+                "memory",
+                "project-vault",
+                "--target",
+                str(tmp_path),
+                "--vault",
+                str(vault),
+                "--max-related",
+                "3",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    hub = (vault / "Brigade Memory" / "Cards" / "Hub.md").read_text(encoding="utf-8")
+    related_section = hub.split("## Related", 1)[1]
+    assert related_section.count("[[") == 3
 
 
 def test_project_vault_omits_a_map_that_covers_every_note(tmp_path: Path, vault: Path, capsys) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Follow-up to #953: the per-note related-link cap (`MAX_RELATED = 12`) was a chosen default, not a derived optimum. This adds `--max-related` to `brigade memory project-vault`, corrects the misleading explicit-ref cap comment, and documents why a single-note corpus emits no maps.

Fixes #966

## Type of change

- [x] Bug fix

## Checklist

- [x] Targeted `pytest tests/test_memory_vault_projection.py` passes locally (21 tests)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR
- [x] No new runtime dependencies

## Changes

- Add `--max-related` CLI flag (default 12) threaded through `project()` → `_relationships()`
- Rename default constant to `DEFAULT_MAX_RELATED`; keep `MAX_RELATED` alias for compatibility
- Correct comment: explicit refs outrank tag/category matches but still respect the cap
- Note in `_render_maps` that a single-note corpus suppresses all maps (intentional)
- Tests: override honor, invalid value rejection, explicit-ref overflow at cap

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a51c0e0b-e8a4-4a51-a9dc-ba584fc789e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a51c0e0b-e8a4-4a51-a9dc-ba584fc789e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

