### PR TITLE
docs: align README wordmark with brigade.tools

### DIFF
--- a/docs/assets/brigade-wordmark.svg
+++ b/docs/assets/brigade-wordmark.svg
@@ -73,16 +73,16 @@
 </g>
 </g>
   </defs>
-  <g id="wordmark" fill="#dde3ea" transform="translate(209 8)">
+  <g id="wordmark" fill="#dde3ea" transform="translate(180.5 8)">
 <use xlink:href="#wordmark-glyph-0" x="0" y="143.375"/>
-<use xlink:href="#wordmark-glyph-1" x="83.639648" y="143.375"/>
-<use xlink:href="#wordmark-glyph-2" x="136.279297" y="143.375"/>
-<use xlink:href="#wordmark-glyph-3" x="167.918945" y="143.375"/>
-<use xlink:href="#wordmark-glyph-4" x="252.558594" y="143.375"/>
-<use xlink:href="#wordmark-glyph-5" x="329.198242" y="143.375"/>
-<use xlink:href="#wordmark-glyph-6" x="412.837891" y="143.375"/>
+<use xlink:href="#wordmark-glyph-1" x="93.139648" y="143.375"/>
+<use xlink:href="#wordmark-glyph-2" x="155.279297" y="143.375"/>
+<use xlink:href="#wordmark-glyph-3" x="196.418945" y="143.375"/>
+<use xlink:href="#wordmark-glyph-4" x="290.558594" y="143.375"/>
+<use xlink:href="#wordmark-glyph-5" x="376.698242" y="143.375"/>
+<use xlink:href="#wordmark-glyph-6" x="469.837891" y="143.375"/>
   </g>
-  <circle id="i-dot" cx="366.2" cy="53" r="11.8" fill="#e0a45c"/>
+  <circle id="i-dot" cx="356.7" cy="53" r="11.8" fill="#e0a45c"/>
   <g id="maker-line" fill="#9aa4b2" transform="translate(334.5 211)">
 <use xlink:href="#maker-glyph-0" x="0" y="27.125"/>
 <use xlink:href="#maker-glyph-1" x="10" y="27.125"/>

--- a/docs/assets/brigade-wordmark.svg
+++ b/docs/assets/brigade-wordmark.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="920" height="280" viewBox="0 0 920 280" role="img" aria-labelledby="title desc">
   <title id="title">Brigade (by Escoffier Labs)</title>
   <desc id="desc">The lowercase Brigade wordmark in off-white, with one amber dot above the i and the maker line below.</desc>
-  <rect id="panel" x="1" y="1" width="918" height="278" rx="8" fill="#0f1318" stroke="#2a323d" stroke-width="2"/>
+  <rect id="panel" x="0" y="0" width="920" height="280" fill="#0d1014"/>
   <defs>
 <g>
 <g id="wordmark-glyph-0">

--- a/docs/assets/brigade-wordmark.svg
+++ b/docs/assets/brigade-wordmark.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="920" height="280" viewBox="0 0 920 280" role="img" aria-labelledby="title desc">
-  <title id="title">Brigade (by Escoffier Labs)</title>
+  <title id="title">Brigade by Escoffier Labs</title>
   <desc id="desc">The lowercase Brigade wordmark in off-white, with one amber dot above the i and the maker line below.</desc>
   <rect id="panel" x="0" y="0" width="920" height="280" fill="#0d1014"/>
   <defs>
@@ -84,7 +84,6 @@
   </g>
   <circle id="i-dot" cx="356.7" cy="53" r="11.8" fill="#e0a45c"/>
   <g id="maker-line" fill="#9aa4b2" transform="translate(334.5 211)">
-<use xlink:href="#maker-glyph-0" x="0" y="27.125"/>
 <use xlink:href="#maker-glyph-1" x="10" y="27.125"/>
 <use xlink:href="#maker-glyph-2" x="27" y="27.125"/>
 <use xlink:href="#maker-glyph-3" x="43" y="27.125"/>
