### PR TITLE
docs: resolve crates.io deprecation directive for graphtrail

### DIFF
--- a/docs/phase-4a-compatibility-and-archive.md
+++ b/docs/phase-4a-compatibility-and-archive.md
@@ -122,8 +122,9 @@ returns to either mirror.
 ## GraphTrail crates.io policy
 
 Per the 2026-07-21 maintainer decision, no further crates.io releases ship.
-Leave every published crate version unyanked for reproducibility. Mark the
-crate deprecated and maintenance-frozen, and remove current `cargo install`
+Leave every published crate version unyanked for reproducibility. The crate
+is frozen at 0.4.0, with deprecation communicated off-registry since
+crates.io exposes no deprecation flag. Remove current `cargo install`
 guidance from documentation.
 
 ## Phase 4B checklist (compressed)


### PR DESCRIPTION
## Summary
- crates.io exposes no deprecation flag, and republishing to change the description or README is forbidden by the same freeze policy, so the prior wording ("mark the crate deprecated") described an action that cannot be taken on the registry.
- Amends the `## GraphTrail crates.io policy` section in `docs/phase-4a-compatibility-and-archive.md` to state the crate's status directly instead: frozen at 0.4.0, with deprecation communicated off-registry.

Fixes #365

## Test plan
- [x] Doc-only change; read the amended section for accuracy against the rest of the policy doc.