### PR TITLE
feat: reconcile Grok Bot cloud jobs

### DIFF
--- a/src/brigade/center_cmd/agent_activity.py
+++ b/src/brigade/center_cmd/agent_activity.py
@@ -58,8 +58,8 @@ def collect(target: Path, *, now: datetime | None = None) -> list[dict[str, Any]
 def _cloud_tracker_records(target: Path, now: datetime) -> list[dict[str, Any]]:
     """Feed the Cloud machine card from the local cloud dispatch registry (#890).
 
-    Live ``gh`` / ``codex cloud`` probes stay off the request path. Those can
-    hang for seconds; Center reads the local registry snapshot instead.
+    Codex Cloud probes stay off the request path. Center uses the bounded GitHub
+    snapshot to reconcile completed draft PR jobs after merge.
     """
     try:
         from .. import cloud_tracker
@@ -68,7 +68,7 @@ def _cloud_tracker_records(target: Path, now: datetime) -> list[dict[str, Any]]:
             target,
             now=now,
             provider_tasks={},
-            github={"branches": [], "prs": []},
+            github=cloud_tracker.observe_github(target),
             cursor_wired=cloud_tracker.cursor_cloud_wired(),
         )
     except Exception:

--- a/src/brigade/center_cmd/core.py
+++ b/src/brigade/center_cmd/core.py
@@ -846,7 +846,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
 
 
 def status_payload(target: Path) -> dict[str, Any]:
-    from .. import daily_cmd
+    from .. import cloud_tracker, daily_cmd
 
     target = target.expanduser().resolve()
     active = work_cmd._active_session_info(target)
@@ -882,6 +882,7 @@ def status_payload(target: Path) -> dict[str, Any]:
         "operator_report": report_health(target),
         "action_queue": actions_health(target),
         "daily_driver": daily_cmd.health(target),
+        "cloud_tracker": cloud_tracker.health(target),
         "phase_ledger": phases_cmd.health(target),
         "review_queue_count": len(_reviews(target)),
     }

--- a/src/brigade/center_cmd/readiness.py
+++ b/src/brigade/center_cmd/readiness.py
@@ -133,6 +133,18 @@ def _readiness_findings(target: Path, status_data: dict[str, Any]) -> list[dict[
                 "brigade center reviews",
             )
         )
