### PR TITLE
feat(center): plain-language wave framing + drawn dependency edges on Work view (Fixes #977)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Runs dashboard view answers "what verification ran recently, did it pass, and what command was it?" with a summary strip ("N runs this week, M failed, last run Xh ago"), a primary column of command (task for Brigade runs) with a pass/fail chip, Run ID demoted into a `<details>` expander, and relative timestamps ("3h ago"; future stamps render as "just now", unparseable ones as "unknown age"). Refs #974.
+- The center Work view now labels dispatch waves as plain-language steps (for example `Step 2 of 5 - one task at a time (blocks step 3)`) instead of bare `Wave N`, rewords the Parallel tile to Together / yes-or-no with a sentence about whether ready tasks can start at the same time, and draws a small SVG of `blocks` / `parent-child` edges so "what is blocking what" is visible even when waves are absent. The task list stays. Fixes #977.
 - The center dashboard Status view now answers "What needs my attention across handoffs, memory care, verify loop, and inbox hygiene right now?" with a plain-sentence summary strip and health tiles (icon + plain word: OK / ATTENTION / MISSING / TIMED OUT, never color alone), following the Memory Operations baseline. Raw ids move into `<details>` expanders, the placeholder rows for latest verify receipt/signal are dropped, and missing brief sections render as readable MISSING tiles instead of `-` table rows. Refs #972.
 
 ### Security

--- a/src/brigade/center_cmd/dashboard/views/work.py
+++ b/src/brigade/center_cmd/dashboard/views/work.py
@@ -1,7 +1,7 @@
 """Work dashboard view.
 
-Operator question: what can run right now, what is claimed or wedged, and
-what just happened?
+Operator question: what can I dispatch, in what order, who owns it, and
+what is blocking what?
 
 Folds the former Graph, Waves, Claims, and Activity pages into one surface.
 Summary strip in sentences, plain-word tiles, raw IDs in expanders.
@@ -79,6 +79,7 @@ def _ready_body(ready: dict) -> tuple[str, str, str, str]:
         blocked_count = len(blocked_items)
     show_waves = _show_wave_structure(ready)
     summary = _ready_summary(ready_count, blocked_count, show_waves)
+    can_run_together = ready_count > 1 and not show_waves and blocked_count == 0
     tiles = _tiles(
         [
             ("Ready", str(ready_count), "good" if ready_count else "warning", "Tasks that can start now."),
@@ -89,19 +90,24 @@ def _ready_body(ready: dict) -> tuple[str, str, str, str]:
                 "Tasks waiting on another task.",
             ),
             (
-                "Parallel",
-                "yes" if ready_count > 1 and not show_waves and blocked_count == 0 else "no",
-                "good" if ready_count > 1 and not show_waves and blocked_count == 0 else "warning",
-                "Whether the ready set can run at the same time.",
+                "Together",
+                "yes" if can_run_together else "no",
+                "good" if can_run_together else "warning",
+                (
+                    "Ready tasks can start at the same time."
+                    if can_run_together
+                    else "Ready tasks cannot all start at the same time."
+                ),
             ),
         ]
     )
+    diagram = _dependency_diagram(ready)
     if ready_count == 0 and blocked_count == 0:
         body = f"<p>{html.esc('Nothing is ready to run right now.')}</p>"
     elif show_waves:
-        body = _wave_lanes(ready) + _blocked_list(blocked_items)
+        body = _wave_lanes(ready) + _blocked_list(blocked_items) + diagram
     else:
-        body = _plain_task_list(ready_items) + _blocked_list(blocked_items)
+        body = _plain_task_list(ready_items) + _blocked_list(blocked_items) + diagram
     debug = _raw_details("Ready ids and partition", _ready_debug(ready))
     return summary, tiles, body, debug
 
@@ -154,13 +160,17 @@ def _wave_lanes(ready: dict) -> str:
     waves = ready.get("waves")
     if not isinstance(waves, list):
         return _plain_task_list([item for item in (ready.get("ready") or []) if isinstance(item, dict)])
+    valid = [wave for wave in waves if isinstance(wave, dict)]
+    total = len(valid)
     lanes: list[str] = []
-    for wave in waves:
-        if not isinstance(wave, dict):
-            continue
-        index = wave.get("index", 0)
+    for position, wave in enumerate(valid):
+        raw_index = wave.get("index", position)
+        try:
+            index = int(raw_index)
+        except (TypeError, ValueError):
+            index = position
+        heading = _wave_heading(wave, step=index + 1, total=total)
         tasks = _wave_tasks(wave)
-        heading = f"Wave {index}"
         chips = "".join(_task_item(item) for item in tasks) or f"<li>{html.esc('empty wave')}</li>"
         lanes.append(
             f'<section class="wk-lane"><h3 class="wk-lane-title">{html.esc(heading)}</h3>'
@@ -171,11 +181,163 @@ def _wave_lanes(ready: dict) -> str:
     return f'<div class="wk-lanes">{"".join(lanes)}</div>'
 
 
+def _wave_heading(wave: dict, *, step: int, total: int) -> str:
+    exclusive = bool(wave.get("exclusive"))
+    task_count = len(_wave_tasks(wave))
+    if exclusive and task_count <= 1:
+        if step < total:
+            return f"Step {step} of {total} - one task at a time (blocks step {step + 1})"
+        return f"Step {step} of {total} - one task at a time"
+    if exclusive:
+        if step < total:
+            return f"Step {step} of {total} - exclusive (file overlap with later steps)"
+        return f"Step {step} of {total} - exclusive"
+    if task_count > 1:
+        return f"Step {step} of {total} - these can run together"
+    return f"Step {step} of {total} - ready now"
+
+
 def _blocked_list(items: list[dict]) -> str:
     if not items:
         return ""
     rows = "".join(_task_item(item, blocked=True) for item in items)
     return f'<p class="wk-muted">{html.esc("Waiting on a blocker:")}</p><ul class="wk-list">{rows}</ul>'
+
+
+def _dependency_diagram(ready: dict) -> str:
+    edges = wg.dependency_edges(ready)
+    if not edges:
+        return ""
+    nodes = wg.graph_nodes(ready)
+    if not nodes:
+        return ""
+    rows = _diagram_rows(ready, nodes, edges)
+    if not rows:
+        return ""
+
+    box_w = 200
+    box_h = 36
+    gap_x = 24
+    gap_y = 52
+    pad = 24
+    max_cols = max(len(row) for row in rows)
+    width = max(720, pad * 2 + max_cols * box_w + max(0, max_cols - 1) * gap_x)
+    height = pad * 2 + len(rows) * box_h + max(0, len(rows) - 1) * gap_y
+    positions: dict[str, tuple[int, int, int, int]] = {}
+    boxes: list[str] = []
+    for row_index, row in enumerate(rows):
+        count = len(row)
+        row_width = count * box_w + max(0, count - 1) * gap_x
+        start_x = pad if count >= max_cols else max(pad, (width - row_width) // 2)
+        y = pad + row_index * (box_h + gap_y)
+        for col, node in enumerate(row):
+            x = start_x + col * (box_w + gap_x)
+            task_id = str(node.get("id") or "")
+            visible, full = _diagram_label(node)
+            kind = str(node.get("kind") or "other")
+            if kind == "ready":
+                stroke = _STATUS_GOOD
+            elif kind == "blocked":
+                stroke = _STATUS_SERIOUS
+            else:
+                stroke = "#888780"
+            positions[task_id] = (x, y, box_w, box_h)
+            boxes.append(
+                f'<g class="wk-node wk-node-{html.esc(kind)}">'
+                f"<title>{html.esc(full)}</title>"
+                f'<rect x="{x}" y="{y}" width="{box_w}" height="{box_h}" rx="4" '
+                f'fill="{html.esc(_SURFACE)}" stroke="{html.esc(stroke)}" stroke-width="1.5"/>'
+                f'<text x="{x + box_w // 2}" y="{y + 23}" text-anchor="middle" '
+                f'class="wk-svg-label">{html.esc(visible)}</text>'
+                f"</g>"
+            )
+
+    lines: list[str] = []
+    for edge in edges:
+        source = edge["source"]
+        target = edge["target"]
+        if source not in positions or target not in positions:
+            continue
+        sx, sy, sw, sh = positions[source]
+        tx, ty, tw, th = positions[target]
+        x1, y1 = sx + sw // 2, sy + sh
+        x2, y2 = tx + tw // 2, ty
+        edge_type = edge.get("type") or "blocks"
+        verb = "blocks" if edge_type == "blocks" else "leads to"
+        lines.append(
+            f'<g class="wk-edge" data-wk-from="{html.esc(source)}" data-wk-to="{html.esc(target)}" '
+            f'data-wk-type="{html.esc(edge_type)}">'
+            f"<title>{html.esc(f'{source} {verb} {target}')}</title>"
+            f'<path d="M {x1} {y1} L {x2} {y2}" fill="none" stroke="{html.esc(_TEXT_SECONDARY)}" '
+            f'stroke-width="1.5" marker-end="url(#wk-dep-arrow)"/>'
+            f"</g>"
+        )
+    if not lines:
+        return ""
+
+    caption = html.esc("What is blocking what")
+    return (
+        f'<div class="wk-diagram-wrap">'
+        f'<p class="wk-muted">{caption}</p>'
+        f'<svg class="wk-diagram" viewBox="0 0 {width} {height}" width="100%" '
+        f'role="img" aria-label="{caption}">'
+        "<defs>"
+        '<marker id="wk-dep-arrow" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="6" markerHeight="6" orient="auto">'
+        f'<path d="M 0 0 L 10 5 L 0 10 z" fill="{html.esc(_TEXT_SECONDARY)}"/>'
+        "</marker></defs>" + "".join(lines) + "".join(boxes) + "</svg></div>"
+    )
+
+
+def _diagram_rows(ready: dict, nodes: list[dict[str, Any]], edges: list[dict[str, str]]) -> list[list[dict[str, Any]]]:
+    wave_row: dict[str, int] = {}
+    waves = ready.get("waves")
+    if isinstance(waves, list):
+        for wave in waves:
+            if not isinstance(wave, dict):
+                continue
+            raw = wave.get("index", 0)
+            try:
+                rank = int(raw)
+            except (TypeError, ValueError):
+                continue
+            for task in _wave_tasks(wave):
+                task_id = task.get("id")
+                if isinstance(task_id, str) and task_id.strip():
+                    wave_row[task_id] = rank
+
+    by_id = {str(node["id"]): node for node in nodes if isinstance(node.get("id"), str)}
+    rows_map: dict[int, list[dict[str, Any]]] = {}
+    if wave_row:
+        for task_id, rank in wave_row.items():
+            node = by_id.get(task_id)
+            if node is not None:
+                rows_map.setdefault(rank, []).append(node)
+        leftover = [node for node in nodes if str(node["id"]) not in wave_row]
+        extra_start = max(wave_row.values()) + 1
+        leftover_layers = wg.layout_layers(leftover, edges) if leftover else []
+        for offset, layer in enumerate(leftover_layers):
+            if layer:
+                rows_map.setdefault(extra_start + offset, []).extend(layer)
+    else:
+        for offset, layer in enumerate(wg.layout_layers(nodes, edges)):
+            if layer:
+                rows_map.setdefault(offset, []).extend(layer)
+
+    rows: list[list[dict[str, Any]]] = []
+    for key in sorted(rows_map):
+        ordered = sorted(rows_map[key], key=lambda item: str(item.get("id") or ""))
+        if ordered:
+            rows.append(ordered)
+    return rows
+
+
+def _diagram_label(node: dict[str, Any]) -> tuple[str, str]:
+    title = str(node.get("title") or "").strip()
+    task_id = str(node.get("id") or "")
+    full = title or task_id or "Untitled task"
+    visible = full if len(full) <= 28 else f"{full[:25]}..."
+    return visible, full
 
 
 def _task_item(item: dict, *, blocked: bool = False) -> str:
@@ -465,6 +627,13 @@ def _stylesheet(nonce: str) -> str:
   padding: 0.75rem 1rem;
 }}
 .wk-lane-title {{ margin: 0 0 0.5rem; font-size: 0.95rem; }}
+.wk-diagram-wrap {{ overflow-x: auto; max-width: 100%; margin: 0.75rem 0 0; }}
+.wk-diagram {{ display: block; min-height: 120px; }}
+.wk-svg-label {{
+  fill: {_TEXT_PRIMARY};
+  font-size: 12px;
+  font-family: system-ui, sans-serif;
+}}
 .wk-run-ok {{ color: {_STATUS_GOOD}; font-weight: 700; }}
 .wk-run-bad {{ color: {_STATUS_SERIOUS}; font-weight: 700; }}
 .mo-debug {{ margin: 0; font-size: 0.85rem; color: {_TEXT_SECONDARY}; }}

--- a/tests/test_dashboard_work.py
+++ b/tests/test_dashboard_work.py
@@ -119,12 +119,16 @@ def test_independent_single_task_waves_collapse_to_plain_parallel_list():
     assert 'id="ready"' in fragment
     assert "5 tasks are ready and independent" in fragment
     assert "could all run in parallel" in fragment
+    assert ">Together<" in fragment
+    assert "Ready tasks can start at the same time." in fragment
     for title in titles:
         assert title in fragment
     assert "Wave 0" not in fragment
+    assert "Step 1 of 5" not in fragment
     assert "(exclusive)" not in fragment
     assert "file_overlap+symbol_impact" not in fragment.split("<details", 1)[0]
     assert "Parallel-safe partition" not in fragment
+    assert 'class="wk-diagram"' not in fragment
     for task_id in (f"task-{index}" for index in range(5)):
         assert task_id in fragment
         assert "<details" in fragment
@@ -168,8 +172,13 @@ def test_multi_task_wave_keeps_visual_structure():
     assert "Alpha work" in fragment
     assert "Beta work" in fragment
     assert "Gamma work" in fragment
-    assert "Wave 0" in fragment or "wave 0" in fragment.lower()
+    assert "Step 1 of 2 - these can run together" in fragment
+    assert "Step 2 of 2 - one task at a time" in fragment
+    assert "Wave 0" not in fragment
+    assert ">Together<" in fragment
+    assert "Ready tasks cannot all start at the same time." in fragment
     assert "could all run in parallel" not in fragment
+    assert 'class="wk-diagram"' not in fragment
 
 
 def test_conflict_edge_keeps_visual_structure_even_for_single_task_waves():
@@ -202,8 +211,78 @@ def test_conflict_edge_keeps_visual_structure_even_for_single_task_waves():
     fragment = work_view.render(payload, "unused")
     assert "Ready alpha" in fragment
     assert "Blocked beta" in fragment
+    assert "Step 1 of 1 - one task at a time" in fragment
     assert "could all run in parallel" not in fragment
     assert "waiting" in fragment.lower() or "blocked" in fragment.lower()
+    assert 'class="wk-diagram"' in fragment
+    assert "<svg" in fragment
+    assert 'data-wk-from="task-a"' in fragment
+    assert 'data-wk-to="task-b"' in fragment
+    assert "What is blocking what" in fragment
+    assert "style=" not in fragment.split("<style", 1)[-1].split("</style>", 1)[-1]
+
+
+def test_exclusive_single_task_waves_use_plain_step_headings_when_edges_force_lanes():
+    titles = [
+        "Mint stable card ids",
+        "Repair outcome ledger",
+        "Paginate runs view",
+        "Fold claims into work",
+        "Rewrite activity strip",
+    ]
+    ready = _exclusive_singles(titles)
+    ready["edges"] = [{"source": "task-0", "target": "task-1", "type": "blocks"}]
+    ready["blocked_count"] = 0
+    fragment = work_view.render(_payload(ready=ready), "step-nonce")
+
+    assert '<style nonce="step-nonce">' in fragment
+    assert "Step 2 of 5 - one task at a time (blocks step 3)" in fragment
+    assert "Step 1 of 5 - one task at a time (blocks step 2)" in fragment
+    assert "Step 5 of 5 - one task at a time" in fragment
+    assert "Wave 0" not in fragment
+    assert "Wave 1" not in fragment
+    assert ">Together<" in fragment
+    assert "Ready tasks cannot all start at the same time." in fragment
+    assert 'class="wk-diagram"' in fragment
+    assert 'data-wk-from="task-0"' in fragment
+    assert 'data-wk-to="task-1"' in fragment
+    for title in titles:
+        assert title in fragment
+
+
+def test_drawn_edges_render_when_waves_are_absent():
+    payload = _payload(
+        ready={
+            "ready_count": 1,
+            "blocked_count": 1,
+            "ready": [_ready_task("task-a", "Ready alpha")],
+            "blocked": [
+                {
+                    "id": "task-b",
+                    "title": "Blocked beta",
+                    "status": "pending",
+                    "blockers": [{"id": "task-a", "status": "pending", "via": ["blocks"]}],
+                }
+            ],
+            "edges": [{"source": "task-a", "target": "task-b", "type": "blocks"}],
+            "parallel_safe": True,
+        }
+    )
+    fragment = work_view.render(payload, "edge-nonce")
+    assert '<style nonce="edge-nonce">' in fragment
+    assert "Ready alpha" in fragment
+    assert "Blocked beta" in fragment
+    assert 'class="wk-lane"' not in fragment
+    assert "Wave " not in fragment
+    assert "Step 1 of" not in fragment
+    assert 'class="wk-diagram"' in fragment
+    assert "<svg" in fragment
+    assert 'data-wk-from="task-a"' in fragment
+    assert 'data-wk-to="task-b"' in fragment
+    assert 'data-wk-type="blocks"' in fragment
+    assert "What is blocking what" in fragment
+    assert ">Together<" in fragment
+    assert "Ready tasks cannot all start at the same time." in fragment
 
 
 def test_claims_use_plain_words_not_footprint_jargon(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The Work view still answered "what is blocking what" only in prose: lane headings were bare `Wave N`, the Parallel tile read as jargon, and `dependency_edges` already in the ready payload were never drawn. This slice makes exclusive single-step waves legible (`Step 2 of 5 - one task at a time (blocks step 3)`), rewords the tile to Together / yes-or-no, and adds a small layered SVG beside the existing list.

Fixes #977. Part of the #904 coherence audit.

## Type of change

- [x] Operator-facing dashboard copy and rendering (Work view)
- [ ] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change)

## What changed

- `_wave_lanes` headings are now `Step N of M` with exclusive / together copy. Independent exclusive singles with no edges still collapse to a plain list (existing behavior).
- The Parallel tile is now **Together** with a sentence about whether ready tasks can start at the same time.
- `_dependency_diagram` draws `wg.dependency_edges(ready)` as a layered SVG (wave index for vertical order; `layout_layers` when waves are absent). The task list stays.
- CSP: stylesheet keeps `nonce="{esc(nonce)}"`; no inline `style=` attributes; SVG uses classes and presentation attributes.

`work_graph.py` was not changed. Existing `dependency_edges`, `graph_nodes`, and `layout_layers` were enough.

## Checklist

- [x] Targeted pytest green: `python3 -m pytest tests/test_dashboard_work.py tests/test_center_dashboard.py tests/test_center_page_load.py -q` (66 passed)
- [x] `ruff check` and `ruff format --check` on touched files
- [x] Added or updated tests covering step headings (including a single-task wave), the Together tile, drawn edges, and the waves-absent-but-edges-present case
- [x] Updated the `Unreleased` section of `CHANGELOG.md`
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

## Walkthrough

[Independent singles still collapse; Together tile says yes](https://cursor.com/agents/bc-4b3375a8-88b8-4f1b-a01e-be5776c14421/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwork_view_collapsed_independent.webp)

[Step 1 of 2 these can run together and Step 2 of 2 one task at a time](https://cursor.com/agents/bc-4b3375a8-88b8-4f1b-a01e-be5776c14421/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwork_view_multi_task_steps.webp)

[Drawn dependency edge between exclusive single-step tasks](https://cursor.com/agents/bc-4b3375a8-88b8-4f1b-a01e-be5776c14421/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwork_view_exclusive_steps_and_edges.webp)

[Waves absent but edges still drawn as SVG](https://cursor.com/agents/bc-4b3375a8-88b8-4f1b-a01e-be5776c14421/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwork_view_waves_absent_edges.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b3375a8-88b8-4f1b-a01e-be5776c14421?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b3375a8-88b8-4f1b-a01e-be5776c14421&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

