### PR TITLE
feat(roadmap): fail the audit when the version headline lags pyproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,18 @@ jobs:
           exit "$status"
         env:
           BRIGADE_EXTRAS: "1"
+      - name: Roadmap Version
+        run: |
+          set +e
+          brigade roadmap audit --check
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::error file=ROADMAP.md::ROADMAP.md version headline is stale or unparseable; update the Where things stand headline to **vX.Y.x on main** matching pyproject.toml major.minor"
+          fi
+          exit "$status"
+        env:
+          BRIGADE_EXTRAS: "1"
       - name: Template Audit
         run: brigade security template-audit --target . --json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Origin-scoped ingest redaction now maps `work import context` (and `--source external-web` / `external-service`) to the external detector tier, normalizes free-form `--source` with `strip().lower()`, and fails closed to `unknown` on unmapped values. An equal-but-unredacted scanner result is treated as failure, and research findings redact title/summary/evidence per field so a multi-line summary cannot migrate into evidence. (#498)
 
 ### Added
+- `brigade roadmap audit` now fails closed when the ROADMAP.md "Where things stand" headline (`**vX.Y.x on main**`) lags the `pyproject.toml` major.minor, or when that headline is missing or unparseable. Patch-only differences stay green. `brigade roadmap audit --check` exits non-zero so the repo-metadata CI job can fail a lagging headline with an update hint. (#1000)
 - Evidence ingest now applies an origin-scoped redaction policy (`brigade.evidence-redaction.v1`) before persistence. Sources classify to the provenance envelope origin; each origin selects detectors; the stored item keeps only redacted bytes plus a count/detector record (never the removed values). Scanner failure, timeout, or unavailability cannot produce a clean verdict and persists a placeholder instead of the original. The policy version is stamped on every decision and applies to future writes only — existing rows and provenance backfill are not rewritten. (#498)
 
 - Inter-seat planner, worker, and synthesis messages now carry a

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -745,7 +745,7 @@ Start-of-day commands:
 - `brigade work sweep` explicitly runs due scanner producers, ingests configured JSONL outputs by default, and writes one local sweep report for review.
 - `brigade work sweep-review latest` shows created imports, skipped or dismissed fingerprints, grouping, and next commands for the latest sweep.
 - `brigade work sweep closeout latest` records that all actionable sweep imports were promoted, dismissed, archived, or explicitly deferred.
-- `brigade roadmap audit` reports roadmap status, stale phase sections, documented command drift, and optional roadmap-audit work imports.
+- `brigade roadmap audit` reports roadmap status, stale phase sections, documented command drift, ROADMAP version-headline freshness against `pyproject.toml` major.minor, and optional roadmap-audit work imports. `brigade roadmap audit --check` fails when that headline lags or is unparseable.
 - `brigade roadmap patterns` shows neutral inspiration pattern coverage and source-pattern decisions without naming private references.
 - `brigade roadmap commands` shows parser-derived command groups, writes `docs/command-inventory.md`, and can fail stale inventory checks for docs drift.
 - `brigade repos scan` inspects configured local repos for safe setup metadata, and `brigade repos import-issues` routes repo-fleet gaps into the work inbox.
@@ -899,7 +899,7 @@ The scanner registry is explicit and local. Brigade does not install cron jobs, 
 
 Roadmap and repo-fleet commands:
 
-- `brigade roadmap audit` parses `ROADMAP.md`, classifies roadmap bullets, detects stale current or next phase sections, compares documented commands with the CLI, and can import roadmap hygiene issues with `--import-issues`.
+- `brigade roadmap audit` parses `ROADMAP.md`, classifies roadmap bullets, detects stale current or next phase sections, fails when the "Where things stand" version headline lags `pyproject.toml` major.minor or is unparseable, compares documented commands with the CLI, and can import roadmap hygiene issues with `--import-issues`. `--check` exits non-zero on a stale or missing version headline.
 - `brigade roadmap patterns` shows neutral pattern-family coverage and local source-pattern decisions: `bake-in`, `integrate`, `catalog-only`, `move-candidate`, and `leave-alone`.
 - `brigade roadmap commands` reports the public command documentation contract in text or JSON for wrappers and docs drift checks. Use `--write` to regenerate `docs/command-inventory.md` from the CLI parser and `--check` to fail when the inventory is missing or stale.
 - `brigade repos init` writes gitignored `.brigade/repos.toml`.

--- a/src/brigade/cli/roadmap.py
+++ b/src/brigade/cli/roadmap.py
@@ -17,6 +17,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_roadmap_audit.add_argument(
         "--import-issues", action="store_true", help="Import roadmap audit issues into the work inbox."
     )
+    p_roadmap_audit.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail when the ROADMAP version headline lags pyproject or is unparseable.",
+    )
     p_roadmap_patterns = roadmap_sub.add_parser("patterns", help="Show neutral inspiration pattern coverage.")
     p_roadmap_patterns.add_argument(
         "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
@@ -45,7 +50,12 @@ def dispatch(args) -> int:
     from .. import roadmap_cmd
 
     if args.roadmap_command == "audit":
-        return roadmap_cmd.audit(target=args.target, json_output=args.json, import_issues=args.import_issues)
+        return roadmap_cmd.audit(
+            target=args.target,
+            json_output=args.json,
+            import_issues=args.import_issues,
+            check_version=args.check,
+        )
     if args.roadmap_command == "patterns":
         return roadmap_cmd.patterns(target=args.target, json_output=args.json)
     if args.roadmap_command == "archive":

--- a/src/brigade/roadmap_cmd.py
+++ b/src/brigade/roadmap_cmd.py
@@ -44,6 +44,9 @@ DOC_COMMAND_TOP_LEVELS = {
 }
 COMMAND_INVENTORY_RELATIVE_PATH = Path("docs") / "command-inventory.md"
 ROADMAP_ARCHIVE_RELATIVE_PATH = Path("docs") / "roadmap-archive.md"
+ROADMAP_VERSION_HEADLINE_RE = re.compile(r"\*\*v(\d+)\.(\d+)\.(?:x|\d+) on main\*\*")
+PROJECT_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)")
+ROADMAP_VERSION_CHECK_NAMES = frozenset({"roadmap_version_current", "roadmap_version_headline_unparseable"})
 
 PATTERN_FAMILIES: tuple[dict[str, Any], ...] = (
     {
@@ -388,6 +391,91 @@ def _parse_roadmap(target: Path) -> dict[str, Any]:
     }
 
 
+def _parse_major_minor(version: str) -> tuple[int, int] | None:
+    match = PROJECT_VERSION_RE.match(version.strip())
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _parse_roadmap_headline_version(text: str) -> tuple[int, int] | None:
+    in_section = False
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith("#"):
+            title = stripped.lstrip("#").strip()
+            if in_section:
+                break
+            in_section = title.casefold() == "where things stand"
+            continue
+        if not in_section:
+            continue
+        match = ROADMAP_VERSION_HEADLINE_RE.search(stripped)
+        if match:
+            return int(match.group(1)), int(match.group(2))
+    return None
+
+
+def _parse_pyproject_major_minor(target: Path) -> tuple[int, int] | None:
+    from . import toml_compat
+
+    text = _read_text(target / "pyproject.toml")
+    if not text:
+        return None
+    try:
+        data = toml_compat.loads(text)
+    except Exception:
+        return None
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return None
+    version = project.get("version")
+    if not isinstance(version, str) or not version.strip():
+        return None
+    return _parse_major_minor(version)
+
+
+def _format_major_minor(pair: tuple[int, int]) -> str:
+    return f"{pair[0]}.{pair[1]}"
+
+
+def _roadmap_version_check(target: Path, text: str) -> dict[str, Any]:
+    headline = _parse_roadmap_headline_version(text)
+    if headline is None:
+        return {
+            "status": FAIL,
+            "name": "roadmap_version_headline_unparseable",
+            "detail": (
+                "ROADMAP.md Where things stand headline is missing or unparseable (expected **vX.Y.x on main**)"
+            ),
+        }
+    project = _parse_pyproject_major_minor(target)
+    if project is None:
+        return {
+            "status": FAIL,
+            "name": "roadmap_version_current",
+            "detail": "could not read project.version from pyproject.toml",
+            "headline": _format_major_minor(headline),
+        }
+    headline_label = f"v{headline[0]}.{headline[1]}.x"
+    project_label = _format_major_minor(project)
+    if headline < project:
+        return {
+            "status": FAIL,
+            "name": "roadmap_version_current",
+            "detail": f"ROADMAP.md headline {headline_label} lags pyproject {project_label}",
+            "headline": _format_major_minor(headline),
+            "pyproject": project_label,
+        }
+    return {
+        "status": OK,
+        "name": "roadmap_version_current",
+        "detail": f"ROADMAP.md headline {headline_label} matches pyproject {project_label}",
+        "headline": _format_major_minor(headline),
+        "pyproject": project_label,
+    }
+
+
 def _section_stale_checks(sections: list[dict[str, Any]]) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     for section in sections:
@@ -581,6 +669,7 @@ def audit_payload(target: Path) -> dict[str, Any]:
         checks.append({"status": WARN, "name": "roadmap_exists", "detail": "ROADMAP.md missing"})
     else:
         checks.append({"status": OK, "name": "roadmap_exists", "detail": roadmap["path"]})
+        checks.append(_roadmap_version_check(target, _read_text(_roadmap_path(target))))
     checks.extend(_section_stale_checks(roadmap["sections"]))
 
     owns_cli = _target_owns_brigade_cli(target)
@@ -680,7 +769,19 @@ def _roadmap_import_records(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return records
 
 
-def audit(*, target: Path, json_output: bool = False, import_issues: bool = False) -> int:
+def _audit_exit_code(payload: dict[str, Any], *, check_version: bool) -> int:
+    if not check_version:
+        return 0
+    if any(
+        check.get("name") in ROADMAP_VERSION_CHECK_NAMES and check.get("status") != OK
+        for check in payload.get("checks", [])
+        if isinstance(check, dict)
+    ):
+        return 1
+    return 0
+
+
+def audit(*, target: Path, json_output: bool = False, import_issues: bool = False, check_version: bool = False) -> int:
     payload = audit_payload(target)
     imported: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
@@ -694,7 +795,7 @@ def audit(*, target: Path, json_output: bool = False, import_issues: bool = Fals
         payload["dismissed"] = len(dismissed)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
+        return _audit_exit_code(payload, check_version=check_version)
     print(f"roadmap audit: {payload['target']}")
     print(f"roadmap: {payload['roadmap']['path']}")
     print(f"sections: {len(payload['roadmap']['sections'])}")
@@ -706,7 +807,7 @@ def audit(*, target: Path, json_output: bool = False, import_issues: bool = Fals
         print(f"imported: {len(imported)}")
         print(f"skipped: {len(skipped)}")
         print(f"dismissed: {len(dismissed)}")
-    return 0
+    return _audit_exit_code(payload, check_version=check_version)
 
 
 def patterns_payload(target: Path) -> dict[str, Any]:

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -259,6 +259,17 @@ def test_repo_metadata_command_inventory_failure_is_actionable_and_preserves_sta
     assert 'exit "$status"' in section
 
 
+def test_repo_metadata_roadmap_version_failure_is_actionable_and_preserves_status():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+    section = _workflow_job_section(text, "repo-metadata")
+
+    assert "brigade roadmap audit --check" in section
+    assert (
+        'echo "::error file=ROADMAP.md::ROADMAP.md version headline is stale or unparseable; '
+        'update the Where things stand headline to **vX.Y.x on main** matching pyproject.toml major.minor"'
+    ) in section
+
+
 def test_ci_component_manifest_provenance_job_installs_dev_test_dependencies():
     text = (ROOT / ".github/workflows/ci.yml").read_text()
     section = _workflow_job_section(text, "component-manifest-provenance")

--- a/tests/test_roadmap_cmd.py
+++ b/tests/test_roadmap_cmd.py
@@ -48,6 +48,56 @@ def test_target_owns_brigade_cli_ignores_malformed_pyproject(tmp_path):
     assert roadmap_cmd._target_owns_brigade_cli(tmp_path) is False
 
 
+def _write_versioned_roadmap(tmp_path: Path, *, headline: str, project_version: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(f'[project]\nname = "brigade-cli"\nversion = "{project_version}"\n')
+    (tmp_path / "ROADMAP.md").write_text(f"# Roadmap\n\n## Where things stand\n\n{headline} is current.\n")
+
+
+def test_roadmap_audit_version_current_when_headline_matches_minor(tmp_path):
+    _write_versioned_roadmap(tmp_path, headline="**v0.27.x on main**", project_version="0.27.0")
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    check = next(item for item in payload["checks"] if item["name"] == "roadmap_version_current")
+    assert check["status"] == "ok"
+    assert not any(item["name"] == "roadmap_version_current" for item in payload["issues"])
+    assert not any(item["name"] == "roadmap_version_headline_unparseable" for item in payload["issues"])
+
+
+def test_roadmap_audit_version_issue_when_headline_minor_behind(tmp_path):
+    _write_versioned_roadmap(tmp_path, headline="**v0.26.x on main**", project_version="0.27.0")
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    issue = next(item for item in payload["issues"] if item["name"] == "roadmap_version_current")
+    assert issue["status"] == "fail"
+    assert "0.26" in issue["detail"]
+    assert "0.27" in issue["detail"]
+    assert not any(item["name"] == "roadmap_version_headline_unparseable" for item in payload["issues"])
+
+
+def test_roadmap_audit_version_fail_closed_when_headline_unparseable(tmp_path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "brigade-cli"\nversion = "0.27.0"\n')
+    (tmp_path / "ROADMAP.md").write_text("# Roadmap\n\n## Current Phase\n- Keep going.\n")
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    issue = next(item for item in payload["issues"] if item["name"] == "roadmap_version_headline_unparseable")
+    assert issue["status"] == "fail"
+    assert not any(item["name"] == "roadmap_version_current" for item in payload["issues"])
+
+
+def test_roadmap_audit_version_ok_when_patch_differs(tmp_path):
+    _write_versioned_roadmap(tmp_path, headline="**v0.27.x on main**", project_version="0.27.5")
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    check = next(item for item in payload["checks"] if item["name"] == "roadmap_version_current")
+    assert check["status"] == "ok"
+    assert not any(item["name"] == "roadmap_version_current" for item in payload["issues"])
+
+
+def test_roadmap_audit_check_exits_nonzero_when_headline_lags(tmp_path):
+    _write_versioned_roadmap(tmp_path, headline="**v0.26.x on main**", project_version="0.27.0")
+    assert cli.main(["roadmap", "audit", "--target", str(tmp_path), "--check"]) == 1
+
+
 def test_roadmap_audit_classifies_stale_sections_and_command_mismatch(tmp_path):
     (tmp_path / "ROADMAP.md").write_text(
         "# Roadmap\n\n"
@@ -274,7 +324,10 @@ def test_roadmap_cli_dispatch(tmp_path, monkeypatch):
     assert cli.main(["roadmap", "commands", "--target", str(tmp_path), "--json"]) == 0
 
     assert seen == [
-        ("audit", {"target": tmp_path, "json_output": True, "import_issues": True}),
+        (
+            "audit",
+            {"target": tmp_path, "json_output": True, "import_issues": True, "check_version": False},
+        ),
         ("patterns", {"target": tmp_path, "json_output": True}),
         ("archive", {"target": tmp_path, "json_output": True}),
         ("commands", {"target": tmp_path, "json_output": True, "write_inventory": False, "check_inventory": False}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

`brigade roadmap audit` now fails when ROADMAP.md's "Where things stand" headline lags the `pyproject.toml` major.minor, and fails closed when that headline is missing or unparseable. The repo-metadata CI job runs `brigade roadmap audit --check` so a stale headline turns the job red with an update hint. Patch-only differences stay green.

Fixes #1000

This is the guard half of #1000. The catch-up half already landed in #1001 (`**v0.27.x on main**`); this PR does not rewrite roadmap prose.

## Type of change

- [x] Bug fix (unenforced freshness: audit stayed green while the headline lagged)
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

`--check` is an additive flag on the existing extras `roadmap audit` command.

## Checklist

- [x] `pytest -q` passes locally (`./scripts/verify`: 8139 passed, 5 skipped, 68 subtests, 83.74% coverage)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages, no AI co-authorship trailers

## Verification

- `tests/test_roadmap_cmd.py` and `tests/test_roadmap_inventory_cmd.py` plus the repo-metadata CI contract tests
- On this tree: `env BRIGADE_EXTRAS=1 python -m brigade roadmap audit` exits 0 (`roadmap_version_current` ok: headline v0.27.x matches pyproject 0.27)
- `env BRIGADE_EXTRAS=1 python -m brigade roadmap audit --check` exits 0

No blockers after the allowed two attempts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c1d6d75-b356-493b-9cf9-1580249920f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c1d6d75-b356-493b-9cf9-1580249920f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

