### PR TITLE
fix(center): distinguish run timeline CLI errors from empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON run contracts rewrite home-directory prefixes (`/home/<user>`, `/Users/<user>`) to `~` on every string that enters the list, show, latest, and watch payloads. Artifacts and human CLI output are unchanged. Refs #631. Refs #958.
 
 ### Fixed
+- The center Runs view now treats a missing runs directory as the existing "No Brigade runs yet." empty state, and renders a distinct error panel for other `brigade runs list` CLI failures (timeout, invalid JSON, unreadable store). `brigade.run-detail.v1` docs name the verification field `command`. Fixes #991.
 - Changelog footer link definitions cover every release section again (24 were missing, 0.8.2 through 0.26.1), and `[Unreleased]` compares against v0.26.1 instead of v0.26.0.
 - Center dashboard chip-icon backgrounds now render under the nonce-only Content-Security-Policy: Memory Operations and Status views use one stylesheet class per status role instead of per-element `style=` attributes (which `style-src` with a nonce refuses). Work, Runs, Agent Activity, and Outcomes already used classes or had no chip-icon inline styles. Fixes #1077.
 - Evidence crawl import (`miseledger import sourceharvest` / `crawl files|gitlog|docs`) and provenance backfill retry the SQLITE_BUSY family (primary code 5, including snapshot 517 and recovery 261) from a concurrent writer instead of failing the runbook. A lock that outlives the bound names the holder-diagnosis step rather than the raw SQLite string. Fixes #1067.

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -973,7 +973,7 @@ Both commands share one serializer:
 - `workers`: per-result state (ok/status, bounded detail, duration, exit code,
   timeout flag, requested model, transport, failure class).
 - `verification`: verify receipt summaries (receipt run id, status, duration,
-  command label, and exit code) from recorded ground truth.
+  `command`, and exit code) from recorded ground truth.
 - `briefs`: attachment markers for the Code Intelligence (`code-graph`),
   drift (`drift-impact`), and Evidence Ledger (`evidence`) briefs.
 

--- a/src/brigade/center_cmd/dashboard/views/run_timeline.py
+++ b/src/brigade/center_cmd/dashboard/views/run_timeline.py
@@ -132,13 +132,25 @@ def _run_id_details(run_id: object) -> str:
     return f"<details><summary>Run ID</summary><code>{rendered}</code></details>"
 
 
+_MISSING_RUNS_DIR_MARKER = "runs directory not found"
+
+
+def _is_missing_runs_directory(error: object) -> bool:
+    """True only for the CLI's missing-runs-dir message, not other fetch failures."""
+    return _MISSING_RUNS_DIR_MARKER in str(error)
+
+
 def _render_brigade_panel(payload: dict) -> str:
     title = "Brigade runs"
     error = payload.get("error")
     if error:
-        # A missing runs directory is an empty state, not a failure.
-        detail = f"<details><summary>{html.esc('CLI diagnostic')}</summary><pre>{html.esc(str(error))}</pre></details>"
-        return html.panel(html.esc(title), f"<p>{html.esc('No Brigade runs yet.')}</p>{detail}")
+        if _is_missing_runs_directory(error):
+            # A missing runs directory is an empty state, not a failure.
+            detail = (
+                f"<details><summary>{html.esc('CLI diagnostic')}</summary><pre>{html.esc(str(error))}</pre></details>"
+            )
+            return html.panel(html.esc(title), f"<p>{html.esc('No Brigade runs yet.')}</p>{detail}")
+        return html.error_panel(title, str(error))
 
     runs = payload.get("runs")
     if not isinstance(runs, list) or not runs:

--- a/tests/test_dashboard_runs.py
+++ b/tests/test_dashboard_runs.py
@@ -95,6 +95,34 @@ def test_render_brigade_runs_error_is_empty_state_with_diagnostic():
     assert "CLI diagnostic" in fragment
     assert "runs directory not found" in fragment
     assert "<root>" not in fragment
+    assert 'class="error"' not in fragment
+
+
+def test_run_detail_docs_name_verification_command_field():
+    text = Path(__file__).resolve().parents[1].joinpath("docs", "receipt-schemas.md").read_text(encoding="utf-8")
+    start = text.index("### `brigade.run-detail.v1`")
+    end = text.index("### `brigade.run-watch.v1`")
+    section = text[start:end]
+    assert "`command`" in section
+    assert "command label" not in section
+
+
+def test_render_brigade_runs_cli_failure_is_error_state_not_empty():
+    messages = (
+        "command timed out",
+        "invalid JSON from command",
+        "error: permission denied reading runs store",
+        "expected JSON object from command",
+    )
+    for message in messages:
+        fragment = run_timeline.render(
+            {"brigade": {"error": message}, "verify": {"runs": []}},
+            "unused",
+        )
+        assert "No Brigade runs yet." not in fragment, message
+        assert "CLI diagnostic" not in fragment, message
+        assert 'class="error"' in fragment, message
+        assert message in fragment
 
 
 def test_render_lists_verify_runs_newest_first_with_bounded_receipts():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The center Runs view treated every `brigade runs list` CLI error as "No Brigade runs yet." A missing runs directory stays that empty state (with the CLI diagnostic disclosure). Timeouts, invalid JSON, and other fetch failures now render the shared error panel so a degraded store is not mistaken for an empty one. The `brigade.run-detail.v1` docs now name the verification field `command`.

Closes #991

[Runs panel empty state vs CLI timeout error panel](https://cursor.com/agents/bc-810f56f1-4f2c-4f31-9207-b55a888ece7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fruns-panel-screenshot.webp)

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [x] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] `pytest -q tests/test_dashboard_runs.py` passes locally (13 passed)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages, no AI co-authorship trailers


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-810f56f1-4f2c-4f31-9207-b55a888ece7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-810f56f1-4f2c-4f31-9207-b55a888ece7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

