### PR TITLE
fix(runs): Windows home-path redaction, regex edges, allowlist coupling pin, docs (Fixes #1064)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- JSON run contracts redact Windows `C:\Users\<name>\` and `C:/Users/<name>/` home prefixes to `~` at the same `_clean_str` chokepoint as POSIX `/home/<user>` and `/Users/<user>`, including doubled slashes and usernames that contain a space or apostrophe. An allowlist key without a cleaned counterpart can no longer pass a raw source value. Fixes #1064. Refs #631.
 - `brigade runs list --json` and the Run View `GET /api/runs` list now drop a child directory that is a symlink, or whose `resolve()` leaves the runs root, and count it in `skipped_invalid`. Per-run serve routes already 404 those ids; the shared collector did not, so a symlink alias could leak out-of-root task text in the list while its detail route 404'd. Refs #631.
 - Scanner lifecycle rewrites now require the verifier-held run proof, `before.source == scanner.source`, and a legal `pending → dismissed` transition. A replacement row is applied as that narrow action, so a matching built-in scanner cannot dismiss another source's finding, resurrect a dismissed row, or assign an arbitrary status. Fixes #1039.
 - Explicit `import_path` ingestion retains the same publication snapshot as self-import (pre-commit inbox, persisted proofs, and file bindings) until the final scanner receipt binds. A failed receipt write rolls the import and proofs back together. Fixes #1040.

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -914,8 +914,15 @@ Versioned, read-only CLI JSON contracts for higher-level surfaces (the Center
 Runs view). Each payload is an explicit allowlist over run artifacts: it never
 includes environment values, auth or control tokens, secret references, full
 prompts, transcript bodies, raw stdout/stderr, log paths, or absolute
-workspace paths. Task and detail strings are bounded before emission; the
-authoritative artifacts are never modified.
+workspace paths. Every string that enters a list, detail, or watch JSON
+contract passes through one `_clean_str` chokepoint: the value is bounded,
+then home-directory prefixes are rewritten to `~` as the last transform.
+That rewrite is universal — not limited to `failure.detail` or
+`commands[].command`. Matched prefixes are POSIX `/home/<user>` and
+`/Users/<user>` (including a doubled slash such as `/home//<user>`, and
+usernames that contain a space or an apostrophe) and Windows
+`C:\Users\<name>\` plus `C:/Users/<name>/`. The authoritative artifacts
+and human CLI output are never modified.
 
 `brigade runs serve` exposes the same three contracts on loopback as
 `GET /api/runs`, `GET /api/runs/<run-id>`, and `GET /api/runs/<run-id>/events`
@@ -959,18 +966,14 @@ Both commands share one serializer:
   (`kind`, `parent_run_id`, `branch_point_event_id`, `shared_prefix`,
   and `children` discovered from sibling receipts the same way as
   human `runs show`) when the run is a durable parent or child.
-  Child `status` and `branch_point_event_id` are bounded. Home-directory
-  prefixes in `failure.detail` are rewritten to `~` in this JSON
-  contract only.
+  Child `status` and `branch_point_event_id` are bounded.
 - `roster`: orchestrator, worker limits, allowed models, and per-seat `cli`,
   `model`, `reasoning`, bounded `role`, and `timeout_seconds`.
 - `plan`: worker `assignments` with stage, worker, and bounded task.
 - `workers`: per-result state (ok/status, bounded detail, duration, exit code,
   timeout flag, requested model, transport, failure class).
 - `verification`: verify receipt summaries (receipt run id, status, duration,
-  command label, and exit code) from recorded ground truth. Home-directory
-  prefixes in `commands[].command` are rewritten to `~` in this JSON
-  contract only.
+  command label, and exit code) from recorded ground truth.
 - `briefs`: attachment markers for the Code Intelligence (`code-graph`),
   drift (`drift-impact`), and Evidence Ledger (`evidence`) briefs.
 
@@ -991,9 +994,8 @@ unknown future record types. `brigade runs events` keeps its own
 - `event` records emit only `method` and `item_type`. Auth tokens,
   prompts, transcript bodies, raw stdout/stderr, log paths, and
   absolute paths in `params` are omitted.
-- `final` text is one-lined and bounded; home-directory prefixes
-  are rewritten to `~`; a value that cannot be rendered safely is
-  omitted. Artifacts and human CLI output are unchanged.
+- `final` text is one-lined and bounded through the same `_clean_str`
+  chokepoint; a value that cannot be rendered safely is omitted.
 
 ---
 

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -1671,11 +1671,15 @@ def _stale_timeout(run_dir: Path, meta: dict[str, Any]) -> float | None:
     return timeout if time.time() - started.timestamp() > timeout else None
 
 
-_HOME_PREFIX_RE = re.compile(r"/(?:home|Users)/[^/\s\"']+")
+# Windows alternative is first so `C:/Users/<name>` is not left as `C:~`.
+# `/+` and `[/\\]+` accept doubled separators; `[^/\\]+` keeps spaces and apostrophes.
+_HOME_PREFIX_RE = re.compile(
+    r"(?:[A-Za-z]:[/\\]+(?i:Users)[/\\]+|/(?:home|Users)/+)[^/\\]+",
+)
 
 
 def _redact_home_prefixes(text: str) -> str:
-    """Rewrite `/home/<user>` and `/Users/<user>` prefixes to `~` for JSON contracts."""
+    """Rewrite POSIX and Windows home prefixes to `~` for JSON contracts."""
     return _HOME_PREFIX_RE.sub("~", text)
 
 
@@ -1704,15 +1708,31 @@ def _compact(payload: dict[str, object]) -> dict[str, object]:
     return {key: value for key, value in payload.items() if value is not None}
 
 
+class _MergedSource(dict[str, object]):
+    """Source overlay that records which keys passed through the cleaner."""
+
+    cleaned_keys: frozenset[str]
+
+    def __init__(self, data: Mapping[str, Any] | None = None) -> None:
+        super().__init__(data or {})
+        self.cleaned_keys = frozenset()
+
+
 def _merge_source(source: Mapping[str, Any] | None, cleaned: Mapping[str, object]) -> dict[str, object]:
     """Overlay cleaned fields on the source mapping so `_allowlisted` must drop extras."""
-    payload: dict[str, object] = dict(source) if source is not None else {}
+    payload = _MergedSource(source)
     payload.update(cleaned)
+    payload.cleaned_keys = frozenset(cleaned)
     return payload
 
 
 def _allowlisted(payload: Mapping[str, object], allowed: frozenset[str]) -> dict[str, object]:
     """Keep only explicitly allowlisted keys; drop None the same way as `_compact`."""
+    if not isinstance(payload, _MergedSource):
+        raise AssertionError("JSON contract allowlist requires _merge_source overlay")
+    missing = allowed - payload.cleaned_keys
+    if missing:
+        raise AssertionError("allowlist keys have no cleaned counterpart: " + ", ".join(sorted(missing)))
     return {key: value for key, value in payload.items() if key in allowed and value is not None}
 
 

--- a/tests/test_runs_json_contracts.py
+++ b/tests/test_runs_json_contracts.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from brigade import cli
 from brigade import runs_cmd
 
@@ -17,8 +19,18 @@ PLANTED_ENV_VALUE = "planted-env-OPENAI-not-a-real-key"
 PLANTED_SECRET = "sk-live-EXAMPLESECRETVALUE99"
 PLANTED_HOME = "/home/example-user/.config/brigade/secret.env"
 PLANTED_ABS_HOME = "/home/someuser"
+PLANTED_WIN_HOME = r"C:\Users\win-user"
+PLANTED_WIN_HOME_FWD = "C:/Users/win-user"
+PLANTED_DOUBLE_SLASH_HOME = "/home//alice"
+PLANTED_SPACED_HOME = "/Users/John Smith"
+PLANTED_APOSTROPHE_HOME = "/home/o'brien"
 PLANTED_VISIBLE = "planted-visible-marker"
-PLANTED_TASK = f"inspect {PLANTED_VISIBLE} under {PLANTED_ABS_HOME}/project/task"
+PLANTED_TASK = (
+    f"inspect {PLANTED_VISIBLE} under {PLANTED_ABS_HOME}/project/task "
+    f"{PLANTED_WIN_HOME}\\x {PLANTED_WIN_HOME_FWD}/x "
+    f"{PLANTED_DOUBLE_SLASH_HOME}/x {PLANTED_SPACED_HOME}/x "
+    f"{PLANTED_APOSTROPHE_HOME}/x"
+)
 PLANTED_ERROR = f"run error in {PLANTED_ABS_HOME}/project/error.py"
 PLANTED_ABS_COMMAND = f"{PLANTED_ABS_HOME}/.venv/bin/pytest -q planted-verify"
 PLANTED_ABS_FAILURE = f"worker failed in {PLANTED_ABS_HOME}/project/src/module.py"
@@ -68,8 +80,22 @@ PLANTED_NEEDLES = (
     PLANTED_EVENT_METHOD,
     PLANTED_EVENT_ITEM_TYPE,
     UNEXPECTED_CONTRACT_VALUE,
+    PLANTED_WIN_HOME,
+    PLANTED_WIN_HOME_FWD,
+    PLANTED_DOUBLE_SLASH_HOME,
+    PLANTED_SPACED_HOME,
+    PLANTED_APOSTROPHE_HOME,
 )
-HOME_PREFIX_MARKERS = ("/home/", "/Users/")
+HOME_PREFIX_MARKERS = ("/home/", "/Users/", "C:\\Users\\", "C:/Users/")
+# Leftovers the pre-#1064 regex left behind, plus Windows/double-slash usernames.
+HOME_LEAK_FRAGMENTS = (
+    "C:\\Users\\",
+    "C:/Users/",
+    "/home//",
+    " Smith/",
+    "'brien",
+    "win-user",
+)
 FORBIDDEN_KEYS = frozenset(
     {
         "env",
@@ -110,12 +136,14 @@ def _walk_payload(value: object):
 
 
 def _assert_no_home_prefix(value: object) -> None:
-    """Walk every key and value; no `/home/<user>` or `/Users/<user>` prefix may remain."""
+    """Walk every key and value; no home prefix or regex-edge leftover may remain."""
     for item in _walk_payload(value):
         if not isinstance(item, str):
             continue
         for marker in HOME_PREFIX_MARKERS:
             assert marker not in item, f"home-prefix leaked into contract field: {item!r}"
+        for fragment in HOME_LEAK_FRAGMENTS:
+            assert fragment not in item, f"home-prefix fragment leaked into contract field: {item!r}"
 
 
 def _assert_allowlist(payload: object) -> None:
@@ -139,6 +167,9 @@ def _assert_raw_clean(raw: str) -> None:
     assert UNEXPECTED_CONTRACT_KEY not in raw
     for marker in HOME_PREFIX_MARKERS:
         assert marker not in raw, f"home-prefix leaked into JSON text: {marker!r}"
+    for fragment in HOME_LEAK_FRAGMENTS:
+        assert fragment not in raw, f"home-prefix fragment leaked into JSON text: {fragment!r}"
+    assert json.dumps(PLANTED_WIN_HOME)[1:-1] not in raw
 
 
 def _plant_sensitive_run(run_dir: Path, *, task: str = PLANTED_TASK) -> None:
@@ -196,7 +227,7 @@ def _plant_sensitive_run(run_dir: Path, *, task: str = PLANTED_TASK) -> None:
             "orchestrator": "chef",
             "max_workers": 1,
             "timeout_seconds": 60.0,
-            "allow_models": ["codex", PLANTED_ALLOW_MODEL],
+            "allow_models": ["codex", PLANTED_ALLOW_MODEL, f"{PLANTED_DOUBLE_SLASH_HOME}/models/custom"],
             "agents": {
                 "chef": {
                     "cli": "codex",
@@ -211,7 +242,12 @@ def _plant_sensitive_run(run_dir: Path, *, task: str = PLANTED_TASK) -> None:
     )
     _write_json(
         run_dir / "plan.json",
-        {"assignments": [{"stage": 1, "worker": "coder", "task": PLANTED_PLAN_TASK}]},
+        {
+            "assignments": [
+                {"stage": 1, "worker": "coder", "task": PLANTED_PLAN_TASK},
+                {"stage": 2, "worker": "reviewer", "task": f"plan {PLANTED_SPACED_HOME}/project/plan.py"},
+            ]
+        },
     )
     _write_json(
         run_dir / "worker-results.json",
@@ -231,7 +267,13 @@ def _plant_sensitive_run(run_dir: Path, *, task: str = PLANTED_TASK) -> None:
                         "class": "tool",
                         "detail": PLANTED_WORKER_FAILURE,
                     },
-                }
+                },
+                {
+                    "worker": "reviewer",
+                    "task": f"review {PLANTED_APOSTROPHE_HOME}/project/worker.py",
+                    "ok": True,
+                    "detail": f"reviewed {PLANTED_APOSTROPHE_HOME}/project/out.py",
+                },
             ],
             "ground_truth": {
                 "available": True,
@@ -247,7 +289,17 @@ def _plant_sensitive_run(run_dir: Path, *, task: str = PLANTED_TASK) -> None:
                                 "command": PLANTED_ABS_COMMAND,
                                 "exit_code": 0,
                                 "duration_seconds": 1.4,
-                            }
+                            },
+                            {
+                                "command": rf"{PLANTED_WIN_HOME}\.venv\bin\pytest -q planted-win",
+                                "exit_code": 0,
+                                "duration_seconds": 0.4,
+                            },
+                            {
+                                "command": f"{PLANTED_WIN_HOME_FWD}/.venv/bin/pytest -q planted-win-fwd",
+                                "exit_code": 0,
+                                "duration_seconds": 0.3,
+                            },
                         ],
                     }
                 ],
@@ -388,8 +440,14 @@ def _assert_artifacts_keep_home_needles(run_dir: Path) -> None:
         PLANTED_ABS_FINAL,
         PLANTED_BRIEF_PATH,
         PLANTED_EVENT_METHOD,
+        PLANTED_WIN_HOME,
+        PLANTED_WIN_HOME_FWD,
+        PLANTED_DOUBLE_SLASH_HOME,
+        PLANTED_SPACED_HOME,
+        PLANTED_APOSTROPHE_HOME,
     ):
-        assert needle in disk_text, f"artifact lost planted home path: {needle!r}"
+        escaped = json.dumps(needle)[1:-1]
+        assert needle in disk_text or escaped in disk_text, f"artifact lost planted home path: {needle!r}"
 
 
 def test_json_contracts_omit_planted_env_secret_home_and_prompt(tmp_path, capsys):
@@ -467,6 +525,11 @@ def test_json_contracts_omit_planted_env_secret_home_and_prompt(tmp_path, capsys
     assert PLANTED_ABS_COMMAND in human
     assert PLANTED_ABS_FINAL in human
     assert PLANTED_ABS_HOME in human
+    assert PLANTED_WIN_HOME in human
+    assert PLANTED_WIN_HOME_FWD in human
+    assert PLANTED_DOUBLE_SLASH_HOME in human
+    assert PLANTED_SPACED_HOME in human
+    assert PLANTED_APOSTROPHE_HOME in human
     _assert_artifacts_keep_home_needles(run_dir)
 
 
@@ -669,3 +732,19 @@ def test_human_list_and_show_remain_text_when_json_omitted(tmp_path, capsys):
     shown = capsys.readouterr().out
     assert shown.startswith(f"run: {run_dir.resolve()}")
     assert "brigade.run-detail.v1" not in shown
+
+
+def test_allowlisted_rejects_allowlist_key_without_cleaned_counterpart():
+    """An allowlist key with no cleaned overlay cannot pass a raw source value."""
+    source = {"task": "raw-task", "secret": "raw-secret"}
+    cleaned = {"task": "clean-task"}
+    with pytest.raises(AssertionError, match="cleaned counterpart"):
+        runs_cmd._allowlisted(
+            runs_cmd._merge_source(source, cleaned),
+            frozenset({"task", "secret"}),
+        )
+    payload = runs_cmd._allowlisted(
+        runs_cmd._merge_source(source, {**cleaned, "secret": None}),
+        frozenset({"task", "secret"}),
+    )
+    assert payload == {"task": "clean-task"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

JSON run contracts now redact Windows `C:\Users\<name>\` / `C:/Users/<name>/` home prefixes and the POSIX regex edges (`/home//alice`, `/Users/John Smith`, `/home/o'brien`) at the existing `_clean_str` chokepoint. An allowlist key without a cleaned counterpart can no longer pass a raw source value. Docs describe that universal rule instead of naming only `failure.detail` and `commands[].command`.

Closes #1064

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [x] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] `pytest -q tests/test_runs_json_contracts.py` passes locally (12 passed)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages

## Notes

- Redaction stays the last transform inside `_clean_str`. No per-field patches.
- Revert-check: restoring `r"/(?:home|Users)/[^/\s\"']+"` fails the new needles (`C:\Users\win-user` leak, `C:~/x`, `/home//alice`, `~ Smith/`, `~'brien/`).
- `PLANTED_TASK` stays at 155 characters so list JSON (`_LIST_TASK_LIMIT` 160) is not truncated.

[Contracts suite green](https://cursor.com/agents/bc-0c31939e-a6a2-4786-8aca-017ddec46e55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fruns_json_contracts_pytest.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c31939e-a6a2-4786-8aca-017ddec46e55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c31939e-a6a2-4786-8aca-017ddec46e55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

