### PR TITLE
docs(roadmap): catch up to 0.27.x - archive shipped slices, record the provenance and dashboard programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same repo-local recovery recipe. (#860)
 
 ### Documentation
+- ROADMAP.md "Where things stand" now tracks v0.27.x: the provenance and
+  evidence-trust program, the read-only Center dashboard, the memory
+  vault and stable-card-id program, scanner and verifier authority
+  hardening, and the cross-session Stop-gate fix. Shipped Next and Later
+  slices (dashboard first slice, work-inbox graph, wiring durability,
+  handoff standalone-chunk lint) moved to docs/roadmap-archive.md.
+  Part of #1000.
 - Quickstart commit guidance now states that `.claude/` stays local-only
   except the managed `.claude/memory-handoffs/TEMPLATE.md` Claude onboarding
   requires tracked, cross-linking the repo-local shadow recovery from #858.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,17 +21,22 @@ Execution model: Brigade runs only on explicit invocation. An external scheduler
 
 ## Where things stand
 
-**v0.21.x on main** carries the product core plus the evidence and multi-harness work that closed late spring / early summer 2026:
+**v0.27.x on main** carries the product core plus the provenance, dashboard, and memory work that closed through mid-August 2026:
 
 - Portable setup (`operator quickstart`), handoffs with lint and source coverage, daily operator loop, work inbox, fleet and release receipts, tool catalog, skill registry, research, runbooks, chat sweeps, backup visibility, station manifests.
 - **Receipts and learning**: verify/run receipts with digests and optional HMAC signing, code-graph deltas, outcome capture from verify and run receipts, Wilson ranking, reconcile promote/rollback, git provenance, MiseLedger export/import of receipts.
 - **Evidence loop**: GraphTrail context packs and deltas on runs, MiseLedger evidence briefs into work context, first-class `evidence` and `pantry` station CLIs, mechanical context evals (`brief_hit_rate`), no-op write-task flags, atomic `run.json` writes.
-- **Guard and memory**: content-guard vendored as `brigade guard` / `scrub`; memory-doctor folded into `brigade memory`.
+- **Provenance and evidence trust**: `brigade.provenance-envelope.v1` on Python producers (#582), trust-policy enforcement on briefs, context, citations, and promotion, provenance-hash verification on read surfaces, inter-seat message envelopes (#988 / #585), causal lineage receipts (#989 / #493), origin-scoped ingest redaction (#997 / #498).
+- **Center operator dashboard**: `brigade center serve` is a loopback-bound read-only view over existing `--json` contracts (Status, Runs, Research, Work, Code Graph, Agent Activity). Runs list, detail, and watch use versioned JSON contracts (#958 / #631).
+- **Memory**: stable card IDs (`card-<uuid4>`, #984 / #867), Obsidian vault round trip (`memory project-vault` #953, `memory vault-search` #983 / #943, `memory vault-propose` #993 / #945), memory care, reinforcement dedup on ingest.
+- **Guard and memory tooling**: content-guard vendored as `brigade guard` / `scrub`; memory-doctor folded into `brigade memory`.
+- **Scanner and verifier authority**: receipt and import-proof bytes bind to verifier-owned identity (#949); scanner run authority releases on proof failure and inside the scan loop (#946, #982).
+- **Stop-gate**: the Claude Stop closeout gate no longer treats another session's writes in a shared workspace as this session's unverified work (#987 / #959).
 - **Harness fidelity**: Grok and Hermes MCP adapters, Grok headless approval for write tasks, Codex empty-args fingerprints, url-only MCP import as remote, verify `--argv-json`, skill template metadata shipping.
 - **Model scorecard**: `brigade model scorecard` aggregates per-(cli, model) outcomes from run artifacts (read-only).
 - **Product surfaces**: share / remember / prove / improve framing on the README and brigade.tools hub; station product pages (including content-guard and token-glace); GEO work (compare pages, PyPI URLs, Wikidata, Bing IndexNow + URL submission follow-up).
 
-See the [archive](docs/roadmap-archive.md) for the pre-v0.21 completion record. Command inventory stays the source of truth for the CLI surface.
+See the [archive](docs/roadmap-archive.md) for shipped-slice closeouts and the pre-v0.21 completion record. Command inventory stays the source of truth for the CLI surface.
 
 ## Now: respond to real usage and close the loops we opened
 
@@ -48,9 +53,7 @@ The proving-ground milestone still holds: the maintainer workspace runs Brigade 
 ## Next: deepen what already sits on the loop
 
 - **Security plugin depth**: richer rule packs for agent workspaces (hooks, MCP configs, prompt-injection patterns), policy packs per audience, optional offline threat-intel enrichment.
-- **Wiring durability and instruction hygiene**: every guidance block Brigade writes into a foreign file becomes a hash-stamped managed section (version, profile, content hash) so re-runs are byte-identical no-ops, a checker reports missing/stale/current, and removal is surgical. The work brief becomes the single source of truth for workflow guidance, with static installed blocks shrunk to short pointers and split into a minimal profile for hook-capable harnesses and a full profile for file-only ones. Hook output follows a strict contract: a valid empty payload when there is nothing to say, a doctor pointer instead of an error dump on failure, capped context injection at whole-record boundaries with an elision banner naming the cap, an anti-truncation notice, and a one-shot marker that restores the brief after host compaction. Doctor grows an agent-facing mode that omits passing checks, emits observed/expected/fix-command findings, treats dormancy as a first-class warning, and stays silent about harnesses that are not present.
-- **Work inbox graph**: inbox items gain typed dependency edges (blocks, parent-child, discovered-from) with a computed ready set and a "why is this blocked" explanation, bulk graph creation from a plan file, and an atomic claim with compare-and-set guards, a distinct guard-mismatch exit code, and fail-closed filter scoping so multiple worker seats can pull from one queue without stepping on each other. Ready/blocked JSON feeds the operator dashboard once both exist.
-- **Memory care depth**: smarter staleness, contradiction, and evidence checks for cards, with safe gated metadata repairs. Reinforcement dedup shipped in #724 (ingest fingerprints + near-match proposals + gated fingerprint backfill). Remaining retrieval-adjacent slice: a standalone-chunk lint for handoffs (flag unresolved references like "that file" or "the fix above" in durable facts, since a card that needs its session to be understood is a card retrieval cannot surface usefully).
+- **Memory care depth**: smarter staleness, contradiction, and evidence checks for cards, with safe gated metadata repairs. Reinforcement dedup shipped in #724 (ingest fingerprints + near-match proposals + gated fingerprint backfill). Standalone-chunk lint for handoffs shipped in #730 / #773.
 - **Retrieval honesty**: memory search stays keyword-first until an eval proves otherwise. The local retrieval harness at `evals/memory-retrieval/` (fixture corpus, plain-grep baseline, precision/recall at K; run with `python -m brigade.memory_retrieval_eval`) gates any semantic upgrade (#722), and a label-free recall signal (a repeat search with disjoint results shortly after the first counts as a miss) feeds memory-care status from real usage (#723).
 - **Scorecard and lane ops**: per-model orchestrator success rate, clearer DNF vs worker-fail, documented probe protocol for new CLI lanes (file write in cwd, never trust reply text alone).
 - **MCP and harness fidelity**: continue adapter round-trips (empty args, url-only remotes, headless approvals) as harnesses change; prefer fix-the-adapter over more docs.
@@ -63,7 +66,7 @@ Chat surface scanners and backup visibility already shipped; remaining slices (s
 
 The CLI is the skeleton that carries everything. Every future surface sits on top of an existing command plus its JSON contract, never a parallel implementation.
 
-- A workspace UI that is a view over the CLI: model comparison (scorecard-backed), a document editor, a viewer for research reports and operator-center state. First slice: a read-only operator dashboard served locally on explicit command, loopback-bound, rendering only what existing `--json` contracts already emit (work status, handoff inbox, memory cards, outcome rank, run timelines). It ships with a strict security floor from day one: nonce-based CSP with no inline handlers, a Host-header allowlist against DNS rebinding, and a refusal to bind beyond loopback without a token plus an explicit host list.
+- A workspace UI that is a view over the CLI: model comparison (scorecard-backed) and a document editor on top of the read-only operator dashboard that already ships as `brigade center serve`.
 - Optional local semantic memory retrieval (on-device embeddings over `memory/cards/`), staying file-first and optional, and landing only after the retrieval harness above shows a real win over the grep baseline.
 - Owner-scoped tool gating so a publicly reachable instance refuses high-risk tools by default.
 - Multi-channel operator notifications beyond the terminal, still opt-in (`agent-notify` and friends).

--- a/docs/roadmap-archive.md
+++ b/docs/roadmap-archive.md
@@ -19,6 +19,38 @@ brigade roadmap audit
 
 ## Archived Items
 
+### Read-Only Operator Dashboard First Slice
+
+- id: `read-only-operator-dashboard-first-slice`
+- status: implemented
+- closed phase: n/a
+- owner: center
+- reason: Closed with `brigade center serve` as a loopback-bound read-only dashboard (#729, #784) over existing `--json` contracts, with nonce CSP, a Host-header allowlist, and no bind beyond loopback without a token plus an explicit host list. Status, Runs, Research, Work, Code Graph, and Agent Activity views shipped; runs list, detail, and watch use versioned JSON contracts (#958, #631). Remaining workspace UI (scorecard-backed model comparison, document editor) stays on the live roadmap.
+
+### Work Inbox Graph
+
+- id: `work-inbox-graph`
+- status: implemented
+- closed phase: n/a
+- owner: work
+- reason: Closed with typed dependency edges (`blocks`, `parent-child`, `discovered-from`), a computed ready set with blocked reasons, bulk graph creation from a plan file (`brigade work task add --graph`), atomic compare-and-set claims with a distinct guard-mismatch exit, and fail-closed filter scoping (#783, #796, #797, #856, #948). Ready and blocked JSON feed the operator dashboard Work view.
+
+### Wiring Durability And Instruction Hygiene
+
+- id: `wiring-durability-instruction-hygiene`
+- status: implemented
+- closed phase: n/a
+- owner: harness
+- reason: Closed with hash-stamped managed instruction blocks (version, profile, content hash; `brigade harness sync --check` classifies missing/stale/current) (#732), work brief as the instruction source of truth with minimal and full depth profiles (#733), hook output envelope (valid empty payload, doctor pointer, elision banner, compaction restore) (#736), and `brigade doctor --agent` (#808 / #734).
+
+### Handoff Standalone-Chunk Lint
+
+- id: `handoff-standalone-chunk-lint`
+- status: implemented
+- closed phase: n/a
+- owner: memory
+- reason: Closed with `brigade handoff lint` warnings for context-dependent durable facts (#730, #773). Remaining memory-care depth (smarter staleness, contradiction, and evidence checks) stays on the live roadmap.
+
 ### Deeper Roadmap Ownership Modeling
 
 - id: `deeper-roadmap-ownership-modeling`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

ROADMAP.md still said **v0.21.x on main** after six minors and two campaign days. This catch-up records what actually shipped and moves closed Next/Later slices into the archive, following the file's own "How items move" process.

Part of #1000

## Type of change

- [x] Docs

## What moved

Verified against `git log 3874521f..origin/main`, CHANGELOG 0.22.x–Unreleased, and the listed campaign PR titles. Nothing invented.

**Where things stand** now tracks v0.27.x, including:

- Provenance / evidence-trust (`ProvenanceEnvelope` #582, trust enforcement and hash verification, inter-seat envelopes #988/#585, causal receipts #989/#493, origin-scoped redaction #997/#498)
- Center operator dashboard (Status, Runs, Research, Work, Code Graph, Agent Activity; runs JSON contracts #958/#631)
- Memory (stable card IDs #984/#867, vault projection/search/propose #953/#983/#993, memory care)
- Scanner/verifier authority (#949, #946, #982)
- Stop-gate cross-session fix (#987/#959)

**Archived** (status + closing notes in `docs/roadmap-archive.md`):

- Read-only operator dashboard first slice
- Work-inbox graph
- Wiring durability / hash-stamped managed sections, brief SSoT, hook envelope, `brigade doctor --agent`
- Handoff standalone-chunk lint (#730/#773)

Unshipped direction stays in Next/Later (security plugin depth, remaining memory-care checks, retrieval honesty, scorecard/lane ops, MCP fidelity, evidence quality, context-aware Phase 3, workspace UI beyond the dashboard).

This lane did not touch `src/brigade` or CI. Parser-backed `ARCHIVED_ROADMAP_ITEMS` stays with the guard lane.

## Checks

Local (`BRIGADE_EXTRAS=1`):

- `python -m brigade roadmap audit` — 7 sections, 0 issues, every check `[ok]`
- `python -m brigade roadmap commands --check` — inventory current
- `brigade guard scan` on the three edited markdown files — clean

Required GitHub Actions on this PR: all green (lint, test 3.10/3.11/3.12, content-guard, repo-metadata, install-from-source, quickstart-smoke, windows-native-acceptance). No blockers; no retry needed.

## Checklist

- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages, no AI co-authorship trailers beyond the in-house Cursor Agent trailer

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b2f4afe-a09f-4ccd-ae96-a43c3e7538be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b2f4afe-a09f-4ccd-ae96-a43c3e7538be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

