### PR TITLE
fix(repo): union-merge CHANGELOG Unreleased sibling appends

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Adjacent Unreleased appends from sibling PRs should combine, not conflict.
+# Built-in git merge driver; no extra gitconfig needed. See #994.
+CHANGELOG.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
-# Adjacent Unreleased appends from sibling PRs should combine, not conflict.
+# Root Unreleased appends from sibling PRs should combine, not conflict.
 # Built-in git merge driver; no extra gitconfig needed. See #994.
-CHANGELOG.md merge=union
+# Slash-anchored so nested CHANGELOG.md files stay unspecified.
+/CHANGELOG.md merge=union
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recover <operation-id>`. Refs #911.
 
 ### Changed
-- `CHANGELOG.md` is marked `merge=union` in `.gitattributes` so same-day Unreleased appends from sibling PRs combine instead of conflicting. (#994)
+- The root `CHANGELOG.md` is marked `/CHANGELOG.md merge=union` in `.gitattributes` so same-day Unreleased appends from sibling PRs combine instead of conflicting. Nested changelogs are not marked. (#994)
 - Search integrity verification loads item text and provenance in one
   `IN (...)` query keyed by the result ids, instead of one select per
   hit (search limit is up to 200). (#964)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recover <operation-id>`. Refs #911.
 
 ### Changed