+    cloud = status_data.get("cloud_tracker") if isinstance(status_data.get("cloud_tracker"), dict) else {}
+    if int(cloud.get("issue_count") or 0) > 0:
+        top = cloud.get("top_issue") if isinstance(cloud.get("top_issue"), dict) else {}
+        findings.append(
+            _readiness_finding(
+                "cloud_tracker",
+                str(top.get("name") or "grokbot_queue_attention"),
+                "warning",
+                _readiness_safe_text(target, str(top.get("detail") or "Grok Bot queue needs attention")),
+                "brigade run cloud status --json",
+            )
+        )
     release = status_data.get("release_readiness") if isinstance(status_data.get("release_readiness"), dict) else None
     if not release:
         findings.append(

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -28,7 +28,7 @@ def register(sub: argparse._SubParsersAction) -> None:
 
     p_register = cloud_sub.add_parser("register", help="Register a dispatched cloud task.")
     p_register.add_argument("--target", type=Path, default=Path("."))
-    p_register.add_argument("--provider", required=True, choices=("codex-cloud", "cursor-cloud"))
+    p_register.add_argument("--provider", required=True, choices=("codex-cloud", "cursor-cloud", "grokbot-cloud"))
     p_register.add_argument("--task-id", required=True)
     p_register.add_argument("--label", required=True)
     p_register.add_argument("--prompt-hash", default=None, help="sha256:... of the prompt; never store prompt text.")
@@ -44,7 +44,7 @@ def register(sub: argparse._SubParsersAction) -> None:
 
     p_adopt = cloud_sub.add_parser("adopt", help="Back-register an already-running task or orphaned branch.")
     p_adopt.add_argument("--target", type=Path, default=Path("."))
-    p_adopt.add_argument("--provider", required=True, choices=("codex-cloud", "cursor-cloud"))
+    p_adopt.add_argument("--provider", required=True, choices=("codex-cloud", "cursor-cloud", "grokbot-cloud"))
     p_adopt.add_argument("--task-id", default=None)
     p_adopt.add_argument("--branch", default=None)
     p_adopt.add_argument("--label", default=None)

--- a/src/brigade/cloud_tracker.py
+++ b/src/brigade/cloud_tracker.py
@@ -341,9 +341,12 @@ def _orphan_branch_rows(
     registry_entries: list[dict[str, Any]],
     github: dict[str, Any],
     now: datetime,
+    known_branches: set[str] | None = None,
 ) -> list[dict[str, Any]]:
-    known_branches = {e.get("branch") for e in registry_entries if isinstance(e.get("branch"), str) and e.get("branch")}
-    known_branches |= {
+    registered_branches = {
+        e.get("branch") for e in registry_entries if isinstance(e.get("branch"), str) and e.get("branch")
+    }
+    registered_branches |= {
         e.get("expected_artifact", {}).get("pattern")
         for e in registry_entries
         if isinstance(e.get("expected_artifact"), dict)
@@ -351,11 +354,13 @@ def _orphan_branch_rows(
         and "/" in str(e.get("expected_artifact", {}).get("pattern"))
         and "*" not in str(e.get("expected_artifact", {}).get("pattern"))
     }
+    if known_branches:
+        registered_branches |= known_branches
     rows: list[dict[str, Any]] = []
     for name in sorted(_branch_names(github)):
         if not name.startswith(CLOUD_BRANCH_PREFIXES):
             continue
-        if name in known_branches:
+        if name in registered_branches:
             continue
         provider = _provider_for_branch(name)
         rows.append(
@@ -515,8 +520,21 @@ def status_payload(
         )
         for entry in registry["entries"]
     ]
-    entries.extend(_grokbot_rows(target, github=github, now=observed, stale_ready_hours=stale_ready_hours))
-    entries.extend(_orphan_branch_rows(registry_entries=registry["entries"], github=github, now=observed))
+    grokbot_rows = _grokbot_rows(target, github=github, now=observed, stale_ready_hours=stale_ready_hours)
+    entries.extend(grokbot_rows)
+    known_queue_branches = {
+        refs["branch"]
+        for row in grokbot_rows
+        if isinstance((refs := row.get("artifact_refs")), dict) and isinstance(refs.get("branch"), str)
+    }
+    entries.extend(
+        _orphan_branch_rows(
+            registry_entries=registry["entries"],
+            github=github,
+            now=observed,
+            known_branches=known_queue_branches,
+        )
+    )
 
     return {
         "schema": STATUS_SCHEMA,
@@ -843,9 +861,15 @@ def center_activity_records(
     return records
 
 
-def health(target: Path, *, now: datetime | None = None) -> dict[str, Any]:
+def health(
+    target: Path,
+    *,
+    now: datetime | None = None,
+    github: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Return a bounded local queue health summary for operator consumers."""
-    payload = status_payload(target, now=now, provider_tasks={}, github={"branches": [], "prs": []})
+    snapshot = github if isinstance(github, dict) else observe_github(target)
+    payload = status_payload(target, now=now, provider_tasks={}, github=snapshot)
     entries = [row for row in payload.get("entries", []) if row.get("provider") == "grokbot-cloud"]
     classifications = {name: sum(1 for row in entries if row.get("classification") == name) for name in CLASSIFICATIONS}
     attention = classifications["stale"] + classifications["needs-investigation"] + classifications["orphaned"]

--- a/src/brigade/cloud_tracker.py
+++ b/src/brigade/cloud_tracker.py
@@ -18,11 +18,12 @@ STATUS_SCHEMA = "brigade.run.cloud.status.v1"
 SWEEP_SCHEMA = "brigade.run.cloud.sweep.v1"
 
 DEFAULT_STALE_READY_HOURS = 6
-CLOUD_BRANCH_PREFIXES = ("codex/", "cursor/")
+CLOUD_BRANCH_PREFIXES = ("codex/", "cursor/", "grokbot/")
+TRACKER_PROVIDERS = frozenset({"codex-cloud", "cursor-cloud", "grokbot-cloud"})
 READY_STATES = frozenset({"ready", "completed", "succeeded", "applied"})
 FAILED_STATES = frozenset({"failed", "errored", "error", "cancelled", "canceled", "expired"})
 FINISHED_STATES = frozenset({"finished", "completed", "succeeded", "applied", "ready"})
-PENDING_STATES = frozenset({"pending", "running", "queued", "in_progress", "dispatching"})
+PENDING_STATES = frozenset({"pending", "claimed", "running", "queued", "in_progress", "dispatching"})
 
 CLASSIFICATIONS = (
     "pending",
@@ -138,8 +139,8 @@ def register(
     dispatched_at: str | None = None,
     source: str = "dispatch",
 ) -> dict[str, Any]:
-    if provider not in {"codex-cloud", "cursor-cloud"}:
-        raise ValueError("provider must be codex-cloud or cursor-cloud")
+    if provider not in TRACKER_PROVIDERS:
+        raise ValueError("provider must be codex-cloud, cursor-cloud, or grokbot-cloud")
     if not label.strip():
         raise ValueError("label must not be empty")
     if source == "dispatch" and not task_id:
@@ -271,7 +272,7 @@ def _classify_entry(
     branch_exists = bool(branch and branch in branches)
     raw_expected = entry.get("expected_artifact")
     expected = raw_expected if isinstance(raw_expected, dict) else {}
-    expects_branch = expected.get("kind") == "branch"
+    expects_branch = expected.get("kind") in {"branch", "draft-pr"}
 
     evidence: dict[str, Any] = {
         "registry": {"id": entry.get("id"), "source": entry.get("source"), "dispatched_at": entry.get("dispatched_at")},
@@ -356,7 +357,7 @@ def _orphan_branch_rows(
             continue
         if name in known_branches:
             continue
-        provider = "cursor-cloud" if name.startswith("cursor/") else "codex-cloud"
+        provider = _provider_for_branch(name)
         rows.append(
             {
                 "id": f"orphan-branch:{name}",
@@ -375,11 +376,116 @@ def _orphan_branch_rows(
                     "provider": {"wired": False, "state": None, "task_id": None},
                     "github": {"branch": name, "branch_exists": True, "prs": _prs_for_branch(github, name)},
                 },
-                "pr": None,
+                "pr": _prs_for_branch(github, name)[0] if _prs_for_branch(github, name) else None,
                 "observed_at": _now_iso(now),
             }
         )
     return rows
+
+
+def _provider_for_branch(branch: str) -> str:
+    if branch.startswith("cursor/"):
+        return "cursor-cloud"
+    if branch.startswith("grokbot/"):
+        return "grokbot-cloud"
+    return "codex-cloud"
+
+
+def _grokbot_rows(
+    target: Path, *, github: dict[str, Any], now: datetime, stale_ready_hours: int
+) -> list[dict[str, Any]]:
+    """Project queue jobs into tracker rows without reading private envelopes."""
+    try:
+        from . import grokbot_jobs
+
+        queue_rows = grokbot_jobs.tracker_rows(target)
+    except Exception:  # noqa: BLE001 - tracker remains available when queue storage is unavailable
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for job in queue_rows:
+        job_id = job.get("job_id")
+        if not isinstance(job_id, str):
+            continue
+        raw_artifact = job.get("artifact")
+        artifact: dict[str, Any] = raw_artifact if isinstance(raw_artifact, dict) else {}
+        raw_completed = job.get("result_artifact")
+        completed: dict[str, Any] = raw_completed if isinstance(raw_completed, dict) else {}
+        branch = completed.get("branch") if isinstance(completed.get("branch"), str) else None
+        refs = _grokbot_artifact_refs(artifact=artifact, completed=completed, github=github, branch=branch)
+        augmented_github = github
+        if branch and refs.get("pr_url") and not _prs_for_branch(github, branch):
+            raw_prs = github.get("prs")
+            prs: list[Any] = list(raw_prs) if isinstance(raw_prs, list) else []
+            augmented_github = {
+                **github,
+                "prs": [
+                    *prs,
+                    {"head": branch, "state": "OPEN", "url": refs["pr_url"]},
+                ],
+            }
+        classification_row = _classify_entry(
+            {
+                "id": f"grokbot:{job_id}",
+                "provider": "grokbot-cloud",
+                "task_id": job_id,
+                "label": job.get("label"),
+                "branch": branch,
+                "dispatched_at": job.get("queued_at"),
+                "source": "grokbot-queue",
+                "expected_artifact": artifact,
+            },
+            provider_tasks={job_id: {"state": job.get("state"), "ready_at": job.get("updated_at")}},
+            github=augmented_github,
+            stale_ready_hours=stale_ready_hours,
+            now=now,
+            cursor_wired=False,
+        )
+        row: dict[str, Any] = {
+            "id": f"grokbot:{job_id}",
+            "provider": "grokbot-cloud",
+            "job_id": job_id,
+            "label": job.get("label"),
+            "task_hash": job.get("task_hash"),
+            "state": job.get("state"),
+            "classification": classification_row["classification"],
+            "artifact_refs": refs,
+            "source": "grokbot-queue",
+        }
+        for key in ("created_at", "updated_at", "queued_at", "claimed_at"):
+            if isinstance(job.get(key), str):
+                row[key] = job[key]
+        rows.append(row)
+    return rows
+
+
+def _grokbot_artifact_refs(
+    *, artifact: dict[str, Any], completed: dict[str, Any], github: dict[str, Any], branch: str | None
+) -> dict[str, Any]:
+    """Keep only artifact identifiers and GitHub PR metadata safe for operators."""
+    kind = artifact.get("kind") if isinstance(artifact.get("kind"), str) else None
+    refs: dict[str, Any] = {"kind": kind}
+    if branch:
+        refs["branch"] = branch
+    if kind == "draft-pr":
+        url = completed.get("url") if isinstance(completed.get("url"), str) else None
+        pr = _prs_for_branch(github, branch)[0] if branch and _prs_for_branch(github, branch) else None
+        if isinstance(pr, dict):
+            if isinstance(pr.get("url"), str):
+                url = pr["url"]
+            if isinstance(pr.get("isDraft"), bool):
+                refs["is_draft"] = pr["isDraft"]
+            if isinstance(pr.get("headRefOid"), str):
+                refs["head_sha"] = pr["headRefOid"]
+        if url:
+            refs["pr_url"] = url
+    elif kind == "branch" and isinstance(completed.get("commit"), str):
+        refs["head_sha"] = completed["commit"]
+    elif kind == "report":
+        for key in ("path", "sha256"):
+            if isinstance(completed.get(key), str):
+                refs[key] = completed[key]
+    return refs
 
 
 def status_payload(
@@ -409,6 +515,7 @@ def status_payload(
         )
         for entry in registry["entries"]
     ]
+    entries.extend(_grokbot_rows(target, github=github, now=observed, stale_ready_hours=stale_ready_hours))
     entries.extend(_orphan_branch_rows(registry_entries=registry["entries"], github=github, now=observed))
 
     return {
@@ -423,6 +530,7 @@ def status_payload(
                 "authority": "best-effort" if cursor_wired else "unwired",
                 "detail": None if cursor_wired else "no API key; cursor cloud left unwired",
             },
+            "grokbot-cloud": {"wired": True, "authority": "local-queue"},
             "github": {"wired": True, "authority": "ground-truth"},
         },
         "entries": entries,
@@ -611,7 +719,17 @@ def observe_github(target: Path) -> dict[str, Any]:
 
     prs: list[dict[str, Any]] = []
     code, stdout, _ = _run_text(
-        ["gh", "pr", "list", "--state", "all", "--json", "number,state,headRefName", "--limit", "100"],
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--json",
+            "number,state,headRefName,url,isDraft,headRefOid",
+            "--limit",
+            "100",
+        ],
         cwd=target,
     )
     if code == 0 and stdout.strip():
@@ -625,7 +743,16 @@ def observe_github(target: Path) -> dict[str, Any]:
                     continue
                 head = item.get("headRefName")
                 if isinstance(head, str) and head.startswith(CLOUD_BRANCH_PREFIXES):
-                    prs.append({"head": head, "state": item.get("state"), "number": item.get("number")})
+                    prs.append(
+                        {
+                            "head": head,
+                            "state": item.get("state"),
+                            "number": item.get("number"),
+                            "url": item.get("url"),
+                            "isDraft": item.get("isDraft"),
+                            "headRefOid": item.get("headRefOid"),
+                        }
+                    )
     return {"branches": branches, "prs": prs}
 
 
@@ -703,12 +830,42 @@ def center_activity_records(
                 },
                 "links": {
                     "status": "brigade run cloud status --json",
-                    "task_id": row.get("task_id"),
-                    "branch": row.get("branch"),
+                    "task_id": row.get("task_id") or row.get("job_id"),
+                    "branch": row.get("branch")
+                    or (
+                        (row.get("artifact_refs") or {}).get("branch")
+                        if isinstance(row.get("artifact_refs"), dict)
+                        else None
+                    ),
                 },
             }
         )
     return records
+
+
+def health(target: Path, *, now: datetime | None = None) -> dict[str, Any]:
+    """Return a bounded local queue health summary for operator consumers."""
+    payload = status_payload(target, now=now, provider_tasks={}, github={"branches": [], "prs": []})
+    entries = [row for row in payload.get("entries", []) if row.get("provider") == "grokbot-cloud"]
+    classifications = {name: sum(1 for row in entries if row.get("classification") == name) for name in CLASSIFICATIONS}
+    attention = classifications["stale"] + classifications["needs-investigation"] + classifications["orphaned"]
+    top = next(
+        (row for row in entries if row.get("classification") in {"stale", "needs-investigation", "orphaned"}), None
+    )
+    return {
+        "job_count": len(entries),
+        "classification_counts": classifications,
+        "issue_count": attention,
+        "top_issue": (
+            {
+                "name": "grokbot_queue_attention",
+                "detail": f"{top.get('label') or top.get('job_id')}: {top.get('classification')}",
+                "job_id": top.get("job_id"),
+            }
+            if isinstance(top, dict)
+            else None
+        ),
+    }
 
 
 def set_stale_ready_hours(target: Path, hours: int) -> dict[str, Any]:

--- a/src/brigade/daily_cmd/status_plan.py
+++ b/src/brigade/daily_cmd/status_plan.py
@@ -22,6 +22,7 @@ from uuid import uuid4
 
 from .. import (
     center_cmd,
+    cloud_tracker,
     context_cmd,
     handoff_cmd,
     memory_cmd,
@@ -149,6 +150,7 @@ def _daily_center_status_payload(target: Path) -> dict[str, Any]:
         "notifications": notifications,
         "tool_catalog": {},
         "release_readiness": None,
+        "cloud_tracker": cloud_tracker.health(target),
     }
 
 
@@ -276,6 +278,7 @@ def status_payload(target: Path) -> dict[str, Any]:
         "open_daily_action_count": (center.get("action_queue") or {}).get("open_count", 0)
         if isinstance(center.get("action_queue"), dict)
         else 0,
+        "grokbot_cloud": center.get("cloud_tracker") if isinstance(center.get("cloud_tracker"), dict) else {},
         "top_readiness_blocker": readiness.get("blockers", [None])[0] if readiness.get("blockers") else None,
         "pending_handoff_draft_count": (handoffs.get("counts") or {}).get("pending", 0)
         if isinstance(handoffs.get("counts"), dict)

--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -173,6 +173,42 @@ def status(target: Path, job_id: str | None = None) -> dict[str, Any]:
         return {"jobs": jobs}
 
 
+def tracker_rows(target: Path) -> list[dict[str, Any]]:
+    """Return the bounded queue fields that the cloud tracker may project.
+
+    This deliberately differs from the queue CLI projection. The tracker needs
+    completion artifact references to reconcile draft PRs, but it never needs
+    the private envelope, lease holder, or verification commands.
+    """
+    root = Path(target).expanduser() / ".brigade" / "cloud" / "grokbot"
+    if not root.exists():
+        return []
+    with _storage_paths(target) as storage:
+        rows: list[dict[str, Any]] = []
+        for name in _list_names(storage.jobs, prefix="grokbot-", suffix=".json"):
+            record = _read_json_file(storage.jobs, name)
+            if record is None:
+                raise GrokbotJobError("corrupt-storage")
+            valid = _validate_record(record)
+            spec = valid["spec"]
+            assert isinstance(spec, dict)
+            row: dict[str, Any] = {
+                "job_id": valid["job_id"],
+                "label": spec["label"],
+                "task_hash": valid["task_hash"],
+                "state": valid["state"],
+                "created_at": valid["created_at"],
+                "updated_at": valid["updated_at"],
+                "queued_at": valid["queued_at"],
+                "artifact": spec["artifact"],
+            }
+            for key in ("claimed_at", "result_artifact"):
+                if key in valid:
+                    row[key] = valid[key]
+            rows.append(row)
+        return rows
+
+
 def claim(
     target: Path,
     job_id: str,

--- a/src/brigade/operator_cmd/health.py
+++ b/src/brigade/operator_cmd/health.py
@@ -42,6 +42,7 @@ def status_payload(target: Path, *, profile: str = "internal-dogfood") -> dict[s
     daily_health = daily_cmd.health(target)
     security_health = security_cmd.health(target)
     readiness = center_cmd._readiness_payload(target)
+    cloud_health = center_cmd.status_payload(target).get("cloud_tracker")
     notification_health = notifications_cmd.health(target)
     content_guard_health = scrub.hook_status(target)
     dogfood_ready = dogfood_cmd.config_path(target).exists() and codex_path is not None
@@ -126,6 +127,7 @@ def status_payload(target: Path, *, profile: str = "internal-dogfood") -> dict[s
             "latest_plan": daily_health.get("latest_plan"),
             "latest_run": daily_health.get("latest_run"),
         },
+        "grokbot_cloud": cloud_health if isinstance(cloud_health, dict) else {},
         "security": {
             "issue_count": security_health.get("issue_count"),
             "top_issue": security_health.get("top_issue"),

--- a/src/brigade/work_cmd/session/briefing.py
+++ b/src/brigade/work_cmd/session/briefing.py
@@ -675,7 +675,8 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
                 continue
             print(
                 f"  - {row.get('label')} provider={row.get('provider')} "
-                f"task={row.get('task_id')} branch={row.get('branch')}"
+                f"task={row.get('task_id') or row.get('job_id')} "
+                f"branch={row.get('branch') or ((row.get('artifact_refs') or {}).get('branch') if isinstance(row.get('artifact_refs'), dict) else None)}"
             )
 
     print(f"next_source: {payload['next_source']}")

--- a/tests/test_center_agent_activity.py
+++ b/tests/test_center_agent_activity.py
@@ -112,6 +112,64 @@ def test_center_activity_projects_grokbot_queue_without_private_instructions(tmp
     assert "PRIVATE CENTER INSTRUCTIONS" not in json.dumps(records)
 
 
+def test_center_activity_marks_merged_grokbot_draft_pr_succeeded(tmp_path, monkeypatch):
+    now = datetime.now(timezone.utc)
+    job_id = grokbot_jobs.enqueue(
+        tmp_path,
+        {
+            "label": "Merged Grok Bot tracker",
+            "role": "implementation-worker",
+            "repository": "example/brigade",
+            "base_ref": "main",
+            "ownership_paths": ["src/brigade/cloud_tracker.py"],
+            "instructions": "PRIVATE MERGED INSTRUCTIONS",
+            "verification_commands": ["pytest -q tests/test_center_agent_activity.py"],
+            "artifact": {"kind": "draft-pr"},
+            "timeout_seconds": 900,
+        },
+        "merged-grokbot-tracker",
+        now=now,
+    )["job_id"]
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 600, now=now)
+    grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=now)
+    grokbot_jobs.transition(
+        tmp_path,
+        job_id,
+        "bot-a",
+        "lease-a",
+        "completed",
+        now=now,
+        artifact={
+            "kind": "draft-pr",
+            "branch": "grokbot/merged-grokbot-tracker",
+            "url": "https://github.com/example/brigade/pull/456",
+        },
+    )
+    monkeypatch.setattr(
+        "brigade.cloud_tracker.observe_github",
+        lambda _: {
+            "branches": [],
+            "prs": [
+                {
+                    "head": "grokbot/merged-grokbot-tracker",
+                    "state": "MERGED",
+                    "url": "https://github.com/example/brigade/pull/456",
+                    "isDraft": True,
+                    "headRefOid": "c" * 40,
+                }
+            ],
+        },
+    )
+    home = tmp_path / "empty-home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
+
+    records = activity_records.collect(tmp_path, now=now + timedelta(hours=30))
+    row = next(record for record in records if record["links"].get("task_id") == job_id)
+    assert row["classification"] == "landed"
+    assert row["state"] == "succeeded"
+
+
 def test_session_discovery_bounds_directory_walks(tmp_path, monkeypatch):
     root = tmp_path / "sessions"
     for index in range(300):

--- a/tests/test_center_agent_activity.py
+++ b/tests/test_center_agent_activity.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timedelta, timezone
 
-from brigade import center_cmd
+from brigade import center_cmd, grokbot_jobs
 from brigade.center_cmd import agent_activity as activity_records
 from brigade.center_cmd.dashboard.views import agent_activity
 
@@ -80,6 +80,36 @@ def test_center_activity_observes_codex_and_cursor_session_files_without_transcr
     rendered = json.dumps(records)
     assert "private prompt" not in rendered
     assert "private transcript" not in rendered
+
+
+def test_center_activity_projects_grokbot_queue_without_private_instructions(tmp_path, monkeypatch):
+    now = datetime.now(timezone.utc)
+    job_id = grokbot_jobs.enqueue(
+        tmp_path,
+        {
+            "label": "Center Grok Bot tracker",
+            "role": "implementation-worker",
+            "repository": "example/brigade",
+            "base_ref": "main",
+            "ownership_paths": ["src/brigade/cloud_tracker.py"],
+            "instructions": "PRIVATE CENTER INSTRUCTIONS TOKEN=do-not-display",
+            "verification_commands": ["pytest -q tests/test_center_agent_activity.py"],
+            "artifact": {"kind": "draft-pr"},
+            "timeout_seconds": 900,
+        },
+        "center-grokbot-tracker",
+        now=now,
+    )["job_id"]
+    home = tmp_path / "empty-home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
+
+    records = activity_records.collect(tmp_path, now=now)
+    row = next(record for record in records if record["links"].get("task_id") == job_id)
+    assert row["provider"] == "grokbot"
+    assert row["harness"] == "grokbot-cloud"
+    assert row["state"] == "running"
+    assert "PRIVATE CENTER INSTRUCTIONS" not in json.dumps(records)
 
 
 def test_session_discovery_bounds_directory_walks(tmp_path, monkeypatch):

--- a/tests/test_center_readiness_cmd.py
+++ b/tests/test_center_readiness_cmd.py
@@ -1,6 +1,7 @@
 import json
+from datetime import datetime, timezone
 
-from brigade import center_cmd, cli
+from brigade import center_cmd, cli, grokbot_jobs
 
 
 def _write_command_inventory(path):
@@ -75,6 +76,33 @@ def test_center_readiness_blockers_and_imports(tmp_path, capsys):
     assert cli.main(["center", "readiness", "import-issues", "--target", str(tmp_path), "--json"]) == 0
     imported = json.loads(capsys.readouterr().out)
     assert imported["imported"] >= 1
+
+
+def test_center_readiness_surfaces_failed_grokbot_job_without_private_instructions(tmp_path):
+    now = datetime.now(timezone.utc)
+    job_id = grokbot_jobs.enqueue(
+        tmp_path,
+        {
+            "label": "Readiness Grok Bot job",
+            "role": "implementation-worker",
+            "repository": "example/brigade",
+            "base_ref": "main",
+            "ownership_paths": ["src/brigade/cloud_tracker.py"],
+            "instructions": "PRIVATE READINESS INSTRUCTIONS TOKEN=do-not-display",
+            "verification_commands": ["pytest -q tests/test_center_readiness_cmd.py"],
+            "artifact": {"kind": "draft-pr"},
+            "timeout_seconds": 900,
+        },
+        "readiness-grokbot-job",
+        now=now,
+    )["job_id"]
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 600, now=now)
+    grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "failed", now=now)
+
+    readiness = center_cmd._readiness_payload(tmp_path)
+    finding = next(item for item in readiness["findings"] if item["subsystem"] == "cloud_tracker")
+    assert finding["name"] == "grokbot_queue_attention"
+    assert "PRIVATE READINESS INSTRUCTIONS" not in json.dumps(readiness)
 
 
 def test_center_readiness_waiver_allows_reviewed_closeout(tmp_path, capsys):

--- a/tests/test_cloud_tracker.py
+++ b/tests/test_cloud_tracker.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, cloud_tracker
+from brigade import cli, cloud_tracker, grokbot_jobs
 
 
 NOW = datetime(2026, 8, 12, 20, 0, 0, tzinfo=timezone.utc)
@@ -21,6 +21,40 @@ def _iso(dt: datetime) -> str:
 
 def _prompt_hash(text: str) -> str:
     return "sha256:" + hashlib.sha256(text.encode()).hexdigest()
+
+
+def _grokbot_spec() -> dict[str, object]:
+    return {
+        "label": "Tracker-safe Grok Bot job",
+        "role": "implementation-worker",
+        "repository": "example/brigade",
+        "base_ref": "main",
+        "ownership_paths": ["src/brigade/cloud_tracker.py"],
+        "instructions": "PRIVATE TRACKER INSTRUCTIONS TOKEN=do-not-display",
+        "verification_commands": ["pytest -q tests/test_cloud_tracker.py"],
+        "artifact": {"kind": "draft-pr"},
+        "timeout_seconds": 900,
+    }
+
+
+def _completed_grokbot_job(tmp_path: Path, *, now: datetime = NOW) -> str:
+    job_id = grokbot_jobs.enqueue(tmp_path, _grokbot_spec(), "tracker-safe-job", now=now)["job_id"]
+    grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 600, now=now)
+    grokbot_jobs.transition(tmp_path, job_id, "bot-a", "lease-a", "running", now=now + timedelta(seconds=1))
+    grokbot_jobs.transition(
+        tmp_path,
+        job_id,
+        "bot-a",
+        "lease-a",
+        "completed",
+        artifact={
+            "kind": "draft-pr",
+            "url": "https://github.com/example/brigade/pull/123",
+            "branch": "grokbot/tracker-safe-job",
+        },
+        now=now + timedelta(seconds=2),
+    )
+    return job_id
 
 
 def test_register_persists_entry_without_prompt_text(tmp_path: Path):
@@ -241,6 +275,87 @@ def test_cursor_cloud_is_unwired_never_guessed(tmp_path: Path):
     assert row["evidence"]["provider"] == "unwired"
 
 
+def test_grokbot_queue_projects_safe_rows_and_reconciles_claimed_and_draft_pr(tmp_path: Path):
+    queued = grokbot_jobs.enqueue(tmp_path, _grokbot_spec(), "queued-tracker-job", now=NOW)["job_id"]
+    queued_status = cloud_tracker.status_payload(
+        tmp_path, now=NOW, provider_tasks={}, github={"branches": [], "prs": []}
+    )
+    queued_row = next(row for row in queued_status["entries"] if row.get("job_id") == queued)
+    assert queued_row["classification"] == "pending"
+    assert queued_row["state"] == "queued"
+    assert "PRIVATE TRACKER INSTRUCTIONS" not in json.dumps(queued_status)
+
+    grokbot_jobs.claim(tmp_path, queued, "bot-a", "lease-a", 600, now=NOW)
+    claimed_status = cloud_tracker.status_payload(
+        tmp_path, now=NOW, provider_tasks={}, github={"branches": [], "prs": []}
+    )
+    claimed_row = next(row for row in claimed_status["entries"] if row.get("job_id") == queued)
+    assert claimed_row["classification"] == "pending"
+    assert claimed_row["state"] == "claimed"
+    assert claimed_row["claimed_at"] == _iso(NOW)
+
+    completed = _completed_grokbot_job(tmp_path, now=NOW + timedelta(hours=1))
+    github = {
+        "branches": [{"name": "grokbot/tracker-safe-job"}],
+        "prs": [
+            {
+                "head": "grokbot/tracker-safe-job",
+                "state": "OPEN",
+                "url": "https://github.com/example/brigade/pull/123",
+                "isDraft": True,
+                "headRefOid": "a" * 40,
+            }
+        ],
+    }
+    completed_status = cloud_tracker.status_payload(tmp_path, now=NOW + timedelta(hours=1, minutes=1), github=github)
+    row = next(row for row in completed_status["entries"] if row.get("job_id") == completed)
+    assert row["provider"] == "grokbot-cloud"
+    assert row["classification"] == "ready-to-land"
+    assert row["artifact_refs"] == {
+        "kind": "draft-pr",
+        "branch": "grokbot/tracker-safe-job",
+        "pr_url": "https://github.com/example/brigade/pull/123",
+        "is_draft": True,
+        "head_sha": "a" * 40,
+    }
+    assert set(row) <= {
+        "id",
+        "provider",
+        "job_id",
+        "label",
+        "task_hash",
+        "state",
+        "classification",
+        "artifact_refs",
+        "source",
+        "created_at",
+        "updated_at",
+        "queued_at",
+        "claimed_at",
+    }
+    assert completed_status["sources"]["grokbot-cloud"] == {"wired": True, "authority": "local-queue"}
+
+
+def test_grokbot_branch_is_orphaned_and_cloud_sweep_keeps_safe_references(tmp_path: Path):
+    status = cloud_tracker.status_payload(
+        tmp_path,
+        now=NOW,
+        github={"branches": [{"name": "grokbot/unregistered"}], "prs": []},
+    )
+    orphan = next(row for row in status["entries"] if row["id"] == "orphan-branch:grokbot/unregistered")
+    assert orphan["provider"] == "grokbot-cloud"
+    assert orphan["classification"] == "orphaned"
+
+    _completed_grokbot_job(tmp_path, now=NOW - timedelta(hours=30))
+    report = cloud_tracker.sweep(
+        tmp_path,
+        now=NOW,
+        status=cloud_tracker.status_payload(tmp_path, now=NOW, github={"branches": [], "prs": []}),
+    )
+    assert any(item["id"].startswith("grokbot:") for item in report["recoverable"])
+    assert "PRIVATE TRACKER INSTRUCTIONS" not in json.dumps(report)
+
+
 def test_stale_ready_threshold_configurable(tmp_path: Path):
     cloud_tracker.save_registry(
         tmp_path,
@@ -352,6 +467,22 @@ def test_stale_entries_surface_in_work_brief(tmp_path: Path, monkeypatch):
     assert any(row["classification"] == "stale" for row in cloud.get("stale_entries", []))
 
 
+def test_grokbot_stale_entry_surfaces_in_work_brief_without_task_text(tmp_path: Path, monkeypatch):
+    _completed_grokbot_job(tmp_path, now=NOW - timedelta(hours=30))
+    monkeypatch.setattr(
+        cloud_tracker,
+        "observe_providers",
+        lambda target, **kwargs: ({}, {"branches": [], "prs": []}, False),
+    )
+    from brigade.work_cmd.session import briefing
+
+    payload = briefing._brief_payload(tmp_path, limit=1)
+    cloud = payload["cloud_tracker"]
+    row = next(item for item in cloud["stale_entries"] if item.get("provider") == "grokbot-cloud")
+    assert row["job_id"].startswith("grokbot-")
+    assert "PRIVATE TRACKER INSTRUCTIONS" not in json.dumps(payload)
+
+
 def test_cli_run_cloud_status_json_contract(tmp_path: Path, capsys, monkeypatch):
     cloud_tracker.register(
         tmp_path,
@@ -376,6 +507,22 @@ def test_cli_run_cloud_status_json_contract(tmp_path: Path, capsys, monkeypatch)
     assert payload["schema"] == cloud_tracker.STATUS_SCHEMA
     assert payload["entries"][0]["classification"] == "pending"
     assert payload["sources"]["cursor-cloud"]["wired"] is False
+
+
+def test_cli_cloud_status_includes_grokbot_without_private_envelope(tmp_path: Path, capsys, monkeypatch):
+    job_id = _completed_grokbot_job(tmp_path, now=NOW - timedelta(hours=1))
+    monkeypatch.setattr(
+        cloud_tracker,
+        "observe_providers",
+        lambda target, **kwargs: ({}, {"branches": [], "prs": []}, False),
+    )
+
+    assert cli.main(["run", "cloud", "status", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    row = next(item for item in payload["entries"] if item.get("job_id") == job_id)
+    assert row["provider"] == "grokbot-cloud"
+    assert row["artifact_refs"]["pr_url"].endswith("/pull/123")
+    assert "PRIVATE TRACKER INSTRUCTIONS" not in json.dumps(payload)
 
 
 def test_cli_run_cloud_register_and_adopt(tmp_path: Path, capsys):

--- a/tests/test_cloud_tracker.py
+++ b/tests/test_cloud_tracker.py
@@ -318,6 +318,13 @@ def test_grokbot_queue_projects_safe_rows_and_reconciles_claimed_and_draft_pr(tm
         "is_draft": True,
         "head_sha": "a" * 40,
     }
+    matching_branch_rows = [
+        entry
+        for entry in completed_status["entries"]
+        if entry.get("artifact_refs", {}).get("branch") == "grokbot/tracker-safe-job"
+        or entry.get("branch") == "grokbot/tracker-safe-job"
+    ]
+    assert [entry["id"] for entry in matching_branch_rows] == [f"grokbot:{completed}"]
     assert set(row) <= {
         "id",
         "provider",
@@ -334,6 +341,27 @@ def test_grokbot_queue_projects_safe_rows_and_reconciles_claimed_and_draft_pr(tm
         "claimed_at",
     }
     assert completed_status["sources"]["grokbot-cloud"] == {"wired": True, "authority": "local-queue"}
+
+
+def test_grokbot_merged_draft_pr_lands_without_queue_attention(tmp_path: Path):
+    completed = _completed_grokbot_job(tmp_path, now=NOW - timedelta(hours=30))
+    github = {
+        "branches": [],
+        "prs": [
+            {
+                "head": "grokbot/tracker-safe-job",
+                "state": "MERGED",
+                "url": "https://github.com/example/brigade/pull/123",
+                "isDraft": True,
+                "headRefOid": "b" * 40,
+            }
+        ],
+    }
+
+    status = cloud_tracker.status_payload(tmp_path, now=NOW, provider_tasks={}, github=github)
+    row = next(entry for entry in status["entries"] if entry.get("job_id") == completed)
+    assert row["classification"] == "landed"
+    assert cloud_tracker.health(tmp_path, now=NOW, github=github)["issue_count"] == 0
 
 
 def test_grokbot_branch_is_orphaned_and_cloud_sweep_keeps_safe_references(tmp_path: Path):

--- a/tests/test_daily_driver_cmd.py
+++ b/tests/test_daily_driver_cmd.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from brigade import (
     center_cmd,
     cli,
     daily_cmd,
+    grokbot_jobs,
     handoff_cmd,
     phases_cmd,
     release_cmd,
@@ -98,6 +100,33 @@ def test_daily_status_text_and_json(tmp_path, capsys):
 
     assert cli.main(["daily", "status", "--target", str(tmp_path)]) == 0
     assert "daily status:" in capsys.readouterr().out
+
+
+def test_daily_status_includes_bounded_grokbot_cloud_summary(tmp_path, capsys):
+    _seed_ready_repo(tmp_path, capsys)
+    now = datetime.now(timezone.utc)
+    grokbot_jobs.enqueue(
+        tmp_path,
+        {
+            "label": "Daily Grok Bot job",
+            "role": "implementation-worker",
+            "repository": "example/brigade",
+            "base_ref": "main",
+            "ownership_paths": ["src/brigade/cloud_tracker.py"],
+            "instructions": "PRIVATE DAILY INSTRUCTIONS TOKEN=do-not-display",
+            "verification_commands": ["pytest -q tests/test_daily_driver_cmd.py"],
+            "artifact": {"kind": "draft-pr"},
+            "timeout_seconds": 900,
+        },
+        "daily-grokbot-job",
+        now=now,
+    )
+
+    assert daily_cmd.status(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["grokbot_cloud"]["job_count"] == 1
+    assert payload["grokbot_cloud"]["classification_counts"]["pending"] == 1
+    assert "PRIVATE DAILY INSTRUCTIONS" not in json.dumps(payload)
 
 
 def test_daily_status_timeout_degrades_slow_candidate_section(tmp_path, capsys, monkeypatch):

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 
-from brigade import cli, install as install_mod, operator_cmd, work_cmd
+from brigade import cli, grokbot_jobs, install as install_mod, operator_cmd, work_cmd
 
 
 def _fake_surface_run(argv, timeout=8):
@@ -52,6 +53,29 @@ def test_operator_plan_lists_safe_local_configs(tmp_path, capsys):
     assert {"daily", "handoff-sources", "work-scanners", "security", "tools"} <= ids
     assert "Does not start services." in payload["boundaries"]
     assert payload["profile"] == "local-operator"
+
+
+def test_operator_status_includes_bounded_grokbot_cloud_summary(tmp_path):
+    grokbot_jobs.enqueue(
+        tmp_path,
+        {
+            "label": "Operator Grok Bot job",
+            "role": "implementation-worker",
+            "repository": "example/brigade",
+            "base_ref": "main",
+            "ownership_paths": ["src/brigade/cloud_tracker.py"],
+            "instructions": "PRIVATE OPERATOR INSTRUCTIONS TOKEN=do-not-display",
+            "verification_commands": ["pytest -q tests/test_operator_cmd.py"],
+            "artifact": {"kind": "draft-pr"},
+            "timeout_seconds": 900,
+        },
+        "operator-grokbot-job",
+        now=datetime.now(timezone.utc),
+    )
+
+    payload = operator_cmd.status_payload(tmp_path, profile="local-operator")
+    assert payload["grokbot_cloud"]["job_count"] == 1
+    assert "PRIVATE OPERATOR INSTRUCTIONS" not in json.dumps(payload)
 
 
 def test_operator_internal_dogfood_plan_includes_dogfood(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- project Grok Bot queue jobs into Brigade's cloud tracker
- add `grokbot-cloud` status across Center, work brief, daily, and operator health
- retain bounded draft PR, branch, and report references without exposing task instructions
- recognize `grokbot/` branches and GitHub draft PR metadata

## Safety boundaries

- Tracker rows contain job identifiers, labels, task hashes, states, timestamps, and artifact references only.
- Raw task instructions, credentials, environment values, and connector headers remain inside the private queue.
- Existing Codex Cloud and Cursor Cloud fields remain compatible.
- This PR does not call Grok Bot or commission live Bots.

## Verification

- Post-review focused tracker and consumer regressions: 162 passed, receipt `20260824-002328-work-verify-ff7d11`
- Full `./scripts/verify` gate: exit 0, receipt `20260823-233234-work-verify-8e98a9`
- Ruff, formatting, mypy, diff check, and public-repository content scan passed
- One independent review found two reconciliation defects. Both were fixed with regressions before push.

Follow-up PR 3 will add the protected remote MCP adapter and live canary flow.

Part of #1130.
