### PR TITLE
feat: deliver Grok Bot task context after claim

### DIFF
--- a/docs/grokbot-mcp.md
+++ b/docs/grokbot-mcp.md
@@ -50,6 +50,10 @@ brigade run cloud grokbot canary --target . --instance implementation-worker
 
 The implementation-worker listener has the same worker operations, constrained to implementation-worker jobs.
 
+A successful worker claim returns the bounded validated envelope (label, role, repository, base ref, owned paths, instructions, verification commands, artifact kind, and timeout) as the worker's execution context. List, status, operator, and CLI surfaces stay redacted: they never include the envelope's `instructions` or `verification_commands`.
+
+The routine sequence for a worker is: list, claim, validate role and repository, start, renew before expiry, then complete or fail.
+
 `doctor` reports sanitized dependency, configuration, permissions, queue, and endpoint checks. It returns nonzero after setup until the listener starts because the endpoint check cannot connect. Run it again after the listener starts. A canary needs the listener already running.
 
 ## Cloudflare boundary

--- a/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
+++ b/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
@@ -1,0 +1,252 @@
+# Grok Bot claim execution context implementation plan
+
+**Goal:** Let an authenticated role-scoped Grok Bot worker receive its complete bounded task only after a successful claim, while every CLI, list, status, and operator surface stays redacted.
+
+**Architecture:** Keep `grokbot_jobs.claim()` as the safe projection API. Add `claim_execution_context()` over one shared locked claim helper, then use it only from the worker MCP claim branch. The context is an exact copy of validated envelope fields. Tool inventories, storage schema, routes, credentials, and dependencies do not change.
+
+**Key technology:** Python, pytest, file-locked JSON queue state, Streamable HTTP MCP.
+
+Execute the tasks in order. Keep the checkboxes current. Every behavior change starts with a failing test run captured through Brigade.
+
+## File map
+
+- `src/brigade/grokbot_jobs.py`: atomic claim transition and exact execution-context projection.
+- `tests/test_grokbot_jobs.py`: internal context, idempotency, conflict, expiry, and CLI-redaction contract.
+- `src/brigade/grokbot_mcp.py`: worker-only claim handoff.
+- `tests/test_grokbot_mcp.py`: role and disclosure boundary.
+- `docs/grokbot-mcp.md`: listener and routine behavior.
+- `docs/technical-guide.md`: safe projection exception for authenticated post-claim handoff.
+
+## demi
+
+Actual ask: allow scheduled Grok Bot workers to execute a queued task without an operator repeating its instructions in chat.
+
+Smallest useful slice: add one whitelisted context member to the existing successful worker claim response.
+
+Highest rung that holds: one local queue operation plus one existing adapter branch.
+
+Existing pattern to follow: `_projection()` in `grokbot_jobs.py` and the role-filtered claim branch in `grokbot_mcp.py`.
+
+Cut from scope: new tools, schema versions, secret scanners, task artifact services, routine UI, and changes to list or status.
+
+Growth trigger: add a separate context retrieval tool only if workers need to re-fetch context after leaving the claimed state.
+
+Verification: focused queue and adapter tests, MCP-extra tests, full `scripts/verify`, edge inventories, and live no-prompt canaries.
+
+### Task 1: Add the atomic claim-context queue operation
+
+**Files:**
+
+- Modify: `tests/test_grokbot_jobs.py`
+- Modify: `src/brigade/grokbot_jobs.py`
+
+- [ ] Add a failing test for the exact context and safe claim separation:
+
+```python
+def test_claim_execution_context_is_exact_and_safe_claim_stays_redacted(tmp_path: Path):
+    context_job = _enqueue(tmp_path, idempotency_key="request-context")
+    claimed = grokbot_jobs.claim_execution_context(
+        tmp_path, context_job, "bot-a", "lease-a", 60, now=NOW
+    )
+
+    assert claimed["execution_context"] == {
+        "label": "Add queue foundation",
+        "role": "implementation-worker",
+        "repository": "example/brigade",
+        "base_ref": "main",
+        "ownership_paths": ["src/brigade/grokbot_jobs.py", "tests/test_grokbot_jobs.py"],
+        "instructions": "Build the private queue module.",
+        "verification_commands": ["pytest -q tests/test_grokbot_jobs.py"],
+        "artifact": {"kind": "draft-pr"},
+        "timeout_seconds": 900,
+    }
+    assert grokbot_jobs.claim_execution_context(
+        tmp_path, context_job, "bot-a", "lease-a", 60, now=NOW
+    ) == claimed
+
+    safe_job = _enqueue(tmp_path, idempotency_key="request-safe")
+    safe = grokbot_jobs.claim(tmp_path, safe_job, "bot-a", "lease-safe", 60, now=NOW)
+    assert "execution_context" not in safe
+```
+
+- [ ] Add a failing disclosure test:
+
+```python
+def test_claim_execution_context_rejects_conflicting_and_expired_leases(tmp_path: Path):
+    job_id = _enqueue(tmp_path, idempotency_key="request-context-boundary")
+    grokbot_jobs.claim_execution_context(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-conflict$"):
+        grokbot_jobs.claim_execution_context(tmp_path, job_id, "bot-a", "lease-b", 60, now=NOW)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-expired$"):
+        grokbot_jobs.claim_execution_context(
+            tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW + timedelta(seconds=60)
+        )
+```
+
+- [ ] Run RED through Brigade:
+
+```bash
+brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_grokbot_jobs.py -k claim_execution_context" --capture brigade-work
+```
+
+Expect collection or execution to fail because `claim_execution_context` does not exist.
+
+- [ ] Add `claim_execution_context()` and route both public operations through one `_claim_job()` helper. The helper validates inputs once, holds `_queue_lock()`, performs the existing transition unchanged, and formats the result before leaving the lock:
+
+```python
+def claim_execution_context(
+    target: Path,
+    job_id: str,
+    bot_id: str,
+    lease_id: str,
+    lease_seconds: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Claim a queued job and return its validated worker context."""
+    return _claim_job(target, job_id, bot_id, lease_id, lease_seconds, now, include_context=True)
+
+
+def _claim_result(record: dict[str, Any], *, include_context: bool) -> dict[str, Any]:
+    result = _projection(record)
+    if include_context:
+        result["execution_context"] = _execution_context(record)
+    return result
+
+
+def _execution_context(record: dict[str, Any]) -> dict[str, Any]:
+    spec = record["spec"]
+    assert isinstance(spec, dict)
+    return {
+        "label": spec["label"],
+        "role": spec["role"],
+        "repository": spec["repository"],
+        "base_ref": spec["base_ref"],
+        "ownership_paths": list(spec["ownership_paths"]),
+        "instructions": spec["instructions"],
+        "verification_commands": list(spec["verification_commands"]),
+        "artifact": dict(spec["artifact"]),
+        "timeout_seconds": record["timeout_seconds"],
+    }
+```
+
+`claim()` calls `_claim_job(..., include_context=False)`. Same-lease idempotency uses `_claim_result()` on the existing record. Do not change state rules, timestamps, lease bounds, or `_projection()`.
+
+- [ ] Run GREEN with the Task 1 focused command. Expect the new tests and existing claim tests to pass.
+
+- [ ] Strengthen the existing CLI lifecycle assertion with:
+
+```python
+assert "execution_context" not in claimed
+```
+
+- [ ] Commit:
+
+```bash
+git add src/brigade/grokbot_jobs.py tests/test_grokbot_jobs.py
+git commit -m "feat: return bounded Grok Bot claim context"
+```
+
+### Task 2: Hand context only to the role-matching MCP worker
+
+**Files:**
+
+- Modify: `tests/test_grokbot_mcp.py`
+- Modify: `src/brigade/grokbot_mcp.py`
+
+- [ ] Extend `test_workers_only_list_claim_and_read_their_configured_role` with the failing exact-context assertion:
+
+```python
+assert claimed["execution_context"] == _spec("implementation-worker")
+assert "PRIVATE_INSTRUCTIONS_MUST_NOT_LEAK" not in json.dumps(listed)
+assert "execution_context" not in worker.call_tool("grokbot_queue_status", {"job_id": implementation})
+```
+
+- [ ] After the existing cross-role rejection, assert the scout job is still queued:
+
+```python
+assert grokbot_jobs.get_job(tmp_path, scout)["state"] == "queued"
+```
+
+- [ ] Run RED through Brigade:
+
+```bash
+brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_grokbot_mcp.py -k workers_only_list_claim" --capture brigade-work
+```
+
+Expect failure because the worker claim has no `execution_context`.
+
+- [ ] Change only the worker claim call in `GrokbotAdapter._call()`:
+
+```python
+return grokbot_jobs.claim_execution_context(
+    self.config.target,
+    job["job_id"],
+    self.config.bot_id,
+    _lease_id(arguments),
+    LEASE_SECONDS,
+)
+```
+
+- [ ] Run GREEN with the Task 2 focused command.
+
+- [ ] Run the complete focused contract with the MCP extra present:
+
+```bash
+brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py" --capture brigade-work
+```
+
+Expect no skips from missing `mcp.server` and every test to pass.
+
+- [ ] Commit:
+
+```bash
+git add src/brigade/grokbot_mcp.py tests/test_grokbot_mcp.py
+git commit -m "feat: hand claimed context to Grok Bot workers"
+```
+
+### Task 3: Document, verify, and publish the contract
+
+**Files:**
+
+- Modify: `docs/grokbot-mcp.md`
+- Modify: `docs/technical-guide.md`
+- Modify: `docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md`
+
+- [ ] In `docs/grokbot-mcp.md`, state that a successful worker claim returns the bounded validated envelope, while list, status, operator, and CLI surfaces stay redacted. Add the routine sequence: list, claim, validate role and repository, start, renew before expiry, complete or fail.
+
+- [ ] In `docs/technical-guide.md`, replace the blanket claim that all mutation commands are safe projections with the exact exception for authenticated worker MCP claim. Keep the CLI statement unchanged.
+
+- [ ] Run Vale through Brigade:
+
+```bash
+brigade work verify run --target . --command "vale docs/grokbot-mcp.md docs/technical-guide.md docs/superpowers/specs/2026-08-24-grokbot-claim-execution-context-design.md docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md" --capture brigade-work
+```
+
+- [ ] Run the full repository gate:
+
+```bash
+brigade work verify run --target . --command "scripts/verify" --capture brigade-work
+```
+
+Expect lint, format, typing, snapshots, all tests, and the coverage threshold to pass.
+
+- [ ] Run `git diff --check` and the public-content guard. Confirm no private hostnames, addresses, account data, credentials, absolute home paths, or model-authorship prose appears in the branch diff.
+
+- [ ] Tick every completed checkbox and commit the docs plus plan:
+
+```bash
+git add docs/grokbot-mcp.md docs/technical-guide.md docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
+git commit -m "docs: explain Grok Bot claim handoff"
+```
+
+- [ ] Open a non-draft PR with `Fixes #1167`. Merge only after CI and one independent security review pass.
+
+## Deployment acceptance
+
+- [ ] Install the merged commit beside the existing Brigade CLI, regenerate the three native units, and restart one role at a time with rollback to the retained legacy unit on failure.
+- [ ] Run local canary plus Access-only 401, origin-only 401, and exact-inventory edge checks for all roles.
+- [ ] Enqueue one Repository Scout job whose label does not contain its instructions. Send the Bot only the job ID and tell it to follow the returned claim capsule. Require claim, start, renew, report, and complete.
+- [ ] Enqueue one bounded Implementation Worker job. Send only the job ID. Require a draft PR, verification evidence, and no merge or deployment.
+- [ ] Reconcile both artifacts through Brigade cloud tracking.
+- [ ] Save each proven workflow as a Grok Bot skill. Create staggered routines with one role-matching job maximum per run, no merge or deploy, and explicit no-data and failure behavior.

