### PR TITLE
perf(evidence-ledger): batch search integrity item lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recover <operation-id>`. Refs #911.
 
 ### Changed
+- Search integrity verification loads item text and provenance in one
+  `IN (...)` query keyed by the result ids, instead of one select per
+  hit (search limit is up to 200). (#964)
 - `brigade memory project-vault` produces a browsable vault on a real corpus.
   Notes take their title from the card's leading heading when frontmatter has
   no `title`, instead of the filename slug, and that heading is no longer

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -10,6 +10,9 @@ Releases before this changelog was started are on the [releases page](https://gi
 
 ### Changed
 
+- Search integrity verification loads item text and provenance in one
+  `IN (...)` query keyed by the result ids, instead of one select per
+  hit (search limit is up to 200). (#964)
 - Memory projection E2 read-path hardening (#843): soft-tombstone superseded
   content-hash versions (and drop their FTS rows) so each
   `(source, collection, external_id)` has one default-live version; generic

--- a/engines/evidence-ledger/internal/app/integrity.go
+++ b/engines/evidence-ledger/internal/app/integrity.go
@@ -247,16 +247,72 @@ func attachIntegrityFields(out map[string]any, view integrityView) {
 	}
 }
 
-func applySearchIntegrity(db *sql.DB, results []SearchResult) error {
-	for i := range results {
-		var text, metadataJSON, rawJSON string
-		if err := db.QueryRow(`select coalesce(text,''), metadata_json, coalesce(raw_json,'') from items where id = ?`, results[i].ID).Scan(&text, &metadataJSON, &rawJSON); err != nil {
-			if err == sql.ErrNoRows {
-				continue
-			}
-			return err
+type itemQuerier interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+type searchIntegrityItem struct {
+	Text         string
+	MetadataJSON string
+	RawJSON      string
+}
+
+func searchResultIDs(results []SearchResult) []string {
+	ids := make([]string, 0, len(results))
+	seen := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		if result.ID == "" {
+			continue
 		}
-		view := inspectItemIntegrity(text, rawJSON, metadataJSON, nil, false)
+		if _, ok := seen[result.ID]; ok {
+			continue
+		}
+		seen[result.ID] = struct{}{}
+		ids = append(ids, result.ID)
+	}
+	return ids
+}
+
+func searchIntegrityLookupSQL(n int) string {
+	return `select id, coalesce(text,''), metadata_json, coalesce(raw_json,'') from items where id in (` + placeholders(n) + `)`
+}
+
+func loadItemsForSearchIntegrity(db itemQuerier, ids []string) (map[string]searchIntegrityItem, error) {
+	if len(ids) == 0 {
+		return map[string]searchIntegrityItem{}, nil
+	}
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	rows, err := db.Query(searchIntegrityLookupSQL(len(args)), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]searchIntegrityItem, len(ids))
+	for rows.Next() {
+		var id string
+		var item searchIntegrityItem
+		if err := rows.Scan(&id, &item.Text, &item.MetadataJSON, &item.RawJSON); err != nil {
+			return nil, err
+		}
+		out[id] = item
+	}
+	return out, rows.Err()
+}
+
+func applySearchIntegrity(db *sql.DB, results []SearchResult) error {
+	items, err := loadItemsForSearchIntegrity(db, searchResultIDs(results))
+	if err != nil {
+		return err
+	}
+	for i := range results {
+		item, ok := items[results[i].ID]
+		if !ok {
+			continue
+		}
+		view := inspectItemIntegrity(item.Text, item.RawJSON, item.MetadataJSON, nil, false)
 		results[i].Origin = view.Origin
 		results[i].Modality = view.Modality
 		results[i].TrustLabel = view.TrustLabel

--- a/engines/evidence-ledger/internal/app/integrity_test.go
+++ b/engines/evidence-ledger/internal/app/integrity_test.go
@@ -259,6 +259,146 @@ func TestForensicContentBlocksUnknownInjectionStatus(t *testing.T) {
 	assertItemNotDeleted(t, id)
 }
 
+func TestSearchIntegrityLookupSQLBatchesIDs(t *testing.T) {
+	got := searchIntegrityLookupSQL(3)
+	if !strings.Contains(got, "id in (?,?,?)") {
+		t.Fatalf("expected one batched IN clause, got %q", got)
+	}
+	if strings.Count(strings.ToLower(got), "select") != 1 {
+		t.Fatalf("expected a single select, got %q", got)
+	}
+}
+
+func TestLoadItemsForSearchIntegritySkipsQueryWhenEmpty(t *testing.T) {
+	counter := &queryCounter{}
+	items, err := loadItemsForSearchIntegrity(counter, searchResultIDs(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counter.selects != 0 {
+		t.Fatalf("empty ids issued %d queries", counter.selects)
+	}
+	if len(items) != 0 {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestLoadItemsForSearchIntegrityUsesOneQuery(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	okID := insertCleanIntegrityItem(t, "UNIQUE_BATCH_LOAD ok body", "untrusted", "clean")
+	badID := insertCleanIntegrityItem(t, "UNIQUE_BATCH_LOAD bad body", "reviewed", "clean")
+	legacyID := insertLegacyIntegrityItem(t, "UNIQUE_BATCH_LOAD legacy body")
+	missingID := "item-does-not-exist"
+
+	db := openTestDB(t)
+	defer db.Close()
+	counter := &queryCounter{DB: db}
+	ids := []string{okID, badID, legacyID, missingID, okID, ""}
+	items, err := loadItemsForSearchIntegrity(counter, searchResultIDs(resultsFromIDs(ids...)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counter.selects != 1 {
+		t.Fatalf("item lookups = %d, want 1", counter.selects)
+	}
+	if len(items) != 3 {
+		t.Fatalf("loaded items = %d, want 3 (missing id skipped): %#v", len(items), items)
+	}
+	if _, ok := items[missingID]; ok {
+		t.Fatalf("missing id should not be present: %#v", items)
+	}
+	if items[okID].Text == "" || items[badID].Text == "" || items[legacyID].Text == "" {
+		t.Fatalf("expected text for known ids: %#v", items)
+	}
+}
+
+func TestApplySearchIntegrityBatchesMultipleResults(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	okID := insertCleanIntegrityItem(t, "UNIQUE_BATCH_APPLY ok body", "untrusted", "clean")
+	badID := insertCleanIntegrityItem(t, "UNIQUE_BATCH_APPLY bad body", "reviewed", "clean")
+	forgeItemContentHash(t, badID, forgedContentDigest)
+	missingID := "item-does-not-exist"
+
+	db := openTestDB(t)
+	defer db.Close()
+	results := []SearchResult{
+		{ID: okID, Snippet: "keep-ok"},
+		{ID: badID, Snippet: "clear-bad"},
+		{ID: missingID, Snippet: "keep-missing"},
+		{ID: okID, Snippet: "keep-dup"},
+	}
+	if err := applySearchIntegrity(db, results); err != nil {
+		t.Fatal(err)
+	}
+	if results[0].IntegrityMismatch || results[0].Snippet != "keep-ok" {
+		t.Fatalf("matching hit changed: %#v", results[0])
+	}
+	if results[0].Origin != "workspace" || results[0].TrustLabel != "untrusted" {
+		t.Fatalf("matching envelope fields = %#v", results[0])
+	}
+	if !results[1].IntegrityMismatch || results[1].Snippet != "" {
+		t.Fatalf("mismatched hit not suppressed: %#v", results[1])
+	}
+	if results[1].TrustLabel != "reviewed" {
+		t.Fatalf("mismatch changed trust: %#v", results[1])
+	}
+	if results[2].IntegrityMismatch || results[2].Snippet != "keep-missing" || results[2].Origin != "" {
+		t.Fatalf("missing id should be left unchanged: %#v", results[2])
+	}
+	if results[3].IntegrityMismatch || results[3].Snippet != "keep-dup" {
+		t.Fatalf("duplicate matching hit changed: %#v", results[3])
+	}
+	assertItemNotDeleted(t, okID)
+	assertItemNotDeleted(t, badID)
+	assertIntegrityEventCount(t, badID, 1)
+}
+
+func TestSearchIntegrityHandlesMultipleHitsInOnePass(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	okID := insertCleanIntegrityItem(t, "UNIQUE_MULTI_HIT ok body", "untrusted", "clean")
+	badID := insertCleanIntegrityItem(t, "UNIQUE_MULTI_HIT bad body", "untrusted", "clean")
+	forgeItemContentHash(t, badID, forgedContentDigest)
+
+	search := runJSON(t, "search", "UNIQUE_MULTI_HIT", "--json", "--limit", "50")
+	results := search["results"].([]any)
+	if len(results) != 2 {
+		t.Fatalf("search results = %#v", search)
+	}
+	byID := map[string]map[string]any{}
+	for _, raw := range results {
+		hit := raw.(map[string]any)
+		id, _ := hit["id"].(string)
+		byID[id] = hit
+	}
+	okHit := byID[okID]
+	if okHit == nil || okHit["integrity_mismatch"] == true {
+		t.Fatalf("matching hit flagged: %#v", okHit)
+	}
+	if snippet, _ := okHit["snippet"].(string); snippet == "" {
+		t.Fatalf("matching hit lost snippet: %#v", okHit)
+	}
+	if okHit["trust_label"] != "untrusted" {
+		t.Fatalf("matching hit trust = %#v", okHit)
+	}
+	badHit := byID[badID]
+	if badHit == nil || badHit["integrity_mismatch"] != true {
+		t.Fatalf("mismatched hit missing flag: %#v", badHit)
+	}
+	if snippet, _ := badHit["snippet"].(string); snippet != "" {
+		t.Fatalf("mismatched hit leaked snippet: %q", snippet)
+	}
+	if badHit["trust_label"] != "untrusted" {
+		t.Fatalf("mismatched hit changed trust: %#v", badHit)
+	}
+	assertItemNotDeleted(t, okID)
+	assertItemNotDeleted(t, badID)
+	assertIntegrityEventCount(t, badID, 1)
+	assertIntegrityEventCount(t, okID, 0)
+}
+
 func TestIntegrityMismatchDoesNotDowngradeTrustLabel(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
@@ -467,6 +607,26 @@ func assertIntegrityEventCount(t *testing.T, itemID string, want int) {
 	if n != want {
 		t.Fatalf("integrity events = %d, want %d", n, want)
 	}
+}
+
+type queryCounter struct {
+	*sql.DB
+	selects int
+}
+
+func (q *queryCounter) Query(query string, args ...any) (*sql.Rows, error) {
+	if strings.Contains(strings.ToLower(query), "from items") {
+		q.selects++
+	}
+	return q.DB.Query(query, args...)
+}
+
+func resultsFromIDs(ids ...string) []SearchResult {
+	out := make([]SearchResult, len(ids))
+	for i, id := range ids {
+		out[i] = SearchResult{ID: id}
+	}
+	return out
 }
 
 func mcpTextPayload(t *testing.T, result map[string]any) map[string]any {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

`applySearchIntegrity` issued one `select ... from items where id = ?` per search hit. Search can return up to 200 rows, so a single read path ran 200 sequential queries. This loads the needed integrity columns in one `IN (...)` query keyed by unique result ids. Integrity behavior is unchanged.

Fixes #964

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] Targeted `go test ./internal/app` integrity suite passes locally (`gofmt` clean, `go vet ./internal/app` clean)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages, no AI co-authorship trailers

## Verification

```
cd engines/evidence-ledger
gofmt -l internal/app/integrity.go internal/app/integrity_test.go
go vet ./internal/app
go test ./internal/app -count=1 -timeout 15m -run 'TestSearchSuppresses|TestShowHides|TestForensic|TestHTTPAndMCPHaveNo|TestEvidenceBundle|TestUppercase|TestIntegrity|TestLoadItems|TestApplySearch|TestSearchIntegrity'
```

Result: PASS (`ok github.com/escoffier-labs/miseledger/internal/app`). `TestLoadItemsForSearchIntegrityUsesOneQuery` asserts the item lookup issues a single `from items` select for mixed, duplicate, and missing ids.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c78cf65-5a61-48f2-b6fd-7aa67214ca2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c78cf65-5a61-48f2-b6fd-7aa67214ca2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

