### PR TITLE
feat(center): Runs view summary strip, primary-column swap, relative time (Fixes #974)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Runs dashboard view answers "what verification ran recently, did it pass, and what command was it?" with a summary strip ("N runs this week, M failed, last run Xh ago"), a primary column of command (task for Brigade runs) with a pass/fail chip, Run ID demoted into a `<details>` expander, and relative timestamps ("3h ago"; future stamps render as "just now", unparseable ones as "unknown age"). Refs #974.
 - The center dashboard Status view now answers "What needs my attention across handoffs, memory care, verify loop, and inbox hygiene right now?" with a plain-sentence summary strip and health tiles (icon + plain word: OK / ATTENTION / MISSING / TIMED OUT, never color alone), following the Memory Operations baseline. Raw ids move into `<details>` expanders, the placeholder rows for latest verify receipt/signal are dropped, and missing brief sections render as readable MISSING tiles instead of `-` table rows. Refs #972.
 
 ### Security

--- a/src/brigade/center_cmd/dashboard/views/run_timeline.py
+++ b/src/brigade/center_cmd/dashboard/views/run_timeline.py
@@ -1,5 +1,7 @@
 """Run timeline dashboard view.
 
+Operator question answered here: what verification ran recently, did it pass, and what command was it?
+
 Renders Brigade orchestration runs from the versioned ``brigade.runs-list.v1``
 CLI contract (issue #631) alongside the existing verify-run receipts. Data
 access stays CLI-owned; this module never reads run artifacts directly.
@@ -8,6 +10,7 @@ access stays CLI-owned; this module never reads run artifacts directly.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from brigade.center_cmd.dashboard import data
@@ -34,7 +37,99 @@ def fetch(target: Path) -> dict:
 def render(payload: dict, nonce: str) -> str:
     brigade_payload = payload.get("brigade") if isinstance(payload.get("brigade"), dict) else {}
     verify_payload = payload.get("verify") if isinstance(payload.get("verify"), dict) else {}
-    return _render_brigade_panel(brigade_payload) + _render_verify_panel(verify_payload, nonce)
+    strip = _summary_strip(brigade_payload, verify_payload)
+    return strip + _render_brigade_panel(brigade_payload) + _render_verify_panel(verify_payload, nonce)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _relative_time(value: object) -> str:
+    parsed = _parse_ts(value)
+    if parsed is None:
+        return "unknown age"
+    delta = _now() - parsed
+    if delta.total_seconds() < 0:
+        # Clock skew: a future stamp is treated as effectively current.
+        return "just now"
+    seconds = int(delta.total_seconds())
+    if seconds < 60:
+        return "just now"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 48:
+        return f"{hours}h ago"
+    return f"{hours // 24}d ago"
+
+
+def _chip(status: object) -> str:
+    failed = str(status or "").strip().lower() in {"failed", "error", "failing"}
+    label = "fail" if failed else "pass"
+    css = "mo-chip-fail" if failed else "mo-chip-pass"
+    return f'<span class="mo-chip {css}">{html.esc(label)}</span>'
+
+
+def _runs_of(payload: dict, key: str) -> list[dict]:
+    runs = payload.get(key)
+    if not isinstance(runs, list):
+        return []
+    return [run for run in runs if isinstance(run, dict)]
+
+
+def _week_start(now: datetime) -> datetime:
+    # Monday 00:00 local server time of the dashboard host.
+    local = now.astimezone()
+    start = local - timedelta(days=local.weekday())
+    return start.replace(hour=0, minute=0, second=0, microsecond=0).astimezone(timezone.utc)
+
+
+def _summary_strip(brigade_payload: dict, verify_payload: dict) -> str:
+    all_runs = _runs_of(brigade_payload, "runs") + _runs_of(verify_payload, "runs")
+    week_start = _week_start(_now())
+    this_week = 0
+    failed = 0
+    stamps: list[tuple[datetime, bool]] = []
+    for run in all_runs:
+        status = str(run.get("status") or "").strip().lower() in {"failed", "error", "failing"}
+        if status:
+            failed += 1
+        parsed = _parse_ts(run.get("started_at"))
+        stamps.append((parsed, status))
+        if parsed is not None and parsed >= week_start:
+            this_week += 1
+    last_run = "unknown age"
+    known = [parsed for (parsed, _) in stamps if parsed is not None]
+    if known:
+        last_run = _relative_time(max(known).isoformat())
+    elif all_runs:
+        last_run = "unknown age"
+    else:
+        last_run = "n/a"
+    summary = f"{this_week} runs this week, {failed} failed, last run {last_run}."
+    return f'<div class="mo-summary">{html.esc(summary)}</div>'
+
+
+def _run_id_details(run_id: object) -> str:
+    rendered = html.esc(str(run_id))
+    return f"<details><summary>Run ID</summary><code>{rendered}</code></details>"
 
 
 def _render_brigade_panel(payload: dict) -> str:
@@ -55,14 +150,13 @@ def _render_brigade_panel(payload: dict) -> str:
             continue
         rows.append(
             [
-                html.esc(_value(run, "run_id")),
-                html.esc(_value(run, "status")),
-                html.esc(_value(run, "task")),
-                html.esc(_value(run, "started_at")),
+                f"{_chip(run.get('status'))} {html.esc(_value(run, 'task'))}",
+                html.esc(_relative_time(run.get("started_at"))),
                 html.esc(_value(run, "duration_seconds")),
                 html.esc(_value(run, "failure_phase")),
                 html.esc(_value(run, "mode")),
                 html.esc("yes" if run.get("resume_available") else "no"),
+                _run_id_details(_value(run, "run_id")),
             ]
         )
     if not rows:
@@ -70,14 +164,13 @@ def _render_brigade_panel(payload: dict) -> str:
 
     table = html.table(
         [
-            html.esc("Run ID"),
-            html.esc("Status"),
             html.esc("Task"),
             html.esc("Started"),
             html.esc("Duration"),
             html.esc("Failure phase"),
             html.esc("Mode"),
             html.esc("Resume"),
+            html.esc("Run ID"),
         ],
         rows,
     )
@@ -110,13 +203,12 @@ def _render_verify_panel(payload: dict, nonce: str) -> str:
         command_records = commands if isinstance(commands, list) else []
         rows.append(
             [
-                html.esc(_value(receipt, "run_id")),
-                html.esc(_value(receipt, "status")),
-                html.esc(_command_values(command_records, "command")),
+                f"{_chip(receipt.get('status'))} {html.esc(_command_values(command_records, 'command'))}",
                 html.esc(_command_values(command_records, "exit_code")),
                 html.esc(_value(receipt, "duration_seconds")),
-                html.esc(_value(receipt, "started_at")),
+                html.esc(_relative_time(receipt.get("started_at"))),
                 _receipt_details(receipt),
+                _run_id_details(_value(receipt, "run_id")),
             ]
         )
 
@@ -125,13 +217,12 @@ def _render_verify_panel(payload: dict, nonce: str) -> str:
 
     table = html.table(
         [
-            html.esc("Run ID"),
-            html.esc("Status"),
             html.esc("Command"),
             html.esc("Exit code"),
             html.esc("Duration"),
             html.esc("Timestamp"),
             html.esc("Receipt"),
+            html.esc("Run ID"),
         ],
         rows,
     )
@@ -177,6 +268,25 @@ def _receipt_details(receipt: dict) -> str:
 
 def _stylesheet(nonce: str) -> str:
     return f"""<style nonce="{html.esc(nonce)}">
+.mo-summary {{
+  font: inherit;
+  margin: 0 0 0.75rem;
+}}
+.mo-chip {{
+  display: inline-block;
+  padding: 0.05rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid #666;
+  font-size: 0.85em;
+}}
+.mo-chip-pass {{
+  color: #0a5c0a;
+  border-color: #0a5c0a;
+}}
+.mo-chip-fail {{
+  color: #8a1010;
+  border-color: #8a1010;
+}}
 .mo-pager {{
   display: flex;
   flex-wrap: wrap;

--- a/tests/test_dashboard_runs.py
+++ b/tests/test_dashboard_runs.py
@@ -1,7 +1,12 @@
 import re
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from brigade.center_cmd.dashboard.views import run_timeline
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def test_fetch_uses_runs_list_and_verify_runs_contracts(monkeypatch, tmp_path):
@@ -35,6 +40,12 @@ def test_fetch_uses_runs_list_and_verify_runs_contracts(monkeypatch, tmp_path):
     assert limit >= 50
 
 
+def test_docstring_answers_operator_question():
+    assert "what verification ran recently" in run_timeline.__doc__.lower()
+    assert "did it pass" in run_timeline.__doc__.lower()
+    assert "command" in run_timeline.__doc__.lower()
+
+
 def test_render_brigade_runs_from_versioned_list_contract():
     payload = {
         "brigade": {
@@ -59,12 +70,17 @@ def test_render_brigade_runs_from_versioned_list_contract():
     fragment = run_timeline.render(payload, "unused")
 
     assert "Brigade runs" in fragment
-    assert "20260101-090000-aaaa" in fragment
     assert "dispatch" in fragment
     assert "read-only" in fragment
     assert "Skipped 2 invalid run directories." in fragment
     assert "build the &lt;thing&gt;" in fragment
     assert "<thing>" not in fragment
+    # Primary column is task + chip; Run ID demoted into a details expander.
+    assert 'class="mo-chip mo-chip-fail">fail</span> build the &lt;thing&gt;' in fragment
+    assert "<details><summary>Run ID</summary><code>20260101-090000-aaaa</code></details>" in fragment
+    first_row = re.search(r"<tr data-mo-row=\"1\">.*?</tr>", fragment, re.DOTALL)
+    assert first_row is None  # brigade panel rows carry no pager hook
+    assert fragment.index("build the &lt;thing&gt;") < fragment.index("<summary>Run ID</summary>")
 
 
 def test_render_brigade_runs_error_is_empty_state_with_diagnostic():
@@ -108,10 +124,13 @@ def test_render_lists_verify_runs_newest_first_with_bounded_receipts():
     fragment = run_timeline.render(payload, "unused")
 
     assert fragment.index("run-late") < fragment.index("run-early")
-    for heading in ("Run ID", "Status", "Command", "Exit code", "Duration", "Timestamp"):
+    for heading in ("Command", "Exit code", "Duration", "Timestamp", "Receipt"):
         assert f"<th>{heading}</th>" in fragment
     assert "<details>" in fragment
     assert "<summary>Receipt JSON</summary>" in fragment
+    # Primary column is command + chip; Run ID demoted into its own expander.
+    assert 'class="mo-chip mo-chip-pass">pass</span> fake check &amp;lt;safe&amp;gt;' in fragment
+    assert "<details><summary>Run ID</summary><code>run-late</code></details>" in fragment
     assert "&amp;lt;safe&amp;gt;" in fragment
     assert "Receipt truncated at 4000 characters." in fragment
     assert "x" * 4_001 not in fragment
@@ -125,7 +144,7 @@ def test_render_error_and_empty_payloads_degrade_safely():
     assert "Nothing here." in run_timeline.render({"verify": {"runs": []}, "brigade": {"runs": []}}, "unused")
 
 
-def test_render_paginates_with_prior_next_like_memory_inventory():
+def test_render_paginates_with_prior_next_like_memory_inventory(monkeypatch):
     runs = []
     for index in range(55):
         runs.append(
@@ -152,3 +171,96 @@ def test_render_paginates_with_prior_next_like_memory_inventory():
     assert 'data-mo-row="1"' in fragment
     assert "check-0000" in fragment
     assert "check-0054" in fragment
+
+
+def test_summary_strip_counts_week_runs_failures_and_last_run(monkeypatch):
+    now = datetime(2026, 8, 21, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(run_timeline, "_now", lambda: now)
+    week_run = now - timedelta(hours=3)
+    old_run = now - timedelta(days=14)
+    payload = {
+        "brigade": {
+            "schema": "brigade.runs-list.v1",
+            "runs": [
+                {
+                    "run_id": "b-week",
+                    "status": "failed",
+                    "task": "week task",
+                    "started_at": _iso(week_run),
+                },
+                {
+                    "run_id": "b-old",
+                    "status": "completed",
+                    "task": "old task",
+                    "started_at": _iso(old_run),
+                },
+            ],
+        },
+        "verify": {
+            "runs": [
+                {
+                    "run_id": "v-week",
+                    "status": "completed",
+                    "started_at": _iso(now - timedelta(minutes=10)),
+                    "commands": [{"command": "fake check", "exit_code": 0}],
+                }
+            ]
+        },
+    }
+
+    fragment = run_timeline.render(payload, "unused")
+
+    assert "2 runs this week, 1 failed, last run 10m ago." in fragment
+
+
+def test_summary_strip_counts_unparseable_stamps_as_unknown_age(monkeypatch):
+    now = datetime(2026, 8, 21, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(run_timeline, "_now", lambda: now)
+    payload = {
+        "brigade": {"schema": "brigade.runs-list.v1", "runs": []},
+        "verify": {"runs": [{"run_id": "v-bad", "status": "completed", "started_at": "not-a-timestamp"}]},
+    }
+
+    fragment = run_timeline.render(payload, "unused")
+
+    assert "0 runs this week, 0 failed, last run unknown age." in fragment
+    assert "<td>unknown age</td>" in fragment
+
+
+def test_relative_time_renders_hours_ago_and_future_skew_as_just_now(monkeypatch):
+    now = datetime.now(timezone.utc)
+    monkeypatch.setattr(run_timeline, "_now", lambda: now)
+    assert run_timeline._relative_time(None) == "unknown age"
+    assert run_timeline._relative_time("garbage") == "unknown age"
+    hours_ago = _iso(now - timedelta(hours=3))
+    minutes_ago = _iso(now - timedelta(minutes=5))
+    days_ago = _iso(now - timedelta(days=3))
+    future = _iso(now + timedelta(minutes=30))
+    assert run_timeline._relative_time(hours_ago) == "3h ago"
+    assert run_timeline._relative_time(minutes_ago) == "5m ago"
+    assert run_timeline._relative_time(days_ago) == "3d ago"
+    # Future stamps (clock skew) render as just now.
+    assert run_timeline._relative_time(future) == "just now"
+
+
+def test_render_timestamps_use_relative_time_in_rows(monkeypatch):
+    now = datetime(2026, 8, 21, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(run_timeline, "_now", lambda: now)
+    payload = {
+        "brigade": {"schema": "brigade.runs-list.v1", "runs": []},
+        "verify": {
+            "runs": [
+                {
+                    "run_id": "v-rel",
+                    "status": "completed",
+                    "started_at": _iso(now - timedelta(hours=2)),
+                    "commands": [{"command": "fake check", "exit_code": 0}],
+                }
+            ]
+        },
+    }
+
+    fragment = run_timeline.render(payload, "unused")
+
+    assert "<td>2h ago</td>" in fragment
+    assert "<td>2026" not in fragment


### PR DESCRIPTION
## What and why

Closes the remaining #974 coherence gaps on the Runs dashboard view (pagination already landed separately; the runs list/run-detail JSON contracts are #958 and out of scope):

- Operator-question docstring: "What verification ran recently, did it pass, and what command was it?"
- Summary strip: "N runs this week, M failed, last run Xh ago."
- Primary column swapped from raw Run ID to command (task for the Brigade-runs panel) + pass/fail chip; Run ID demoted into a `<details>` expander.
- Relative timestamps ("3h ago"); future stamps render "just now", unparseable ones "unknown age" (never silently dropped).

Single view: `run_timeline.py` + test + CHANGELOG. The client-side pager's `tr[data-mo-row]` hook and single-`.mo-pager` selector are preserved (the column reorder keeps the string-replacement anchor intact).

## Verification

`pytest tests/test_dashboard_runs.py tests/test_center_dashboard.py tests/test_center_page_load.py -q` -> 65 passed (Brigade receipt `20260821-185...`). Ruff clean on touched files.

Implemented by the Ox Alpha worker seat from the verified center v3 scope; independent probe review to follow before merge.