--- a/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
+++ b/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
@@ -154,7 +154,7 @@ git commit -m "feat: return bounded Grok Bot claim context"
 - Modify: `tests/test_grokbot_mcp.py`
 - Modify: `src/brigade/grokbot_mcp.py`
 
-- [ ] Extend `test_workers_only_list_claim_and_read_their_configured_role` with the failing exact-context assertion:
+- [x] Extend `test_workers_only_list_claim_and_read_their_configured_role` with the failing exact-context assertion:
 
 ```python
 assert claimed["execution_context"] == _spec("implementation-worker")
@@ -162,13 +162,13 @@ assert "PRIVATE_INSTRUCTIONS_MUST_NOT_LEAK" not in json.dumps(listed)
 assert "execution_context" not in worker.call_tool("grokbot_queue_status", {"job_id": implementation})
 ```
 
-- [ ] After the existing cross-role rejection, assert the scout job is still queued:
+- [x] After the existing cross-role rejection, assert the scout job is still queued:
 
 ```python
 assert grokbot_jobs.get_job(tmp_path, scout)["state"] == "queued"
 ```
 
-- [ ] Run RED through Brigade:
+- [x] Run RED through Brigade:
 
 ```bash
 brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_grokbot_mcp.py -k workers_only_list_claim" --capture brigade-work
@@ -176,7 +176,7 @@ brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_gro
 
 Expect failure because the worker claim has no `execution_context`.
 
-- [ ] Change only the worker claim call in `GrokbotAdapter._call()`:
+- [x] Change only the worker claim call in `GrokbotAdapter._call()`:
 
 ```python
 return grokbot_jobs.claim_execution_context(
@@ -188,9 +188,9 @@ return grokbot_jobs.claim_execution_context(
 )
 ```
 
-- [ ] Run GREEN with the Task 2 focused command.
+- [x] Run GREEN with the Task 2 focused command.
 
-- [ ] Run the complete focused contract with the MCP extra present:
+- [x] Run the complete focused contract with the MCP extra present:
 
 ```bash
 brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py" --capture brigade-work
@@ -198,7 +198,7 @@ brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_gro
 
 Expect no skips from missing `mcp.server` and every test to pass.
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add src/brigade/grokbot_mcp.py tests/test_grokbot_mcp.py

--- a/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
+++ b/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
@@ -213,11 +213,11 @@ git commit -m "feat: hand claimed context to Grok Bot workers"
 - Modify: `docs/technical-guide.md`
 - Modify: `docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md`
 
-- [ ] In `docs/grokbot-mcp.md`, state that a successful worker claim returns the bounded validated envelope, while list, status, operator, and CLI surfaces stay redacted. Add the routine sequence: list, claim, validate role and repository, start, renew before expiry, complete or fail.
+- [x] In `docs/grokbot-mcp.md`, state that a successful worker claim returns the bounded validated envelope, while list, status, operator, and CLI surfaces stay redacted. Add the routine sequence: list, claim, validate role and repository, start, renew before expiry, complete or fail.
 
-- [ ] In `docs/technical-guide.md`, replace the blanket claim that all mutation commands are safe projections with the exact exception for authenticated worker MCP claim. Keep the CLI statement unchanged.
+- [x] In `docs/technical-guide.md`, replace the blanket claim that all mutation commands are safe projections with the exact exception for authenticated worker MCP claim. Keep the CLI statement unchanged.
 
-- [ ] Run Vale through Brigade:
+- [x] Run Vale through Brigade on the changed prose. The full-file command remains blocked by pre-existing `Slop.Semicolon` findings in `docs/technical-guide.md`. Receipt `20260824-223754-work-verify-635786` records the clean changed-prose check.
 
 ```bash
 brigade work verify run --target . --command "vale docs/grokbot-mcp.md docs/technical-guide.md docs/superpowers/specs/2026-08-24-grokbot-claim-execution-context-design.md docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md" --capture brigade-work
@@ -231,7 +231,7 @@ brigade work verify run --target . --command "scripts/verify" --capture brigade-
 
 Expect lint, format, typing, snapshots, all tests, and the coverage threshold to pass.
 
-- [ ] Run `git diff --check` and the public-content guard. Confirm no private hostnames, addresses, account data, credentials, absolute home paths, or model-authorship prose appears in the branch diff.
+- [x] Run `git diff --check` and the public-content guard. Confirm no private hostnames, addresses, account data, credentials, absolute home paths, or model-authorship prose appears in the branch diff.
 
 - [ ] Tick every completed checkbox and commit the docs plus plan:
 

--- a/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
+++ b/docs/superpowers/plans/2026-08-24-grokbot-claim-execution-context.md
@@ -40,7 +40,7 @@ Verification: focused queue and adapter tests, MCP-extra tests, full `scripts/ve
 - Modify: `tests/test_grokbot_jobs.py`
 - Modify: `src/brigade/grokbot_jobs.py`
 
-- [ ] Add a failing test for the exact context and safe claim separation:
+- [x] Add a failing test for the exact context and safe claim separation:
 
 ```python
 def test_claim_execution_context_is_exact_and_safe_claim_stays_redacted(tmp_path: Path):
@@ -69,7 +69,7 @@ def test_claim_execution_context_is_exact_and_safe_claim_stays_redacted(tmp_path
     assert "execution_context" not in safe
 ```
 
-- [ ] Add a failing disclosure test:
+- [x] Add a failing disclosure test:
 
 ```python
 def test_claim_execution_context_rejects_conflicting_and_expired_leases(tmp_path: Path):
@@ -84,7 +84,7 @@ def test_claim_execution_context_rejects_conflicting_and_expired_leases(tmp_path
         )
 ```
 
-- [ ] Run RED through Brigade:
+- [x] Run RED through Brigade:
 
 ```bash
 brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_grokbot_jobs.py -k claim_execution_context" --capture brigade-work
@@ -92,7 +92,7 @@ brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_gro
 
 Expect collection or execution to fail because `claim_execution_context` does not exist.
 
-- [ ] Add `claim_execution_context()` and route both public operations through one `_claim_job()` helper. The helper validates inputs once, holds `_queue_lock()`, performs the existing transition unchanged, and formats the result before leaving the lock:
+- [x] Add `claim_execution_context()` and route both public operations through one `_claim_job()` helper. The helper validates inputs once, holds `_queue_lock()`, performs the existing transition unchanged, and formats the result before leaving the lock:
 
 ```python
 def claim_execution_context(
@@ -132,15 +132,15 @@ def _execution_context(record: dict[str, Any]) -> dict[str, Any]:
 
 `claim()` calls `_claim_job(..., include_context=False)`. Same-lease idempotency uses `_claim_result()` on the existing record. Do not change state rules, timestamps, lease bounds, or `_projection()`.
 
-- [ ] Run GREEN with the Task 1 focused command. Expect the new tests and existing claim tests to pass.
+- [x] Run GREEN with the Task 1 focused command. Expect the new tests and existing claim tests to pass.
 
-- [ ] Strengthen the existing CLI lifecycle assertion with:
+- [x] Strengthen the existing CLI lifecycle assertion with:
 
 ```python
 assert "execution_context" not in claimed
 ```
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add src/brigade/grokbot_jobs.py tests/test_grokbot_jobs.py

--- a/docs/superpowers/specs/2026-08-24-grokbot-claim-execution-context-design.md
+++ b/docs/superpowers/specs/2026-08-24-grokbot-claim-execution-context-design.md
@@ -1,0 +1,100 @@
+# Grok Bot claim execution context
+
+## Status
+
+Approved on 2026-08-24.
+
+## Problem
+
+The native Grok Bot adapter exposes role-scoped queue operations, but every current queue projection omits `base_ref`, `ownership_paths`, `instructions`, and `verification_commands`. Supervised canaries work because an operator repeats that context in the Bot conversation. A scheduled worker can claim a job but cannot determine the bounded work it was assigned.
+
+The queue must hand the complete bounded task to the authenticated worker that successfully claimed it. List, status, operator, and CLI surfaces must remain redacted.
+
+## Decision
+
+Return a whitelisted `execution_context` object only from a successful worker MCP `grokbot_queue_claim` call.
+
+The existing worker tool inventory remains unchanged. `grokbot_queue_list`, `grokbot_queue_status`, and every CLI mutation continue returning safe projections. Operator instances still cannot discover or call worker tools.
+
+The execution context has this exact shape:
+
+```json
+{
+  "label": "Bounded task label",
+  "role": "repository-scout",
+  "repository": "escoffier-labs/brigade",
+  "base_ref": "main",
+  "ownership_paths": ["src/brigade/grokbot_mcp.py"],
+  "instructions": "Perform the assigned bounded task.",
+  "verification_commands": ["pytest -q tests/test_grokbot_mcp.py"],
+  "artifact": {"kind": "report"},
+  "timeout_seconds": 900
+}
+```
+
+The returned claim result is the existing safe projection plus one `execution_context` member. It does not include the idempotency key hash, queue paths, bearer references, environment values, or record internals.
+
+## Architecture
+
+`grokbot_jobs.claim()` remains the safe CLI operation. Add an internal worker operation named `claim_execution_context()` that uses the same queue lock and claim transition as `claim()` but returns the projection plus the whitelisted context.
+
+Both operations share one locked claim helper. They must not independently implement claim state transitions. Context is derived from the already validated immutable job specification while the queue lock is held.
+
+`GrokbotAdapter` calls `claim_execution_context()` only for `grokbot_queue_claim`. The adapter already fixes the target, worker role, bot identity, and lease duration from deployment configuration. The caller may provide only `job_id` and `lease_id`.
+
+## Security boundaries
+
+- Only a successful role-matching worker claim receives context.
+- A retry with the same bot and lease may return the same context.
+- A conflicting lease, expired lease, terminal job, cross-role job, malformed request, or caller-selected authority returns the existing generic adapter error.
+- List, status, operator, and CLI responses never include execution context.
+- The existing envelope validator remains authoritative for sizes, allowed keys, repository syntax, refs, owned paths, commands, roles, artifact kinds, and timeouts.
+- Task instructions are untrusted work data. They cannot alter adapter policy, role identity, target selection, lease duration, approval boundaries, or tool inventory.
+- Queue producers must not place credentials in labels, instructions, commands, or other scalar values. Secret-value heuristics are outside this slice because they would add a separate detection policy with false-positive and false-negative behavior.
+
+## Failure behavior
+
+Context disclosure and claim mutation are one atomic operation. If validation or claim fails, no context is returned. If response serialization fails after the record is claimed, an idempotent retry with the same lease returns the same context. A different lease cannot take over the job.
+
+No new queue state, schema migration, endpoint, credential, dependency, or service is introduced.
+
+## Tests
+
+- Watch a new internal claim-context test fail before implementation.
+- Assert the exact context whitelist after a successful claim.
+- Assert an idempotent same-lease retry returns the same context.
+- Assert conflicting and expired leases disclose no context.
+- Assert worker MCP claim returns context for its role.
+- Assert cross-role claim is rejected before context disclosure.
+- Assert list and status remain redacted.
+- Assert CLI claim remains redacted.
+- Assert the operator inventory and worker inventories remain exactly 4 and 8 tools.
+
+## Documentation
+
+Update `docs/grokbot-mcp.md` and `docs/technical-guide.md` to distinguish safe projections from the authenticated post-claim execution handoff. State that unattended routines should claim first, use only the returned context, renew before lease expiry, and stop on context or role mismatch.
+
+## Rollout and acceptance
+
+1. Merge and deploy the updated Brigade package without changing public routes, credentials, or tool inventories.
+2. Re-run local and edge canaries for all three roles.
+3. Enqueue a bounded Repository Scout job without repeating its instructions in chat.
+4. Have the Bot claim it, read the returned execution context, renew once, and complete it with a report artifact.
+5. Repeat with one bounded Implementation Worker job that produces a draft PR and cannot merge or deploy.
+6. Save the proven workflows as skills, then create staggered routines with at most one claimed job per run.
+
+Acceptance requires both Bots to finish from the claim capsule alone. Manual task instructions in the Bot conversation do not count.
+
+## Alternatives rejected
+
+### Separate context tool
+
+A lease-bound `grokbot_queue_context` tool would make disclosure explicit, but it adds a ninth worker tool, another network round trip, another retry state, and a migration change for every exact-inventory canary. The claim already establishes the disclosure boundary.
+
+### Self-contained labels
+
+Labels are limited to 160 characters and omit base refs, owned paths, commands, and artifact instructions. They cannot carry the worker contract safely.
+
+### Signed task artifact
+
+A separate artifact service or signed download would add storage, URL expiry, credential, and cleanup concerns. The existing authenticated role-scoped MCP connection already reaches the queue authority.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -124,7 +124,7 @@ Queue data lives below `.brigade/cloud/grokbot/` with private file permissions. 
 
 Jobs move through `queued`, `claimed`, `running`, `completed`, `failed`, `expired`, and `canceled`. A bot claims work with its own opaque bot and lease IDs plus a bounded lease duration. The same claim can be retried safely, and `renew` extends the current unexpired lease within the job deadline. `cancel` ends queued work immediately or records a cancellation request for a live lease. The lease holder uses `ack-cancel` to finish that cancellation. `expire` never requeues a job; it finalizes a job after its deadline or lease expires.
 
-Only safe projections are printed by `status` and mutation commands. They include job identity, state, timing, task hash, and artifact metadata, but never the envelope's `instructions` or `verification_commands`.
+Only safe projections are printed by `status` and mutation commands. They include job identity, state, timing, task hash, and artifact metadata, but never the envelope's `instructions` or `verification_commands`. The one exception is the authenticated worker MCP claim: after a successful role-matching claim, the worker receives the bounded validated envelope as its execution context so it can execute the task without the instructions being repeated in chat. The CLI `claim` command keeps returning the redacted projection.
 
 ```bash
 brigade run cloud grokbot enqueue \

--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -218,6 +218,31 @@ def claim(
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Claim a queued job with one opaque bot lease."""
+    return _claim_job(target, job_id, bot_id, lease_id, lease_seconds, now, include_context=False)
+
+
+def claim_execution_context(
+    target: Path,
+    job_id: str,
+    bot_id: str,
+    lease_id: str,
+    lease_seconds: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Claim a queued job and return its validated worker context."""
+    return _claim_job(target, job_id, bot_id, lease_id, lease_seconds, now, include_context=True)
+
+
+def _claim_job(
+    target: Path,
+    job_id: str,
+    bot_id: str,
+    lease_id: str,
+    lease_seconds: int,
+    now: datetime | None,
+    *,
+    include_context: bool,
+) -> dict[str, Any]:
     job_id = _validate_job_id(job_id)
     bot_id = _validate_opaque_id(bot_id, "invalid-bot-id")
     lease_id = _validate_opaque_id(lease_id, "invalid-lease-id")
@@ -228,7 +253,7 @@ def claim(
         if record["state"] == "claimed":
             if record["bot_id"] == bot_id and record["lease_id"] == lease_id:
                 _require_live_lease(record, instant)
-                return _projection(record)
+                return _claim_result(record, include_context=include_context)
             raise GrokbotJobError("lease-conflict")
         if record["state"] != "queued":
             _reject_nonqueued_claim(record)
@@ -245,7 +270,7 @@ def claim(
             }
         )
         _commit_mutation(storage.jobs, record, timestamp)
-        return _projection(record)
+        return _claim_result(record, include_context=include_context)
 
 
 def renew(
@@ -903,6 +928,29 @@ def _projection(record: dict[str, Any]) -> dict[str, Any]:
         if key in record:
             projection[key] = record[key]
     return projection
+
+
+def _claim_result(record: dict[str, Any], *, include_context: bool) -> dict[str, Any]:
+    result = _projection(record)
+    if include_context:
+        result["execution_context"] = _execution_context(record)
+    return result
+
+
+def _execution_context(record: dict[str, Any]) -> dict[str, Any]:
+    spec = record["spec"]
+    assert isinstance(spec, dict)
+    return {
+        "label": spec["label"],
+        "role": spec["role"],
+        "repository": spec["repository"],
+        "base_ref": spec["base_ref"],
+        "ownership_paths": list(spec["ownership_paths"]),
+        "instructions": spec["instructions"],
+        "verification_commands": list(spec["verification_commands"]),
+        "artifact": dict(spec["artifact"]),
+        "timeout_seconds": record["timeout_seconds"],
+    }
 
 
 def _validate_spec(spec: object) -> dict[str, Any]:

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -183,7 +183,7 @@ class GrokbotAdapter:
             return operation(self.config.target, job_id)
         if name == "grokbot_queue_claim":
             job = self._eligible_job(arguments, allowed={"job_id", "lease_id"})
-            return grokbot_jobs.claim(
+            return grokbot_jobs.claim_execution_context(
                 self.config.target, job["job_id"], self.config.bot_id, _lease_id(arguments), LEASE_SECONDS
             )
         if name == "grokbot_queue_renew":

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -309,6 +309,38 @@ def test_claim_is_idempotent_for_same_lease_and_rejects_another(tmp_path: Path):
         grokbot_jobs.claim(tmp_path, job_id, "bot-b", "lease-a", 60, now=NOW)
 
 
+def test_claim_execution_context_is_exact_and_safe_claim_stays_redacted(tmp_path: Path):
+    context_job = _enqueue(tmp_path, idempotency_key="request-context")
+    claimed = grokbot_jobs.claim_execution_context(tmp_path, context_job, "bot-a", "lease-a", 60, now=NOW)
+
+    assert claimed["execution_context"] == {
+        "label": "Add queue foundation",
+        "role": "implementation-worker",
+        "repository": "example/brigade",
+        "base_ref": "main",
+        "ownership_paths": ["src/brigade/grokbot_jobs.py", "tests/test_grokbot_jobs.py"],
+        "instructions": "Build the private queue module.",
+        "verification_commands": ["pytest -q tests/test_grokbot_jobs.py"],
+        "artifact": {"kind": "draft-pr"},
+        "timeout_seconds": 900,
+    }
+    assert grokbot_jobs.claim_execution_context(tmp_path, context_job, "bot-a", "lease-a", 60, now=NOW) == claimed
+
+    safe_job = _enqueue(tmp_path, idempotency_key="request-safe")
+    safe = grokbot_jobs.claim(tmp_path, safe_job, "bot-a", "lease-safe", 60, now=NOW)
+    assert "execution_context" not in safe
+
+
+def test_claim_execution_context_rejects_conflicting_and_expired_leases(tmp_path: Path):
+    job_id = _enqueue(tmp_path, idempotency_key="request-context-boundary")
+    grokbot_jobs.claim_execution_context(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW)
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-conflict$"):
+        grokbot_jobs.claim_execution_context(tmp_path, job_id, "bot-a", "lease-b", 60, now=NOW)
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^lease-expired$"):
+        grokbot_jobs.claim_execution_context(tmp_path, job_id, "bot-a", "lease-a", 60, now=NOW + timedelta(seconds=60))
+
+
 def test_renew_clamps_to_deadline_and_increments_revision(tmp_path: Path):
     job_id = _enqueue(tmp_path)
     grokbot_jobs.claim(tmp_path, job_id, "bot-a", "lease-a", 3600, now=NOW)
@@ -612,6 +644,7 @@ def test_cli_grokbot_lifecycle_commands_keep_private_content_out_of_output(tmp_p
     claimed = capsys.readouterr().out
     assert json.loads(claimed)["state"] == "claimed"
     assert "instructions" not in claimed and "verification_commands" not in claimed
+    assert "execution_context" not in claimed
 
     assert (
         _run_grokbot(

--- a/tests/test_grokbot_mcp.py
+++ b/tests/test_grokbot_mcp.py
@@ -95,9 +95,13 @@ def test_workers_only_list_claim_and_read_their_configured_role(tmp_path: Path):
     assert unauthorized.value.public_error() == {
         "error": {"code": "invalid_request", "message": "Tool input failed validation"}
     }
+    assert grokbot_jobs.get_job(tmp_path, scout)["state"] == "queued"
 
     claimed = worker.call_tool("grokbot_queue_claim", {"job_id": implementation, "lease_id": "lease-a"})
     assert claimed["state"] == "claimed"
+    assert claimed["execution_context"] == _spec("implementation-worker")
+    assert "PRIVATE_INSTRUCTIONS_MUST_NOT_LEAK" not in json.dumps(listed)
+    assert "execution_context" not in worker.call_tool("grokbot_queue_status", {"job_id": implementation})
     assert grokbot_jobs.get_job(tmp_path, implementation)["role"] == "implementation-worker"
 
 


### PR DESCRIPTION
## Summary

- Give successful role-matching Grok Bot worker claims the validated task capsule needed for unattended execution.
- Keep CLI claim, list, status, operator, and cross-role surfaces redacted.
- Document the worker lifecycle and the exact disclosure exception.

## Security

The adapter still fixes the target, role, bot identity, and lease duration from deployment configuration. Context is returned only after the existing atomic claim succeeds. One independent security review found no Critical or Important issues.

## Verification

- Focused queue and MCP contract: 92 passed.
- Changed prose: Vale passed.
- Full repository gate reached 96 percent with zero failures before the local 40-minute receipt timeout. The complete CI matrix is the final repository-wide gate.

Fixes #1167.