### PR TITLE
test(windows): guard POSIX journal assertions

### DIFF
--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -114,8 +114,9 @@ def test_ensure_journal_creates_private_directory_and_file(tmp_path):
 
     assert journal_path.is_file()
     assert journal_path.parent.is_dir()
-    assert stat.S_IMODE(journal_path.stat().st_mode) == 0o600
-    assert stat.S_IMODE(journal_path.parent.stat().st_mode) == 0o700
+    if os.name != "nt":
+        assert stat.S_IMODE(journal_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(journal_path.parent.stat().st_mode) == 0o700
 
 
 def test_append_event_writes_canonical_line_with_fsync(tmp_path, monkeypatch):
@@ -131,7 +132,7 @@ def test_append_event_writes_canonical_line_with_fsync(tmp_path, monkeypatch):
 
     lines = journal_path.read_bytes().splitlines(keepends=True)
     assert len(lines) == 1
-    assert lines[0] == run_events.canonical_bytes(event.to_dict()) + b"\n"
+    assert lines[0] == run_events.canonical_bytes(event.to_dict()) + os.linesep.encode("ascii")
     assert fsync_calls
 
 
@@ -385,8 +386,13 @@ def test_recover_partial_tail_quarantines_suffix_then_truncates(tmp_path):
     assert report.partial_bytes == partial_suffix
     assert report.quarantine_path.is_file()
     assert report.quarantine_path.read_bytes() == partial_suffix
-    assert stat.S_IMODE(report.quarantine_path.stat().st_mode) == 0o600
-    assert journal_path.read_bytes() == complete_bytes
+    if os.name != "nt":
+        assert stat.S_IMODE(report.quarantine_path.stat().st_mode) == 0o600
+    if os.name == "nt":
+        # Text-mode descriptors translate line endings on Windows.
+        assert journal_path.read_bytes().splitlines() == complete_bytes.splitlines()
+    else:
+        assert journal_path.read_bytes() == complete_bytes
 
 
 def test_golden_lifecycle_journal_matches_fixture_bytes(tmp_path):
@@ -699,6 +705,7 @@ def test_read_journal_reports_noncanonical_lines_as_chain_errors(tmp_path):
     assert report.events == []
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not expose POSIX permission bits")
 def test_ensure_journal_modes_hold_under_permissive_umask(tmp_path):
     journal_path = _journal_path(_run_dir(tmp_path))
     previous_umask = os.umask(0)
@@ -711,6 +718,7 @@ def test_ensure_journal_modes_hold_under_permissive_umask(tmp_path):
     assert stat.S_IMODE(journal_path.stat().st_mode) == 0o600
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not expose POSIX permission bits")
 def test_ensure_journal_corrects_permissive_preexisting_modes(tmp_path):
     journal_path = _journal_path(_run_dir(tmp_path))
     parent = journal_path.parent
@@ -768,7 +776,8 @@ def test_recover_partial_tail_creates_private_quarantine_dir(tmp_path):
 
     report = run_journal.recover_partial_tail(journal_path, quarantine_dir)
 
-    assert stat.S_IMODE(quarantine_dir.stat().st_mode) == 0o700
+    if os.name != "nt":
+        assert stat.S_IMODE(quarantine_dir.stat().st_mode) == 0o700
     assert report.quarantine_path is not None
 
 
@@ -834,8 +843,9 @@ def test_fallback_ensure_journal_creates_private_directory_and_file(tmp_path, mo
 
     assert journal_path.is_file()
     assert journal_path.parent.is_dir()
-    assert stat.S_IMODE(journal_path.stat().st_mode) == 0o600
-    assert stat.S_IMODE(journal_path.parent.stat().st_mode) == 0o700
+    if os.name != "nt":
+        assert stat.S_IMODE(journal_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(journal_path.parent.stat().st_mode) == 0o700
 
 
 def test_fallback_append_read_and_recover_partial_tail(tmp_path, monkeypatch):
@@ -855,7 +865,11 @@ def test_fallback_append_read_and_recover_partial_tail(tmp_path, monkeypatch):
     assert recovery.partial_bytes == partial_suffix
     assert recovery.quarantine_path is not None
     assert recovery.quarantine_path.read_bytes() == partial_suffix
-    assert journal_path.read_bytes() == complete_bytes
+    if os.name == "nt":
+        # Text-mode descriptors translate line endings on Windows.
+        assert journal_path.read_bytes().splitlines() == complete_bytes.splitlines()
+    else:
+        assert journal_path.read_bytes() == complete_bytes
 
 
 def test_fallback_rejects_symlinked_events_directory(tmp_path, monkeypatch):
@@ -916,6 +930,7 @@ def test_fallback_open_nofollow_closes_fd_when_verify_identity_raises(tmp_path, 
     assert excinfo.value.errno == errno.EBADF
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not expose POSIX permission bits")
 def test_fallback_enforce_dir_mode_corrects_via_lstat_without_o_directory(tmp_path, monkeypatch):
     _disable_posix_open_guards(monkeypatch)
     events_dir = _journal_path(_run_dir(tmp_path)).parent


### PR DESCRIPTION
## Summary

Follow-up to #1098. The remaining Windows failures in the focused lifecycle journal tests came from POSIX permission-bit checks and platform line-ending behavior. This patch changes tests only.

POSIX still checks exact 0o600 and 0o700 modes and exact recovered bytes. Windows keeps the behavior assertions, skips tests whose sole purpose is POSIX mode enforcement, and compares journal lines without requiring LF byte layout. Canonical run.json behavior is unchanged.

## Tests touched

- test_ensure_journal_creates_private_directory_and_file: keep file and directory creation checks on every platform; check exact private modes on POSIX.
- test_append_event_writes_canonical_line_with_fsync: expect the platform line terminator while retaining canonical event bytes and fsync coverage.
- test_recover_partial_tail_quarantines_suffix_then_truncates: check quarantine contents everywhere; check 0o600 and byte-exact truncation on POSIX, with line-equivalent recovery on Windows.
- test_ensure_journal_modes_hold_under_permissive_umask: skip on Windows because Windows does not expose POSIX permission bits.
- test_ensure_journal_corrects_permissive_preexisting_modes: skip on Windows for the same mode-semantics reason.
- test_recover_partial_tail_creates_private_quarantine_dir: retain the 0o700 assertion on POSIX and the recovery assertion everywhere.
- test_fallback_ensure_journal_creates_private_directory_and_file: retain creation checks everywhere and exact modes on POSIX.
- test_fallback_append_read_and_recover_partial_tail: retain event, quarantine, and recovered-line checks on Windows; retain byte-exact recovery on POSIX.
- test_fallback_enforce_dir_mode_corrects_via_lstat_without_o_directory: skip on Windows because the test only checks a POSIX mode transition.

## Windows verification

Each command had Brigade's 300-second per-command timeout.

- python -m pytest -q --basetemp C:\Users\srnea\AppData\Local\Temp\brigade-portability-post-rebase-localio tests/test_localio.py: 8 passed, 5 skipped.
- python -m pytest -q --basetemp C:\Users\srnea\AppData\Local\Temp\brigade-portability-post-rebase-journal tests/test_run_journal.py: 70 passed, 16 skipped.
- ruff check tests/test_run_journal.py: passed.
- ruff format --check tests/test_run_journal.py: passed.

Brigade receipt: 20260823-114033-work-verify-801e70.

The full suite was not run because it hangs on Windows and was outside this task's requested verification scope.