### PR TITLE
fix(windows): unblock brigade run by fixing two POSIX assumptions

### DIFF
--- a/src/brigade/localio.py
+++ b/src/brigade/localio.py
@@ -57,7 +57,7 @@ def write_text_atomic(path: Path, data: str) -> None:
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_name)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
             handle.write(data)
             handle.flush()
             os.fsync(handle.fileno())
@@ -121,7 +121,7 @@ def write_text_exclusive(path: Path, data: str) -> None:
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_name)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
             handle.write(data)
             handle.flush()
             os.fsync(handle.fileno())

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -56,7 +56,7 @@ _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _HAS_O_NOFOLLOW = _O_NOFOLLOW != 0
 _HAS_O_DIRECTORY = _O_DIRECTORY != 0
-_HAS_FCHMOD = hasattr(os, "fchmod")
+_HAS_FCHMOD = hasattr(os, "fchmod") and os.name == "posix"
 # O_NOFOLLOW rejects symlinked targets so a pre-placed symlink cannot redirect
 # journal writes or quarantine captures outside the private run-artifact tree.
 _OPEN_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_APPEND

--- a/tests/test_localio.py
+++ b/tests/test_localio.py
@@ -179,7 +179,7 @@ def test_canonical_json_digest_excludes_top_level_keys_and_hashes_files(tmp_path
     assert localio.canonical_json_digest(payload, exclude_keys={"digest", "digests"}) == expected
 
     blob = tmp_path / "blob.txt"
-    blob.write_text("hello\n")
+    blob.write_bytes(b"hello\n")  # bytes: write_text emits CRLF on Windows
     assert localio.file_sha256(blob) == "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
 
 
@@ -191,3 +191,27 @@ def test_canonical_json_digest_excludes_top_level_keys_only():
     edited_digest = localio.canonical_json_digest(edited, exclude_keys={"digests"})
 
     assert base_digest != edited_digest
+
+
+def test_write_text_atomic_writes_lf_not_platform_newline(tmp_path: Path):
+    """Regression: on Windows, text mode without newline= translated LF to CRLF.
+
+    run.json is written through this helper, and run_checkpoint compares it byte
+    for byte against a canonical form that only ever contains LF, so a CRLF file
+    could never match and every dispatch failed with "base bytes differ from
+    writer canonical form".
+    """
+    path = tmp_path / "run.json"
+    localio.write_text_atomic(path, json.dumps({"a": 1, "b": 2}, indent=2, sort_keys=True) + "\n")
+
+    raw = path.read_bytes()
+    assert b"\r\n" not in raw
+    assert raw.count(b"\n") == 4
+
+
+def test_write_text_exclusive_writes_lf_not_platform_newline(tmp_path: Path):
+    """The exclusive writer shares write_text_atomic's newline exposure."""
+    path = tmp_path / "once.json"
+    localio.write_text_exclusive(path, "first\nsecond\n")
+
+    assert path.read_bytes() == b"first\nsecond\n"

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -2384,3 +2384,24 @@ def test_fsync_directory_without_o_directory_opens_readonly_and_fsyncs(tmp_path,
 
     assert fsynced
     assert fsynced[0]
+
+
+def test_chmod_fd_or_path_does_not_use_fchmod_off_posix():
+    """Regression: presence of os.fchmod is not proof it works.
+
+    os.fchmod exists on Windows under Python 3.14 but raises PermissionError
+    (WinError 5) when the descriptor was opened O_RDONLY, which
+    _enforce_file_mode always does. Gate on the platform so non-POSIX takes the
+    verified-path os.chmod fallback instead.
+    """
+    assert run_journal._HAS_FCHMOD == (hasattr(os, "fchmod") and os.name == "posix")
+
+
+def test_enforce_file_mode_succeeds_on_a_read_only_descriptor(tmp_path: Path):
+    """ensure_journal must not raise while correcting the journal's mode."""
+    journal = tmp_path / "lifecycle.jsonl"
+    run_journal.ensure_journal(journal)
+
+    assert journal.exists()
+    # Second call re-enters the mode-enforcement path against an existing file.
+    run_journal.ensure_journal(journal)


### PR DESCRIPTION
Fixes #1096. Fixes #1097.

`brigade run` could not start on Windows, and once it could start, no dispatch could complete. Two independent causes, each one line of source.

## 1. `os.fchmod` on a read-only descriptor (#1096)

`run_journal` picked its chmod branch on attribute presence:

```python
_HAS_FCHMOD = hasattr(os, "fchmod")
```

`os.fchmod` exists on Windows under Python 3.14, but Windows requires write access on the handle to change attributes. `_enforce_file_mode` opens the journal `O_RDONLY`, so the call raised `PermissionError [WinError 5]` and every run died with:

```
error: failed to write initial run receipt: lifecycle journal I/O failure (PermissionError)
```

This was unconditional rather than intermittent. Windows reports file modes as `0o666` or `0o444` and never `0o600`, so `S_IMODE(...) != _FILE_MODE` was always true and the failing branch was always taken.

The fix gates on `os.name`, which is what `_supports_directory_fsync()` two functions away already does, so Windows takes the existing verified-path `os.chmod` fallback. That fallback works: `os.lstat`/`os.fstat` populate `st_ino` and `st_dev`, so `_verify_fd_identity` passes.

## 2. Text-mode writes emit CRLF (#1097)

`localio` opened its atomic temp file in text mode with no `newline=`, so Python translated LF to CRLF on write. `run.json` is written through that helper, while `run_checkpoint._writer_canonical_bytes` produces LF and requires byte equality:

```
error: failed to record dispatch lifecycle fact: base bytes differ from writer canonical form
```

A real `run.json` produced by 0.27.0 on Windows measured 150 CRLF and zero bare LF, against a canonical form containing only LF. The comparison could never pass.

Pinning `newline="\n"` in both text writers fixes it and is a no-op on POSIX, where text mode already writes LF. `write_text_exclusive` had the same open call and the same exposure, so both are changed.

## Why they were not caught

The two masked each other. The first aborts in preflight before any dispatch, so the second is only reachable once the first is fixed. A Windows lane that exercises a full dispatch rather than preflight alone would have caught both, which is the testing gap #357 describes.

## Test results

Measured on Windows 11, Python 3.14.6, running `tests/test_localio.py` and `tests/test_run_journal.py`:

| | failed | passed |
|---|---|---|
| before | 56 | 21 |
| after | 9 | 72 |

47 tests fixed. The failure sets were diffed rather than counted: no test that passed before fails now.

The 9 remaining failures are POSIX mode assertions (`0o600`, `0o700`) that cannot hold where `chmod` only toggles the read-only bit. Deciding how Windows should treat journal modes is a separate question and is left alone here.

`ruff check` passes on all four changed files.

## Added tests

- `test_write_text_atomic_writes_lf_not_platform_newline` and `test_write_text_exclusive_writes_lf_not_platform_newline` assert LF output directly, so a regression fails on POSIX too rather than only on Windows.
- `test_chmod_fd_or_path_does_not_use_fchmod_off_posix` locks the capability gate.
- `test_enforce_file_mode_succeeds_on_a_read_only_descriptor` covers the path that raised, including re-entry against an existing journal.

Also fixed a test-side instance of the same newline family: `blob.write_text("hello\n")` produced CRLF on Windows and broke a sha256 assertion. It now writes bytes.

## Verification beyond the suite

With both fixes applied, a real dispatch completes end to end on Windows against an OpenCode seat:

```
workers:
  [ok] ox_worker
```

Related Windows POSIX-assumption work: #357, #1022, #752, #281.
