### PR TITLE
chore(roster): remove dead Kimi seats (k3, k3_kimi)

### DIFF
--- a/docs/seat-catalog.md
+++ b/docs/seat-catalog.md
@@ -128,17 +128,17 @@ role = "Fallback review through the reviewed ACP transport."
 
 The reference is fail-closed: it must resolve to a non-orchestrator Cursor seat with a `grok-*` model and the reviewed ACPX version. Brigade does not search the roster for a similar model. The policy applies only to a typed malformed-final result from a direct Grok `--worker` read-only run; startup, authentication, network, timeout, permission, and nonzero failures are terminal.
 
-### Anthropic-compatible API lanes (Kimi, GLM, and friends)
+### Anthropic-compatible API lanes (GLM and friends)
 
 Several open-weight providers expose Anthropic-compatible endpoints, which means the `claude` CLI can drive them and Brigade can seat them directly. Declare the lane's environment on the seat: plain values inline, secrets by reference with a `_REF` suffix naming the environment variable that holds the value (the roster never stores the secret itself):
 
 ```toml
-[agents.k3]
+[agents.glm52]
 cli = "claude"
-model = "kimi-k3"
+model = "glm-5.2"
 read_only_capable = false
-role = "Open-weight worker on a coding-plan quota; relief for orchestrator-tier work."
-env = { ANTHROPIC_BASE_URL = "https://api.moonshot.ai/anthropic", ANTHROPIC_AUTH_TOKEN_REF = "KIMI_API_KEY", CLAUDE_CONFIG_DIR = "/home/operator/.claude-lanes" }
+role = "Open-weight worker on an Anthropic-compatible API; relief for orchestrator-tier work."
+env = { ANTHROPIC_BASE_URL = "https://api.example.com/anthropic", ANTHROPIC_AUTH_TOKEN_REF = "GLM_API_KEY", CLAUDE_CONFIG_DIR = "/home/operator/.claude-lanes" }
 ```
 
 This proxy example opts out of read-only dispatch. Set the value to `true` only after
@@ -148,7 +148,7 @@ When the proxy credential is rendered into a runtime systemd environment file, p
 reference at that file rather than the parent process environment:
 
 ```toml
-env = { ANTHROPIC_AUTH_TOKEN_REF = "env-file:/run/brigade/k3.env#CLIPROXY_API_KEY" }
+env = { ANTHROPIC_AUTH_TOKEN_REF = "env-file:/run/brigade/glm.env#CLIPROXY_API_KEY" }
 ```
 
 The path must be absolute. Brigade reads only `KEY=VALUE` entries from the file and does not


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The Kimi Code subscription is canceled, so Kimi-backed roster seats (`k3`, `k3_kimi`) should no longer appear in shipped roster guidance or live examples.

This PR removes the only live reference found in shipped roster documentation: the `[agents.k3]` / `kimi-k3` copy-paste stanza in `docs/seat-catalog.md`. It is replaced with a generic GLM Anthropic-compatible lane example so the wiring pattern stays documented without prescribing a dead seat.

## Scope audit

Searched the repository for `k3_kimi`, `k3`, `kimi-k3`, and `kimi` across roster `*.toml` files, docs, presets, and routing defaults:

| Location | Finding |
|---|---|
| `src/brigade/templates/rosters/*.toml` | No `k3` or `k3_kimi` seats |
| `src/brigade/roster_cmd.py` default starter | No Kimi seats |
| `benchmarks/model-ratings-2026-07/*` | Historical benchmark artifacts left intact per instructions |
| `tests/test_roster.py` `ENV_SEAT` fixture | Uses `[agents.k3]` only as env-parsing test data, not shipped config — untouched |
| `k3_kimi` | **Never present** in any branch or commit in this repository |

## Verification

- `python -m pytest -k roster -q` → **218 passed**
- TOML parse check across all `**/*.toml` → **8 files OK**

## Type of change

- [x] Docs
- [ ] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Refactor with no command-surface change
- [ ] Surface change

## Checklist

- [x] `pytest -k roster` passes locally
- [ ] Added or updated tests covering the change (docs-only; no behavior change)
- [ ] Updated `CHANGELOG.md` (docs-only seat-catalog example swap)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59950e43-e6da-4672-b265-4ad65b63a273?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59950e43-e6da-4672-b265-4ad65b63a273&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