+- `CHANGELOG.md` is marked `merge=union` in `.gitattributes` so same-day Unreleased appends from sibling PRs combine instead of conflicting. (#994)
 - Search integrity verification loads item text and provenance in one
   `IN (...)` query keyed by the result ids, instead of one select per
   hit (search limit is up to 200). (#964)
@@ -126,7 +127,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The graphtrail stale-baseline verify test no longer races wall-clock sync delays
   against a tight subprocess timeout on loaded CI runners; sync timeout is injected
   deterministically so the stale-graph assertion is reliable on Python 3.12. (#954)
->>>>>>> origin/main
 - Quarantined items stay quarantined when a pending injection scan comes back clean, so a labeled quarantine cannot be released to untrusted and become content-eligible. Reviewed and verified items keep every consumer surface untrusted already has, including `context`. `brigade receipts verify` reports `verify-pending` (and does not append a local verified event) when the MiseLedger trust notify fails. Provenance-event JSONL now appends and fsyncs instead of rewriting the whole file. (#587)
 - Corrupt or future-version `.brigade/work/tasks.json` ledgers now fail
   closed on every `brigade work` surface (and other commands that read the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,9 @@ Dispatched sessions should open the pull request, run local verification, and pu
 
 ## Changelog
 
-User-visible PRs append a bullet under `CHANGELOG.md` `## [Unreleased]` (effects, not commit subjects). Same-day sibling PRs often edit adjacent Unreleased lines; `.gitattributes` marks `CHANGELOG.md` `merge=union` so those appends combine instead of conflicting. That attribute is for this file only.
+User-visible PRs append a bullet under the root `CHANGELOG.md` `## [Unreleased]` (effects, not commit subjects). `.gitattributes` marks `/CHANGELOG.md merge=union` so sibling PRs that each add their own Unreleased line combine instead of conflicting. Nested `CHANGELOG.md` files are not marked.
+
+Union is safe for that append-only Unreleased list when each entry is its own line. When two branches edit the same line or adjacent lines of an existing bullet, union keeps both versions or interleaves wrapped lines and does not conflict. Treat that clean merge as a rewrite to re-read; a human must reconcile.
 
 ## What kinds of changes land easily
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ gh pr view <number> --json reviewDecision,mergeStateStatus
 
 Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
 
+## Changelog
+
+User-visible PRs append a bullet under `CHANGELOG.md` `## [Unreleased]` (effects, not commit subjects). Same-day sibling PRs often edit adjacent Unreleased lines; `.gitattributes` marks `CHANGELOG.md` `merge=union` so those appends combine instead of conflicting. That attribute is for this file only.
+
 ## What kinds of changes land easily
 
 - **Bug fixes** for `brigade init`, `doctor`, `scrub`, quickstart, security scanning, or the ingester.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Same-day PRs that append adjacent `CHANGELOG.md` Unreleased bullets have been flipping every open sibling to CONFLICTING (the 2026-08-17 and 2026-08-18 landing waves). This lands issue #994 option 1 only: `.gitattributes` marks `/CHANGELOG.md merge=union` so those appends combine the way a hand union already did.

The issue does not ask for towncrier fragments or `merge=union` on other shared docs (`docs/receipt-schemas.md`, `docs/import-schema.md`). Nested `CHANGELOG.md` files stay unspecified.

Also drops a leftover `>>>>>>> origin/main` marker that the #983 landing-wave union left in Unreleased/Fixed.

Fixes #994

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [x] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] Fast verify gates (`ruff`, `ruff format --check`) passed on this follow-up; prior push had full `./scripts/verify` (`8133 passed, 5 skipped`, 83.74% coverage)
- [ ] Added or updated tests covering the change (repo attribute + local merge demonstration; no new Python surface)
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages (in-house co-author trailer per CONTRIBUTING.md)

## Probe review follow-up (`ee524e54`)

Scoped the attribute to `/CHANGELOG.md merge=union`. `git check-attr merge`:

```
CHANGELOG.md: merge: union
tests/_probe_994_fixture/CHANGELOG.md: merge: unspecified
engines/code-graph/CHANGELOG.md: merge: unspecified
engines/evidence-ledger/CHANGELOG.md: merge: unspecified
src/brigade/templates/skills/*/CHANGELOG.md: merge: unspecified
stations/notify/CHANGELOG.md: merge: unspecified
```

`CONTRIBUTING.md` now warns that union is safe for the append-only Unreleased list when each entry is its own line, and that same-line or adjacent-line edits of an existing bullet keep both sides without conflicting. A human must reconcile those.

## Local merge demonstration (re-run after the scope fix)

Throwaway repo using the root-anchored attribute and the current Unreleased text.

**Probe 1, sibling Unreleased appends:** two branches each inserted one new bullet after the first `### Added`. `git merge --no-edit` exited 0. No unmerged paths, no conflict markers. Each probe marker appears once:

```
### Added
- PROBE-APPEND-A-994-1016: sibling Unreleased append from probe branch A.
- PROBE-APPEND-B-994-1016: sibling Unreleased append from probe branch B.
- Evidence ingest now applies an origin-scoped redaction policy ...
```

**Probe 3, adjacent lines of the same wrapped bullet:** branch A prefixed the first line of the `#585` Added bullet; branch B prefixed the next line. `git merge --no-edit` exited 0 with no conflict markers. Union interleaved both sides and left a broken duplicate start:

```
- PROBE-ADJ-A-994-1016 Inter-seat planner, worker, and synthesis messages now carry a
  `brigade.provenance-envelope.v1` with `message.text.utf8.v1` over the exact
- Inter-seat planner, worker, and synthesis messages now carry a
  PROBE-ADJ-B-994-1016 `brigade.provenance-envelope.v1` with `message.text.utf8.v1` over the exact
  outbound UTF-8 bytes. Channel gates run before `parse_plan` or model
```

That clean merge is the documented failure mode, not a successful union of independent appends.

Demo receipts: [original union vs default conflict transcript](https://cursor.com/agents/bc-c9ee8ffc-5b0a-46a6-a3ff-7ee5031320e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchangelog_union_merge_demo.txt) [re-run sibling-append and adjacent-line probes](https://cursor.com/agents/bc-c9ee8ffc-5b0a-46a6-a3ff-7ee5031320e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchangelog_union_probe_rerun.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9ee8ffc-5b0a-46a6-a3ff-7ee5031320e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9ee8ffc-5b0a-46a6-a3ff-7ee5031320e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

