### PR TITLE
feat: add bounded Grok Bot job queue

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -59,7 +59,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade roster`: 4 command path(s)
 - `brigade route`: 1 command path(s)
 - `brigade run`: 1 command path(s)
-- `brigade run-cloud`: 4 command path(s)
+- `brigade run-cloud`: 14 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
 - `brigade runs`: 18 command path(s)
 - `brigade scrub`: 1 command path(s)
@@ -467,6 +467,16 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade route`
 - `brigade run`
 - `brigade run-cloud adopt`
+- `brigade run-cloud grokbot ack-cancel`
+- `brigade run-cloud grokbot cancel`
+- `brigade run-cloud grokbot claim`
+- `brigade run-cloud grokbot complete`
+- `brigade run-cloud grokbot enqueue`
+- `brigade run-cloud grokbot expire`
+- `brigade run-cloud grokbot fail`
+- `brigade run-cloud grokbot renew`
+- `brigade run-cloud grokbot start`
+- `brigade run-cloud grokbot status`
 - `brigade run-cloud register`
 - `brigade run-cloud status`
 - `brigade run-cloud sweep`

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -116,6 +116,32 @@ The Agent Activity dashboard is visual-first: machine cards (rocinante / shadowf
 
 Use `brigade run cloud register` / `adopt` (parser group `brigade run-cloud`) to record dispatches. Codex Cloud register-on-dispatch is automatic from `codex-cloud` seats. Cursor cloud remains an unwired source until an API key exists. `brigade run cloud status --json` joins the registry against best-effort provider state and GitHub branch/PR ground truth. `brigade run cloud sweep` writes a receipted report only. Nothing is deleted automatically. Stale READY entries (threshold `stale_ready_hours`, default 6) surface in `brigade work brief`.
 
+### Grok Bot local job queue
+
+`brigade run cloud grokbot` creates a private local queue contract. It does not call a live provider, commission Grok Bot, or add a synchronous roster seat. The protected MCP adapter is the future network boundary. `cloud_tracker` reconciliation is planned for PR 2.
+
+Queue data lives below `.brigade/cloud/grokbot/` with private file permissions. Submit a complete task envelope from a JSON file with `enqueue --spec`; do not put task instructions, verification commands, credentials, headers, environment values, or artifact bodies on the command line. The envelope identifies a bounded role, repository, base ref, owned paths, artifact kind, and timeout. Completion reads a second JSON file with `complete --artifact`; it accepts artifact references only, such as a GitHub draft-PR URL and branch, a branch and commit, or a report path and SHA-256.
+
+Jobs move through `queued`, `claimed`, `running`, `completed`, `failed`, `expired`, and `canceled`. A bot claims work with its own opaque bot and lease IDs plus a bounded lease duration. The same claim can be retried safely, and `renew` extends the current unexpired lease within the job deadline. `cancel` ends queued work immediately or records a cancellation request for a live lease. The lease holder uses `ack-cancel` to finish that cancellation. `expire` never requeues a job; it finalizes a job after its deadline or lease expires.
+
+Only safe projections are printed by `status` and mutation commands. They include job identity, state, timing, task hash, and artifact metadata, but never the envelope's `instructions` or `verification_commands`.
+
+```bash
+brigade run cloud grokbot enqueue \
+  --target . \
+  --spec .brigade-inputs/grokbot-task.json \
+  --idempotency-key issue-1130-scout
+
+brigade run cloud grokbot claim \
+  --target . \
+  --job-id grokbot-0123456789abcdef01234567 \
+  --bot-id scout-01 \
+  --lease-id lease-01234567 \
+  --lease-seconds 300
+
+brigade run cloud grokbot status --target . --json
+```
+
 For a remote T3 controller journal already available locally, configure an alias and a repo-relative journal path in `.brigade/center/agent-activity-sources.json`:
 
 ```json

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -59,17 +59,64 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_sweep.add_argument("--target", type=Path, default=Path("."))
     p_sweep.add_argument("--json", action="store_true")
 
+    p_grokbot = cloud_sub.add_parser("grokbot", help="Manage the private local Grok Bot job queue.")
+    grokbot_sub = p_grokbot.add_subparsers(dest="grokbot_command", metavar="<grokbot-command>")
+    grokbot_sub.required = True
+
+    def add_target(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--target", type=Path, default=Path("."))
+        command.add_argument("--json", action="store_true")
+
+    p_enqueue = grokbot_sub.add_parser("enqueue", help="Queue a Grok Bot envelope from a JSON file.")
+    add_target(p_enqueue)
+    p_enqueue.add_argument("--spec", type=Path, required=True, help="Path to the private task envelope JSON file.")
+    p_enqueue.add_argument("--idempotency-key", required=True)
+
+    for name, help_text in (("claim", "Claim a queued job."), ("renew", "Renew a current job lease.")):
+        command = grokbot_sub.add_parser(name, help=help_text)
+        add_target(command)
+        command.add_argument("--job-id", required=True)
+        command.add_argument("--bot-id", required=True)
+        command.add_argument("--lease-id", required=True)
+        command.add_argument("--lease-seconds", required=True, type=int)
+
+    for name, help_text in (("start", "Mark a claimed job running."), ("fail", "Mark a live job failed."), ("ack-cancel", "Acknowledge a requested cancellation.")):
+        command = grokbot_sub.add_parser(name, help=help_text)
+        add_target(command)
+        command.add_argument("--job-id", required=True)
+        command.add_argument("--bot-id", required=True)
+        command.add_argument("--lease-id", required=True)
+
+    p_complete = grokbot_sub.add_parser("complete", help="Complete a running job with artifact references.")
+    add_target(p_complete)
+    p_complete.add_argument("--job-id", required=True)
+    p_complete.add_argument("--bot-id", required=True)
+    p_complete.add_argument("--lease-id", required=True)
+    p_complete.add_argument("--artifact", type=Path, required=True, help="Path to the completion artifact JSON file.")
+
+    for name, help_text in (("cancel", "Cancel a queued job or request cancellation."), ("expire", "Expire a deadline or lease-expired job.")):
+        command = grokbot_sub.add_parser(name, help=help_text)
+        add_target(command)
+        command.add_argument("--job-id", required=True)
+
+    p_grokbot_status = grokbot_sub.add_parser("status", help="Show safe Grok Bot job projections.")
+    add_target(p_grokbot_status)
+    p_grokbot_status.add_argument("--job-id", default=None)
+
     p.set_defaults(func=dispatch)
 
 
 def dispatch(args) -> int:
-    from .. import cloud_tracker
-
     command = getattr(args, "run_cloud_command", None)
     target = Path(args.target).expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
+
+    if command == "grokbot":
+        return _dispatch_grokbot(args, target)
+
+    from .. import cloud_tracker
 
     if command == "register":
         try:
@@ -167,3 +214,77 @@ def dispatch(args) -> int:
 
     print(f"error: unknown cloud command: {command}", file=sys.stderr)
     return 2
+
+
+def _dispatch_grokbot(args, target: Path) -> int:
+    """Dispatch local queue operations without loading envelopes into CLI arguments."""
+    from .. import grokbot_jobs
+
+    command = args.grokbot_command
+    try:
+        if command == "enqueue":
+            result = grokbot_jobs.enqueue(target, _read_json_object(args.spec, "--spec"), args.idempotency_key)
+        elif command == "claim":
+            result = grokbot_jobs.claim(target, args.job_id, args.bot_id, args.lease_id, args.lease_seconds)
+        elif command == "renew":
+            result = grokbot_jobs.renew(target, args.job_id, args.bot_id, args.lease_id, args.lease_seconds)
+        elif command == "start":
+            result = grokbot_jobs.transition(target, args.job_id, args.bot_id, args.lease_id, "running")
+        elif command == "complete":
+            result = grokbot_jobs.transition(
+                target,
+                args.job_id,
+                args.bot_id,
+                args.lease_id,
+                "completed",
+                artifact=_read_json_object(args.artifact, "--artifact"),
+            )
+        elif command == "fail":
+            result = grokbot_jobs.transition(target, args.job_id, args.bot_id, args.lease_id, "failed")
+        elif command == "cancel":
+            result = grokbot_jobs.cancel(target, args.job_id)
+        elif command == "ack-cancel":
+            result = grokbot_jobs.acknowledge_cancel(target, args.job_id, args.bot_id, args.lease_id)
+        elif command == "expire":
+            result = grokbot_jobs.expire(target, args.job_id)
+        elif command == "status":
+            result = grokbot_jobs.status(target, args.job_id)
+        else:  # argparse makes this unreachable.
+            print(f"error: unknown Grok Bot command: {command}", file=sys.stderr)
+            return 2
+    except grokbot_jobs.GrokbotJobError as exc:
+        print(f"error: {exc.reason}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    _print_grokbot_result(result)
+    return 0
+
+
+def _read_json_object(path: Path, option: str) -> dict:
+    """Load a command payload only from a regular JSON file."""
+    if not path.is_file():
+        raise ValueError(f"{option} is not a file: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid JSON object in {option}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"invalid JSON object in {option}")
+    return payload
+
+
+def _print_grokbot_result(result: dict) -> None:
+    """Render safe queue projections without exposing task envelope content."""
+    if "jobs" in result:
+        jobs = result["jobs"]
+        print(f"grokbot jobs: {len(jobs)}")
+        for job in jobs:
+            print(f"job {job['job_id']} state={job['state']}")
+        return
+    print(f"job {result['job_id']} state={result['state']}")

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -80,7 +80,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         command.add_argument("--lease-id", required=True)
         command.add_argument("--lease-seconds", required=True, type=int)
 
-    for name, help_text in (("start", "Mark a claimed job running."), ("fail", "Mark a live job failed."), ("ack-cancel", "Acknowledge a requested cancellation.")):
+    for name, help_text in (
+        ("start", "Mark a claimed job running."),
+        ("fail", "Mark a live job failed."),
+        ("ack-cancel", "Acknowledge a requested cancellation."),
+    ):
         command = grokbot_sub.add_parser(name, help=help_text)
         add_target(command)
         command.add_argument("--job-id", required=True)
@@ -94,7 +98,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_complete.add_argument("--lease-id", required=True)
     p_complete.add_argument("--artifact", type=Path, required=True, help="Path to the completion artifact JSON file.")
 
-    for name, help_text in (("cancel", "Cancel a queued job or request cancellation."), ("expire", "Expire a deadline or lease-expired job.")):
+    for name, help_text in (
+        ("cancel", "Cancel a queued job or request cancellation."),
+        ("expire", "Expire a deadline or lease-expired job."),
+    ):
         command = grokbot_sub.add_parser(name, help=help_text)
         add_target(command)
         command.add_argument("--job-id", required=True)

--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -1,0 +1,447 @@
+"""Private, handle-first queue storage for Grok Bot jobs.
+
+This module deliberately has no provider or transport integration. It validates
+and persists private job envelopes, then exposes only safe job projections.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+try:  # pragma: no cover - Windows does not provide fcntl.
+    import fcntl
+except ImportError:  # pragma: no cover - exercised on Windows.
+    fcntl = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - unavailable on POSIX.
+    import msvcrt
+except ImportError:  # pragma: no cover - exercised on POSIX.
+    msvcrt = None  # type: ignore[assignment]
+
+
+JOB_ID_RE = re.compile(r"^grokbot-[0-9a-f]{24}$")
+REPOSITORY_PART_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,98}$")
+IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+JOB_STATES = frozenset({"queued", "claimed", "running", "completed", "failed", "expired", "canceled"})
+ROLES = frozenset({"implementation-worker", "repository-scout"})
+ARTIFACT_KINDS = frozenset({"draft-pr", "branch", "report"})
+REQUIRED_ENVELOPE_KEYS = frozenset(
+    {
+        "label",
+        "role",
+        "repository",
+        "base_ref",
+        "ownership_paths",
+        "instructions",
+        "verification_commands",
+        "artifact",
+        "timeout_seconds",
+    }
+)
+SENSITIVE_KEY_TOKENS = (
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "authorization",
+    "header",
+    "cookie",
+    "environment",
+    "env",
+)
+ROOT_MODE = 0o700
+FILE_MODE = 0o600
+JOB_SCHEMA = "brigade.grokbot.job.v1"
+IDEMPOTENCY_SCHEMA = "brigade.grokbot.idempotency.v1"
+
+
+class GrokbotJobError(ValueError):
+    """A rejected Grok Bot job request with a stable machine-readable reason."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+def enqueue(
+    target: Path,
+    spec: dict[str, Any],
+    idempotency_key: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Queue a validated private envelope and return an opaque handle."""
+    envelope = _validate_spec(spec)
+    key = _validate_idempotency_key(idempotency_key)
+    task_hash = _task_hash(envelope)
+    root, jobs_dir, idempotency_dir, lock_path = _storage_paths(target)
+
+    with _queue_lock(root, lock_path):
+        idempotency_path = idempotency_dir / f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.json"
+        existing = _read_json_file(idempotency_path, missing_ok=True)
+        if existing is not None:
+            if existing.get("task_hash") != task_hash:
+                raise GrokbotJobError("idempotency-conflict")
+            job_id = existing.get("job_id")
+            if not isinstance(job_id, str) or not JOB_ID_RE.fullmatch(job_id):
+                raise GrokbotJobError("corrupt-storage")
+            record = _load_record(jobs_dir, job_id)
+            return _handle(record, idempotent=True)
+
+        timestamp = _now_iso(now)
+        job_id = f"grokbot-{secrets.token_hex(12)}"
+        record = {
+            "schema": JOB_SCHEMA,
+            "job_id": job_id,
+            "task_hash": task_hash,
+            "state": "queued",
+            "created_at": timestamp,
+            "updated_at": timestamp,
+            "queued_at": timestamp,
+            "timeout_seconds": envelope["timeout_seconds"],
+            "revision": 1,
+            "spec": envelope,
+        }
+        _write_json_file(jobs_dir / f"{job_id}.json", record)
+        _write_json_file(
+            idempotency_path,
+            {"schema": IDEMPOTENCY_SCHEMA, "job_id": job_id, "task_hash": task_hash},
+        )
+        return _handle(record, idempotent=False)
+
+
+def get_job(target: Path, job_id: str) -> dict[str, Any]:
+    """Return the safe projection for one job, never its private envelope."""
+    _, jobs_dir, _, _ = _storage_paths(target)
+    return _projection(_load_record(jobs_dir, _validate_job_id(job_id)))
+
+
+def status(target: Path, job_id: str | None = None) -> dict[str, Any]:
+    """Return one job projection or all safe projections in deterministic order."""
+    if job_id is not None:
+        return get_job(target, job_id)
+    _, jobs_dir, _, _ = _storage_paths(target)
+    jobs: list[dict[str, Any]] = []
+    for path in sorted(jobs_dir.glob("grokbot-*.json")):
+        _assert_regular_file(path)
+        record = _read_json_file(path)
+        if record is None:
+            raise GrokbotJobError("corrupt-storage")
+        jobs.append(_projection(_validate_record(record)))
+    return {"jobs": jobs}
+
+
+def _storage_paths(target: Path) -> tuple[Path, Path, Path, Path]:
+    base = Path(target).expanduser().absolute()
+    root = base / ".brigade" / "cloud" / "grokbot"
+    _ensure_directory(root)
+    jobs_dir = root / "jobs"
+    idempotency_dir = root / "idempotency"
+    _ensure_directory(jobs_dir)
+    _ensure_directory(idempotency_dir)
+    lock_path = root / "queue.lock"
+    _assert_regular_or_missing(lock_path)
+    return root, jobs_dir, idempotency_dir, lock_path
+
+
+def _ensure_directory(path: Path) -> None:
+    try:
+        current = path.lstat()
+    except FileNotFoundError:
+        try:
+            path.mkdir(parents=True, mode=ROOT_MODE)
+        except FileExistsError:
+            pass
+        try:
+            current = path.lstat()
+        except FileNotFoundError as exc:
+            raise GrokbotJobError("unsafe-storage") from exc
+    if stat.S_ISLNK(current.st_mode) or not stat.S_ISDIR(current.st_mode):
+        raise GrokbotJobError("unsafe-storage")
+    os.chmod(path, ROOT_MODE)
+
+
+def _assert_regular_or_missing(path: Path) -> None:
+    try:
+        current = path.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(current.st_mode) or not stat.S_ISREG(current.st_mode):
+        raise GrokbotJobError("unsafe-storage")
+
+
+def _assert_regular_file(path: Path) -> None:
+    _assert_regular_or_missing(path)
+    if not path.exists():
+        raise GrokbotJobError("job-not-found")
+
+
+@contextmanager
+def _queue_lock(root: Path, lock_path: Path) -> Iterator[None]:
+    _ensure_directory(root)
+    _assert_regular_or_missing(lock_path)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(lock_path, flags, FILE_MODE)
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    locked = False
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise GrokbotJobError("unsafe-storage")
+        _chmod_file_descriptor(descriptor, lock_path)
+        if fcntl is not None:
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+        elif msvcrt is not None:  # pragma: no cover - Windows only.
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            if os.fstat(descriptor).st_size == 0:
+                os.write(descriptor, b"\0")
+                os.fsync(descriptor)
+                os.lseek(descriptor, 0, os.SEEK_SET)
+            msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+        else:  # pragma: no cover - unsupported Python platform.
+            raise GrokbotJobError("queue-lock-unavailable")
+        locked = True
+        yield
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    finally:
+        if locked:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+                elif msvcrt is not None:  # pragma: no cover - Windows only.
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+            finally:
+                os.close(descriptor)
+        else:
+            os.close(descriptor)
+
+
+def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
+    _ensure_directory(path.parent)
+    _assert_regular_or_missing(path)
+    data = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    descriptor, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    temporary = Path(temporary_name)
+    try:
+        _chmod_file_descriptor(descriptor, temporary)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _assert_regular_or_missing(path)
+        os.replace(temporary, path)
+        os.chmod(path, FILE_MODE)
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _read_json_file(path: Path, *, missing_ok: bool = False) -> dict[str, Any] | None:
+    _assert_regular_or_missing(path)
+    if not path.exists():
+        if missing_ok:
+            return None
+        raise GrokbotJobError("job-not-found")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GrokbotJobError("corrupt-storage") from exc
+    if not isinstance(payload, dict):
+        raise GrokbotJobError("corrupt-storage")
+    return payload
+
+
+def _chmod_file_descriptor(descriptor: int, path: Path) -> None:
+    if hasattr(os, "fchmod"):
+        os.fchmod(descriptor, FILE_MODE)
+        return
+    _assert_regular_file(path)
+    os.chmod(path, FILE_MODE)
+
+
+def _load_record(jobs_dir: Path, job_id: str) -> dict[str, Any]:
+    record = _read_json_file(jobs_dir / f"{job_id}.json")
+    if record is None:  # Kept for the benefit of static type checkers.
+        raise GrokbotJobError("job-not-found")
+    return _validate_record(record)
+
+
+def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
+    if record.get("schema") != JOB_SCHEMA:
+        raise GrokbotJobError("corrupt-storage")
+    job_id = record.get("job_id")
+    if not isinstance(job_id, str) or not JOB_ID_RE.fullmatch(job_id):
+        raise GrokbotJobError("corrupt-storage")
+    if record.get("state") not in JOB_STATES:
+        raise GrokbotJobError("corrupt-storage")
+    if not isinstance(record.get("spec"), dict):
+        raise GrokbotJobError("corrupt-storage")
+    _validate_spec(record["spec"])
+    return record
+
+
+def _handle(record: dict[str, Any], *, idempotent: bool) -> dict[str, Any]:
+    return {"job_id": record["job_id"], "state": record["state"], "idempotent": idempotent}
+
+
+def _projection(record: dict[str, Any]) -> dict[str, Any]:
+    spec = record["spec"]
+    assert isinstance(spec, dict)
+    return {
+        "job_id": record["job_id"],
+        "label": spec["label"],
+        "role": spec["role"],
+        "repository": spec["repository"],
+        "task_hash": record["task_hash"],
+        "state": record["state"],
+        "created_at": record["created_at"],
+        "updated_at": record["updated_at"],
+        "queued_at": record["queued_at"],
+        "timeout_seconds": record["timeout_seconds"],
+        "revision": record["revision"],
+        "artifact": spec["artifact"],
+    }
+
+
+def _validate_spec(spec: object) -> dict[str, Any]:
+    if not isinstance(spec, dict):
+        raise GrokbotJobError("invalid-spec")
+    _reject_sensitive_keys(spec)
+    keys = set(spec)
+    unknown = keys - REQUIRED_ENVELOPE_KEYS
+    if unknown:
+        raise GrokbotJobError("unknown-key")
+    if keys != REQUIRED_ENVELOPE_KEYS:
+        raise GrokbotJobError("missing-key")
+
+    normalized = json.loads(json.dumps(spec, sort_keys=True, separators=(",", ":")))
+    _bounded_string(normalized["label"], reason="invalid-label", maximum=160)
+    role = normalized["role"]
+    if role not in ROLES:
+        raise GrokbotJobError("invalid-role")
+    _validate_repository(normalized["repository"])
+    _validate_base_ref(normalized["base_ref"])
+    _validate_ownership_paths(normalized["ownership_paths"])
+    _bounded_string(normalized["instructions"], reason="invalid-instructions", maximum=16000)
+    _validate_commands(normalized["verification_commands"])
+    _validate_artifact(normalized["artifact"], role=role)
+    timeout = normalized["timeout_seconds"]
+    if type(timeout) is not int or not 60 <= timeout <= 14400:
+        raise GrokbotJobError("invalid-timeout")
+    return normalized
+
+
+def _reject_sensitive_keys(value: object) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise GrokbotJobError("invalid-spec")
+            lowered = key.casefold()
+            if any(token in lowered for token in SENSITIVE_KEY_TOKENS):
+                raise GrokbotJobError("forbidden-key")
+            _reject_sensitive_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            _reject_sensitive_keys(child)
+
+
+def _bounded_string(value: object, *, reason: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > maximum or "\x00" in value:
+        raise GrokbotJobError(reason)
+    return value
+
+
+def _validate_repository(value: object) -> None:
+    repository = _bounded_string(value, reason="invalid-repository", maximum=200)
+    parts = repository.split("/")
+    if len(parts) != 2 or not all(REPOSITORY_PART_RE.fullmatch(part) for part in parts):
+        raise GrokbotJobError("invalid-repository")
+
+
+def _validate_base_ref(value: object) -> None:
+    ref = _bounded_string(value, reason="invalid-base-ref", maximum=128)
+    if (
+        not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", ref)
+        or "//" in ref
+        or ".." in ref
+        or "@{" in ref
+        or ref.endswith((".", "/"))
+        or any(part.endswith(".lock") for part in ref.split("/"))
+    ):
+        raise GrokbotJobError("invalid-base-ref")
+
+
+def _validate_ownership_paths(value: object) -> None:
+    if not isinstance(value, list) or not 1 <= len(value) <= 64:
+        raise GrokbotJobError("invalid-ownership-paths")
+    paths: set[str] = set()
+    for item in value:
+        path = _bounded_string(item, reason="invalid-ownership-paths", maximum=512)
+        if (
+            path in paths
+            or path.startswith("/")
+            or "\\" in path
+            or any(part in {"", ".", ".."} for part in path.split("/"))
+        ):
+            raise GrokbotJobError("invalid-ownership-paths")
+        paths.add(path)
+
+
+def _validate_commands(value: object) -> None:
+    if not isinstance(value, list) or not 1 <= len(value) <= 32:
+        raise GrokbotJobError("invalid-verification-commands")
+    for command in value:
+        _bounded_string(command, reason="invalid-verification-commands", maximum=1000)
+
+
+def _validate_artifact(value: object, *, role: object) -> None:
+    if not isinstance(value, dict):
+        raise GrokbotJobError("invalid-artifact")
+    if set(value) != {"kind"}:
+        raise GrokbotJobError("invalid-artifact")
+    kind = value.get("kind")
+    if kind not in ARTIFACT_KINDS:
+        raise GrokbotJobError("invalid-artifact")
+    if role == "implementation-worker" and kind not in {"draft-pr", "branch"}:
+        raise GrokbotJobError("invalid-artifact")
+    if role == "repository-scout" and kind != "report":
+        raise GrokbotJobError("invalid-artifact")
+
+
+def _validate_idempotency_key(value: object) -> str:
+    if not isinstance(value, str) or not IDEMPOTENCY_KEY_RE.fullmatch(value):
+        raise GrokbotJobError("invalid-idempotency-key")
+    return value
+
+
+def _validate_job_id(value: object) -> str:
+    if not isinstance(value, str) or not JOB_ID_RE.fullmatch(value):
+        raise GrokbotJobError("invalid-job-id")
+    return value
+
+
+def _task_hash(spec: dict[str, Any]) -> str:
+    encoded = json.dumps(spec, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _now_iso(now: datetime | None) -> str:
+    value = now or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -12,8 +12,8 @@ import os
 import re
 import secrets
 import stat
-import tempfile
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator
@@ -81,6 +81,19 @@ class GrokbotJobError(ValueError):
         super().__init__(reason)
 
 
+@dataclass(frozen=True)
+class _Directory:
+    path: Path
+    descriptor: int | None
+
+
+@dataclass(frozen=True)
+class _Storage:
+    root: _Directory
+    jobs: _Directory
+    idempotency: _Directory
+
+
 def enqueue(
     target: Path,
     spec: dict[str, Any],
@@ -91,20 +104,30 @@ def enqueue(
     envelope = _validate_spec(spec)
     key = _validate_idempotency_key(idempotency_key)
     task_hash = _task_hash(envelope)
-    root, jobs_dir, idempotency_dir, lock_path = _storage_paths(target)
-
-    with _queue_lock(root, lock_path):
-        idempotency_path = idempotency_dir / f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.json"
-        existing = _read_json_file(idempotency_path, missing_ok=True)
+    key_hash = _idempotency_key_hash(key)
+    with _storage_paths(target) as storage, _queue_lock(storage):
+        idempotency_name = f"{key_hash.removeprefix('sha256:')}.json"
+        existing = _read_json_file(storage.idempotency, idempotency_name, missing_ok=True)
         if existing is not None:
             idempotency = _validate_idempotency_record(existing)
             if idempotency["task_hash"] != task_hash:
                 raise GrokbotJobError("idempotency-conflict")
             job_id = idempotency["job_id"]
-            record = _load_record(jobs_dir, job_id)
+            record = _load_record(storage.jobs, job_id)
             if record["task_hash"] != task_hash:
                 raise GrokbotJobError("corrupt-storage")
             return _handle(record, idempotent=True)
+
+        recovered = _find_record_by_idempotency_hash(storage.jobs, key_hash)
+        if recovered is not None:
+            if recovered["task_hash"] != task_hash:
+                raise GrokbotJobError("idempotency-conflict")
+            _write_json_file(
+                storage.idempotency,
+                idempotency_name,
+                {"schema": IDEMPOTENCY_SCHEMA, "job_id": recovered["job_id"], "task_hash": task_hash},
+            )
+            return _handle(recovered, idempotent=True)
 
         timestamp = _now_iso(now)
         job_id = f"grokbot-{secrets.token_hex(12)}"
@@ -112,6 +135,7 @@ def enqueue(
             "schema": JOB_SCHEMA,
             "job_id": job_id,
             "task_hash": task_hash,
+            "idempotency_key_hash": key_hash,
             "state": "queued",
             "created_at": timestamp,
             "updated_at": timestamp,
@@ -120,9 +144,10 @@ def enqueue(
             "item_revision": 1,
             "spec": envelope,
         }
-        _write_json_file(jobs_dir / f"{job_id}.json", record)
+        _write_json_file(storage.jobs, f"{job_id}.json", record)
         _write_json_file(
-            idempotency_path,
+            storage.idempotency,
+            idempotency_name,
             {"schema": IDEMPOTENCY_SCHEMA, "job_id": job_id, "task_hash": task_hash},
         )
         return _handle(record, idempotent=False)
@@ -130,23 +155,22 @@ def enqueue(
 
 def get_job(target: Path, job_id: str) -> dict[str, Any]:
     """Return the safe projection for one job, never its private envelope."""
-    _, jobs_dir, _, _ = _storage_paths(target)
-    return _projection(_load_record(jobs_dir, _validate_job_id(job_id)))
+    with _storage_paths(target) as storage:
+        return _projection(_load_record(storage.jobs, _validate_job_id(job_id)))
 
 
 def status(target: Path, job_id: str | None = None) -> dict[str, Any]:
     """Return one job projection or all safe projections in deterministic order."""
     if job_id is not None:
         return get_job(target, job_id)
-    _, jobs_dir, _, _ = _storage_paths(target)
-    jobs: list[dict[str, Any]] = []
-    for path in sorted(jobs_dir.glob("grokbot-*.json")):
-        _assert_regular_file(path)
-        record = _read_json_file(path)
-        if record is None:
-            raise GrokbotJobError("corrupt-storage")
-        jobs.append(_projection(_validate_record(record)))
-    return {"jobs": jobs}
+    with _storage_paths(target) as storage:
+        jobs: list[dict[str, Any]] = []
+        for name in _list_names(storage.jobs, prefix="grokbot-", suffix=".json"):
+            record = _read_json_file(storage.jobs, name)
+            if record is None:
+                raise GrokbotJobError("corrupt-storage")
+            jobs.append(_projection(_validate_record(record)))
+        return {"jobs": jobs}
 
 
 def claim(
@@ -162,10 +186,9 @@ def claim(
     bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
     lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
     lease_seconds = _validate_lease_seconds(lease_seconds)
-    root, jobs_dir, _, lock_path = _storage_paths(target)
     timestamp, instant = _timestamp(now)
-    with _queue_lock(root, lock_path):
-        record = _load_record(jobs_dir, job_id)
+    with _storage_paths(target) as storage, _queue_lock(storage):
+        record = _load_record(storage.jobs, job_id)
         if record["state"] == "claimed":
             if record["bot_id"] == bot_id and record["lease_id"] == lease_id:
                 _require_live_lease(record, instant)
@@ -185,7 +208,7 @@ def claim(
                 "lease_id": lease_id,
             }
         )
-        _commit_mutation(jobs_dir, record, timestamp)
+        _commit_mutation(storage.jobs, record, timestamp)
         return _projection(record)
 
 
@@ -202,15 +225,14 @@ def renew(
     bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
     lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
     lease_seconds = _validate_lease_seconds(lease_seconds)
-    root, jobs_dir, _, lock_path = _storage_paths(target)
     timestamp, instant = _timestamp(now)
-    with _queue_lock(root, lock_path):
-        record = _load_record(jobs_dir, job_id)
+    with _storage_paths(target) as storage, _queue_lock(storage):
+        record = _load_record(storage.jobs, job_id)
         _require_current_lease(record, bot_id, lease_id, instant)
         record["lease_expires_at"] = _format_timestamp(
             min(instant + timedelta(seconds=lease_seconds), _deadline(record))
         )
-        _commit_mutation(jobs_dir, record, timestamp)
+        _commit_mutation(storage.jobs, record, timestamp)
         return _projection(record)
 
 
@@ -230,15 +252,16 @@ def transition(
     lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
     if state not in {"running", "completed", "failed"}:
         raise GrokbotJobError("invalid-transition")
-    root, jobs_dir, _, lock_path = _storage_paths(target)
     timestamp, instant = _timestamp(now)
-    with _queue_lock(root, lock_path):
-        record = _load_record(jobs_dir, job_id)
+    with _storage_paths(target) as storage, _queue_lock(storage):
+        record = _load_record(storage.jobs, job_id)
         _require_current_lease(record, bot_id, lease_id, instant)
         current = record["state"]
         if state == "running":
             if current != "claimed" or artifact is not None:
                 raise GrokbotJobError("invalid-transition")
+            if "cancel_requested_at" in record:
+                raise GrokbotJobError("cancel-requested")
         elif state == "failed":
             if current not in {"claimed", "running"} or artifact is not None:
                 raise GrokbotJobError("invalid-transition")
@@ -249,26 +272,25 @@ def transition(
                 raise GrokbotJobError("cancel-requested")
             record["result_artifact"] = _validate_completion_artifact(artifact, record["spec"])
         record["state"] = state
-        _commit_mutation(jobs_dir, record, timestamp)
+        _commit_mutation(storage.jobs, record, timestamp)
         return _projection(record)
 
 
 def cancel(target: Path, job_id: str, now: datetime | None = None) -> dict[str, Any]:
     """Cancel a queued job or request cooperative cancellation of a live lease."""
     job_id = _validate_job_id(job_id)
-    root, jobs_dir, _, lock_path = _storage_paths(target)
     timestamp, _ = _timestamp(now)
-    with _queue_lock(root, lock_path):
-        record = _load_record(jobs_dir, job_id)
+    with _storage_paths(target) as storage, _queue_lock(storage):
+        record = _load_record(storage.jobs, job_id)
         if record["state"] in {"completed", "failed", "expired", "canceled"}:
             return _projection(record)
         if record["state"] == "queued":
             record["state"] = "canceled"
-            _commit_mutation(jobs_dir, record, timestamp)
+            _commit_mutation(storage.jobs, record, timestamp)
             return _projection(record)
         if "cancel_requested_at" not in record:
             record["cancel_requested_at"] = timestamp
-            _commit_mutation(jobs_dir, record, timestamp)
+            _commit_mutation(storage.jobs, record, timestamp)
         return _projection(record)
 
 
@@ -283,47 +305,113 @@ def acknowledge_cancel(
     job_id = _validate_job_id(job_id)
     bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
     lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
-    root, jobs_dir, _, lock_path = _storage_paths(target)
     timestamp, instant = _timestamp(now)
-    with _queue_lock(root, lock_path):
-        record = _load_record(jobs_dir, job_id)
+    with _storage_paths(target) as storage, _queue_lock(storage):
+        record = _load_record(storage.jobs, job_id)
         _require_current_lease(record, bot_id, lease_id, instant)
         if "cancel_requested_at" not in record:
             raise GrokbotJobError("cancellation-not-requested")
         record["state"] = "canceled"
-        _commit_mutation(jobs_dir, record, timestamp)
+        _commit_mutation(storage.jobs, record, timestamp)
         return _projection(record)
 
 
 def expire(target: Path, job_id: str, now: datetime | None = None) -> dict[str, Any]:
     """Terminalize jobs whose deadline or current lease has elapsed, never requeue."""
     job_id = _validate_job_id(job_id)
-    root, jobs_dir, _, lock_path = _storage_paths(target)
     timestamp, instant = _timestamp(now)
-    with _queue_lock(root, lock_path):
-        record = _load_record(jobs_dir, job_id)
+    with _storage_paths(target) as storage, _queue_lock(storage):
+        record = _load_record(storage.jobs, job_id)
         if record["state"] in {"completed", "failed", "expired", "canceled"}:
             return _projection(record)
         deadline = _deadline(record)
-        expires_at = deadline if record["state"] == "queued" else min(_parse_timestamp(record["lease_expires_at"]), deadline)
+        expires_at = (
+            deadline if record["state"] == "queued" else min(_parse_timestamp(record["lease_expires_at"]), deadline)
+        )
         if instant < expires_at:
             return _projection(record)
         record["state"] = "expired"
-        _commit_mutation(jobs_dir, record, timestamp)
+        _commit_mutation(storage.jobs, record, timestamp)
         return _projection(record)
 
 
-def _storage_paths(target: Path) -> tuple[Path, Path, Path, Path]:
-    base = Path(target).expanduser().absolute()
-    root = base / ".brigade" / "cloud" / "grokbot"
-    _ensure_directory(root)
-    jobs_dir = root / "jobs"
-    idempotency_dir = root / "idempotency"
-    _ensure_directory(jobs_dir)
-    _ensure_directory(idempotency_dir)
-    lock_path = root / "queue.lock"
-    _assert_regular_or_missing(lock_path)
-    return root, jobs_dir, idempotency_dir, lock_path
+@contextmanager
+def _storage_paths(target: Path) -> Iterator[_Storage]:
+    """Open queue directories once so POSIX operations stay below verified fds."""
+    descriptors: list[int] = []
+    try:
+        if os.name != "posix":  # pragma: no cover - exercised on Windows.
+            base = Path(target).expanduser().absolute()
+            root = base / ".brigade" / "cloud" / "grokbot"
+            _ensure_directory(root)
+            jobs = root / "jobs"
+            idempotency = root / "idempotency"
+            _ensure_directory(jobs)
+            _ensure_directory(idempotency)
+            _assert_regular_or_missing(root / "queue.lock")
+            yield _Storage(_Directory(root, None), _Directory(jobs, None), _Directory(idempotency, None))
+            return
+
+        base_fd = _open_directory_path(Path(target).expanduser().absolute())
+        descriptors.append(base_fd)
+        brigade_fd = _open_or_create_directory(base_fd, ".brigade")
+        descriptors.append(brigade_fd)
+        cloud_fd = _open_or_create_directory(brigade_fd, "cloud")
+        descriptors.append(cloud_fd)
+        root_fd = _open_or_create_directory(cloud_fd, "grokbot")
+        descriptors.append(root_fd)
+        jobs_fd = _open_or_create_directory(root_fd, "jobs")
+        descriptors.append(jobs_fd)
+        idempotency_fd = _open_or_create_directory(root_fd, "idempotency")
+        descriptors.append(idempotency_fd)
+        yield _Storage(
+            _Directory(Path(target) / ".brigade" / "cloud" / "grokbot", root_fd),
+            _Directory(Path(target) / ".brigade" / "cloud" / "grokbot" / "jobs", jobs_fd),
+            _Directory(Path(target) / ".brigade" / "cloud" / "grokbot" / "idempotency", idempotency_fd),
+        )
+    except GrokbotJobError:
+        raise
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    finally:
+        close_error: OSError | None = None
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                close_error = exc
+        if close_error is not None:
+            raise GrokbotJobError("unsafe-storage") from close_error
+
+
+def _directory_flags() -> int:
+    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+
+
+def _open_directory_path(path: Path) -> int:
+    descriptor = os.open(os.fspath(path), _directory_flags())
+    _assert_directory_descriptor(descriptor)
+    return descriptor
+
+
+def _open_or_create_directory(parent: int, name: str) -> int:
+    try:
+        os.mkdir(name, ROOT_MODE, dir_fd=parent)
+    except FileExistsError:
+        pass
+    descriptor = os.open(name, _directory_flags(), dir_fd=parent)
+    try:
+        _assert_directory_descriptor(descriptor)
+        os.fchmod(descriptor, ROOT_MODE)
+    except OSError:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _assert_directory_descriptor(descriptor: int) -> None:
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        raise GrokbotJobError("unsafe-storage")
 
 
 def _ensure_directory(path: Path) -> None:
@@ -359,12 +447,14 @@ def _assert_regular_file(path: Path) -> None:
 
 
 @contextmanager
-def _queue_lock(root: Path, lock_path: Path) -> Iterator[None]:
-    _ensure_directory(root)
-    _assert_regular_or_missing(lock_path)
+def _queue_lock(storage: _Storage) -> Iterator[None]:
+    if storage.root.descriptor is None:  # pragma: no cover - exercised on Windows.
+        with _queue_lock_windows(storage.root.path, storage.root.path / "queue.lock"):
+            yield
+        return
     flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
     try:
-        descriptor = os.open(lock_path, flags, FILE_MODE)
+        descriptor = os.open("queue.lock", flags, FILE_MODE, dir_fd=storage.root.descriptor)
     except OSError as exc:
         raise GrokbotJobError("unsafe-storage") from exc
     locked = False
@@ -372,7 +462,7 @@ def _queue_lock(root: Path, lock_path: Path) -> Iterator[None]:
         info = os.fstat(descriptor)
         if not stat.S_ISREG(info.st_mode):
             raise GrokbotJobError("unsafe-storage")
-        _chmod_file_descriptor(descriptor, lock_path)
+        _chmod_file_descriptor(descriptor, None)
         if fcntl is not None:
             fcntl.flock(descriptor, fcntl.LOCK_EX)
         elif msvcrt is not None:  # pragma: no cover - Windows only.
@@ -402,28 +492,168 @@ def _queue_lock(root: Path, lock_path: Path) -> Iterator[None]:
             os.close(descriptor)
 
 
-def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
+@contextmanager
+def _queue_lock_windows(root: Path, lock_path: Path) -> Iterator[None]:  # pragma: no cover - Windows only.
+    _ensure_directory(root)
+    _assert_regular_or_missing(lock_path)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(lock_path, flags, FILE_MODE)
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    locked = False
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise GrokbotJobError("unsafe-storage")
+        _chmod_file_descriptor(descriptor, lock_path)
+        if msvcrt is None:
+            raise GrokbotJobError("queue-lock-unavailable")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+            os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+        locked = True
+        yield
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    finally:
+        try:
+            if locked:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        except OSError as exc:
+            raise GrokbotJobError("unsafe-storage") from exc
+        finally:
+            os.close(descriptor)
+
+
+def _write_json_file(directory: _Directory, name: str, payload: dict[str, Any]) -> None:
+    data = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    if directory.descriptor is None:  # pragma: no cover - exercised on Windows.
+        _write_json_file_windows(directory.path / name, data)
+        return
+    temporary = f".{name}.{secrets.token_hex(12)}.tmp"
+    descriptor: int | None = None
+    temporary_created = False
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+            FILE_MODE,
+            dir_fd=directory.descriptor,
+        )
+        temporary_created = True
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise GrokbotJobError("unsafe-storage")
+        _chmod_file_descriptor(descriptor, None)
+        _write_all(descriptor, data)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(temporary, name, src_dir_fd=directory.descriptor, dst_dir_fd=directory.descriptor)
+        temporary_created = False
+        os.fsync(directory.descriptor)
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    finally:
+        cleanup_error: OSError | None = None
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                cleanup_error = exc
+        if temporary_created:
+            try:
+                os.unlink(temporary, dir_fd=directory.descriptor)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                cleanup_error = exc
+        if cleanup_error is not None:
+            raise GrokbotJobError("unsafe-storage") from cleanup_error
+
+
+def _write_json_file_windows(path: Path, data: bytes) -> None:  # pragma: no cover - Windows only.
     _ensure_directory(path.parent)
     _assert_regular_or_missing(path)
-    data = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
-    descriptor, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
-    temporary = Path(temporary_name)
+    descriptor: int | None = None
+    temporary: Path | None = None
     try:
+        temporary = path.parent / f".{path.name}.{secrets.token_hex(12)}.tmp"
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, FILE_MODE)
         _chmod_file_descriptor(descriptor, temporary)
-        with os.fdopen(descriptor, "wb") as handle:
-            handle.write(data)
-            handle.flush()
-            os.fsync(handle.fileno())
-        _assert_regular_or_missing(path)
+        _write_all(descriptor, data)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
         os.replace(temporary, path)
+        temporary = None
         os.chmod(path, FILE_MODE)
     except OSError as exc:
         raise GrokbotJobError("unsafe-storage") from exc
     finally:
-        temporary.unlink(missing_ok=True)
+        if descriptor is not None:
+            os.close(descriptor)
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError as exc:
+                raise GrokbotJobError("unsafe-storage") from exc
 
 
-def _read_json_file(path: Path, *, missing_ok: bool = False) -> dict[str, Any] | None:
+def _write_all(descriptor: int, data: bytes) -> None:
+    offset = 0
+    while offset < len(data):
+        written = os.write(descriptor, data[offset:])
+        if written <= 0:
+            raise OSError("short write")
+        offset += written
+
+
+def _read_json_file(directory: _Directory, name: str, *, missing_ok: bool = False) -> dict[str, Any] | None:
+    if directory.descriptor is None:  # pragma: no cover - exercised on Windows.
+        return _read_json_file_windows(directory.path / name, missing_ok=missing_ok)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            name, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0), dir_fd=directory.descriptor
+        )
+    except FileNotFoundError:
+        if missing_ok:
+            return None
+        raise GrokbotJobError("job-not-found") from None
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise GrokbotJobError("unsafe-storage")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        payload = json.loads(b"".join(chunks).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GrokbotJobError("corrupt-storage") from exc
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                raise GrokbotJobError("unsafe-storage") from exc
+    if not isinstance(payload, dict):
+        raise GrokbotJobError("corrupt-storage")
+    return payload
+
+
+def _read_json_file_windows(
+    path: Path, *, missing_ok: bool
+) -> dict[str, Any] | None:  # pragma: no cover - Windows only.
     _assert_regular_or_missing(path)
     if not path.exists():
         if missing_ok:
@@ -431,26 +661,55 @@ def _read_json_file(path: Path, *, missing_ok: bool = False) -> dict[str, Any] |
         raise GrokbotJobError("job-not-found")
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise GrokbotJobError("corrupt-storage") from exc
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
     if not isinstance(payload, dict):
         raise GrokbotJobError("corrupt-storage")
     return payload
 
 
-def _chmod_file_descriptor(descriptor: int, path: Path) -> None:
+def _chmod_file_descriptor(descriptor: int, path: Path | None) -> None:
     if hasattr(os, "fchmod"):
         os.fchmod(descriptor, FILE_MODE)
         return
+    if path is None:
+        raise GrokbotJobError("unsafe-storage")
     _assert_regular_file(path)
     os.chmod(path, FILE_MODE)
 
 
-def _load_record(jobs_dir: Path, job_id: str) -> dict[str, Any]:
-    record = _read_json_file(jobs_dir / f"{job_id}.json")
+def _load_record(jobs_dir: _Directory, job_id: str) -> dict[str, Any]:
+    record = _read_json_file(jobs_dir, f"{job_id}.json")
     if record is None:  # Kept for the benefit of static type checkers.
         raise GrokbotJobError("job-not-found")
     return _validate_record(record)
+
+
+def _list_names(directory: _Directory, *, prefix: str, suffix: str) -> list[str]:
+    try:
+        if directory.descriptor is None:  # pragma: no cover - exercised on Windows.
+            names = [path.name for path in directory.path.glob(f"{prefix}*{suffix}")]
+        else:
+            names = os.listdir(directory.descriptor)
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
+    return sorted(name for name in names if name.startswith(prefix) and name.endswith(suffix))
+
+
+def _find_record_by_idempotency_hash(jobs_dir: _Directory, key_hash: str) -> dict[str, Any] | None:
+    match: dict[str, Any] | None = None
+    for name in _list_names(jobs_dir, prefix="grokbot-", suffix=".json"):
+        record = _read_json_file(jobs_dir, name)
+        if record is None:
+            raise GrokbotJobError("corrupt-storage")
+        validated = _validate_record(record)
+        if validated["idempotency_key_hash"] == key_hash:
+            if match is not None:
+                raise GrokbotJobError("corrupt-storage")
+            match = validated
+    return match
 
 
 def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
@@ -458,6 +717,7 @@ def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
         "schema",
         "job_id",
         "task_hash",
+        "idempotency_key_hash",
         "state",
         "created_at",
         "updated_at",
@@ -489,6 +749,9 @@ def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
     task_hash = record.get("task_hash")
     if not isinstance(task_hash, str) or not TASK_HASH_RE.fullmatch(task_hash) or task_hash != _task_hash(spec):
         raise GrokbotJobError("corrupt-storage")
+    idempotency_key_hash = record.get("idempotency_key_hash")
+    if not isinstance(idempotency_key_hash, str) or not TASK_HASH_RE.fullmatch(idempotency_key_hash):
+        raise GrokbotJobError("corrupt-storage")
     if type(record.get("item_revision")) is not int or record["item_revision"] < 1:
         raise GrokbotJobError("corrupt-storage")
     created_at = _parse_timestamp(record.get("created_at"))
@@ -509,9 +772,12 @@ def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
         _validate_opaque_id(record["bot_id"], "corrupt-storage")
         _validate_opaque_id(record["lease_id"], "corrupt-storage")
     if "cancel_requested_at" in record:
-        if not present_live_fields or not _parse_timestamp(record["claimed_at"]) <= _parse_timestamp(
-            record["cancel_requested_at"]
-        ) <= updated_at:
+        if (
+            not present_live_fields
+            or not _parse_timestamp(record["claimed_at"])
+            <= _parse_timestamp(record["cancel_requested_at"])
+            <= updated_at
+        ):
             raise GrokbotJobError("corrupt-storage")
     state = record["state"]
     if state == "queued" and (present_live_fields or "cancel_requested_at" in record or "result_artifact" in record):
@@ -519,7 +785,7 @@ def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
     if state in {"claimed", "running", "failed", "completed"} and not present_live_fields:
         raise GrokbotJobError("corrupt-storage")
     if state == "completed":
-        if "result_artifact" not in record:
+        if "result_artifact" not in record or "cancel_requested_at" in record:
             raise GrokbotJobError("corrupt-storage")
         _validate_completion_artifact(record["result_artifact"], spec)
     elif "result_artifact" in record:
@@ -543,10 +809,12 @@ def _validate_idempotency_record(record: object) -> dict[str, Any]:
     return record
 
 
-def _commit_mutation(jobs_dir: Path, record: dict[str, Any], timestamp: str) -> None:
+def _commit_mutation(jobs_dir: _Directory, record: dict[str, Any], timestamp: str) -> None:
+    if _parse_timestamp(timestamp) < _parse_timestamp(record["updated_at"]):
+        raise GrokbotJobError("clock-regression")
     record["updated_at"] = timestamp
     record["item_revision"] += 1
-    _write_json_file(jobs_dir / f"{record['job_id']}.json", record)
+    _write_json_file(jobs_dir, f"{record['job_id']}.json", record)
 
 
 def _reject_nonqueued_claim(record: dict[str, Any]) -> None:
@@ -733,6 +1001,10 @@ def _validate_job_id(value: object) -> str:
 def _task_hash(spec: dict[str, Any]) -> str:
     encoded = json.dumps(spec, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _idempotency_key_hash(key: str) -> str:
+    return "sha256:" + hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
 def _now_iso(now: datetime | None) -> str:

--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -14,7 +14,7 @@ import secrets
 import stat
 import tempfile
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -32,6 +32,13 @@ except ImportError:  # pragma: no cover - exercised on POSIX.
 JOB_ID_RE = re.compile(r"^grokbot-[0-9a-f]{24}$")
 REPOSITORY_PART_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,98}$")
 IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+TASK_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+OPAQUE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+GITHUB_PULL_URL_RE = re.compile(
+    r"^https://github\.com/[A-Za-z0-9][A-Za-z0-9_.-]{0,98}/[A-Za-z0-9][A-Za-z0-9_.-]{0,98}/pull/[1-9][0-9]*$"
+)
+LOWER_HEX_40_RE = re.compile(r"^[0-9a-f]{40}$")
+LOWER_HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
 
 JOB_STATES = frozenset({"queued", "claimed", "running", "completed", "failed", "expired", "canceled"})
 ROLES = frozenset({"implementation-worker", "repository-scout"})
@@ -90,12 +97,13 @@ def enqueue(
         idempotency_path = idempotency_dir / f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.json"
         existing = _read_json_file(idempotency_path, missing_ok=True)
         if existing is not None:
-            if existing.get("task_hash") != task_hash:
+            idempotency = _validate_idempotency_record(existing)
+            if idempotency["task_hash"] != task_hash:
                 raise GrokbotJobError("idempotency-conflict")
-            job_id = existing.get("job_id")
-            if not isinstance(job_id, str) or not JOB_ID_RE.fullmatch(job_id):
-                raise GrokbotJobError("corrupt-storage")
+            job_id = idempotency["job_id"]
             record = _load_record(jobs_dir, job_id)
+            if record["task_hash"] != task_hash:
+                raise GrokbotJobError("corrupt-storage")
             return _handle(record, idempotent=True)
 
         timestamp = _now_iso(now)
@@ -109,7 +117,7 @@ def enqueue(
             "updated_at": timestamp,
             "queued_at": timestamp,
             "timeout_seconds": envelope["timeout_seconds"],
-            "revision": 1,
+            "item_revision": 1,
             "spec": envelope,
         }
         _write_json_file(jobs_dir / f"{job_id}.json", record)
@@ -139,6 +147,170 @@ def status(target: Path, job_id: str | None = None) -> dict[str, Any]:
             raise GrokbotJobError("corrupt-storage")
         jobs.append(_projection(_validate_record(record)))
     return {"jobs": jobs}
+
+
+def claim(
+    target: Path,
+    job_id: str,
+    bot_id: str,
+    lease_id: str,
+    lease_seconds: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Claim a queued job with one opaque bot lease."""
+    job_id = _validate_job_id(job_id)
+    bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
+    lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
+    lease_seconds = _validate_lease_seconds(lease_seconds)
+    root, jobs_dir, _, lock_path = _storage_paths(target)
+    timestamp, instant = _timestamp(now)
+    with _queue_lock(root, lock_path):
+        record = _load_record(jobs_dir, job_id)
+        if record["state"] == "claimed":
+            if record["bot_id"] == bot_id and record["lease_id"] == lease_id:
+                _require_live_lease(record, instant)
+                return _projection(record)
+            raise GrokbotJobError("lease-conflict")
+        if record["state"] != "queued":
+            _reject_nonqueued_claim(record)
+        deadline = _deadline(record)
+        if instant >= deadline:
+            raise GrokbotJobError("job-expired")
+        record.update(
+            {
+                "state": "claimed",
+                "claimed_at": timestamp,
+                "lease_expires_at": _format_timestamp(min(instant + timedelta(seconds=lease_seconds), deadline)),
+                "bot_id": bot_id,
+                "lease_id": lease_id,
+            }
+        )
+        _commit_mutation(jobs_dir, record, timestamp)
+        return _projection(record)
+
+
+def renew(
+    target: Path,
+    job_id: str,
+    bot_id: str,
+    lease_id: str,
+    lease_seconds: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Renew the current unexpired lease without changing state."""
+    job_id = _validate_job_id(job_id)
+    bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
+    lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
+    lease_seconds = _validate_lease_seconds(lease_seconds)
+    root, jobs_dir, _, lock_path = _storage_paths(target)
+    timestamp, instant = _timestamp(now)
+    with _queue_lock(root, lock_path):
+        record = _load_record(jobs_dir, job_id)
+        _require_current_lease(record, bot_id, lease_id, instant)
+        record["lease_expires_at"] = _format_timestamp(
+            min(instant + timedelta(seconds=lease_seconds), _deadline(record))
+        )
+        _commit_mutation(jobs_dir, record, timestamp)
+        return _projection(record)
+
+
+def transition(
+    target: Path,
+    job_id: str,
+    bot_id: str,
+    lease_id: str,
+    state: str,
+    *,
+    artifact: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Make one valid lease-holder lifecycle transition."""
+    job_id = _validate_job_id(job_id)
+    bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
+    lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
+    if state not in {"running", "completed", "failed"}:
+        raise GrokbotJobError("invalid-transition")
+    root, jobs_dir, _, lock_path = _storage_paths(target)
+    timestamp, instant = _timestamp(now)
+    with _queue_lock(root, lock_path):
+        record = _load_record(jobs_dir, job_id)
+        _require_current_lease(record, bot_id, lease_id, instant)
+        current = record["state"]
+        if state == "running":
+            if current != "claimed" or artifact is not None:
+                raise GrokbotJobError("invalid-transition")
+        elif state == "failed":
+            if current not in {"claimed", "running"} or artifact is not None:
+                raise GrokbotJobError("invalid-transition")
+        else:
+            if current != "running":
+                raise GrokbotJobError("invalid-transition")
+            if "cancel_requested_at" in record:
+                raise GrokbotJobError("cancel-requested")
+            record["result_artifact"] = _validate_completion_artifact(artifact, record["spec"])
+        record["state"] = state
+        _commit_mutation(jobs_dir, record, timestamp)
+        return _projection(record)
+
+
+def cancel(target: Path, job_id: str, now: datetime | None = None) -> dict[str, Any]:
+    """Cancel a queued job or request cooperative cancellation of a live lease."""
+    job_id = _validate_job_id(job_id)
+    root, jobs_dir, _, lock_path = _storage_paths(target)
+    timestamp, _ = _timestamp(now)
+    with _queue_lock(root, lock_path):
+        record = _load_record(jobs_dir, job_id)
+        if record["state"] in {"completed", "failed", "expired", "canceled"}:
+            return _projection(record)
+        if record["state"] == "queued":
+            record["state"] = "canceled"
+            _commit_mutation(jobs_dir, record, timestamp)
+            return _projection(record)
+        if "cancel_requested_at" not in record:
+            record["cancel_requested_at"] = timestamp
+            _commit_mutation(jobs_dir, record, timestamp)
+        return _projection(record)
+
+
+def acknowledge_cancel(
+    target: Path,
+    job_id: str,
+    bot_id: str,
+    lease_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Terminalize a previously requested cooperative cancellation."""
+    job_id = _validate_job_id(job_id)
+    bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
+    lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
+    root, jobs_dir, _, lock_path = _storage_paths(target)
+    timestamp, instant = _timestamp(now)
+    with _queue_lock(root, lock_path):
+        record = _load_record(jobs_dir, job_id)
+        _require_current_lease(record, bot_id, lease_id, instant)
+        if "cancel_requested_at" not in record:
+            raise GrokbotJobError("cancellation-not-requested")
+        record["state"] = "canceled"
+        _commit_mutation(jobs_dir, record, timestamp)
+        return _projection(record)
+
+
+def expire(target: Path, job_id: str, now: datetime | None = None) -> dict[str, Any]:
+    """Terminalize jobs whose deadline or current lease has elapsed, never requeue."""
+    job_id = _validate_job_id(job_id)
+    root, jobs_dir, _, lock_path = _storage_paths(target)
+    timestamp, instant = _timestamp(now)
+    with _queue_lock(root, lock_path):
+        record = _load_record(jobs_dir, job_id)
+        if record["state"] in {"completed", "failed", "expired", "canceled"}:
+            return _projection(record)
+        deadline = _deadline(record)
+        expires_at = deadline if record["state"] == "queued" else min(_parse_timestamp(record["lease_expires_at"]), deadline)
+        if instant < expires_at:
+            return _projection(record)
+        record["state"] = "expired"
+        _commit_mutation(jobs_dir, record, timestamp)
+        return _projection(record)
 
 
 def _storage_paths(target: Path) -> tuple[Path, Path, Path, Path]:
@@ -282,7 +454,27 @@ def _load_record(jobs_dir: Path, job_id: str) -> dict[str, Any]:
 
 
 def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
-    if record.get("schema") != JOB_SCHEMA:
+    required = {
+        "schema",
+        "job_id",
+        "task_hash",
+        "state",
+        "created_at",
+        "updated_at",
+        "queued_at",
+        "timeout_seconds",
+        "item_revision",
+        "spec",
+    }
+    optional = {
+        "claimed_at",
+        "lease_expires_at",
+        "bot_id",
+        "lease_id",
+        "cancel_requested_at",
+        "result_artifact",
+    }
+    if set(record) - required - optional or not required <= set(record) or record.get("schema") != JOB_SCHEMA:
         raise GrokbotJobError("corrupt-storage")
     job_id = record.get("job_id")
     if not isinstance(job_id, str) or not JOB_ID_RE.fullmatch(job_id):
@@ -291,8 +483,95 @@ def _validate_record(record: dict[str, Any]) -> dict[str, Any]:
         raise GrokbotJobError("corrupt-storage")
     if not isinstance(record.get("spec"), dict):
         raise GrokbotJobError("corrupt-storage")
-    _validate_spec(record["spec"])
+    spec = _validate_spec(record["spec"])
+    if record["spec"] != spec or record.get("timeout_seconds") != spec["timeout_seconds"]:
+        raise GrokbotJobError("corrupt-storage")
+    task_hash = record.get("task_hash")
+    if not isinstance(task_hash, str) or not TASK_HASH_RE.fullmatch(task_hash) or task_hash != _task_hash(spec):
+        raise GrokbotJobError("corrupt-storage")
+    if type(record.get("item_revision")) is not int or record["item_revision"] < 1:
+        raise GrokbotJobError("corrupt-storage")
+    created_at = _parse_timestamp(record.get("created_at"))
+    queued_at = _parse_timestamp(record.get("queued_at"))
+    updated_at = _parse_timestamp(record.get("updated_at"))
+    if not created_at <= queued_at <= updated_at:
+        raise GrokbotJobError("corrupt-storage")
+    deadline = created_at + timedelta(seconds=spec["timeout_seconds"])
+    live_fields = {"claimed_at", "lease_expires_at", "bot_id", "lease_id"}
+    present_live_fields = live_fields & set(record)
+    if present_live_fields and present_live_fields != live_fields:
+        raise GrokbotJobError("corrupt-storage")
+    if present_live_fields:
+        claimed_at = _parse_timestamp(record["claimed_at"])
+        lease_expires_at = _parse_timestamp(record["lease_expires_at"])
+        if not created_at <= claimed_at <= updated_at or not claimed_at <= lease_expires_at <= deadline:
+            raise GrokbotJobError("corrupt-storage")
+        _validate_opaque_id(record["bot_id"], "corrupt-storage")
+        _validate_opaque_id(record["lease_id"], "corrupt-storage")
+    if "cancel_requested_at" in record:
+        if not present_live_fields or not _parse_timestamp(record["claimed_at"]) <= _parse_timestamp(
+            record["cancel_requested_at"]
+        ) <= updated_at:
+            raise GrokbotJobError("corrupt-storage")
+    state = record["state"]
+    if state == "queued" and (present_live_fields or "cancel_requested_at" in record or "result_artifact" in record):
+        raise GrokbotJobError("corrupt-storage")
+    if state in {"claimed", "running", "failed", "completed"} and not present_live_fields:
+        raise GrokbotJobError("corrupt-storage")
+    if state == "completed":
+        if "result_artifact" not in record:
+            raise GrokbotJobError("corrupt-storage")
+        _validate_completion_artifact(record["result_artifact"], spec)
+    elif "result_artifact" in record:
+        raise GrokbotJobError("corrupt-storage")
+    if state == "canceled" and "cancel_requested_at" in record and not present_live_fields:
+        raise GrokbotJobError("corrupt-storage")
     return record
+
+
+def _validate_idempotency_record(record: object) -> dict[str, Any]:
+    if not isinstance(record, dict) or set(record) != {"schema", "job_id", "task_hash"}:
+        raise GrokbotJobError("corrupt-storage")
+    if record.get("schema") != IDEMPOTENCY_SCHEMA:
+        raise GrokbotJobError("corrupt-storage")
+    job_id = record.get("job_id")
+    task_hash = record.get("task_hash")
+    if not isinstance(job_id, str) or not JOB_ID_RE.fullmatch(job_id):
+        raise GrokbotJobError("corrupt-storage")
+    if not isinstance(task_hash, str) or not TASK_HASH_RE.fullmatch(task_hash):
+        raise GrokbotJobError("corrupt-storage")
+    return record
+
+
+def _commit_mutation(jobs_dir: Path, record: dict[str, Any], timestamp: str) -> None:
+    record["updated_at"] = timestamp
+    record["item_revision"] += 1
+    _write_json_file(jobs_dir / f"{record['job_id']}.json", record)
+
+
+def _reject_nonqueued_claim(record: dict[str, Any]) -> None:
+    if record["state"] in {"completed", "failed", "expired", "canceled"}:
+        raise GrokbotJobError("terminal-state")
+    raise GrokbotJobError("invalid-state")
+
+
+def _require_current_lease(record: dict[str, Any], bot_id: str, lease_id: str, instant: datetime) -> None:
+    if record["state"] in {"completed", "failed", "expired", "canceled"}:
+        raise GrokbotJobError("terminal-state")
+    if record["state"] not in {"claimed", "running"}:
+        raise GrokbotJobError("invalid-state")
+    if record["bot_id"] != bot_id or record["lease_id"] != lease_id:
+        raise GrokbotJobError("lease-conflict")
+    _require_live_lease(record, instant)
+
+
+def _require_live_lease(record: dict[str, Any], instant: datetime) -> None:
+    if instant >= min(_parse_timestamp(record["lease_expires_at"]), _deadline(record)):
+        raise GrokbotJobError("lease-expired")
+
+
+def _deadline(record: dict[str, Any]) -> datetime:
+    return _parse_timestamp(record["created_at"]) + timedelta(seconds=record["timeout_seconds"])
 
 
 def _handle(record: dict[str, Any], *, idempotent: bool) -> dict[str, Any]:
@@ -302,7 +581,7 @@ def _handle(record: dict[str, Any], *, idempotent: bool) -> dict[str, Any]:
 def _projection(record: dict[str, Any]) -> dict[str, Any]:
     spec = record["spec"]
     assert isinstance(spec, dict)
-    return {
+    projection = {
         "job_id": record["job_id"],
         "label": spec["label"],
         "role": spec["role"],
@@ -313,9 +592,13 @@ def _projection(record: dict[str, Any]) -> dict[str, Any]:
         "updated_at": record["updated_at"],
         "queued_at": record["queued_at"],
         "timeout_seconds": record["timeout_seconds"],
-        "revision": record["revision"],
+        "item_revision": record["item_revision"],
         "artifact": spec["artifact"],
     }
+    for key in ("claimed_at", "lease_expires_at", "cancel_requested_at"):
+        if key in record:
+            projection[key] = record[key]
+    return projection
 
 
 def _validate_spec(spec: object) -> dict[str, Any]:
@@ -429,6 +712,18 @@ def _validate_idempotency_key(value: object) -> str:
     return value
 
 
+def _validate_opaque_id(value: object, reason: str) -> str:
+    if not isinstance(value, str) or not OPAQUE_ID_RE.fullmatch(value):
+        raise GrokbotJobError(reason)
+    return value
+
+
+def _validate_lease_seconds(value: object) -> int:
+    if type(value) is not int or not 30 <= value <= 3600:
+        raise GrokbotJobError("invalid-lease-seconds")
+    return value
+
+
 def _validate_job_id(value: object) -> str:
     if not isinstance(value, str) or not JOB_ID_RE.fullmatch(value):
         raise GrokbotJobError("invalid-job-id")
@@ -441,7 +736,90 @@ def _task_hash(spec: dict[str, Any]) -> str:
 
 
 def _now_iso(now: datetime | None) -> str:
+    return _timestamp(now)[0]
+
+
+def _timestamp(now: datetime | None) -> tuple[str, datetime]:
     value = now or datetime.now(timezone.utc)
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
+    value = value.astimezone(timezone.utc)
+    return _format_timestamp(value), value
+
+
+def _format_timestamp(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: object) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise GrokbotJobError("corrupt-storage")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise GrokbotJobError("corrupt-storage") from exc
+    if parsed.tzinfo is None or _format_timestamp(parsed) != value:
+        raise GrokbotJobError("corrupt-storage")
+    return parsed.astimezone(timezone.utc)
+
+
+def _validate_completion_artifact(artifact: object, spec: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(artifact, dict):
+        raise GrokbotJobError("invalid-artifact")
+    expected = spec.get("artifact")
+    if not isinstance(expected, dict):  # Covered by record validation; retained for type safety.
+        raise GrokbotJobError("corrupt-storage")
+    kind = expected["kind"]
+    if artifact.get("kind") != kind:
+        raise GrokbotJobError("artifact-mismatch")
+    if kind == "draft-pr":
+        if set(artifact) != {"kind", "url", "branch"}:
+            raise GrokbotJobError("invalid-artifact")
+        url = artifact.get("url")
+        if not isinstance(url, str) or not GITHUB_PULL_URL_RE.fullmatch(url):
+            raise GrokbotJobError("invalid-artifact")
+        _validate_repo_relative_branch(artifact.get("branch"))
+    elif kind == "branch":
+        if set(artifact) != {"kind", "branch", "commit"}:
+            raise GrokbotJobError("invalid-artifact")
+        _validate_repo_relative_branch(artifact.get("branch"))
+        commit = artifact.get("commit")
+        if not isinstance(commit, str) or not LOWER_HEX_40_RE.fullmatch(commit):
+            raise GrokbotJobError("invalid-artifact")
+    elif kind == "report":
+        if set(artifact) != {"kind", "path", "sha256"}:
+            raise GrokbotJobError("invalid-artifact")
+        _validate_repo_relative_path(artifact.get("path"))
+        digest = artifact.get("sha256")
+        if not isinstance(digest, str) or not LOWER_HEX_64_RE.fullmatch(digest):
+            raise GrokbotJobError("invalid-artifact")
+    else:  # _validate_spec guarantees this cannot happen for a valid record.
+        raise GrokbotJobError("corrupt-storage")
+    return artifact
+
+
+def _validate_repo_relative_branch(value: object) -> str:
+    branch = _bounded_string(value, reason="invalid-artifact", maximum=255)
+    if (
+        not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", branch)
+        or "//" in branch
+        or branch.startswith("-")
+        or ".." in branch
+        or "@{" in branch
+        or branch.endswith((".", "/", ".lock"))
+        or any(part in {"", ".", ".."} or part.endswith(".lock") for part in branch.split("/"))
+    ):
+        raise GrokbotJobError("invalid-artifact")
+    return branch
+
+
+def _validate_repo_relative_path(value: object) -> str:
+    path = _bounded_string(value, reason="invalid-artifact", maximum=512)
+    if (
+        path.startswith("/")
+        or "\\" in path
+        or any(part in {"", ".", ".."} for part in path.split("/"))
+        or any(ord(character) < 32 for character in path)
+    ):
+        raise GrokbotJobError("invalid-artifact")
+    return path

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import stat
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from multiprocessing import Pipe, Process
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,33 @@ def _spec() -> dict[str, object]:
     }
 
 
+def _claim_in_process(target: str, job_id: str, lease_id: str, connection) -> None:
+    """Attempt a claim in a separate process for the lock contract test."""
+    try:
+        result = grokbot_jobs.claim(
+            Path(target),
+            job_id,
+            "bot-a",
+            lease_id,
+            60,
+            now=NOW,
+        )
+    except grokbot_jobs.GrokbotJobError as exc:
+        connection.send(exc.reason)
+    else:
+        connection.send(result["state"])
+    finally:
+        connection.close()
+
+
+def _enqueue(tmp_path: Path, *, artifact: str = "draft-pr", idempotency_key: str | None = None) -> str:
+    spec = _spec()
+    spec["artifact"] = {"kind": artifact}
+    if artifact == "report":
+        spec["role"] = "repository-scout"
+    return grokbot_jobs.enqueue(tmp_path, spec, idempotency_key or f"request-{artifact}", now=NOW)["job_id"]
+
+
 def test_enqueue_returns_opaque_handle_and_private_projection(tmp_path: Path):
     handle = grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
 
@@ -43,7 +71,7 @@ def test_enqueue_returns_opaque_handle_and_private_projection(tmp_path: Path):
     assert job["state"] == "queued"
     assert job["task_hash"].startswith("sha256:")
     assert job["timeout_seconds"] == 900
-    assert job["revision"] == 1
+    assert job["item_revision"] == 1
     assert job["artifact"] == {"kind": "draft-pr"}
     assert job["created_at"] == "2026-08-23T12:00:00Z"
     assert "instructions" not in job
@@ -89,7 +117,7 @@ def test_status_returns_only_safe_projections(tmp_path: Path):
             "updated_at",
             "queued_at",
             "timeout_seconds",
-            "revision",
+            "item_revision",
             "artifact",
         }
         assert "instructions" not in job
@@ -215,3 +243,212 @@ def test_storage_refuses_symlinked_queue_files(tmp_path: Path, stored_file: str)
             grokbot_jobs.get_job(tmp_path, handle["job_id"])
         else:
             grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+
+
+def test_concurrent_claims_have_one_winner(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    first_parent, first_child = Pipe(duplex=False)
+    second_parent, second_child = Pipe(duplex=False)
+    first = Process(target=_claim_in_process, args=(str(tmp_path), job_id, "lease-a", first_child))
+    second = Process(target=_claim_in_process, args=(str(tmp_path), job_id, "lease-b", second_child))
+
+    first.start()
+    second.start()
+    first_child.close()
+    second_child.close()
+    outcomes = {first_parent.recv(), second_parent.recv()}
+    first.join()
+    second.join()
+
+    assert first.exitcode == 0
+    assert second.exitcode == 0
+    assert outcomes == {"claimed", "lease-conflict"}
+
+
+def test_claim_is_idempotent_for_same_lease_and_rejects_another(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    claimed = grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    retried = grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+
+    assert claimed["state"] == "claimed"
+    assert claimed["item_revision"] == 2
+    assert retried == claimed
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-conflict$"):
+        grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-b", 60, now=NOW)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-conflict$"):
+        grokbot_jobs.claim(tmp_path, job_id, "bot-b", "lease-a", 60, now=NOW)
+
+
+def test_renew_clamps_to_deadline_and_increments_revision(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 3600, now=NOW)
+    renewed = grokbot_jobs.renew(
+        tmp_path,
+        job_id,
+        "bot-a",
+        "lease-a",
+        3600,
+        now=NOW + timedelta(seconds=100),
+    )
+
+    assert renewed["item_revision"] == 3
+    assert renewed["lease_expires_at"] == "2026-08-23T12:15:00Z"
+    assert renewed["updated_at"] == "2026-08-23T12:01:40Z"
+
+
+@pytest.mark.parametrize("lease_seconds", [29, 3601])
+def test_claim_rejects_out_of_range_leases(tmp_path: Path, lease_seconds: int):
+    job_id = _enqueue(tmp_path)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^invalid-lease-seconds$"):
+        grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", lease_seconds, now=NOW)
+
+
+def test_valid_lifecycle_transition_and_draft_pr_artifact(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    running = grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
+    completed = grokbot_jobs.transition(
+        tmp_path,
+        job_id,
+        "bot-a",
+        "lease-a",
+        "completed",
+        artifact={"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/123", "branch": "grokbot/job-1"},
+        now=NOW,
+    )
+
+    assert running["state"] == "running"
+    assert completed["state"] == "completed"
+    assert completed["item_revision"] == 4
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^terminal-state$"):
+        grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "failed", now=NOW)
+
+
+@pytest.mark.parametrize(
+    ("artifact_kind", "artifact", "reason"),
+    [
+        ("draft-pr", {"kind": "draft-pr", "url": "http://github.com/example/brigade/pull/1", "branch": "safe"}, "invalid-artifact"),
+        ("draft-pr", {"kind": "draft-pr", "url": "https://github.com/example/brigade/issues/1", "branch": "safe"}, "invalid-artifact"),
+        ("draft-pr", {"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "bad@{ref"}, "invalid-artifact"),
+        ("branch", {"kind": "branch", "branch": "../bad", "commit": "a" * 40}, "invalid-artifact"),
+        ("branch", {"kind": "branch", "branch": "safe", "commit": "A" * 40}, "invalid-artifact"),
+        ("report", {"kind": "report", "path": "/report.md", "sha256": "a" * 64}, "invalid-artifact"),
+        ("report", {"kind": "report", "path": "report.md", "sha256": "A" * 64}, "invalid-artifact"),
+        ("branch", {"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "safe"}, "artifact-mismatch"),
+    ],
+)
+def test_completed_artifacts_are_exact_and_match_specification(
+    tmp_path: Path, artifact_kind: str, artifact: dict[str, str], reason: str
+):
+    job_id = _enqueue(tmp_path, artifact=artifact_kind)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match=rf"^{reason}$"):
+        grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "completed", artifact=artifact, now=NOW)
+
+
+def test_branch_and_report_artifacts_complete_their_allowed_roles(tmp_path: Path):
+    branch_job = _enqueue(tmp_path, artifact="branch")
+    report_job = _enqueue(tmp_path, artifact="report")
+    for job_id, artifact in (
+        (branch_job, {"kind": "branch", "branch": "grokbot/branch", "commit": "a" * 40}),
+        (report_job, {"kind": "report", "path": "artifacts/report.md", "sha256": "b" * 64}),
+    ):
+        grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+        grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
+        assert grokbot_jobs.transition(
+            tmp_path, job_id, "bot-a", "lease-a", "completed", artifact=artifact, now=NOW
+        )["state"] == "completed"
+
+
+def test_failure_terminalizes_claimed_or_running_job(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    failed = grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "failed", now=NOW)
+
+    assert failed["state"] == "failed"
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^terminal-state$"):
+        grokbot_jobs.renew(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+
+
+def test_transitions_require_the_current_unexpired_lease(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^invalid-state$"):
+        grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 30, now=NOW)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-conflict$"):
+        grokbot_jobs.transition(tmp_path, job_id, "bot-b", "lease-a", "running", now=NOW)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-expired$"):
+        grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW + timedelta(seconds=30))
+
+
+def test_cancel_queued_and_cooperative_live_job(tmp_path: Path):
+    queued_job = _enqueue(tmp_path)
+    assert grokbot_jobs.cancel(tmp_path, queued_job, now=NOW)["state"] == "canceled"
+    assert grokbot_jobs.cancel(tmp_path, queued_job, now=NOW)["state"] == "canceled"
+
+    live_job = _enqueue(tmp_path, idempotency_key="request-live")
+    grokbot_jobs.claim(tmp_path, live_job, "bot-a", "lease-a", 60, now=NOW)
+    requested = grokbot_jobs.cancel(tmp_path, live_job, now=NOW)
+    repeated = grokbot_jobs.cancel(tmp_path, live_job, now=NOW + timedelta(seconds=1))
+    assert requested["state"] == "claimed"
+    assert requested["cancel_requested_at"] == repeated["cancel_requested_at"]
+    assert grokbot_jobs.acknowledge_cancel(tmp_path, live_job, "bot-a", "lease-a", now=NOW)["state"] == "canceled"
+
+
+def test_expiry_never_requeues_and_late_completion_is_rejected(tmp_path: Path):
+    queued_job = _enqueue(tmp_path)
+    assert grokbot_jobs.expire(tmp_path, queued_job, now=NOW + timedelta(seconds=900))["state"] == "expired"
+
+    live_job = _enqueue(tmp_path, idempotency_key="request-live")
+    grokbot_jobs.claim(tmp_path, live_job, "bot-a", "lease-a", 30, now=NOW)
+    grokbot_jobs.transition(tmp_path, live_job, "bot-a", "lease-a", "running", now=NOW)
+    assert grokbot_jobs.expire(tmp_path, live_job, now=NOW + timedelta(seconds=30))["state"] == "expired"
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^terminal-state$"):
+        grokbot_jobs.transition(
+            tmp_path,
+            live_job,
+            "bot-a",
+            "lease-a",
+            "completed",
+            artifact={"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "safe"},
+            now=NOW + timedelta(seconds=30),
+        )
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    ["task_hash", "timestamps", "item_revision", "lease_deadline", "invalid_bot", "invalid_cancel"],
+)
+def test_corrupted_lifecycle_records_fail_closed(tmp_path: Path, corruption: str):
+    job_id = _enqueue(tmp_path)
+    if corruption in {"lease_deadline", "invalid_bot", "invalid_cancel"}:
+        grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    path = tmp_path / ".brigade" / "cloud" / "grokbot" / "jobs" / f"{job_id}.json"
+    raw = __import__("json").loads(path.read_text())
+    if corruption == "task_hash":
+        raw["task_hash"] = "sha256:" + "0" * 64
+    elif corruption == "timestamps":
+        raw["updated_at"] = "not-a-time"
+    elif corruption == "item_revision":
+        raw["item_revision"] = 0
+    elif corruption == "lease_deadline":
+        raw["lease_expires_at"] = "2026-08-23T12:15:01Z"
+    elif corruption == "invalid_bot":
+        raw["bot_id"] = "bot id"
+    else:
+        raw["cancel_requested_at"] = "2026-08-23T11:59:59Z"
+    path.write_text(__import__("json").dumps(raw))
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^corrupt-storage$"):
+        grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+
+
+def test_corrupted_idempotency_record_fails_closed(tmp_path: Path):
+    _enqueue(tmp_path)
+    path = next((tmp_path / ".brigade" / "cloud" / "grokbot" / "idempotency").glob("*.json"))
+    path.write_text('{"schema":"brigade.grokbot.idempotency.v1","job_id":"bad","task_hash":"wrong"}')
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^corrupt-storage$"):
+        grokbot_jobs.enqueue(tmp_path, _spec(), "request-draft-pr", now=NOW)

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -138,6 +138,34 @@ def test_enqueue_is_idempotent_only_for_identical_canonical_task_content(tmp_pat
     assert exc.value.reason == "idempotency-conflict"
 
 
+def test_enqueue_recovers_a_job_when_the_idempotency_write_failed(tmp_path: Path, monkeypatch):
+    original_replace = grokbot_jobs.os.replace
+    calls = 0
+
+    def fail_index_replace(source, destination, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected idempotency write failure")
+        return original_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(grokbot_jobs.os, "replace", fail_index_replace)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^unsafe-storage$"):
+        grokbot_jobs.enqueue(tmp_path, _spec(), "request-recovery", now=NOW)
+
+    monkeypatch.setattr(grokbot_jobs.os, "replace", original_replace)
+    recovered = grokbot_jobs.enqueue(tmp_path, _spec(), "request-recovery", now=NOW)
+    changed = _spec()
+    changed["label"] = "Different task"
+
+    assert recovered["idempotent"] is True
+    assert len(list((tmp_path / ".brigade" / "cloud" / "grokbot" / "jobs").glob("*.json"))) == 1
+    raw = json.loads((tmp_path / ".brigade" / "cloud" / "grokbot" / "jobs" / f"{recovered['job_id']}.json").read_text())
+    assert raw["idempotency_key_hash"] == "sha256:" + __import__("hashlib").sha256(b"request-recovery").hexdigest()
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^idempotency-conflict$"):
+        grokbot_jobs.enqueue(tmp_path, changed, "request-recovery", now=NOW)
+
+
 @pytest.mark.parametrize(
     ("change", "reason"),
     [
@@ -329,14 +357,30 @@ def test_valid_lifecycle_transition_and_draft_pr_artifact(tmp_path: Path):
 @pytest.mark.parametrize(
     ("artifact_kind", "artifact", "reason"),
     [
-        ("draft-pr", {"kind": "draft-pr", "url": "http://github.com/example/brigade/pull/1", "branch": "safe"}, "invalid-artifact"),
-        ("draft-pr", {"kind": "draft-pr", "url": "https://github.com/example/brigade/issues/1", "branch": "safe"}, "invalid-artifact"),
-        ("draft-pr", {"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "bad@{ref"}, "invalid-artifact"),
+        (
+            "draft-pr",
+            {"kind": "draft-pr", "url": "http://github.com/example/brigade/pull/1", "branch": "safe"},
+            "invalid-artifact",
+        ),
+        (
+            "draft-pr",
+            {"kind": "draft-pr", "url": "https://github.com/example/brigade/issues/1", "branch": "safe"},
+            "invalid-artifact",
+        ),
+        (
+            "draft-pr",
+            {"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "bad@{ref"},
+            "invalid-artifact",
+        ),
         ("branch", {"kind": "branch", "branch": "../bad", "commit": "a" * 40}, "invalid-artifact"),
         ("branch", {"kind": "branch", "branch": "safe", "commit": "A" * 40}, "invalid-artifact"),
         ("report", {"kind": "report", "path": "/report.md", "sha256": "a" * 64}, "invalid-artifact"),
         ("report", {"kind": "report", "path": "report.md", "sha256": "A" * 64}, "invalid-artifact"),
-        ("branch", {"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "safe"}, "artifact-mismatch"),
+        (
+            "branch",
+            {"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "safe"},
+            "artifact-mismatch",
+        ),
     ],
 )
 def test_completed_artifacts_are_exact_and_match_specification(
@@ -359,9 +403,12 @@ def test_branch_and_report_artifacts_complete_their_allowed_roles(tmp_path: Path
     ):
         grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
         grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
-        assert grokbot_jobs.transition(
-            tmp_path, job_id, "bot-a", "lease-a", "completed", artifact=artifact, now=NOW
-        )["state"] == "completed"
+        assert (
+            grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "completed", artifact=artifact, now=NOW)[
+                "state"
+            ]
+            == "completed"
+        )
 
 
 def test_failure_terminalizes_claimed_or_running_job(tmp_path: Path):
@@ -399,6 +446,58 @@ def test_cancel_queued_and_cooperative_live_job(tmp_path: Path):
     assert grokbot_jobs.acknowledge_cancel(tmp_path, live_job, "bot-a", "lease-a", now=NOW)["state"] == "canceled"
 
 
+def test_cancel_requested_claim_cannot_start(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    grokbot_jobs.cancel(tmp_path, job_id, now=NOW)
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^cancel-requested$"):
+        grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
+
+
+def test_mutation_rejects_backward_clock(tmp_path: Path):
+    job_id = _enqueue(tmp_path)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^clock-regression$"):
+        grokbot_jobs.renew(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW - timedelta(seconds=1))
+
+
+def test_storage_os_errors_use_the_unsafe_storage_reason(tmp_path: Path, monkeypatch, capsys):
+    job_id = _enqueue(tmp_path)
+    original_open = grokbot_jobs.os.open
+
+    def fail_job_open(path, *args, **kwargs):
+        if path == f"{job_id}.json" and kwargs.get("dir_fd") is not None:
+            raise OSError("injected read failure")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(grokbot_jobs.os, "open", fail_job_open)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^unsafe-storage$"):
+        grokbot_jobs.get_job(tmp_path, job_id)
+
+    assert _run_grokbot(tmp_path, "status", "--job-id", job_id) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: unsafe-storage"
+
+
+@pytest.mark.skipif(grokbot_jobs.os.name != "posix", reason="POSIX directory descriptor contract")
+def test_posix_storage_write_stays_anchored_when_visible_directory_is_replaced(tmp_path: Path):
+    root = tmp_path / ".brigade" / "cloud" / "grokbot"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    with grokbot_jobs._storage_paths(tmp_path) as storage:
+        moved = root / "jobs-pinned"
+        (root / "jobs").rename(moved)
+        (root / "jobs").symlink_to(outside, target_is_directory=True)
+        grokbot_jobs._write_json_file(storage.jobs, "probe.json", {"anchored": True})
+
+    assert json.loads((moved / "probe.json").read_text()) == {"anchored": True}
+    assert not (outside / "probe.json").exists()
+
+
 def test_expiry_never_requeues_and_late_completion_is_rejected(tmp_path: Path):
     queued_job = _enqueue(tmp_path)
     assert grokbot_jobs.expire(tmp_path, queued_job, now=NOW + timedelta(seconds=900))["state"] == "expired"
@@ -421,12 +520,23 @@ def test_expiry_never_requeues_and_late_completion_is_rejected(tmp_path: Path):
 
 @pytest.mark.parametrize(
     "corruption",
-    ["task_hash", "timestamps", "item_revision", "lease_deadline", "invalid_bot", "invalid_cancel"],
+    ["task_hash", "timestamps", "item_revision", "lease_deadline", "invalid_bot", "invalid_cancel", "completed_cancel"],
 )
 def test_corrupted_lifecycle_records_fail_closed(tmp_path: Path, corruption: str):
     job_id = _enqueue(tmp_path)
-    if corruption in {"lease_deadline", "invalid_bot", "invalid_cancel"}:
+    if corruption in {"lease_deadline", "invalid_bot", "invalid_cancel", "completed_cancel"}:
         grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    if corruption == "completed_cancel":
+        grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
+        grokbot_jobs.transition(
+            tmp_path,
+            job_id,
+            "bot-a",
+            "lease-a",
+            "completed",
+            artifact={"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "safe"},
+            now=NOW,
+        )
     path = tmp_path / ".brigade" / "cloud" / "grokbot" / "jobs" / f"{job_id}.json"
     raw = __import__("json").loads(path.read_text())
     if corruption == "task_hash":
@@ -439,8 +549,10 @@ def test_corrupted_lifecycle_records_fail_closed(tmp_path: Path, corruption: str
         raw["lease_expires_at"] = "2026-08-23T12:15:01Z"
     elif corruption == "invalid_bot":
         raw["bot_id"] = "bot id"
-    else:
+    elif corruption == "invalid_cancel":
         raw["cancel_requested_at"] = "2026-08-23T11:59:59Z"
+    else:
+        raw["cancel_requested_at"] = raw["updated_at"]
     path.write_text(__import__("json").dumps(raw))
 
     with pytest.raises(grokbot_jobs.GrokbotJobError, match="^corrupt-storage$"):
@@ -481,55 +593,62 @@ def test_cli_grokbot_lifecycle_commands_keep_private_content_out_of_output(tmp_p
     assert "pytest -q tests/test_grokbot_jobs.py" not in queued.out
     job_id = queued.out.split()[1]
 
-    assert _run_grokbot(
-        tmp_path,
-        "claim",
-        "--job-id",
-        job_id,
-        "--bot-id",
-        "bot-a",
-        "--lease-id",
-        "lease-a",
-        "--lease-seconds",
-        "60",
-        "--json",
-    ) == 0
+    assert (
+        _run_grokbot(
+            tmp_path,
+            "claim",
+            "--job-id",
+            job_id,
+            "--bot-id",
+            "bot-a",
+            "--lease-id",
+            "lease-a",
+            "--lease-seconds",
+            "60",
+            "--json",
+        )
+        == 0
+    )
     claimed = capsys.readouterr().out
     assert json.loads(claimed)["state"] == "claimed"
     assert "instructions" not in claimed and "verification_commands" not in claimed
 
-    assert _run_grokbot(
-        tmp_path,
-        "renew",
-        "--job-id",
-        job_id,
-        "--bot-id",
-        "bot-a",
-        "--lease-id",
-        "lease-a",
-        "--lease-seconds",
-        "60",
-    ) == 0
+    assert (
+        _run_grokbot(
+            tmp_path,
+            "renew",
+            "--job-id",
+            job_id,
+            "--bot-id",
+            "bot-a",
+            "--lease-id",
+            "lease-a",
+            "--lease-seconds",
+            "60",
+        )
+        == 0
+    )
     assert f"job {job_id} state=claimed" in capsys.readouterr().out
 
-    assert _run_grokbot(
-        tmp_path, "start", "--job-id", job_id, "--bot-id", "bot-a", "--lease-id", "lease-a"
-    ) == 0
+    assert _run_grokbot(tmp_path, "start", "--job-id", job_id, "--bot-id", "bot-a", "--lease-id", "lease-a") == 0
     assert f"job {job_id} state=running" in capsys.readouterr().out
 
-    assert _run_grokbot(
-        tmp_path,
-        "complete",
-        "--job-id",
-        job_id,
-        "--bot-id",
-        "bot-a",
-        "--lease-id",
-        "lease-a",
-        "--artifact",
-        str(artifact_path),
-        "--json",
-    ) == 0
+    assert (
+        _run_grokbot(
+            tmp_path,
+            "complete",
+            "--job-id",
+            job_id,
+            "--bot-id",
+            "bot-a",
+            "--lease-id",
+            "lease-a",
+            "--artifact",
+            str(artifact_path),
+            "--json",
+        )
+        == 0
+    )
     completed = capsys.readouterr().out
     assert json.loads(completed)["state"] == "completed"
     assert "instructions" not in completed and "verification_commands" not in completed
@@ -538,18 +657,21 @@ def test_cli_grokbot_lifecycle_commands_keep_private_content_out_of_output(tmp_p
         assert _run_grokbot(tmp_path, "enqueue", "--spec", str(spec_path), "--idempotency-key", f"cli-{suffix}") == 0
         next_job = capsys.readouterr().out.split()[1]
         if suffix == "fail":
-            assert _run_grokbot(
-                tmp_path,
-                "claim",
-                "--job-id",
-                next_job,
-                "--bot-id",
-                "bot-a",
-                "--lease-id",
-                "lease-a",
-                "--lease-seconds",
-                "60",
-            ) == 0
+            assert (
+                _run_grokbot(
+                    tmp_path,
+                    "claim",
+                    "--job-id",
+                    next_job,
+                    "--bot-id",
+                    "bot-a",
+                    "--lease-id",
+                    "lease-a",
+                    "--lease-seconds",
+                    "60",
+                )
+                == 0
+            )
             capsys.readouterr()
             command = ["fail", "--job-id", next_job, "--bot-id", "bot-a", "--lease-id", "lease-a"]
         else:
@@ -559,24 +681,27 @@ def test_cli_grokbot_lifecycle_commands_keep_private_content_out_of_output(tmp_p
 
     assert _run_grokbot(tmp_path, "enqueue", "--spec", str(spec_path), "--idempotency-key", "cli-ack") == 0
     cancel_job = capsys.readouterr().out.split()[1]
-    assert _run_grokbot(
-        tmp_path,
-        "claim",
-        "--job-id",
-        cancel_job,
-        "--bot-id",
-        "bot-a",
-        "--lease-id",
-        "lease-a",
-        "--lease-seconds",
-        "60",
-    ) == 0
+    assert (
+        _run_grokbot(
+            tmp_path,
+            "claim",
+            "--job-id",
+            cancel_job,
+            "--bot-id",
+            "bot-a",
+            "--lease-id",
+            "lease-a",
+            "--lease-seconds",
+            "60",
+        )
+        == 0
+    )
     capsys.readouterr()
     assert _run_grokbot(tmp_path, "cancel", "--job-id", cancel_job) == 0
     capsys.readouterr()
-    assert _run_grokbot(
-        tmp_path, "ack-cancel", "--job-id", cancel_job, "--bot-id", "bot-a", "--lease-id", "lease-a"
-    ) == 0
+    assert (
+        _run_grokbot(tmp_path, "ack-cancel", "--job-id", cancel_job, "--bot-id", "bot-a", "--lease-id", "lease-a") == 0
+    )
     assert f"job {cancel_job} state=canceled" in capsys.readouterr().out
 
     assert _run_grokbot(tmp_path, "status", "--job-id", job_id, "--json") == 0
@@ -594,7 +719,10 @@ def test_cli_grokbot_lifecycle_commands_keep_private_content_out_of_output(tmp_p
     ("command", "expected_error"),
     [
         (("enqueue", "--spec", "missing.json", "--idempotency-key", "missing"), "--spec is not a file"),
-        (("claim", "--job-id", "not-a-job", "--bot-id", "bot-a", "--lease-id", "lease-a", "--lease-seconds", "60"), "invalid-job-id"),
+        (
+            ("claim", "--job-id", "not-a-job", "--bot-id", "bot-a", "--lease-id", "lease-a", "--lease-seconds", "60"),
+            "invalid-job-id",
+        ),
     ],
 )
 def test_cli_grokbot_rejects_invalid_inputs_with_exit_2(tmp_path: Path, capsys, command, expected_error: str):
@@ -634,18 +762,21 @@ def test_cli_grokbot_complete_rejects_invalid_artifact_files(
     if payload is not None:
         artifact_path.write_text(payload)
 
-    assert _run_grokbot(
-        tmp_path,
-        "complete",
-        "--job-id",
-        job_id,
-        "--bot-id",
-        "bot-a",
-        "--lease-id",
-        "lease-a",
-        "--artifact",
-        str(artifact_path),
-    ) == 2
+    assert (
+        _run_grokbot(
+            tmp_path,
+            "complete",
+            "--job-id",
+            job_id,
+            "--bot-id",
+            "bot-a",
+            "--lease-id",
+            "lease-a",
+            "--artifact",
+            str(artifact_path),
+        )
+        == 2
+    )
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err.strip().startswith("error: ")

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import stat
 from datetime import datetime, timedelta, timezone
 from multiprocessing import Pipe, Process
@@ -10,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from brigade import grokbot_jobs
+from brigade import cli
 
 
 NOW = datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc)
@@ -452,3 +454,207 @@ def test_corrupted_idempotency_record_fails_closed(tmp_path: Path):
 
     with pytest.raises(grokbot_jobs.GrokbotJobError, match="^corrupt-storage$"):
         grokbot_jobs.enqueue(tmp_path, _spec(), "request-draft-pr", now=NOW)
+
+
+def _run_grokbot(target: Path, *command: str) -> int:
+    return cli.main(["run", "cloud", "grokbot", *command, "--target", str(target)])
+
+
+def test_cli_grokbot_lifecycle_commands_keep_private_content_out_of_output(tmp_path: Path, capsys):
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(_spec()))
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(
+        json.dumps(
+            {
+                "kind": "draft-pr",
+                "url": "https://github.com/example/brigade/pull/123",
+                "branch": "grokbot/cli-complete",
+            }
+        )
+    )
+
+    assert _run_grokbot(tmp_path, "enqueue", "--spec", str(spec_path), "--idempotency-key", "cli-complete") == 0
+    queued = capsys.readouterr()
+    assert "grokbot-" in queued.out and "queued" in queued.out
+    assert "Build the private queue module." not in queued.out
+    assert "pytest -q tests/test_grokbot_jobs.py" not in queued.out
+    job_id = queued.out.split()[1]
+
+    assert _run_grokbot(
+        tmp_path,
+        "claim",
+        "--job-id",
+        job_id,
+        "--bot-id",
+        "bot-a",
+        "--lease-id",
+        "lease-a",
+        "--lease-seconds",
+        "60",
+        "--json",
+    ) == 0
+    claimed = capsys.readouterr().out
+    assert json.loads(claimed)["state"] == "claimed"
+    assert "instructions" not in claimed and "verification_commands" not in claimed
+
+    assert _run_grokbot(
+        tmp_path,
+        "renew",
+        "--job-id",
+        job_id,
+        "--bot-id",
+        "bot-a",
+        "--lease-id",
+        "lease-a",
+        "--lease-seconds",
+        "60",
+    ) == 0
+    assert f"job {job_id} state=claimed" in capsys.readouterr().out
+
+    assert _run_grokbot(
+        tmp_path, "start", "--job-id", job_id, "--bot-id", "bot-a", "--lease-id", "lease-a"
+    ) == 0
+    assert f"job {job_id} state=running" in capsys.readouterr().out
+
+    assert _run_grokbot(
+        tmp_path,
+        "complete",
+        "--job-id",
+        job_id,
+        "--bot-id",
+        "bot-a",
+        "--lease-id",
+        "lease-a",
+        "--artifact",
+        str(artifact_path),
+        "--json",
+    ) == 0
+    completed = capsys.readouterr().out
+    assert json.loads(completed)["state"] == "completed"
+    assert "instructions" not in completed and "verification_commands" not in completed
+
+    for suffix, state in (("fail", "failed"), ("cancel", "canceled"), ("expire", "queued")):
+        assert _run_grokbot(tmp_path, "enqueue", "--spec", str(spec_path), "--idempotency-key", f"cli-{suffix}") == 0
+        next_job = capsys.readouterr().out.split()[1]
+        if suffix == "fail":
+            assert _run_grokbot(
+                tmp_path,
+                "claim",
+                "--job-id",
+                next_job,
+                "--bot-id",
+                "bot-a",
+                "--lease-id",
+                "lease-a",
+                "--lease-seconds",
+                "60",
+            ) == 0
+            capsys.readouterr()
+            command = ["fail", "--job-id", next_job, "--bot-id", "bot-a", "--lease-id", "lease-a"]
+        else:
+            command = [suffix, "--job-id", next_job]
+        assert _run_grokbot(tmp_path, *command) == 0
+        assert f"job {next_job} state={state}" in capsys.readouterr().out
+
+    assert _run_grokbot(tmp_path, "enqueue", "--spec", str(spec_path), "--idempotency-key", "cli-ack") == 0
+    cancel_job = capsys.readouterr().out.split()[1]
+    assert _run_grokbot(
+        tmp_path,
+        "claim",
+        "--job-id",
+        cancel_job,
+        "--bot-id",
+        "bot-a",
+        "--lease-id",
+        "lease-a",
+        "--lease-seconds",
+        "60",
+    ) == 0
+    capsys.readouterr()
+    assert _run_grokbot(tmp_path, "cancel", "--job-id", cancel_job) == 0
+    capsys.readouterr()
+    assert _run_grokbot(
+        tmp_path, "ack-cancel", "--job-id", cancel_job, "--bot-id", "bot-a", "--lease-id", "lease-a"
+    ) == 0
+    assert f"job {cancel_job} state=canceled" in capsys.readouterr().out
+
+    assert _run_grokbot(tmp_path, "status", "--job-id", job_id, "--json") == 0
+    status = capsys.readouterr().out
+    assert json.loads(status)["job_id"] == job_id
+    assert "instructions" not in status and "verification_commands" not in status
+    assert _run_grokbot(tmp_path, "status") == 0
+    status_text = capsys.readouterr().out
+    assert "grokbot jobs:" in status_text
+    assert "Build the private queue module." not in status_text
+    assert "pytest -q tests/test_grokbot_jobs.py" not in status_text
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_error"),
+    [
+        (("enqueue", "--spec", "missing.json", "--idempotency-key", "missing"), "--spec is not a file"),
+        (("claim", "--job-id", "not-a-job", "--bot-id", "bot-a", "--lease-id", "lease-a", "--lease-seconds", "60"), "invalid-job-id"),
+    ],
+)
+def test_cli_grokbot_rejects_invalid_inputs_with_exit_2(tmp_path: Path, capsys, command, expected_error: str):
+    assert _run_grokbot(tmp_path, *command) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip().startswith("error: ")
+    assert expected_error in captured.err
+
+
+@pytest.mark.parametrize("payload", ["not json", "[]"])
+def test_cli_grokbot_rejects_invalid_json_files(tmp_path: Path, capsys, payload: str):
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(payload)
+
+    assert _run_grokbot(tmp_path, "enqueue", "--spec", str(spec_path), "--idempotency-key", "invalid-json") == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: invalid JSON object in --spec"
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload", "expected_error"),
+    [
+        ("missing-artifact.json", None, "--artifact is not a file"),
+        ("artifact.json", "not json", "invalid JSON object in --artifact"),
+        ("artifact.json", "[]", "invalid JSON object in --artifact"),
+    ],
+)
+def test_cli_grokbot_complete_rejects_invalid_artifact_files(
+    tmp_path: Path, capsys, filename: str, payload: str | None, expected_error: str
+):
+    job_id = _enqueue(tmp_path)
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+    grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=NOW)
+    artifact_path = tmp_path / filename
+    if payload is not None:
+        artifact_path.write_text(payload)
+
+    assert _run_grokbot(
+        tmp_path,
+        "complete",
+        "--job-id",
+        job_id,
+        "--bot-id",
+        "bot-a",
+        "--lease-id",
+        "lease-a",
+        "--artifact",
+        str(artifact_path),
+    ) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip().startswith("error: ")
+    assert expected_error in captured.err
+
+
+def test_cli_grokbot_validates_target_before_queue_access(tmp_path: Path, capsys):
+    not_directory = tmp_path / "not-a-directory"
+    not_directory.write_text("x")
+
+    assert _run_grokbot(not_directory, "status") == 2
+    assert capsys.readouterr().err.strip() == f"error: --target is not a directory: {not_directory.resolve()}"

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -1,0 +1,217 @@
+"""Private, handle-first Grok Bot queue contract tests."""
+
+from __future__ import annotations
+
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from brigade import grokbot_jobs
+
+
+NOW = datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc)
+
+
+def _spec() -> dict[str, object]:
+    return {
+        "label": "Add queue foundation",
+        "role": "implementation-worker",
+        "repository": "example/brigade",
+        "base_ref": "main",
+        "ownership_paths": ["src/brigade/grokbot_jobs.py", "tests/test_grokbot_jobs.py"],
+        "instructions": "Build the private queue module.",
+        "verification_commands": ["pytest -q tests/test_grokbot_jobs.py"],
+        "artifact": {"kind": "draft-pr"},
+        "timeout_seconds": 900,
+    }
+
+
+def test_enqueue_returns_opaque_handle_and_private_projection(tmp_path: Path):
+    handle = grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+
+    assert handle == {"job_id": handle["job_id"], "state": "queued", "idempotent": False}
+    assert handle["job_id"].startswith("grokbot-")
+    assert len(handle["job_id"]) == len("grokbot-") + 24
+
+    job = grokbot_jobs.get_job(tmp_path, handle["job_id"])
+    assert job["job_id"] == handle["job_id"]
+    assert job["label"] == "Add queue foundation"
+    assert job["role"] == "implementation-worker"
+    assert job["repository"] == "example/brigade"
+    assert job["state"] == "queued"
+    assert job["task_hash"].startswith("sha256:")
+    assert job["timeout_seconds"] == 900
+    assert job["revision"] == 1
+    assert job["artifact"] == {"kind": "draft-pr"}
+    assert job["created_at"] == "2026-08-23T12:00:00Z"
+    assert "instructions" not in job
+    assert "verification_commands" not in job
+
+
+def test_storage_is_private_and_keeps_the_full_envelope(tmp_path: Path):
+    handle = grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+    root = tmp_path / ".brigade" / "cloud" / "grokbot"
+    job_path = root / "jobs" / f"{handle['job_id']}.json"
+    idempotency_files = list((root / "idempotency").glob("*.json"))
+
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    assert stat.S_IMODE((root / "jobs").stat().st_mode) == 0o700
+    assert stat.S_IMODE((root / "idempotency").stat().st_mode) == 0o700
+    assert stat.S_IMODE((root / "queue.lock").stat().st_mode) == 0o600
+    assert stat.S_IMODE(job_path.stat().st_mode) == 0o600
+    assert len(idempotency_files) == 1
+    assert stat.S_IMODE(idempotency_files[0].stat().st_mode) == 0o600
+    raw = job_path.read_text()
+    assert "Build the private queue module." in raw
+    assert "pytest -q tests/test_grokbot_jobs.py" in raw
+
+
+def test_status_returns_only_safe_projections(tmp_path: Path):
+    first = grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+    scout = _spec()
+    scout.update({"label": "Scout", "role": "repository-scout", "artifact": {"kind": "report"}})
+    second = grokbot_jobs.enqueue(tmp_path, scout, "request-2", now=NOW)
+
+    result = grokbot_jobs.status(tmp_path)
+
+    assert [job["job_id"] for job in result["jobs"]] == sorted([first["job_id"], second["job_id"]])
+    for job in result["jobs"]:
+        assert set(job) == {
+            "job_id",
+            "label",
+            "role",
+            "repository",
+            "task_hash",
+            "state",
+            "created_at",
+            "updated_at",
+            "queued_at",
+            "timeout_seconds",
+            "revision",
+            "artifact",
+        }
+        assert "instructions" not in job
+        assert "verification_commands" not in job
+
+
+def test_enqueue_is_idempotent_only_for_identical_canonical_task_content(tmp_path: Path):
+    first = grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+    repeated = grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+    changed = _spec()
+    changed["label"] = "Different task"
+
+    assert repeated == {"job_id": first["job_id"], "state": "queued", "idempotent": True}
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^idempotency-conflict$") as exc:
+        grokbot_jobs.enqueue(tmp_path, changed, "request-1", now=NOW)
+    assert exc.value.reason == "idempotency-conflict"
+
+
+@pytest.mark.parametrize(
+    ("change", "reason"),
+    [
+        (lambda spec: spec.update({"unexpected": "value"}), "unknown-key"),
+        (lambda spec: spec.pop("label"), "missing-key"),
+        (lambda spec: spec.update({"role": "writer"}), "invalid-role"),
+        (lambda spec: spec.update({"repository": "not/a/repo"}), "invalid-repository"),
+        (lambda spec: spec.update({"base_ref": "main..bad"}), "invalid-base-ref"),
+        (lambda spec: spec.update({"ownership_paths": ["/absolute.py"]}), "invalid-ownership-paths"),
+        (lambda spec: spec.update({"ownership_paths": ["../escape.py"]}), "invalid-ownership-paths"),
+        (lambda spec: spec.update({"ownership_paths": ["src\\escape.py"]}), "invalid-ownership-paths"),
+        (lambda spec: spec.update({"ownership_paths": ["same.py", "same.py"]}), "invalid-ownership-paths"),
+        (lambda spec: spec.update({"instructions": ""}), "invalid-instructions"),
+        (lambda spec: spec.update({"verification_commands": []}), "invalid-verification-commands"),
+        (lambda spec: spec.update({"verification_commands": ["x" * 1001]}), "invalid-verification-commands"),
+        (lambda spec: spec.update({"artifact": {"kind": "report"}}), "invalid-artifact"),
+        (lambda spec: spec.update({"timeout_seconds": 59}), "invalid-timeout"),
+        (lambda spec: spec.update({"timeout_seconds": 14401}), "invalid-timeout"),
+    ],
+)
+def test_enqueue_rejects_invalid_envelope_classes(tmp_path: Path, change, reason: str):
+    spec = _spec()
+    change(spec)
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match=rf"^{reason}$") as exc:
+        grokbot_jobs.enqueue(tmp_path, spec, "request-1", now=NOW)
+    assert exc.value.reason == reason
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ("artifact", "accessToken"),
+        ("artifact", "nested", "deployment_secret"),
+        ("unknown_header",),
+    ],
+)
+def test_enqueue_recursively_rejects_sensitive_field_names(tmp_path: Path, path: tuple[str, ...]):
+    spec = _spec()
+    cursor = spec
+    for key in path[:-1]:
+        next_value = cursor.get(key)
+        if not isinstance(next_value, dict):
+            next_value = {}
+            cursor[key] = next_value
+        cursor = next_value
+    cursor[path[-1]] = "value"
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^forbidden-key$") as exc:
+        grokbot_jobs.enqueue(tmp_path, spec, "request-1", now=NOW)
+    assert exc.value.reason == "forbidden-key"
+
+
+@pytest.mark.parametrize("key", ["", "space key", "x" * 129])
+def test_enqueue_rejects_invalid_idempotency_keys(tmp_path: Path, key: str):
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^invalid-idempotency-key$"):
+        grokbot_jobs.enqueue(tmp_path, _spec(), key, now=NOW)
+
+
+def test_enqueue_rejects_scout_artifact_mismatch(tmp_path: Path):
+    spec = _spec()
+    spec.update({"role": "repository-scout", "artifact": {"kind": "branch"}})
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^invalid-artifact$"):
+        grokbot_jobs.enqueue(tmp_path, spec, "request-1", now=NOW)
+
+
+@pytest.mark.parametrize("name", ["grokbot-not-hex", "other-0123456789abcdef01234567"])
+def test_get_job_rejects_malformed_handles(tmp_path: Path, name: str):
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^invalid-job-id$"):
+        grokbot_jobs.get_job(tmp_path, name)
+
+
+@pytest.mark.parametrize("component", ["grokbot", "jobs", "idempotency", "queue.lock"])
+def test_storage_refuses_symlinked_queue_components(tmp_path: Path, component: str):
+    root = tmp_path / ".brigade" / "cloud" / "grokbot"
+    root.parent.mkdir(parents=True)
+    destination = tmp_path / "outside"
+    destination.mkdir()
+    if component == "grokbot":
+        root.symlink_to(destination, target_is_directory=True)
+    else:
+        root.mkdir(mode=0o700)
+        (root / component).symlink_to(destination, target_is_directory=component != "queue.lock")
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^unsafe-storage$"):
+        grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+
+
+@pytest.mark.parametrize("stored_file", ["job", "idempotency"])
+def test_storage_refuses_symlinked_queue_files(tmp_path: Path, stored_file: str):
+    handle = grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)
+    root = tmp_path / ".brigade" / "cloud" / "grokbot"
+    if stored_file == "job":
+        path = root / "jobs" / f"{handle['job_id']}.json"
+    else:
+        path = next((root / "idempotency").glob("*.json"))
+    destination = tmp_path / "outside.json"
+    destination.write_text("{}")
+    path.unlink()
+    path.symlink_to(destination)
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^unsafe-storage$"):
+        if stored_file == "job":
+            grokbot_jobs.get_job(tmp_path, handle["job_id"])
+        else:
+            grokbot_jobs.enqueue(tmp_path, _spec(), "request-1", now=NOW)


### PR DESCRIPTION
## Summary

- add a private local Grok Bot job queue with strict task envelopes and safe status projections
- add leased claims, cancellation, expiry, bounded artifact references, and recoverable idempotency
- expose `brigade run cloud grokbot` commands and document the local-only boundary

## Why

Brigade's worker transport is synchronous. Grok Bot needs a handle-first queue so its cloud computer can claim bounded work without holding a Brigade worker process open. This is PR 1 of #1130.

## Safety boundaries

- no live provider call and no Grok Bot roster seat
- no credentials, headers, environment values, instructions, or verification commands in status output
- no merge, release, deployment, or arbitrary repository authority
- private queue modes, no-follow POSIX directory descriptors, atomic writes, and Windows locking fallback
- failed and expired leases never requeue automatically

## Verification

- focused post-rebase gate: 75 tests passed, Ruff passed, format check passed, mypy passed, command inventory current
- full post-rebase gate: `./scripts/verify`, 8,754 tests passed, 5 skipped, 68 subtests passed, 83.60% coverage
- Brigade receipts: `20260823-215808-work-verify-42e712`, `20260823-215836-work-verify-9d66e8`
- independent review: no outstanding Critical or Important findings after the storage and cancellation fixes

## Follow-up

- PR 2 adds `cloud_tracker` reconciliation
- PR 3 adds the protected remote adapter, commissions the Repository Scout and Implementation Worker Bots, and runs the live canaries

Part of #1130
