### PR TITLE
feat(center): rebuild Status view on Memory Operations baseline (Fixes #972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The center dashboard Status view now answers "What needs my attention across handoffs, memory care, verify loop, and inbox hygiene right now?" with a plain-sentence summary strip and health tiles (icon + plain word: OK / ATTENTION / MISSING / TIMED OUT, never color alone), following the Memory Operations baseline. Raw ids move into `<details>` expanders, the placeholder rows for latest verify receipt/signal are dropped, and missing brief sections render as readable MISSING tiles instead of `-` table rows. Refs #972.
+
 ### Security
 - `brigade runs list --json` and the Run View `GET /api/runs` list now drop a child directory that is a symlink, or whose `resolve()` leaves the runs root, and count it in `skipped_invalid`. Per-run serve routes already 404 those ids; the shared collector did not, so a symlink alias could leak out-of-root task text in the list while its detail route 404'd. Refs #631.
 - Scanner lifecycle rewrites now require the verifier-held run proof, `before.source == scanner.source`, and a legal `pending → dismissed` transition. A replacement row is applied as that narrow action, so a matching built-in scanner cannot dismiss another source's finding, resurrect a dismissed row, or assign an arbitrary status. Fixes #1039.

--- a/src/brigade/center_cmd/dashboard/views/status_grid.py
+++ b/src/brigade/center_cmd/dashboard/views/status_grid.py
@@ -1,4 +1,11 @@
-"""Status grid dashboard view (stub)."""
+"""Status dashboard view: what needs my attention across handoffs, memory
+care, verify loop, and inbox hygiene right now?
+
+Follows the Memory Operations baseline: a plain-sentence summary strip plus
+health tiles whose chips pair an icon with a plain-word status (never color
+alone). Raw ids stay in ``<details>`` expanders. Missing or slow sub-fetches
+degrade to readable tiles rather than an empty table.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +17,23 @@ from brigade.center_cmd.dashboard import render as html
 NAME = "status"
 TITLE = "Status"
 ORDER = 1
+
+# Status palette (dataviz reserved): always paired with icon + word, never color alone.
+_STATUS_GOOD = "#0ca30c"
+_STATUS_WARNING = "#fab219"
+_STATUS_SERIOUS = "#ec835a"
+_TEXT_PRIMARY = "#0b0b0b"
+_TEXT_SECONDARY = "#52514e"
+_SURFACE = "#fcfcfb"
+_BORDER = "rgba(11,11,11,0.10)"
+
+_TILES = (
+    ("handoff_issues", "Handoffs"),
+    ("memory_care", "Memory care"),
+    ("outcome_loop", "Verify loop"),
+    ("inbox_hygiene", "Inbox hygiene"),
+    ("pending_tasks", "Pending tasks"),
+)
 
 
 def fetch(target: Path) -> dict:
@@ -23,30 +47,12 @@ def render(payload: dict, nonce: str) -> str:
     if not payload:
         return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
 
-    handoff_issues = _section(payload, "handoff_issues")
-    memory_care = _section(payload, "memory_care")
-    outcome_loop = _section(payload, "outcome_loop")
-    inbox_hygiene = _section(payload, "inbox_hygiene")
-    pending_tasks = payload.get("pending_tasks")
-
-    rows = [
-        ("Pending handoff issues", _value(handoff_issues, "count")),
-        ("Total handoff issues", _value(handoff_issues, "total_count")),
-        ("Memory cards at refresh risk", _value(memory_care, "issue_count")),
-        # work brief does not currently emit the latest receipt or signal.
-        ("Latest verify receipt", "-"),
-        ("Latest verify signal", "-"),
-        ("Verify runs", _value(outcome_loop, "verify_run_count")),
-        ("Outcome records", _value(outcome_loop, "record_count")),
-        ("Eligible outcome receipts", _value(outcome_loop, "eligible_receipt_count")),
-        ("Open work-inbox items", len(pending_tasks) if isinstance(pending_tasks, list) else "-"),
-        ("Inbox hygiene issues", _value(inbox_hygiene, "issue_count")),
+    parts = [
+        _stylesheet(),
+        _summary_strip(payload),
+        html.panel(html.esc(TITLE), _health_tiles(payload)),
     ]
-    escaped_rows = [[html.esc(label), html.esc(value)] for label, value in rows]
-    return html.panel(
-        html.esc(TITLE),
-        html.table([html.esc("Signal"), html.esc("Value")], escaped_rows),
-    )
+    return "".join(parts)
 
 
 def _section(payload: dict, name: str) -> dict:
@@ -54,6 +60,268 @@ def _section(payload: dict, name: str) -> dict:
     return value if isinstance(value, dict) else {}
 
 
-def _value(section: dict, name: str) -> object:
+def _int(section: dict, name: str) -> int | None:
     value = section.get(name)
-    return "-" if value is None else value
+    return value if isinstance(value, int) else None
+
+
+def _pending_task_count(payload: dict) -> int | None:
+    tasks = payload.get("pending_tasks")
+    return len(tasks) if isinstance(tasks, list) else None
+
+
+def _tile_counts(payload: dict, key: str) -> tuple[int | None, dict]:
+    """Headline count + raw section for a tile; missing keys degrade, never raise."""
+    if key == "handoff_issues":
+        section = _section(payload, key)
+        count = _int(section, "count")
+        return (_int(section, "total_count") if count is None else count), section
+    if key == "memory_care":
+        section = _section(payload, key)
+        return _int(section, "issue_count"), section
+    if key == "inbox_hygiene":
+        section = _section(payload, key)
+        return _int(section, "issue_count"), section
+    if key == "outcome_loop":
+        section = _section(payload, key)
+        runs = _int(section, "verify_run_count")
+        records = _int(section, "record_count")
+        if runs is not None:
+            return runs, section
+        return records, section
+    if key == "pending_tasks":
+        return _pending_task_count(payload), {}
+    return None, {}
+
+
+def _status_word(section: dict, count: int | None) -> str:
+    """Plain operator word for a chip: OK / ATTENTION / MISSING / TIMED OUT."""
+    if bool(section.get("timed_out")):
+        return "TIMED OUT"
+    if count is None:
+        return "MISSING"
+    return "ATTENTION" if count > 0 else "OK"
+
+
+def _status_role(word: str) -> tuple[str, str, str]:
+    """Map a plain status word to (role, icon, color); never color alone."""
+    if word == "OK":
+        return ("good", "\u2713", _STATUS_GOOD)
+    if word == "TIMED OUT":
+        return ("serious", "!", _STATUS_SERIOUS)
+    if word == "MISSING":
+        return ("serious", "?", _STATUS_SERIOUS)
+    return ("warning", "!", _STATUS_WARNING)
+
+
+def _plural(n: int, one: str, many: str) -> str:
+    noun = one if n == 1 else many
+    return f"{n} {noun}"
+
+
+def _top_issue_detail(section: dict) -> str:
+    top = section.get("top_issue") if isinstance(section.get("top_issue"), dict) else {}
+    detail = str(top.get("detail") or "").strip()
+    return detail
+
+
+def _tile_meaning(key: str, section: dict, count: int | None) -> str:
+    if key == "handoff_issues":
+        if count is None:
+            return "Handoff issue counts are not available."
+        known = _int(section, "known_count")
+        suffix = ""
+        if isinstance(known, int) and known > 0:
+            suffix = f" {_plural(known, 'known issue', 'known issues')} already tracked."
+        if count <= 0:
+            return "No new handoff issues." + suffix
+        return f"{_plural(count, 'new handoff issue needs', 'new handoff issues need')} review.{suffix}"
+    if key == "memory_care":
+        if count is None:
+            return "Memory-care health is not available."
+        if count <= 0:
+            return "No memory cards are waiting on care."
+        base = f"{_plural(count, 'card needs', 'cards need')} memory care."
+        detail = _top_issue_detail(section)
+        return f"{base} Top issue: {detail}." if detail else base
+    if key == "outcome_loop":
+        if count is None:
+            return "Verify-loop counts are not available."
+        eligible = _int(section, "eligible_receipt_count")
+        ineligible = _int(section, "ineligible_receipt_count")
+        if isinstance(eligible, int) and isinstance(ineligible, int) and eligible + ineligible > 0:
+            rate = ineligible * 100 // (eligible + ineligible)
+            return f"{_plural(count, 'verify run', 'verify runs')}; {rate}% of receipts were ineligible."
+        return f"{_plural(count, 'verify run', 'verify runs')} recorded."
+    if key == "inbox_hygiene":
+        if count is None:
+            return "Inbox hygiene status is not available."
+        if count <= 0:
+            return "The work inbox is clean."
+        base = f"{_plural(count, 'inbox hygiene issue found', 'inbox hygiene issues found')}."
+        detail = _top_issue_detail(section)
+        return f"{base} Top issue: {detail}." if detail else base
+    if key == "pending_tasks":
+        if count is None:
+            return "Task ledger state is not available."
+        if count <= 0:
+            return "No pending tasks."
+        return f"{_plural(count, 'task is', 'tasks are')} pending in the ledger."
+    return "See details below."
+
+
+def _raw_details(section: dict) -> str:
+    bits: list[str] = []
+    for sort_key in sorted(section):
+        value = section[sort_key]
+        if isinstance(value, (dict, list)):
+            continue
+        if value not in (None, ""):
+            bits.append(f"{sort_key}={value}")
+    if not bits:
+        return ""
+    return (
+        f'<details class="sg-debug"><summary>{html.esc("Raw signal")}</summary>'
+        f"<code>{html.esc(', '.join(bits))}</code></details>"
+    )
+
+
+def _raw_ids_details(items: list) -> str:
+    ids = [str(t.get("id")) for t in items if isinstance(t, dict) and t.get("id") is not None]
+    if not ids:
+        return ""
+    shown = ", ".join(ids[:10]) + (f", +{len(ids) - 10} more" if len(ids) > 10 else "")
+    return f'<details class="sg-debug"><summary>{html.esc("Raw ids")}</summary><code>{html.esc(shown)}</code></details>'
+
+
+def _health_tiles(payload: dict) -> str:
+    tiles = []
+    for key, label in _TILES:
+        count, section = _tile_counts(payload, key)
+        word = _status_word(section, count)
+        role, icon, color = _status_role(word)
+        meaning = _tile_meaning(key, section, count)
+        debug = ""
+        if key == "pending_tasks":
+            tasks = payload.get("pending_tasks")
+            if isinstance(tasks, list):
+                debug = _raw_ids_details(tasks)
+        elif section:
+            debug = _raw_details(section)
+        tiles.append(
+            f'<article class="sg-tile sg-tile-{html.esc(role)}" data-sg-tile="{html.esc(key)}">'
+            '<div class="sg-tile-head">'
+            '<span class="sg-chip-icon" aria-hidden="true" '
+            f'style="background:{html.esc(color)}">{html.esc(icon)}</span>'
+            f'<span class="sg-tile-label">{html.esc(label)}</span>'
+            f'<span class="sg-chip-word">{html.esc(word)}</span>'
+            "</div>"
+            f'<p class="sg-tile-meaning">{html.esc(meaning)}</p>'
+            f"{debug}"
+            "</article>"
+        )
+    return f'<div class="sg-tiles">{"".join(tiles)}</div>'
+
+
+def _summary_strip(payload: dict) -> str:
+    sentences: list[str] = []
+
+    new_handoffs = _tile_counts(payload, "handoff_issues")[0]
+    if new_handoffs is None:
+        sentences.append("Handoff issue counts are unavailable.")
+    elif new_handoffs > 0:
+        noun = "issue is" if new_handoffs == 1 else "issues are"
+        sentences.append(f"{new_handoffs} new handoff {noun} waiting.")
+    else:
+        sentences.append("No new handoff issues.")
+
+    care_issues = _tile_counts(payload, "memory_care")[0]
+    if care_issues is None:
+        sentences.append("Memory-care health is unavailable.")
+    elif care_issues > 0:
+        noun = "card is" if care_issues == 1 else "cards are"
+        sentences.append(f"{care_issues} {noun} waiting on care review.")
+    else:
+        sentences.append("No cards are waiting on care review.")
+
+    inbox_issues = _tile_counts(payload, "inbox_hygiene")[0]
+    if inbox_issues is None:
+        sentences.append("Inbox hygiene status is unavailable.")
+    elif inbox_issues > 0:
+        noun = "issue is" if inbox_issues == 1 else "issues are"
+        sentences.append(f"The work inbox has {inbox_issues} hygiene {noun} open.")
+    else:
+        sentences.append("The work inbox is clean.")
+
+    body = " ".join(sentences[:3])
+    return (
+        f'<section class="sg-summary" data-sg-summary="1" aria-label="{html.esc("Attention summary")}">'
+        f"<p>{html.esc(body)}</p>"
+        "</section>"
+    )
+
+
+def _stylesheet() -> str:
+    return f"""<style>
+.sg-summary {{
+  margin: 0 0 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid {_BORDER};
+  border-radius: 0.35rem;
+  background: {_SURFACE};
+  color: {_TEXT_PRIMARY};
+}}
+.sg-summary p {{ margin: 0; color: {_TEXT_PRIMARY}; }}
+.sg-tiles {{
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 0.75rem;
+}}
+.sg-tile {{
+  border: 1px solid {_BORDER};
+  border-radius: 0.35rem;
+  padding: 0.75rem;
+  background: {_SURFACE};
+}}
+.sg-tile-head {{
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.35rem;
+  color: {_TEXT_PRIMARY};
+}}
+.sg-tile-label {{
+  font-weight: 600;
+  color: {_TEXT_PRIMARY};
+  flex: 1;
+}}
+.sg-tile-meaning {{
+  margin: 0;
+  color: {_TEXT_SECONDARY};
+  font-size: 0.92rem;
+}}
+.sg-chip-word {{
+  color: {_TEXT_PRIMARY};
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}}
+.sg-chip-icon {{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  color: #fff;
+  font-size: 0.7rem;
+  line-height: 1;
+}}
+.sg-debug {{
+  margin-top: 0.35rem;
+  color: {_TEXT_SECONDARY};
+  font-size: 0.85rem;
+}}
+.sg-debug summary {{ cursor: pointer; color: {_TEXT_SECONDARY}; }}
+.sg-debug code {{ color: {_TEXT_PRIMARY}; word-break: break-word; }}
+</style>"""

--- a/src/brigade/center_cmd/dashboard/views/status_grid.py
+++ b/src/brigade/center_cmd/dashboard/views/status_grid.py
@@ -41,14 +41,13 @@ def fetch(target: Path) -> dict:
 
 
 def render(payload: dict, nonce: str) -> str:
-    del nonce
     if payload.get("error"):
         return html.error_panel(TITLE, str(payload["error"]))
     if not payload:
         return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
 
     parts = [
-        _stylesheet(),
+        _stylesheet(nonce),
         _summary_strip(payload),
         html.panel(html.esc(TITLE), _health_tiles(payload)),
     ]
@@ -248,7 +247,7 @@ def _summary_strip(payload: dict) -> str:
     if inbox_issues is None:
         sentences.append("Inbox hygiene status is unavailable.")
     elif inbox_issues > 0:
-        noun = "issue is" if inbox_issues == 1 else "issues are"
+        noun = "issue" if inbox_issues == 1 else "issues"
         sentences.append(f"The work inbox has {inbox_issues} hygiene {noun} open.")
     else:
         sentences.append("The work inbox is clean.")
@@ -261,8 +260,8 @@ def _summary_strip(payload: dict) -> str:
     )
 
 
-def _stylesheet() -> str:
-    return f"""<style>
+def _stylesheet(nonce: str) -> str:
+    return f"""<style nonce="{html.esc(nonce)}">
 .sg-summary {{
   margin: 0 0 1rem;
   padding: 0.85rem 1rem;

--- a/tests/test_dashboard_status.py
+++ b/tests/test_dashboard_status.py
@@ -38,8 +38,11 @@ def test_render_shows_summary_strip_and_plain_word_tiles():
         "inbox_hygiene": {"issue_count": 1},
     }
 
-    fragment = status_grid.render(payload, "unused")
+    fragment = status_grid.render(payload, "status-nonce")
 
+    # The stylesheet must carry the CSP nonce or the browser refuses it.
+    assert '<style nonce="status-nonce">' in fragment
+    assert "<style>" not in fragment
     assert 'data-sg-summary="1"' in fragment
     assert "new handoff issues are waiting" in fragment
     assert "No cards are waiting on care review" in fragment

--- a/tests/test_dashboard_status.py
+++ b/tests/test_dashboard_status.py
@@ -17,14 +17,22 @@ def test_fetch_uses_work_brief_json(monkeypatch, tmp_path):
     assert calls == [(tmp_path, ["work", "brief"], 60.0)]
 
 
-def test_render_displays_status_signals():
+def test_docstring_states_operator_question():
+    doc = status_grid.__doc__ or ""
+    assert "attention" in doc.lower()
+    for topic in ("handoffs", "memory", "verify loop", "inbox hygiene"):
+        assert topic in doc.lower()
+
+
+def test_render_shows_summary_strip_and_plain_word_tiles():
     payload = {
-        "handoff_issues": {"count": 2, "total_count": 5},
-        "memory_care": {"issue_count": 3},
+        "handoff_issues": {"count": 2, "known_count": 3, "total_count": 5},
+        "memory_care": {"issue_count": 0},
         "outcome_loop": {
             "verify_run_count": 12,
             "record_count": 9,
             "eligible_receipt_count": 7,
+            "ineligible_receipt_count": 1,
         },
         "pending_tasks": [{"id": "task-a"}, {"id": "task-b"}],
         "inbox_hygiene": {"issue_count": 1},
@@ -32,22 +40,34 @@ def test_render_displays_status_signals():
 
     fragment = status_grid.render(payload, "unused")
 
-    assert "Pending handoff issues" in fragment
-    assert "Total handoff issues" in fragment
-    assert "Memory cards at refresh risk" in fragment
-    assert "Latest verify receipt" in fragment
-    assert "Latest verify signal" in fragment
-    assert "Verify runs" in fragment
-    assert "Outcome records" in fragment
-    assert "Open work-inbox items" in fragment
-    assert "Inbox hygiene issues" in fragment
-    for value in ("2", "5", "3", "12", "9", "7", "1"):
-        assert f">{value}<" in fragment
-    assert ">-<" in fragment
+    assert 'data-sg-summary="1"' in fragment
+    assert "new handoff issues are waiting" in fragment
+    assert "No cards are waiting on care review" in fragment
+    assert "The work inbox has" in fragment
+
+    for label in ("Handoffs", "Memory care", "Verify loop", "Inbox hygiene", "Pending tasks"):
+        assert label in fragment
+    # Plain words, never color alone.
+    for word in ("ATTENTION", "OK"):
+        assert word in fragment
+    assert "MISSING" not in fragment
+
+    assert "Raw ids" in fragment
+    assert "task-a" in fragment
+    assert "Latest verify receipt" not in fragment
+    assert "Latest verify signal" not in fragment
+
+
+def test_render_missing_sections_show_missing_tiles():
+    fragment = status_grid.render({"handoff_issues": {"count": 0}}, "unused")
+    assert "MISSING" in fragment
+    assert "not available" in fragment or "unavailable" in fragment
 
 
 def test_render_error_and_empty_payloads_degrade_safely():
-    assert "boom" in status_grid.render({"error": "boom"}, "unused")
+    error_fragment = status_grid.render({"error": "boom"}, "unused")
+    assert "boom" in error_fragment
+    assert "Status" in error_fragment
 
-    fragment = status_grid.render({}, "unused")
-    assert "Nothing here." in fragment
+    empty_fragment = status_grid.render({}, "unused")
+    assert "Nothing here." in empty_fragment


### PR DESCRIPTION
## What and why

Rebuilds the landing-page Status view on the Memory Operations baseline per #972 (the largest remaining contract violation from the #904 coherence audit):

- Operator-question docstring: "What needs my attention across handoffs, memory care, verify loop, and inbox hygiene right now?"
- Plain-sentence summary strip + five tiles (Handoffs, Memory care, Verify loop, Inbox hygiene, Pending tasks) with icon + plain-word chips (OK / ATTENTION / MISSING / TIMED OUT, never color alone), `<details>` expanders for raw values and ids.
- Placeholder "Latest verify receipt/signal" rows dropped (no briefing.py changes; receipt backfill stays out of scope per the issue).
- Degraded paths kept readable: `{"error":...}` -> error panel, `{}` -> empty state, missing section keys -> MISSING tiles.

Single-view change: `status_grid.py`, its test file, CHANGELOG. The 60s work-brief timeout remains #902's scope.

## Verification

`pytest tests/test_dashboard_status.py tests/test_center_dashboard.py tests/test_center_page_load.py -q` -> 59 passed (Brigade receipt `20260821-183633-work-verify-69f2e0`). Ruff clean on touched files.

Implemented by the Ox Alpha worker seat from the verified center v3 scope; independent probe review to follow before merge.