@@ -102,6 +101,5 @@
 <use xlink:href="#maker-glyph-13" x="193" y="27.125"/>
 <use xlink:href="#maker-glyph-1" x="209" y="27.125"/>
 <use xlink:href="#maker-glyph-5" x="226" y="27.125"/>
-<use xlink:href="#maker-glyph-14" x="241" y="27.125"/>
   </g>
 </svg>

--- a/docs/superpowers/plans/2026-08-21-borderless-readme-wordmark.md
+++ b/docs/superpowers/plans/2026-08-21-borderless-readme-wordmark.md
@@ -1,0 +1,27 @@
+# Borderless README wordmark implementation plan
+
+**Goal:** Remove the visible frame from the README wordmark while keeping enough contrast on GitHub light mode.
+
+**Files:**
+
+- `tests/test_readme_brand_header.py`
+- `docs/assets/brigade-wordmark.svg`
+
+### Task 1: Lock the SVG contract
+
+- [ ] Update the focused test to require a full-bleed `#0d1014` panel with no stroke or radius.
+- [ ] Lock the existing dot center at `cx="366.2"`.
+- [ ] Run the focused test through Brigade and record the expected failure.
+
+### Task 2: Apply the approved treatment
+
+- [ ] Expand the panel to the full `920 x 280` viewBox.
+- [ ] Remove the stroke, stroke width, and corner radius.
+- [ ] Re-run the focused test through Brigade and record the pass.
+
+### Task 3: Verify and publish
+
+- [ ] Render the SVG in Chromium and inspect the edge and dot alignment.
+- [ ] Run the focused test and changed-file quality checks through Brigade.
+- [ ] Review the diff, push the feature branch, open the PR, wait for required checks, and squash merge.
+

--- a/docs/superpowers/plans/2026-08-21-borderless-readme-wordmark.md
+++ b/docs/superpowers/plans/2026-08-21-borderless-readme-wordmark.md
@@ -9,19 +9,18 @@
 
 ### Task 1: Lock the SVG contract
 
-- [ ] Update the focused test to require a full-bleed `#0d1014` panel with no stroke or radius.
-- [ ] Lock the existing dot center at `cx="366.2"`.
-- [ ] Run the focused test through Brigade and record the expected failure.
+- [x] Update the focused test to require a full-bleed `#0d1014` panel with no stroke or radius.
+- [x] Lock the existing dot center at `cx="366.2"`.
+- [x] Run the focused test through Brigade and record the expected failure.
 
 ### Task 2: Apply the approved treatment
 
-- [ ] Expand the panel to the full `920 x 280` viewBox.
-- [ ] Remove the stroke, stroke width, and corner radius.
-- [ ] Re-run the focused test through Brigade and record the pass.
+- [x] Expand the panel to the full `920 x 280` viewBox.
+- [x] Remove the stroke, stroke width, and corner radius.
+- [x] Re-run the focused test through Brigade and record the pass.
 
 ### Task 3: Verify and publish
 
-- [ ] Render the SVG in Chromium and inspect the edge and dot alignment.
+- [x] Render the SVG in Chromium and inspect the edge and dot alignment.
 - [ ] Run the focused test and changed-file quality checks through Brigade.
 - [ ] Review the diff, push the feature branch, open the PR, wait for required checks, and squash merge.
-

--- a/tests/test_readme_brand_header.py
+++ b/tests/test_readme_brand_header.py
@@ -17,9 +17,14 @@ def test_readme_header_matches_brigade_tools_brand() -> None:
 
     panel = root.find(f"{SVG_NS}rect[@id='panel']")
     assert panel is not None
-    assert panel.attrib["fill"] == "#0f1318"
-    assert panel.attrib["stroke"] == "#2a323d"
-    assert panel.attrib["rx"] == "8"
+    assert panel.attrib["x"] == "0"
+    assert panel.attrib["y"] == "0"
+    assert panel.attrib["width"] == "920"
+    assert panel.attrib["height"] == "280"
+    assert panel.attrib["fill"] == "#0d1014"
+    assert "stroke" not in panel.attrib
+    assert "stroke-width" not in panel.attrib
+    assert "rx" not in panel.attrib
 
     wordmark = root.find(f"{SVG_NS}g[@id='wordmark']")
     assert wordmark is not None
