### PR TITLE
fix(work): release scanner run authority inside the scan loop

### DIFF
--- a/src/brigade/work_cmd/scanners.py
+++ b/src/brigade/work_cmd/scanners.py
@@ -1563,96 +1563,102 @@ def _scanner_run_one(
         "forced": force,
     }
     _SCANNER_RUN_DIRECTORY_AUTHORITIES[id(receipt)] = authority
-    _write_scanner_run_receipt(receipt)
-    if blocker is not None:
-        completed = helpers._now()
-        receipt.update(
-            {
-                "status": "failed",
-                "completed_at": completed.isoformat(),
-                "duration_seconds": (completed - started).total_seconds(),
-                "exit_code": None,
-                "timed_out": False,
-                "error": blocker,
-                "stdout_summary": "",
-                "stderr_summary": blocker,
-                "output_after": _scanner_output_snapshot(output_path),
-            }
-        )
-        _write_scanner_run_file(authority, "stdout.log", b"")
-        _write_scanner_run_file(authority, "stderr.log", (blocker + "\n").encode("utf-8"))
-        _write_scanner_run_receipt(receipt)
-        return receipt
-    if not cwd.is_dir():
-        completed = helpers._now()
-        error = f"scanner cwd does not exist: {cwd}"
-        receipt.update(
-            {
-                "status": "failed",
-                "completed_at": completed.isoformat(),
-                "duration_seconds": (completed - started).total_seconds(),
-                "exit_code": None,
-                "timed_out": False,
-                "error": error,
-                "stdout_summary": "",
-                "stderr_summary": error,
-                "output_after": _scanner_output_snapshot(output_path),
-            }
-        )
-        _write_scanner_run_file(authority, "stdout.log", b"")
-        _write_scanner_run_file(authority, "stderr.log", (error + "\n").encode("utf-8"))
-        _write_scanner_run_receipt(receipt)
-        return receipt
-    _prebind_child_visible_directories(target)
     try:
