### PR TITLE
feat(evidence): add origin-scoped ingest redaction with counted removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Origin-scoped ingest redaction now maps `work import context` (and `--source external-web` / `external-service`) to the external detector tier, normalizes free-form `--source` with `strip().lower()`, and fails closed to `unknown` on unmapped values. An equal-but-unredacted scanner result is treated as failure, and research findings redact title/summary/evidence per field so a multi-line summary cannot migrate into evidence. (#498)
+
 ### Added
 - Evidence ingest now applies an origin-scoped redaction policy (`brigade.evidence-redaction.v1`) before persistence. Sources classify to the provenance envelope origin; each origin selects detectors; the stored item keeps only redacted bytes plus a count/detector record (never the removed values). Scanner failure, timeout, or unavailability cannot produce a clean verdict and persists a placeholder instead of the original. The policy version is stamped on every decision and applies to future writes only — existing rows and provenance backfill are not rewritten. (#498)
 - Canonical memory cards mint one opaque `card-<uuid4>` ID on create, and the reviewed `memory care backfill` path can mint an ID on a legacy card, including complete care cards that only lack an ID. Valid IDs are never replaced. Care queues, recall and search logs, refresh imports, and retrieval-eval fixtures dual-read explicit IDs and legacy path/stem/topic aliases; alias collisions fail without rewriting cards. Dry-run backfill writes a deterministic mapping receipt with coverage and old-to-new IDs (relative paths only; `old_id` is the consumer-facing identity). A zero-candidate dry run writes nothing. Duplicate-ID coverage does not require `memory/NAMESPACE`. Missing IDs stay a doctor warning until coverage is 100 percent. (#867)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Evidence ingest now applies an origin-scoped redaction policy (`brigade.evidence-redaction.v1`) before persistence. Sources classify to the provenance envelope origin; each origin selects detectors; the stored item keeps only redacted bytes plus a count/detector record (never the removed values). Scanner failure, timeout, or unavailability cannot produce a clean verdict and persists a placeholder instead of the original. The policy version is stamped on every decision and applies to future writes only — existing rows and provenance backfill are not rewritten. (#498)
 - Canonical memory cards mint one opaque `card-<uuid4>` ID on create, and the reviewed `memory care backfill` path can mint an ID on a legacy card, including complete care cards that only lack an ID. Valid IDs are never replaced. Care queues, recall and search logs, refresh imports, and retrieval-eval fixtures dual-read explicit IDs and legacy path/stem/topic aliases; alias collisions fail without rewriting cards. Dry-run backfill writes a deterministic mapping receipt with coverage and old-to-new IDs (relative paths only; `old_id` is the consumer-facing identity). A zero-candidate dry run writes nothing. Duplicate-ID coverage does not require `memory/NAMESPACE`. Missing IDs stay a doctor warning until coverage is 100 percent. (#867)
 - `brigade memory vault-index`, `vault-search`, `vault-show`, and `vault-doctor`
   close the operator-vault projection round trip. Config lives in

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -302,6 +302,19 @@ Default briefs, context packs, citations, and promotion omit `unknown` and `quar
 
 Public read surfaces recompute `hashes.content` (and `hashes.raw` when materialized) against the exact stored bytes. Search suppresses a mismatched snippet and sets `integrity_mismatch: true`. Direct `miseledger show` / `brigade evidence show` hide a mismatched or synthesized-legacy body unless `--forensic-content` is passed. `--forensic-content` never changes trust and only reveals a body when injection status is the explicit known-safe value `clean`; empty, unknown, and parse-lost statuses block. MCP, HTTP, bundles, briefs, and context stay metadata-only on mismatch. One idempotent downgrade event is appended per item/hash/mismatch; the row is never deleted.
 
+### Origin-scoped redaction (#498)
+
+New work-import, research-finding, and receipt-index writes run `brigade.evidence-redaction.v1` before the item text is persisted. The policy keys off envelope `origin`:
+
+| Origin | Detectors |
+| --- | --- |
+| `operator-input`, `workspace` | secrets |
+| `agent-session` | secrets, PII |
+| `external-service`, `external-web` | secrets, PII, infrastructure |
+| `unknown` | fail-closed maximum set |
+
+The optional envelope `redaction` object stores `schema`, `schema_version`, `policy_version`, `origin`, `status` (`clean` / `redacted` / `error`), `count`, and `detectors`. It never stores removed values, excerpts, or original bytes. `hashes.content` is the digest of the persisted (already redacted) text. Scanner failure, timeout, or unavailability records `status=error`, persists `[ingestion-redaction-failed]`, and cannot be treated as clean. A missing redaction record on a legacy row is not a clean verdict. New policy versions apply to future writes only; provenance backfill does not rewrite existing text.
+
 ### Legacy banner
 
 When an item carries no provenance, `synthesize_legacy_provenance()` returns a non-null envelope with `origin = unknown`, `modality = unknown`, `attribution = inferred`, `trust.label = unknown`, null `repository`/`session`/`collection_id`/`item_id`/`locator`, and a null content digest. The display string is `UNKNOWN PROVENANCE - legacy item` (`provenance.LEGACY_DISPLAY`). A missing envelope is never treated as trusted.

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -313,6 +313,8 @@ New work-import, research-finding, and receipt-index writes run `brigade.evidenc
 | `external-service`, `external-web` | secrets, PII, infrastructure |
 | `unknown` | fail-closed maximum set |
 
+Work-import `--source` is normalized with `strip().lower()` and fails closed to `unknown` when unmapped. `external-web` and `external-service` are selectable source names. `work import context` is an external-content surface: weaker mapped sources upgrade to `external-web` so secrets, PII, and infrastructure are in scope.
+
 The optional envelope `redaction` object stores `schema`, `schema_version`, `policy_version`, `origin`, `status` (`clean` / `redacted` / `error`), `count`, and `detectors`. It never stores removed values, excerpts, or original bytes. `hashes.content` is the digest of the persisted (already redacted) text. Scanner failure, timeout, or unavailability records `status=error`, persists `[ingestion-redaction-failed]`, and cannot be treated as clean. A missing redaction record on a legacy row is not a clean verdict. New policy versions apply to future writes only; provenance backfill does not rewrite existing text.
 
 ### Legacy banner

--- a/src/brigade/evidence_redaction.py
+++ b/src/brigade/evidence_redaction.py
@@ -1,0 +1,254 @@
+"""Origin-scoped evidence-ingestion redaction policy (#498).
+
+Classifies capture sources, redacts sensitive values before persistence, and
+records counts only. Removed bytes never persist on the verdict, the envelope
+record, or the stored item. Scanner failure, timeout, or unavailability cannot
+produce a clean verdict. A new policy version applies to future writes only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .guard.engine import scan_text
+from .guard.policy import Policy
+from .guard.rules import DEFAULT_RULES
+from .guard.types import Action, Finding, GuardResult, ScanOptions
+
+SCHEMA = "brigade.evidence-redaction.v1"
+SCHEMA_VERSION = 1
+POLICY_VERSION = "brigade.evidence-redaction.v1"
+
+ORIGINS = frozenset({"operator-input", "workspace", "agent-session", "external-service", "external-web", "unknown"})
+STATUSES = frozenset({"clean", "redacted", "error"})
+FAILED_PLACEHOLDER = "[ingestion-redaction-failed]"
+MAX_DETECTORS = 32
+
+# Work-inbox producers. Unknown sources stay workspace, matching the existing
+# ledger default. Envelope origin ``unknown`` is a separate fail-closed class.
+SOURCE_ORIGINS: dict[str, str] = {
+    "manual": "operator-input",
+    "backup-health": "workspace",
+    "chat-memory-sweep": "agent-session",
+    "code-review": "workspace",
+    "context-pack": "workspace",
+    "handoff-ingest": "agent-session",
+    "learning-loop": "workspace",
+    "memory-care": "workspace",
+    "memory-refresh": "workspace",
+    "project-consolidation": "workspace",
+    "repo-fleet": "workspace",
+    "repo-fleet-release": "workspace",
+    "roadmap-audit": "workspace",
+    "scanner-health": "workspace",
+    "security-scan": "workspace",
+    "tool-catalog": "workspace",
+}
+
+# Origin-scoped detector categories. ``unknown`` is fail-closed maximum scope.
+ORIGIN_CATEGORIES: dict[str, frozenset[str]] = {
+    "operator-input": frozenset({"secret"}),
+    "workspace": frozenset({"secret"}),
+    "agent-session": frozenset({"secret", "pii"}),
+    "external-service": frozenset({"secret", "pii", "infrastructure"}),
+    "external-web": frozenset({"secret", "pii", "infrastructure"}),
+    "unknown": frozenset({"secret", "pii", "infrastructure", "attribution"}),
+}
+
+_RECORD_KEYS = frozenset({"schema", "schema_version", "policy_version", "origin", "status", "count", "detectors"})
+_FORBIDDEN_RECORD_KEYS = frozenset(
+    {
+        "bytes",
+        "excerpts",
+        "match",
+        "matches",
+        "original",
+        "raw",
+        "removed",
+        "secrets",
+        "snippet",
+        "text",
+        "value",
+        "values",
+    }
+)
+_EXAMPLE_RULE_PREFIX = "example-"
+
+ScanFn = Callable[..., GuardResult]
+
+
+@dataclass(frozen=True)
+class RedactionVerdict:
+    """Ingest-time redaction decision. ``persisted_text`` is the only payload."""
+
+    policy_version: str
+    origin: str
+    status: str
+    count: int
+    detectors: tuple[str, ...]
+    persisted_text: str
+
+    def record(self) -> dict[str, Any]:
+        """Return the persistable count record. Never includes removed bytes."""
+        return {
+            "schema": SCHEMA,
+            "schema_version": SCHEMA_VERSION,
+            "policy_version": self.policy_version,
+            "origin": self.origin,
+            "status": self.status,
+            "count": self.count,
+            "detectors": list(self.detectors),
+        }
+
+
+def classify_source_origin(source: str) -> str:
+    """Map a producer source name to a closed envelope origin."""
+    cleaned = source.strip() if isinstance(source, str) else ""
+    if not cleaned:
+        return "workspace"
+    return SOURCE_ORIGINS.get(cleaned, "workspace")
+
+
+def resolve_origin(origin: str) -> str:
+    """Return a closed origin. Unknown or empty values fail closed to ``unknown``."""
+    if origin in ORIGIN_CATEGORIES:
+        return origin
+    return "unknown"
+
+
+def ingest_verdict_is_clean(record: object) -> bool:
+    """Return True only for an explicit completed clean scan of the current policy.
+
+    Missing, malformed, error, or other-version records are not clean. Existing
+    rows without a redaction record therefore cannot look scanned-clean.
+    """
+    if validate_redaction_record(record):
+        return False
+    assert isinstance(record, Mapping)
+    return record.get("status") == "clean" and record.get("count") == 0
+
+
+def validate_redaction_record(record: object) -> list[str]:
+    """Return problems on a persistable redaction record. Extra value keys fail."""
+    if not isinstance(record, Mapping):
+        return ["redaction must be a JSON object"]
+    errors: list[str] = []
+    extra = sorted(set(record) - _RECORD_KEYS)
+    forbidden = sorted(set(record) & _FORBIDDEN_RECORD_KEYS)
+    if forbidden:
+        errors.append("redaction must not store removed values")
+    elif extra:
+        errors.append("redaction has unsupported keys")
+    if record.get("schema") != SCHEMA:
+        errors.append(f"redaction.schema must be {SCHEMA!r}")
+    if record.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"redaction.schema_version must be {SCHEMA_VERSION}")
+    if record.get("policy_version") != POLICY_VERSION:
+        errors.append(f"redaction.policy_version must be {POLICY_VERSION!r}")
+    origin = record.get("origin")
+    if origin not in ORIGINS:
+        errors.append(f"redaction.origin {origin!r} is not in the closed set")
+    status = record.get("status")
+    if status not in STATUSES:
+        errors.append(f"redaction.status {status!r} is not in the closed set")
+    count = record.get("count")
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        errors.append("redaction.count must be a nonnegative integer")
+    elif status == "clean" and count != 0:
+        errors.append("redaction.status clean requires count 0")
+    elif status == "redacted" and count < 1:
+        errors.append("redaction.status redacted requires a positive count")
+    detectors = record.get("detectors")
+    if not isinstance(detectors, Sequence) or isinstance(detectors, (str, bytes)):
+        errors.append("redaction.detectors must be a list")
+    else:
+        if len(detectors) > MAX_DETECTORS:
+            errors.append(f"redaction.detectors exceeds {MAX_DETECTORS} entries")
+        for detector in detectors:
+            if not isinstance(detector, str) or not detector or detector.startswith(_EXAMPLE_RULE_PREFIX):
+                errors.append("redaction.detectors entries must be non-empty detector ids")
+                break
+            if any(ch.isspace() for ch in detector) or "=" in detector or len(detector) > 64:
+                errors.append("redaction.detectors entries must be detector ids, not values")
+                break
+    return errors
+
+
+def apply_origin_redaction(
+    text: str,
+    *,
+    origin: str,
+    scanner: ScanFn | None = None,
+) -> RedactionVerdict:
+    """Redact ``text`` for one origin. Fail closed. Never return removed values."""
+    resolved = resolve_origin(origin)
+    scan = scanner or scan_text
+    try:
+        result = scan(
+            text,
+            policy=_policy_for_origin(resolved),
+            options=ScanOptions(honor_allow_comments=False, include_opf=False),
+        )
+    except Exception:
+        return _error_verdict(resolved)
+    if not isinstance(result, GuardResult):
+        return _error_verdict(resolved)
+    redacting = [finding for finding in result.findings if _counts(finding)]
+    detectors = tuple(sorted({finding.rule_id for finding in redacting})[:MAX_DETECTORS])
+    count = len(redacting)
+    persisted = result.redacted_text if isinstance(result.redacted_text, str) else FAILED_PLACEHOLDER
+    if persisted is text and count:
+        return _error_verdict(resolved)
+    status = "redacted" if count else "clean"
+    return RedactionVerdict(
+        policy_version=POLICY_VERSION,
+        origin=resolved,
+        status=status,
+        count=count,
+        detectors=detectors,
+        persisted_text=persisted,
+    )
+
+
+def apply_and_record(text: str, *, origin: str, scanner: ScanFn | None = None) -> tuple[str, dict[str, Any], bool]:
+    """Return ``(persisted_text, record, failed)`` for an ingest writer."""
+    verdict = apply_origin_redaction(text, origin=origin, scanner=scanner)
+    return verdict.persisted_text, verdict.record(), verdict.status == "error"
+
+
+def _error_verdict(origin: str) -> RedactionVerdict:
+    return RedactionVerdict(
+        policy_version=POLICY_VERSION,
+        origin=origin,
+        status="error",
+        count=0,
+        detectors=(),
+        persisted_text=FAILED_PLACEHOLDER,
+    )
+
+
+def _counts(finding: Finding) -> bool:
+    return finding.redacts and finding.start < finding.end and not finding.rule_id.startswith(_EXAMPLE_RULE_PREFIX)
+
+
+def _policy_for_origin(origin: str) -> Policy:
+    categories = ORIGIN_CATEGORIES[origin]
+    allow_rules: dict[str, Action] = {
+        rule.id: "allow"
+        for rule in DEFAULT_RULES
+        if rule.category not in categories or rule.id.startswith(_EXAMPLE_RULE_PREFIX)
+    }
+    defaults: dict[str, Action] = {
+        "infrastructure": "allow",
+        "secret": "allow",
+        "pii": "allow",
+        "personal": "allow",
+        "business": "allow",
+        "attribution": "allow",
+        "tooling": "allow",
+    }
+    for category in categories:
+        defaults[category] = "redact"
+    return Policy(name=f"evidence-redaction:{origin}", defaults=defaults, rules=allow_rules)

--- a/src/brigade/evidence_redaction.py
+++ b/src/brigade/evidence_redaction.py
@@ -26,8 +26,9 @@ STATUSES = frozenset({"clean", "redacted", "error"})
 FAILED_PLACEHOLDER = "[ingestion-redaction-failed]"
 MAX_DETECTORS = 32
 
-# Work-inbox producers. Unknown sources stay workspace, matching the existing
-# ledger default. Envelope origin ``unknown`` is a separate fail-closed class.
+# Work-inbox producers. Unknown or empty sources fail closed to ``unknown``
+# (maximum detector scope), matching ``resolve_origin``. External-content
+# ingest surfaces upgrade weaker origins via ``origin_for_external_ingest``.
 SOURCE_ORIGINS: dict[str, str] = {
     "manual": "operator-input",
     "backup-health": "workspace",
@@ -45,7 +46,13 @@ SOURCE_ORIGINS: dict[str, str] = {
     "scanner-health": "workspace",
     "security-scan": "workspace",
     "tool-catalog": "workspace",
+    "external-service": "external-service",
+    "external-web": "external-web",
 }
+
+# Origins that already carry the external (or fail-closed) detector set.
+_EXTERNAL_INGEST_ORIGINS = frozenset({"external-service", "external-web", "unknown"})
+_EXTERNAL_INGEST_DEFAULT = "external-web"
 
 # Origin-scoped detector categories. ``unknown`` is fail-closed maximum scope.
 ORIGIN_CATEGORIES: dict[str, frozenset[str]] = {
@@ -104,11 +111,27 @@ class RedactionVerdict:
 
 
 def classify_source_origin(source: str) -> str:
-    """Map a producer source name to a closed envelope origin."""
-    cleaned = source.strip() if isinstance(source, str) else ""
+    """Map a producer source name to a closed envelope origin.
+
+    ``--source`` is free-form. Lookup is ``strip().lower()``. Unknown or empty
+    values fail closed to ``unknown`` (maximum scope), matching ``resolve_origin``.
+    """
+    cleaned = source.strip().lower() if isinstance(source, str) else ""
     if not cleaned:
-        return "workspace"
-    return SOURCE_ORIGINS.get(cleaned, "workspace")
+        return "unknown"
+    return SOURCE_ORIGINS.get(cleaned, "unknown")
+
+
+def origin_for_external_ingest(source: str) -> str:
+    """Classify a source for an external-content ingest surface.
+
+    Keeps an already-external or fail-closed origin. Weaker mapped origins
+    upgrade to ``external-web`` so secrets, PII, and infrastructure are in scope.
+    """
+    origin = classify_source_origin(source)
+    if origin in _EXTERNAL_INGEST_ORIGINS:
+        return origin
+    return _EXTERNAL_INGEST_DEFAULT
 
 
 def resolve_origin(origin: str) -> str:
@@ -199,7 +222,7 @@ def apply_origin_redaction(
     detectors = tuple(sorted({finding.rule_id for finding in redacting})[:MAX_DETECTORS])
     count = len(redacting)
     persisted = result.redacted_text if isinstance(result.redacted_text, str) else FAILED_PLACEHOLDER
-    if persisted is text and count:
+    if persisted == text and count:
         return _error_verdict(resolved)
     status = "redacted" if count else "clean"
     return RedactionVerdict(

--- a/src/brigade/provenance.py
+++ b/src/brigade/provenance.py
@@ -77,6 +77,12 @@ _ENVELOPE_METADATA_FIELDS = {
         "content_digest",
         "raw_digest",
     ),
+    "redaction": (
+        "redaction",
+        "redaction_status",
+        "redaction_count",
+        "redaction_detectors",
+    ),
     "timestamps": ("captured_at", "ingested_at"),
 }
 ENVELOPE_METADATA_RESERVED_KEYS = frozenset(
@@ -344,6 +350,12 @@ def validate_envelope(
         if val is not None and not isinstance(val, str):
             errors.append(f"{key} must be a string or null")
 
+    if "redaction" in env:
+        from . import evidence_redaction
+
+        redaction_errors = evidence_redaction.validate_redaction_record(env.get("redaction"))
+        errors.extend(redaction_errors)
+
     if errors:
         return errors
 
@@ -380,6 +392,7 @@ def build_envelope(
     content_scope: str,
     captured_at: str | None,
     ingested_at: str | None,
+    redaction: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     content_digest = content_sha256(text)
     if raw_bytes is None:
@@ -432,6 +445,8 @@ def build_envelope(
         "captured_at": captured_at,
         "ingested_at": ingested_at,
     }
+    if redaction is not None:
+        env["redaction"] = dict(redaction)
     errors = validate_envelope(env)
     if errors:
         raise ValueError("invalid provenance envelope: " + "; ".join(errors))

--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -17,6 +17,7 @@ from . import __version__
 from . import code_references
 from . import component_bins
 from . import localio
+from . import evidence_redaction
 from . import provenance
 from . import receipt_signing
 from . import trust_gate
@@ -1167,6 +1168,8 @@ def _stamp_receipt_provenance(
     collection_id: str,
     source_kind: str,
     producer: str,
+    redaction: dict[str, Any] | None = None,
+    redaction_failed: bool = False,
 ) -> dict[str, Any]:
     """Stamp a receipt adapter envelope. Indexing always starts untrusted."""
     captured = str(payload.get("started_at") or payload.get("completed_at") or payload.get("finished_at") or "")
@@ -1185,6 +1188,8 @@ def _stamp_receipt_provenance(
     session_id = session_raw if provenance.is_safe_identity_label(session_raw) else None
     locator_kind, locator_value = _receipt_locator(path, target, item_external_id)
     injection_status, injection_count, injection_rules = _receipt_injection(text)
+    if redaction_failed:
+        injection_status = "error"
     return provenance.build_envelope(
         source_system="receipts",
         source_kind=source_kind,
@@ -1200,7 +1205,7 @@ def _stamp_receipt_provenance(
         locator_value=locator_value,
         attribution="observed",
         modality="tool-output",
-        trust_label="untrusted",
+        trust_label="quarantined" if redaction_failed else "untrusted",
         trust_assigned_by="ingest:receipts_cmd.index_miseledger_receipts",
         trust_assigned_at=ingested_at,
         injection_status=injection_status,
@@ -1211,7 +1216,12 @@ def _stamp_receipt_provenance(
         content_scope="item.text.utf8.v1",
         captured_at=captured,
         ingested_at=ingested_at,
+        redaction=redaction,
     )
+
+
+def _receipt_redact(text: str) -> tuple[str, dict[str, Any], bool]:
+    return evidence_redaction.apply_and_record(text, origin="agent-session")
 
 
 def _receipt_injection(text: str) -> tuple[str, int, list[str]]:
@@ -1257,6 +1267,7 @@ def _verify_miseledger_item(payload: dict[str, Any], path: Path, target: Path, o
     if command_text:
         text = f"{text} Commands: {command_text}."
     text = _append_delta_text(text, payload)
+    text, redaction_record, redaction_failed = _receipt_redact(text)
     metadata["provenance"] = _stamp_receipt_provenance(
         text=text,
         payload=payload,
@@ -1266,6 +1277,8 @@ def _verify_miseledger_item(payload: dict[str, Any], path: Path, target: Path, o
         collection_id="brigade_work_verify_runs",
         source_kind="verify-receipt",
         producer="receipts_cmd._verify_miseledger_item",
+        redaction=redaction_record,
+        redaction_failed=redaction_failed,
     )
     artifacts = [_receipt_artifact(item_external_id, path, target, receipt_hash)]
     artifacts.extend(_verify_log_artifacts(item_external_id, payload, path, target))
@@ -1327,6 +1340,7 @@ def _run_miseledger_item(payload: dict[str, Any], path: Path, target: Path, ordi
     if task:
         text += f" Task: {task}."
     text = _append_delta_text(text, payload)
+    text, redaction_record, redaction_failed = _receipt_redact(text)
     metadata["provenance"] = _stamp_receipt_provenance(
         text=text,
         payload=payload,
@@ -1336,6 +1350,8 @@ def _run_miseledger_item(payload: dict[str, Any], path: Path, target: Path, ordi
         collection_id="brigade_runs",
         source_kind="run-receipt",
         producer="receipts_cmd._run_miseledger_item",
+        redaction=redaction_record,
+        redaction_failed=redaction_failed,
     )
     artifacts = [_receipt_artifact(item_external_id, path, target, receipt_hash)]
     output_dir = payload.get("artifacts")

--- a/src/brigade/research/provenance.py
+++ b/src/brigade/research/provenance.py
@@ -71,12 +71,32 @@ def map_legacy_trust_origin_modality(trust: str) -> tuple[str, str]:
     return _LEGACY_TRUST_ORIGIN_MODALITY.get(trust, ("unknown", "unknown"))
 
 
-def _split_redacted_finding_text(text: str) -> tuple[str, str, str]:
-    parts = text.split("\n", 2)
-    title = parts[0] if parts else ""
-    summary = parts[1] if len(parts) > 1 else ""
-    evidence = parts[2] if len(parts) > 2 else ""
-    return title, summary, evidence
+def _redact_finding_fields(
+    title: str, summary: str, evidence: str, *, origin: str
+) -> tuple[str, str, str, dict[str, Any], bool]:
+    """Redact title, summary, and evidence separately so newlines cannot migrate."""
+    verdicts = (
+        evidence_redaction.apply_origin_redaction(title, origin=origin),
+        evidence_redaction.apply_origin_redaction(summary, origin=origin),
+        evidence_redaction.apply_origin_redaction(evidence, origin=origin),
+    )
+    if any(verdict.status == "error" for verdict in verdicts):
+        failed = next(verdict for verdict in verdicts if verdict.status == "error")
+        return evidence_redaction.FAILED_PLACEHOLDER, "", "", failed.record(), True
+    persist_title, persist_summary, persist_evidence = (verdict.persisted_text for verdict in verdicts)
+    count = sum(verdict.count for verdict in verdicts)
+    detectors = tuple(
+        sorted({detector for verdict in verdicts for detector in verdict.detectors})[: evidence_redaction.MAX_DETECTORS]
+    )
+    record = evidence_redaction.RedactionVerdict(
+        policy_version=evidence_redaction.POLICY_VERSION,
+        origin=verdicts[0].origin,
+        status="redacted" if count else "clean",
+        count=count,
+        detectors=detectors,
+        persisted_text=finding_text(persist_title, persist_summary, persist_evidence),
+    ).record()
+    return persist_title, persist_summary, persist_evidence, record, False
 
 
 def _injection_trust(text: str) -> tuple[str, str, int, list[str]]:
@@ -167,16 +187,12 @@ def stamp_finding_payload(
     redaction_failed = False
     if not inferred:
         origin_for_redaction, _modality = map_legacy_trust_origin_modality(str(payload.get("trust") or ""))
-        persist_text, redaction_record, redaction_failed = evidence_redaction.apply_and_record(
-            text,
+        title, summary, evidence, redaction_record, redaction_failed = _redact_finding_fields(
+            title,
+            summary,
+            evidence,
             origin=origin_for_redaction,
         )
-        if redaction_failed:
-            title = evidence_redaction.FAILED_PLACEHOLDER
-            summary = ""
-            evidence = ""
-        elif persist_text != text:
-            title, summary, evidence = _split_redacted_finding_text(persist_text)
         payload["title"] = title
         payload["summary"] = summary
         payload["evidence"] = evidence

--- a/src/brigade/research/provenance.py
+++ b/src/brigade/research/provenance.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
 
-from brigade import localio, provenance, trust_gate
+from brigade import evidence_redaction, localio, provenance, trust_gate
 from brigade.untrusted import scan_handoff_injection_heuristics
 
 from .types import CitationAudit, CitationRecord, Finding, finding_text
@@ -69,6 +69,14 @@ def audit_citations(report: str, findings: Sequence[Finding]) -> CitationAudit:
 def map_legacy_trust_origin_modality(trust: str) -> tuple[str, str]:
     """Map legacy Finding.trust to envelope origin/modality only."""
     return _LEGACY_TRUST_ORIGIN_MODALITY.get(trust, ("unknown", "unknown"))
+
+
+def _split_redacted_finding_text(text: str) -> tuple[str, str, str]:
+    parts = text.split("\n", 2)
+    title = parts[0] if parts else ""
+    summary = parts[1] if len(parts) > 1 else ""
+    evidence = parts[2] if len(parts) > 2 else ""
+    return title, summary, evidence
 
 
 def _injection_trust(text: str) -> tuple[str, str, int, list[str]]:
@@ -155,6 +163,26 @@ def stamp_finding_payload(
         payload["provenance"] = dict(existing)
         return payload
 
+    redaction_record: dict[str, Any] | None = None
+    redaction_failed = False
+    if not inferred:
+        origin_for_redaction, _modality = map_legacy_trust_origin_modality(str(payload.get("trust") or ""))
+        persist_text, redaction_record, redaction_failed = evidence_redaction.apply_and_record(
+            text,
+            origin=origin_for_redaction,
+        )
+        if redaction_failed:
+            title = evidence_redaction.FAILED_PLACEHOLDER
+            summary = ""
+            evidence = ""
+        elif persist_text != text:
+            title, summary, evidence = _split_redacted_finding_text(persist_text)
+        payload["title"] = title
+        payload["summary"] = summary
+        payload["evidence"] = evidence
+        text = finding_text(title, summary, evidence)
+        payload["text"] = text
+
     legacy_trust = str(payload.get("trust") or "")
     origin, modality = map_legacy_trust_origin_modality(legacy_trust)
     now = ingested_at or localio.utc_now_iso()
@@ -179,6 +207,8 @@ def stamp_finding_payload(
         source_producer = producer
         if trust_label in {"reviewed", "verified"}:
             trust_label = "untrusted"
+        if redaction_failed:
+            trust_label = "quarantined"
 
     payload["provenance"] = provenance.build_envelope(
         source_system="research",
@@ -206,6 +236,7 @@ def stamp_finding_payload(
         content_scope="item.text.utf8.v1",
         captured_at=captured,
         ingested_at=now,
+        redaction=redaction_record,
     )
     return payload
 
@@ -220,9 +251,9 @@ def stamp_finding(
     stamped = stamp_finding_payload(finding, run_id=run_id, index=index, producer=producer)
     return Finding(
         source_ids=finding.source_ids,
-        title=finding.title,
-        summary=finding.summary,
-        evidence=finding.evidence,
+        title=str(stamped["title"]),
+        summary=str(stamped["summary"]),
+        evidence=str(stamped["evidence"]),
         trust=finding.trust,
         extraction_lane=finding.extraction_lane,
         extracted_at=finding.extracted_at,

--- a/src/brigade/work_cmd/ledger.py
+++ b/src/brigade/work_cmd/ledger.py
@@ -2691,7 +2691,8 @@ _IMPORT_FINGERPRINT_METADATA_SKIP = frozenset(
 # Default origin/modality for work-inbox producers. Authoritative source,
 # origin, and modality always come from this mapping (plus the local
 # work-inbox producer stamp). Validated inbound envelopes may reuse only
-# non-authoritative identity fields. Unknown sources stay workspace/tool-output.
+# non-authoritative identity fields. Unknown sources fail closed to
+# origin ``unknown``; modality still defaults to tool-output.
 _IMPORT_SOURCE_ORIGIN_MODALITY: dict[str, tuple[str, str]] = {
     "manual": ("operator-input", "human-written"),
     "backup-health": ("workspace", "tool-output"),
@@ -2733,9 +2734,13 @@ def _import_fingerprint(item: dict[str, Any]) -> str | None:
     )
 
 
-def _import_origin_modality(source: str) -> tuple[str, str]:
-    origin = evidence_redaction.classify_source_origin(source)
-    modality = _IMPORT_SOURCE_ORIGIN_MODALITY.get(source, ("workspace", "tool-output"))[1]
+def _import_origin_modality(source: str, *, kind: str | None = None) -> tuple[str, str]:
+    cleaned = source.strip().lower() if isinstance(source, str) else ""
+    if kind == "context":
+        origin = evidence_redaction.origin_for_external_ingest(source)
+    else:
+        origin = evidence_redaction.classify_source_origin(source)
+    modality = _IMPORT_SOURCE_ORIGIN_MODALITY.get(cleaned, ("workspace", "tool-output"))[1]
     return origin, modality
 
 
@@ -3048,6 +3053,7 @@ def _stamp_import_provenance(
     inbound_provenance: object = None,
     redaction: Mapping[str, Any] | None = None,
     redaction_failed: bool = False,
+    kind: str | None = None,
 ) -> dict[str, Any]:
     """Build a locally assigned work-inbox provenance envelope for one import.
 
@@ -3060,7 +3066,7 @@ def _stamp_import_provenance(
     trust_label, injection_status, injection_count, injection_rules = _import_injection_trust(text)
     if redaction_failed:
         trust_label = "quarantined"
-    origin, modality = _import_origin_modality(source)
+    origin, modality = _import_origin_modality(source, kind=kind)
     source_system = "work-inbox"
     source_kind = source
     source_producer = "ledger._make_import"
@@ -4040,7 +4046,7 @@ def _make_import(
     provenance_authority = (
         provenance_source.strip() if isinstance(provenance_source, str) and provenance_source.strip() else source_text
     )
-    origin, _modality = _import_origin_modality(provenance_authority)
+    origin, _modality = _import_origin_modality(provenance_authority, kind=kind)
     persist_text, redaction_record, redaction_failed = evidence_redaction.apply_and_record(text, origin=origin)
     item_id = f"{now.strftime('%Y%m%d-%H%M%S')}-{kind}-{helpers._slug(persist_text)}-{uuid4().hex[:6]}"
     item: dict[str, Any] = {
@@ -4075,6 +4081,7 @@ def _make_import(
         inbound_provenance=inbound_provenance,
         redaction=redaction_record,
         redaction_failed=redaction_failed,
+        kind=kind,
     )
     item["metadata"] = stamped_metadata
     return item

--- a/src/brigade/work_cmd/ledger.py
+++ b/src/brigade/work_cmd/ledger.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, Sequence
 from uuid import uuid4
 from . import constants, edges as edges_mod, helpers
-from .. import component_paths, provenance, runguard, trust_gate
+from .. import component_paths, evidence_redaction, provenance, runguard, trust_gate
 from ..untrusted import scan_handoff_injection_heuristics
 
 
@@ -2734,7 +2734,9 @@ def _import_fingerprint(item: dict[str, Any]) -> str | None:
 
 
 def _import_origin_modality(source: str) -> tuple[str, str]:
-    return _IMPORT_SOURCE_ORIGIN_MODALITY.get(source, ("workspace", "tool-output"))
+    origin = evidence_redaction.classify_source_origin(source)
+    modality = _IMPORT_SOURCE_ORIGIN_MODALITY.get(source, ("workspace", "tool-output"))[1]
+    return origin, modality
 
 
 _IMPORT_IDENTITY_MAX_LEN = 256
@@ -3044,6 +3046,8 @@ def _stamp_import_provenance(
     metadata: dict[str, Any],
     ingested_at: str,
     inbound_provenance: object = None,
+    redaction: Mapping[str, Any] | None = None,
+    redaction_failed: bool = False,
 ) -> dict[str, Any]:
     """Build a locally assigned work-inbox provenance envelope for one import.
 
@@ -3054,6 +3058,8 @@ def _stamp_import_provenance(
     """
     reusable = _reusable_inbound_provenance(inbound_provenance)
     trust_label, injection_status, injection_count, injection_rules = _import_injection_trust(text)
+    if redaction_failed:
+        trust_label = "quarantined"
     origin, modality = _import_origin_modality(source)
     source_system = "work-inbox"
     source_kind = source
@@ -3126,6 +3132,7 @@ def _stamp_import_provenance(
             content_scope="item.text.utf8.v1",
             captured_at=captured_at,
             ingested_at=ingested_at,
+            redaction=redaction,
         )
     except ValueError as exc:
         raise _ImportProvenanceError(str(exc)) from exc
@@ -3652,6 +3659,7 @@ _PROVENANCE_ENVELOPE_KEYS = frozenset(
         "modality",
         "trust",
         "hashes",
+        "redaction",
         "captured_at",
         "ingested_at",
     }
@@ -3663,6 +3671,9 @@ _PROVENANCE_LOCATOR_KEYS = frozenset({"kind", "value"})
 _PROVENANCE_TRUST_KEYS = frozenset({"label", "assigned_by", "assigned_at", "trust_policy", "injection"})
 _PROVENANCE_TRUST_POLICY_KEYS = frozenset({"schema", "schema_version"})
 _PROVENANCE_INJECTION_KEYS = frozenset({"status", "count", "rules"})
+_PROVENANCE_REDACTION_KEYS = frozenset(
+    {"schema", "schema_version", "policy_version", "origin", "status", "count", "detectors"}
+)
 _PROVENANCE_HASHES_KEYS = frozenset(
     {"content_algorithm", "content_scope", "content", "raw_algorithm", "raw_scope", "raw"}
 )
@@ -3703,6 +3714,8 @@ def _handoff_private_fields_in_validated_provenance(
                     child_allowed = _PROVENANCE_INJECTION_KEYS
                 elif key_text == "hashes":
                     child_allowed = _PROVENANCE_HASHES_KEYS
+                elif key_text == "redaction":
+                    child_allowed = _PROVENANCE_REDACTION_KEYS
                 else:
                     child_allowed = None
                 if isinstance(item, (dict, list)) and child_allowed is not None:
@@ -4027,12 +4040,14 @@ def _make_import(
     provenance_authority = (
         provenance_source.strip() if isinstance(provenance_source, str) and provenance_source.strip() else source_text
     )
-    item_id = f"{now.strftime('%Y%m%d-%H%M%S')}-{kind}-{helpers._slug(text)}-{uuid4().hex[:6]}"
+    origin, _modality = _import_origin_modality(provenance_authority)
+    persist_text, redaction_record, redaction_failed = evidence_redaction.apply_and_record(text, origin=origin)
+    item_id = f"{now.strftime('%Y%m%d-%H%M%S')}-{kind}-{helpers._slug(persist_text)}-{uuid4().hex[:6]}"
     item: dict[str, Any] = {
         "id": item_id,
         "kind": kind,
         "source": source_text,
-        "text": text,
+        "text": persist_text,
         "status": "pending",
         "created_at": created,
         "updated_at": created,
@@ -4052,12 +4067,14 @@ def _make_import(
     inbound_provenance = stamped_metadata.pop("provenance", None)
     stamped_metadata = _sanitize_import_identity_metadata(stamped_metadata)
     stamped_metadata["provenance"] = _stamp_import_provenance(
-        text=text,
+        text=persist_text,
         source=provenance_authority,
         item_id=item_id,
         metadata=stamped_metadata,
         ingested_at=created,
         inbound_provenance=inbound_provenance,
+        redaction=redaction_record,
+        redaction_failed=redaction_failed,
     )
     item["metadata"] = stamped_metadata
     return item

--- a/tests/test_evidence_redaction.py
+++ b/tests/test_evidence_redaction.py
@@ -7,10 +7,16 @@ from pathlib import Path
 
 import pytest
 
-from brigade import evidence_redaction, provenance, receipts_cmd
+from brigade import evidence_redaction, provenance, receipts_cmd, work_cmd
+from brigade.guard.types import Finding as GuardFinding
+from brigade.guard.types import GuardResult
 from brigade.research.provenance import stamp_finding, stamp_finding_payload
 from brigade.research.types import Finding
 from brigade.work_cmd import ledger
+
+PLANTED_EMAIL = "planted.canary9931@probe-corp-canary.com"
+PLANTED_IP = "192.168.4.70"
+PLANTED_BEARER = "zqXK9tPLANTEDBEARER7731aabbccddeeff0011"
 
 FAKE_SECRET = 'api_key="sk-test-abcdefghijklmnopqrstuv"'
 FAKE_EMAIL = "operator@contoso.example"
@@ -28,8 +34,45 @@ def _scan_boom(_text: str, **_kwargs: object) -> object:
 def test_classify_source_origin_matches_work_inbox_producers() -> None:
     for source, (origin, _modality) in ledger._IMPORT_SOURCE_ORIGIN_MODALITY.items():
         assert evidence_redaction.classify_source_origin(source) == origin
-    assert evidence_redaction.classify_source_origin("unmapped-producer") == "workspace"
-    assert evidence_redaction.classify_source_origin("") == "workspace"
+    assert evidence_redaction.classify_source_origin("external-web") == "external-web"
+    assert evidence_redaction.classify_source_origin("external-service") == "external-service"
+    assert evidence_redaction.classify_source_origin("unmapped-producer") == "unknown"
+    assert evidence_redaction.classify_source_origin("") == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("source", "origin"),
+    [
+        ("chat-memory-sweep", "agent-session"),
+        ("Chat-Memory-Sweep", "agent-session"),
+        ("CHAT-MEMORY-SWEEP", "agent-session"),
+        ("chat-memory-sweep ", "agent-session"),
+        (" chat-memory-sweep", "agent-session"),
+        ("", "unknown"),
+        ("zzz-garbage-source", "unknown"),
+        ("Handoff-Ingest", "agent-session"),
+        ("external-web", "external-web"),
+        ("External-Web", "external-web"),
+        ("EXTERNAL-SERVICE", "external-service"),
+        ("external-service ", "external-service"),
+    ],
+)
+def test_classify_source_origin_normalizes_and_fails_closed(source: str, origin: str) -> None:
+    assert evidence_redaction.classify_source_origin(source) == origin
+
+
+@pytest.mark.parametrize(
+    ("source", "origin"),
+    [
+        ("manual", "external-web"),
+        ("external-web", "external-web"),
+        ("external-service", "external-service"),
+        ("zzz-garbage-source", "unknown"),
+        ("chat-memory-sweep", "external-web"),
+    ],
+)
+def test_origin_for_external_ingest_upgrades_weaker_tiers(source: str, origin: str) -> None:
+    assert evidence_redaction.origin_for_external_ingest(source) == origin
 
 
 def test_unknown_or_invalid_origin_fails_closed_to_unknown() -> None:
@@ -252,3 +295,121 @@ def test_build_envelope_accepts_optional_redaction_record() -> None:
     tainted["excerpts"] = ["secret"]
     with pytest.raises(ValueError, match="removed values"):
         provenance.build_envelope(**kwargs, redaction=tainted)
+
+
+def _cleartext_hits(root: Path, *needles: str) -> list[Path]:
+    hits: list[Path] = []
+    encoded = [needle.encode() for needle in needles]
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        data = path.read_bytes()
+        if any(needle in data for needle in encoded):
+            hits.append(path)
+    return hits
+
+
+@pytest.mark.parametrize(
+    ("source", "origin"),
+    [
+        ("external-web", "external-web"),
+        ("manual", "external-web"),
+        ("external-service", "external-service"),
+    ],
+)
+def test_import_context_redacts_planted_email_and_private_ip(tmp_path: Path, source: str, origin: str) -> None:
+    text = f"External page says mail {PLANTED_EMAIL} ip {PLANTED_IP}"
+    assert (
+        work_cmd.import_context(
+            target=tmp_path,
+            text=text,
+            source=source,
+            context_kind="transcript",
+        )
+        == 0
+    )
+    assert _cleartext_hits(tmp_path, PLANTED_EMAIL, PLANTED_IP) == []
+    item = ledger._read_imports(tmp_path)[0]
+    dumped = json.dumps(item)
+    assert PLANTED_EMAIL not in item["text"]
+    assert PLANTED_IP not in item["text"]
+    assert PLANTED_EMAIL not in dumped
+    assert PLANTED_IP not in dumped
+    env = item["metadata"]["provenance"]
+    assert env["origin"] == origin
+    assert env["redaction"]["origin"] == origin
+    assert env["redaction"]["status"] == "redacted"
+    assert "email" in env["redaction"]["detectors"]
+    assert "private-ipv4" in env["redaction"]["detectors"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["chat-memory-sweep", "Chat-Memory-Sweep", "CHAT-MEMORY-SWEEP", "Handoff-Ingest"],
+)
+def test_import_add_case_variant_source_redacts_email(tmp_path: Path, source: str) -> None:
+    assert (
+        work_cmd.import_add(
+            target=tmp_path,
+            text=f"case variant contact {PLANTED_EMAIL}",
+            kind="finding",
+            source=source,
+        )
+        == 0
+    )
+    item = ledger._read_imports(tmp_path)[0]
+    assert PLANTED_EMAIL not in item["text"]
+    assert PLANTED_EMAIL not in json.dumps(item)
+    env = item["metadata"]["provenance"]
+    assert env["origin"] == "agent-session"
+    assert env["redaction"]["origin"] == "agent-session"
+    assert env["redaction"]["status"] == "redacted"
+    assert "email" in env["redaction"]["detectors"]
+
+
+def test_equal_but_distinct_unredacted_text_fails_closed() -> None:
+    secret = f"Bearer {PLANTED_BEARER}"
+
+    def scanner(text: str, **_kwargs: object) -> GuardResult:
+        finding = GuardFinding(
+            rule_id="bearer-token",
+            category="secret",
+            action="redact",
+            match=secret,
+            replacement="[redacted-secret]",
+            line=1,
+            column=1,
+            start=0,
+            end=len(secret),
+        )
+        return GuardResult(text=text, redacted_text=str(text), findings=[finding])
+
+    verdict = evidence_redaction.apply_origin_redaction(secret, origin="workspace", scanner=scanner)
+    assert verdict.status == "error"
+    assert verdict.count == 0
+    assert secret not in verdict.persisted_text
+    assert PLANTED_BEARER not in verdict.persisted_text
+    assert verdict.persisted_text == evidence_redaction.FAILED_PLACEHOLDER
+    assert secret not in json.dumps(verdict.record())
+
+
+def test_stamp_finding_keeps_multiline_summary_out_of_evidence() -> None:
+    finding = Finding(
+        source_ids=("src-1111111111111111",),
+        title="Token note",
+        summary=f"summary line one contact {PLANTED_EMAIL}\nsummary line TWO stays in summary",
+        evidence="evidence body here",
+        trust="web",
+        extraction_lane="luna",
+        extracted_at="2026-08-13T12:00:00+00:00",
+    )
+    stamped = stamp_finding(finding, run_id="run-redact", index=0)
+    assert PLANTED_EMAIL not in stamped.summary
+    assert PLANTED_EMAIL not in stamped.evidence
+    assert PLANTED_EMAIL not in stamped.text
+    assert "summary line TWO stays in summary" in stamped.summary
+    assert "summary line TWO stays in summary" not in stamped.evidence
+    assert stamped.evidence == "evidence body here"
+    assert isinstance(stamped.provenance, dict)
+    assert stamped.provenance["redaction"]["status"] == "redacted"
+    assert "email" in stamped.provenance["redaction"]["detectors"]

--- a/tests/test_evidence_redaction.py
+++ b/tests/test_evidence_redaction.py
@@ -382,7 +382,10 @@ def test_equal_but_distinct_unredacted_text_fails_closed() -> None:
             start=0,
             end=len(secret),
         )
-        return GuardResult(text=text, redacted_text=str(text), findings=[finding])
+        # str(text) on a str returns the SAME object in CPython, which made
+        # this test vacuous against the old `persisted is text` identity
+        # check. Build a genuinely equal-but-distinct string instead.
+        return GuardResult(text=text, redacted_text="".join(list(text)), findings=[finding])
 
     verdict = evidence_redaction.apply_origin_redaction(secret, origin="workspace", scanner=scanner)
     assert verdict.status == "error"

--- a/tests/test_evidence_redaction.py
+++ b/tests/test_evidence_redaction.py
@@ -1,0 +1,254 @@
+"""Origin-scoped evidence-ingestion redaction (#498)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import evidence_redaction, provenance, receipts_cmd
+from brigade.research.provenance import stamp_finding, stamp_finding_payload
+from brigade.research.types import Finding
+from brigade.work_cmd import ledger
+
+FAKE_SECRET = 'api_key="sk-test-abcdefghijklmnopqrstuv"'
+FAKE_EMAIL = "operator@contoso.example"
+FAKE_IPV4 = "10.0.0.1"
+
+
+def _secret_text() -> str:
+    return f"note {FAKE_SECRET} done"
+
+
+def _scan_boom(_text: str, **_kwargs: object) -> object:
+    raise TimeoutError("scanner unavailable")
+
+
+def test_classify_source_origin_matches_work_inbox_producers() -> None:
+    for source, (origin, _modality) in ledger._IMPORT_SOURCE_ORIGIN_MODALITY.items():
+        assert evidence_redaction.classify_source_origin(source) == origin
+    assert evidence_redaction.classify_source_origin("unmapped-producer") == "workspace"
+    assert evidence_redaction.classify_source_origin("") == "workspace"
+
+
+def test_unknown_or_invalid_origin_fails_closed_to_unknown() -> None:
+    assert evidence_redaction.resolve_origin("external-web") == "external-web"
+    assert evidence_redaction.resolve_origin("not-an-origin") == "unknown"
+    assert evidence_redaction.resolve_origin("") == "unknown"
+
+
+def test_workspace_redacts_secrets_but_not_email_or_host() -> None:
+    text = f"contact {FAKE_EMAIL} host {FAKE_IPV4} {FAKE_SECRET}"
+    verdict = evidence_redaction.apply_origin_redaction(text, origin="workspace")
+    assert verdict.status == "redacted"
+    assert verdict.count >= 1
+    assert "api-key-assignment" in verdict.detectors
+    assert FAKE_SECRET not in verdict.persisted_text
+    assert FAKE_EMAIL in verdict.persisted_text
+    assert FAKE_IPV4 in verdict.persisted_text
+    dumped = json.dumps(verdict.record())
+    assert FAKE_SECRET not in dumped
+    assert "sk-test-" not in dumped
+
+
+def test_agent_session_redacts_email_and_secret() -> None:
+    text = f"contact {FAKE_EMAIL} {FAKE_SECRET}"
+    verdict = evidence_redaction.apply_origin_redaction(text, origin="agent-session")
+    assert verdict.status == "redacted"
+    assert FAKE_SECRET not in verdict.persisted_text
+    assert FAKE_EMAIL not in verdict.persisted_text
+    assert "email" in verdict.detectors
+    assert "api-key-assignment" in verdict.detectors
+
+
+def test_external_web_redacts_private_ipv4() -> None:
+    text = f"probe {FAKE_IPV4} ok"
+    workspace = evidence_redaction.apply_origin_redaction(text, origin="workspace")
+    assert workspace.status == "clean"
+    assert FAKE_IPV4 in workspace.persisted_text
+    web = evidence_redaction.apply_origin_redaction(text, origin="external-web")
+    assert web.status == "redacted"
+    assert FAKE_IPV4 not in web.persisted_text
+    assert "private-ipv4" in web.detectors
+
+
+def test_unknown_origin_uses_fail_closed_detector_set() -> None:
+    text = f"contact {FAKE_EMAIL} host {FAKE_IPV4} {FAKE_SECRET}"
+    verdict = evidence_redaction.apply_origin_redaction(text, origin="unknown")
+    assert verdict.origin == "unknown"
+    assert verdict.status == "redacted"
+    assert FAKE_SECRET not in verdict.persisted_text
+    assert FAKE_EMAIL not in verdict.persisted_text
+    assert FAKE_IPV4 not in verdict.persisted_text
+
+
+def test_clean_scan_records_policy_version_and_zero_count() -> None:
+    verdict = evidence_redaction.apply_origin_redaction("ordinary operator note", origin="operator-input")
+    record = verdict.record()
+    assert verdict.status == "clean"
+    assert verdict.count == 0
+    assert record["policy_version"] == evidence_redaction.POLICY_VERSION
+    assert record["schema"] == evidence_redaction.SCHEMA
+    assert evidence_redaction.ingest_verdict_is_clean(record)
+    assert evidence_redaction.validate_redaction_record(record) == []
+
+
+def test_scanner_failure_is_not_clean_and_does_not_persist_original() -> None:
+    original = _secret_text()
+    verdict = evidence_redaction.apply_origin_redaction(original, origin="workspace", scanner=_scan_boom)
+    record = verdict.record()
+    assert verdict.status == "error"
+    assert verdict.policy_version == evidence_redaction.POLICY_VERSION
+    assert verdict.persisted_text == evidence_redaction.FAILED_PLACEHOLDER
+    assert original not in verdict.persisted_text
+    assert FAKE_SECRET not in json.dumps(record)
+    assert not evidence_redaction.ingest_verdict_is_clean(record)
+    assert evidence_redaction.validate_redaction_record(record) == []
+
+
+def test_allow_comment_cannot_bypass_ingest_redaction() -> None:
+    text = f"<!-- content-guard: allow all file -->\n{_secret_text()}"
+    verdict = evidence_redaction.apply_origin_redaction(text, origin="workspace")
+    assert verdict.status == "redacted"
+    assert FAKE_SECRET not in verdict.persisted_text
+
+
+def test_missing_or_foreign_record_is_not_a_clean_verdict() -> None:
+    assert not evidence_redaction.ingest_verdict_is_clean(None)
+    assert not evidence_redaction.ingest_verdict_is_clean({})
+    assert not evidence_redaction.ingest_verdict_is_clean(
+        {**evidence_redaction.apply_origin_redaction("ok", origin="workspace").record(), "policy_version": "other.v0"}
+    )
+
+
+def test_validate_redaction_record_rejects_stored_values() -> None:
+    record = evidence_redaction.apply_origin_redaction(_secret_text(), origin="workspace").record()
+    record["values"] = [FAKE_SECRET]
+    errors = evidence_redaction.validate_redaction_record(record)
+    assert errors
+    assert any("removed values" in error for error in errors)
+
+
+def test_make_import_redacts_before_persist_and_hashes_redacted_bytes() -> None:
+    item = ledger._make_import(_secret_text(), kind="task", source="security-scan")
+    env = item["metadata"]["provenance"]
+    assert FAKE_SECRET not in item["text"]
+    assert env["redaction"]["status"] == "redacted"
+    assert env["redaction"]["count"] >= 1
+    assert env["redaction"]["policy_version"] == evidence_redaction.POLICY_VERSION
+    assert env["hashes"]["content"] == provenance.content_sha256(item["text"])
+    assert provenance.validate_envelope(env) == []
+    assert FAKE_SECRET not in json.dumps(env)
+
+
+def test_make_import_scanner_failure_quarantines_and_drops_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(evidence_redaction, "scan_text", _scan_boom)
+    item = ledger._make_import(_secret_text(), kind="task", source="manual")
+    env = item["metadata"]["provenance"]
+    assert item["text"] == evidence_redaction.FAILED_PLACEHOLDER
+    assert FAKE_SECRET not in item["text"]
+    assert env["redaction"]["status"] == "error"
+    assert env["trust"]["label"] == "quarantined"
+    assert not evidence_redaction.ingest_verdict_is_clean(env["redaction"])
+
+
+def test_backfill_does_not_rewrite_existing_secret_text(tmp_path: Path) -> None:
+    legacy = {
+        "id": "20260101-000000-task-legacy-redact",
+        "kind": "task",
+        "source": "manual",
+        "text": _secret_text(),
+        "status": "pending",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    ledger._write_imports(tmp_path, [legacy])
+    result = ledger._backfill_import_provenance(tmp_path)
+    loaded = ledger._read_imports(tmp_path)
+    assert result["stamped"] == 1
+    assert loaded[0]["text"] == _secret_text()
+    env = loaded[0]["metadata"]["provenance"]
+    assert "redaction" not in env
+    assert not evidence_redaction.ingest_verdict_is_clean(env.get("redaction"))
+
+
+def test_receipt_index_redacts_before_persist() -> None:
+    text, record, failed = receipts_cmd._receipt_redact(f"Brigade run demo. Task: {_secret_text()}.")
+    assert failed is False
+    assert FAKE_SECRET not in text
+    assert record["origin"] == "agent-session"
+    assert record["status"] == "redacted"
+    assert record["count"] >= 1
+    assert FAKE_SECRET not in json.dumps(record)
+
+
+def test_research_new_write_redacts_and_backfill_does_not() -> None:
+    finding = Finding(
+        source_ids=("src-1111111111111111",),
+        title="Token note",
+        summary="keep",
+        evidence=_secret_text(),
+        trust="web",
+        extraction_lane="luna",
+        extracted_at="2026-08-13T12:00:00+00:00",
+    )
+    stamped = stamp_finding(finding, run_id="run-redact", index=0)
+    assert FAKE_SECRET not in stamped.evidence
+    assert FAKE_SECRET not in stamped.text
+    assert isinstance(stamped.provenance, dict)
+    assert stamped.provenance["redaction"]["status"] == "redacted"
+    assert stamped.provenance["hashes"]["content"] == provenance.content_sha256(stamped.text)
+
+    legacy = {
+        "source_ids": ["src-1111111111111111"],
+        "title": "Legacy",
+        "summary": "Old",
+        "evidence": _secret_text(),
+        "trust": "web",
+        "extraction_lane": "legacy",
+        "extracted_at": "1970-01-01T00:00:00+00:00",
+    }
+    payload = stamp_finding_payload(legacy, run_id="run-redact", index=0, inferred=True)
+    assert payload["evidence"] == _secret_text()
+    assert payload["text"].endswith(_secret_text())
+    assert "redaction" not in payload["provenance"]
+
+
+def test_build_envelope_accepts_optional_redaction_record() -> None:
+    kwargs = dict(
+        source_system="work-inbox",
+        source_kind="manual",
+        source_producer="ledger._make_import",
+        origin="operator-input",
+        repository_id="escoffier-labs/brigade",
+        repository_revision=None,
+        session_id="demo-session",
+        session_harness="cursor",
+        collection_id="demo-collection",
+        item_id="demo:item:1",
+        locator_kind="repo-relative",
+        locator_value="demo/item.txt",
+        attribution="observed",
+        modality="human-written",
+        trust_label="untrusted",
+        trust_assigned_by="ingest:ledger._make_import",
+        trust_assigned_at="2026-07-26T21:31:37.123456+00:00",
+        injection_status="clean",
+        injection_count=0,
+        injection_rules=[],
+        text="ordinary note",
+        raw_bytes=None,
+        content_scope="item.text.utf8.v1",
+        captured_at="2026-07-26T21:31:37+00:00",
+        ingested_at="2026-07-26T21:31:38+00:00",
+    )
+    clean = evidence_redaction.apply_origin_redaction("ordinary note", origin="operator-input").record()
+    env = provenance.build_envelope(**kwargs, redaction=clean)
+    assert provenance.validate_envelope(env) == []
+    assert env["redaction"]["status"] == "clean"
+
+    tainted = dict(clean)
+    tainted["excerpts"] = ["secret"]
+    with pytest.raises(ValueError, match="removed values"):
+        provenance.build_envelope(**kwargs, redaction=tainted)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Evidence ingest now classifies sources to a provenance origin, redacts sensitive values before persistence, and records only redaction counts and detector ids. Removed bytes never persist. Scanner failure, timeout, or unavailability cannot produce a clean verdict. The policy version is stamped on every decision and applies to future writes only.

Fixes #498

## Type of change

- [x] Evidence ingest policy (origin-scoped redaction at the persist boundary)

## Checklist

- [x] Targeted pytest for touched modules passes locally (273 passed; full `pytest -q` not run)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages

## Scope

- New `brigade.evidence-redaction.v1` policy in `src/brigade/evidence_redaction.py`
- Wired into work-import `_make_import`, research finding new writes, and receipt indexing
- Optional envelope `redaction` field: schema, policy version, origin, status, count, detectors
- Provenance backfill and existing rows are not rewritten
- Historical rescan worker is out of scope (per the #498 amendment)

## Verification

```text
pytest -q tests/test_evidence_redaction.py tests/test_provenance_envelope.py \
  tests/test_research_finding_envelope.py tests/test_work_import_provenance_stamp.py \
  tests/test_research_provenance.py tests/test_receipts_cmd.py \
  -k "provenance or envelope or redact or miseledger_item or import_stamp or indexing_envelope"
273 passed, 63 deselected
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97fb97b4-552a-4292-8035-3312a6b37339?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97fb97b4-552a-4292-8035-3312a6b37339&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