@@ -33,6 +38,9 @@ def test_readme_header_matches_brigade_tools_brand() -> None:
 
     accent_elements = [element for element in root.iter() if element.attrib.get("fill") == "#e0a45c"]
     assert [(element.tag, element.attrib.get("id")) for element in accent_elements] == [(f"{SVG_NS}circle", "i-dot")]
+    i_dot = root.find(f"{SVG_NS}circle[@id='i-dot']")
+    assert i_dot is not None
+    assert i_dot.attrib["cx"] == "366.2"
 
     assert root.findall(f".//{SVG_NS}path")
     assert not root.findall(f".//{SVG_NS}text")

--- a/tests/test_readme_brand_header.py
+++ b/tests/test_readme_brand_header.py
@@ -29,7 +29,16 @@ def test_readme_header_matches_brigade_tools_brand() -> None:
     wordmark = root.find(f"{SVG_NS}g[@id='wordmark']")
     assert wordmark is not None
     assert wordmark.attrib["fill"] == "#dde3ea"
-    assert wordmark.findall(f".//{SVG_NS}use")
+    assert wordmark.attrib["transform"] == "translate(180.5 8)"
+    assert [use.attrib["x"] for use in wordmark.findall(f".//{SVG_NS}use")] == [
+        "0",
+        "93.139648",
+        "155.279297",
+        "196.418945",
+        "290.558594",
+        "376.698242",
+        "469.837891",
+    ]
 
     maker = root.find(f"{SVG_NS}g[@id='maker-line']")
     assert maker is not None
@@ -40,7 +49,7 @@ def test_readme_header_matches_brigade_tools_brand() -> None:
     assert [(element.tag, element.attrib.get("id")) for element in accent_elements] == [(f"{SVG_NS}circle", "i-dot")]
     i_dot = root.find(f"{SVG_NS}circle[@id='i-dot']")
     assert i_dot is not None
-    assert i_dot.attrib["cx"] == "366.2"
+    assert i_dot.attrib["cx"] == "356.7"
 
     assert root.findall(f".//{SVG_NS}path")
     assert not root.findall(f".//{SVG_NS}text")

--- a/tests/test_readme_brand_header.py
+++ b/tests/test_readme_brand_header.py
@@ -13,7 +13,7 @@ def test_readme_header_matches_brigade_tools_brand() -> None:
 
     title = root.find(f"{SVG_NS}title")
     assert title is not None
-    assert title.text == "Brigade (by Escoffier Labs)"
+    assert title.text == "Brigade by Escoffier Labs"
 
     panel = root.find(f"{SVG_NS}rect[@id='panel']")
     assert panel is not None
@@ -43,7 +43,11 @@ def test_readme_header_matches_brigade_tools_brand() -> None:
     maker = root.find(f"{SVG_NS}g[@id='maker-line']")
     assert maker is not None
     assert maker.attrib["fill"] == "#9aa4b2"
-    assert maker.findall(f".//{SVG_NS}use")
+    maker_glyphs = maker.findall(f".//{SVG_NS}use")
+    assert maker_glyphs
+    href = "{http://www.w3.org/1999/xlink}href"
+    assert maker_glyphs[0].attrib[href] == "#maker-glyph-1"
+    assert maker_glyphs[-1].attrib[href] == "#maker-glyph-5"
 
     accent_elements = [element for element in root.iter() if element.attrib.get("fill") == "#e0a45c"]
     assert [(element.tag, element.attrib.get("id")) for element in accent_elements] == [(f"{SVG_NS}circle", "i-dot")]


### PR DESCRIPTION
## Summary

- replace the framed README wordmark panel with a full-bleed off-black background
- use natural letter spacing and center the amber dot on the dotless-i stem
- change the maker line to `by Escoffier Labs` without parentheses
- keep the ShieldCN badge row intact

## Verification

- `./scripts/verify`
- `python3 -m pytest -q tests/test_readme_brand_header.py`
- direct Chromium render at 920 x 280