-        with _scanner_child_environment_sandbox(target) as child_env:
-            completed_process = subprocess.run(
-                argv,
-                cwd=cwd,
-                text=True,
-                capture_output=True,
-                timeout=float(scanner.get("timeout") or 300),
-                shell=False,
-                env=child_env,
+        _write_scanner_run_receipt(receipt)
+        if blocker is not None:
+            completed = helpers._now()
+            receipt.update(
+                {
+                    "status": "failed",
+                    "completed_at": completed.isoformat(),
+                    "duration_seconds": (completed - started).total_seconds(),
+                    "exit_code": None,
+                    "timed_out": False,
+                    "error": blocker,
+                    "stdout_summary": "",
+                    "stderr_summary": blocker,
+                    "output_after": _scanner_output_snapshot(output_path),
+                }
             )
-        stdout = completed_process.stdout or ""
-        stderr = completed_process.stderr or ""
-        _write_scanner_run_file(authority, "stdout.log", stdout.encode("utf-8"))
-        _write_scanner_run_file(authority, "stderr.log", stderr.encode("utf-8"))
-        completed = helpers._now()
-        receipt.update(
-            {
-                "status": "completed" if completed_process.returncode == 0 else "failed",
-                "completed_at": completed.isoformat(),
-                "duration_seconds": (completed - started).total_seconds(),
-                "exit_code": completed_process.returncode,
-                "timed_out": False,
-                "stdout_summary": _scanner_run_summary(stdout),
-                "stderr_summary": _scanner_run_summary(stderr),
-                "output_after": _scanner_output_snapshot(output_path),
-            }
-        )
-    except subprocess.TimeoutExpired as exc:
-        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
-        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
-        _write_scanner_run_file(authority, "stdout.log", stdout.encode("utf-8"))
-        _write_scanner_run_file(authority, "stderr.log", stderr.encode("utf-8"))
-        completed = helpers._now()
-        receipt.update(
-            {
-                "status": "failed",
-                "completed_at": completed.isoformat(),
-                "duration_seconds": (completed - started).total_seconds(),
-                "exit_code": None,
-                "timed_out": True,
-                "error": f"scanner timed out after {scanner.get('timeout')} seconds",
-                "stdout_summary": _scanner_run_summary(stdout),
-                "stderr_summary": _scanner_run_summary(stderr),
-                "output_after": _scanner_output_snapshot(output_path),
-            }
-        )
-    _write_scanner_run_receipt(receipt)
-    return receipt
+            _write_scanner_run_file(authority, "stdout.log", b"")
+            _write_scanner_run_file(authority, "stderr.log", (blocker + "\n").encode("utf-8"))
+            _write_scanner_run_receipt(receipt)
+            return receipt
+        if not cwd.is_dir():
+            completed = helpers._now()
+            error = f"scanner cwd does not exist: {cwd}"
+            receipt.update(
+                {
+                    "status": "failed",
+                    "completed_at": completed.isoformat(),
+                    "duration_seconds": (completed - started).total_seconds(),
+                    "exit_code": None,
+                    "timed_out": False,
+                    "error": error,
+                    "stdout_summary": "",
+                    "stderr_summary": error,
+                    "output_after": _scanner_output_snapshot(output_path),
+                }
+            )
+            _write_scanner_run_file(authority, "stdout.log", b"")
+            _write_scanner_run_file(authority, "stderr.log", (error + "\n").encode("utf-8"))
+            _write_scanner_run_receipt(receipt)
+            return receipt
+        _prebind_child_visible_directories(target)
+        try:
+            with _scanner_child_environment_sandbox(target) as child_env:
+                completed_process = subprocess.run(
+                    argv,
+                    cwd=cwd,
+                    text=True,
+                    capture_output=True,
+                    timeout=float(scanner.get("timeout") or 300),
+                    shell=False,
+                    env=child_env,
+                )
+            stdout = completed_process.stdout or ""
+            stderr = completed_process.stderr or ""
+            _write_scanner_run_file(authority, "stdout.log", stdout.encode("utf-8"))
+            _write_scanner_run_file(authority, "stderr.log", stderr.encode("utf-8"))
+            completed = helpers._now()
+            receipt.update(
+                {
+                    "status": "completed" if completed_process.returncode == 0 else "failed",
+                    "completed_at": completed.isoformat(),
+                    "duration_seconds": (completed - started).total_seconds(),
+                    "exit_code": completed_process.returncode,
+                    "timed_out": False,
+                    "stdout_summary": _scanner_run_summary(stdout),
+                    "stderr_summary": _scanner_run_summary(stderr),
+                    "output_after": _scanner_output_snapshot(output_path),
+                }
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+            _write_scanner_run_file(authority, "stdout.log", stdout.encode("utf-8"))
+            _write_scanner_run_file(authority, "stderr.log", stderr.encode("utf-8"))
+            completed = helpers._now()
+            receipt.update(
+                {
+                    "status": "failed",
+                    "completed_at": completed.isoformat(),
+                    "duration_seconds": (completed - started).total_seconds(),
+                    "exit_code": None,
+                    "timed_out": True,
+                    "error": f"scanner timed out after {scanner.get('timeout')} seconds",
+                    "stdout_summary": _scanner_run_summary(stdout),
+                    "stderr_summary": _scanner_run_summary(stderr),
+                    "output_after": _scanner_output_snapshot(output_path),
+                }
+            )
+        _write_scanner_run_receipt(receipt)
+        return receipt
+    except BaseException:
+        # The payload finally only releases runs that reached `runs.append`.
+        # Release here so a failure after install cannot retain the descriptors.
+        _release_scanner_run_directory_authority(receipt)
+        raise
 
 
 def _scanner_plan_payload(target: Path) -> dict[str, Any]:
@@ -2290,6 +2296,8 @@ def _scanners_run_payload(
                 if isinstance(item, dict) and isinstance(item.get("id"), str)
             }
             run = _scanner_run_one(target, scanner, force=force)
+            # Cover stamp/receipt failures: authority exists from `_scanner_run_one`.
+            runs.append(run)
             _register_scanner_run_proof(scanner, run)
             stamped_ids = _scanner_stamp_new_imports(
                 target=target,
@@ -2303,7 +2311,6 @@ def _scanners_run_payload(
             if stamped_ids:
                 run["stamped_import_ids"] = stamped_ids
             _write_scanner_run_receipt(run)
-            runs.append(run)
             contexts.append((scanner, run))
         ingest_errors: list[str] = []
         ingest_payloads: list[tuple[dict[str, Any], dict[str, Any], Path, list[dict[str, Any]]]] = []

--- a/tests/test_work_cmd_scanners.py
+++ b/tests/test_work_cmd_scanners.py
@@ -787,6 +787,118 @@ conflict_window = "02:00-02:10"
         assert raised.value.errno == errno.EBADF
 
 
+def _repo_scan_config(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    script = tmp_path / "scanner.py"
+    script.write_text("\n")
+    config = tmp_path / ".brigade" / "scanners.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        f"""
+[[scanner]]
+id = "repo-scan"
+source = "repo-scan"
+command = "{sys.executable} {script}"
+cadence = "daily@02:00"
+enabled = true
+timeout = 30
+output_path = ".brigade/scanner-imports.jsonl"
+import_path = ".brigade/scanner-imports.jsonl"
+import_format = "jsonl"
+conflict_window = "02:00-02:10"
+"""
+    )
+
+
+def _capture_retained_scanner_run_authorities(
+    prior_keys: set[int],
+) -> tuple[list[int], list[tuple[int, int]]]:
+    from brigade.work_cmd import scanners as scanners_mod
+
+    authorities = scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES
+    retained = {key: authority for key, authority in authorities.items() if key not in prior_keys}
+    assert retained, "expected retained scanner-run directory authority"
+    captured_keys: list[int] = []
+    captured_fds: list[tuple[int, int]] = []
+    for key, authority in retained.items():
+        captured_keys.append(key)
+        captured_fds.append((authority.root, authority.directory))
+        os.fstat(authority.root)
+        os.fstat(authority.directory)
+    return captured_keys, captured_fds
+
+
+def _assert_scanner_run_authorities_released(
+    prior_keys: set[int],
+    captured_keys: list[int],
+    captured_fds: list[tuple[int, int]],
+) -> None:
+    from brigade.work_cmd import scanners as scanners_mod
+
+    remaining = scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES
+    assert set(remaining) == prior_keys
+    for key in captured_keys:
+        assert key not in remaining
+    for root, directory in captured_fds:
+        with pytest.raises(OSError) as raised:
+            os.fstat(root)
+        assert raised.value.errno == errno.EBADF
+        with pytest.raises(OSError) as raised:
+            os.fstat(directory)
+        assert raised.value.errno == errno.EBADF
+
+
+def test_scanners_run_releases_directory_authority_when_stamp_raises(tmp_path, monkeypatch):
+    from brigade.work_cmd import scanners as scanners_mod
+
+    _repo_scan_config(tmp_path)
+    prior_keys = set(scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES)
+    captured_keys: list[int] = []
+    captured_fds: list[tuple[int, int]] = []
+
+    def fail_stamp(*_args: object, **_kwargs: object) -> list[str]:
+        keys, fds = _capture_retained_scanner_run_authorities(prior_keys)
+        captured_keys.extend(keys)
+        captured_fds.extend(fds)
+        raise RuntimeError("forced stamp failure")
+
+    monkeypatch.setattr(scanners_mod, "_scanner_stamp_new_imports", fail_stamp)
+
+    with pytest.raises(RuntimeError, match="forced stamp failure"):
+        scanners_mod._scanners_run_payload(target=tmp_path, scanner_id="repo-scan")
+
+    assert captured_keys
+    assert captured_fds
+    _assert_scanner_run_authorities_released(prior_keys, captured_keys, captured_fds)
+
+
+def test_scanners_run_releases_directory_authority_when_receipt_rewrite_raises(tmp_path, monkeypatch):
+    from brigade.work_cmd import scanners as scanners_mod
+
+    _repo_scan_config(tmp_path)
+    prior_keys = set(scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES)
+    captured_keys: list[int] = []
+    captured_fds: list[tuple[int, int]] = []
+    real_write = scanners_mod._write_scanner_run_receipt
+
+    def fail_loop_local_receipt(run: dict[str, object]) -> None:
+        if "provenance_imports_stamped" in run:
+            keys, fds = _capture_retained_scanner_run_authorities(prior_keys)
+            captured_keys.extend(keys)
+            captured_fds.extend(fds)
+            raise RuntimeError("forced receipt rewrite failure")
+        real_write(run)
+
+    monkeypatch.setattr(scanners_mod, "_write_scanner_run_receipt", fail_loop_local_receipt)
+
+    with pytest.raises(RuntimeError, match="forced receipt rewrite failure"):
+        scanners_mod._scanners_run_payload(target=tmp_path, scanner_id="repo-scan")
+
+    assert captured_keys
+    assert captured_fds
+    _assert_scanner_run_authorities_released(prior_keys, captured_keys, captured_fds)
+
+
 def test_work_scanners_ingest_output_sanitizes_hostile_records_and_owns_identity(tmp_path, capsys):
     _init_git_repo(tmp_path)
     script = tmp_path / "scanner.py"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

PR #946 released scanner-run directory descriptors from `_scanners_run_payload`'s `finally`, but only for runs already appended to `runs`. Stamp and the loop-local receipt rewrite still happened before `runs.append`, and `_scanner_run_one` could raise after installing the authority. Those windows leaked the run-root and run-leaf descriptors until process exit.

This change appends each run immediately after `_scanner_run_one` returns so the payload `finally` covers stamp and receipt-rewrite failures, and releases inside `_scanner_run_one` when it raises after install. The success path still leaves the authority for the caller.

Fixes #952

Follow-up to #883 / #946.

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] Targeted `python -m pytest tests/test_work_cmd_scanners.py tests/test_work_import_provenance_stamp.py -q` passes locally (262 passed)
- [x] Added or updated tests covering the change
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages

Internal descriptor-release fix; no user-visible changelog entry, same as #946. In-house commit includes the allowed Cursor agent trailer.

## Test plan

- `test_scanners_run_releases_directory_authority_when_stamp_raises` forces `_scanner_stamp_new_imports` to raise and asserts the authority-map key set is restored and both descriptors return `EBADF`.
- `test_scanners_run_releases_directory_authority_when_receipt_rewrite_raises` lets `_scanner_run_one` write receipts, then fails the loop-local rewrite once `provenance_imports_stamped` is set, with the same EBADF assertions.
- Existing `test_scanners_run_releases_directory_authority_when_import_publication_raises` still passes.
- Full scanner + provenance-stamp modules: `python -m pytest tests/test_work_cmd_scanners.py tests/test_work_import_provenance_stamp.py -q` → 262 passed.

[Targeted scanner authority-release tests](https://cursor.com/agents/bc-fac7aef4-59f0-44f0-9b48-433fad1f8027/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscanner_authority_release_tests.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fac7aef4-59f0-44f0-9b48-433fad1f8027?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fac7aef4-59f0-44f0-9b48-433fad1f8027&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

