### PR TITLE
feat: add approved Grok Bot queue feed

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -59,7 +59,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade roster`: 4 command path(s)
 - `brigade route`: 1 command path(s)
 - `brigade run`: 1 command path(s)
-- `brigade run-cloud`: 19 command path(s)
+- `brigade run-cloud`: 20 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
 - `brigade runs`: 18 command path(s)
 - `brigade scrub`: 1 command path(s)
@@ -482,6 +482,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade run-cloud grokbot enqueue`
 - `brigade run-cloud grokbot expire`
 - `brigade run-cloud grokbot fail`
+- `brigade run-cloud grokbot feed`
 - `brigade run-cloud grokbot install-service`
 - `brigade run-cloud grokbot renew`
 - `brigade run-cloud grokbot serve`

--- a/docs/grokbot-mcp.md
+++ b/docs/grokbot-mcp.md
@@ -69,6 +69,21 @@ Migration is an operator-run comparison, not an automatic conversion.
 3. Confirm that the test bot receives the matching role-specific tool inventory, then run its passing non-mutating canary.
 4. Keep the old sidecar available until the comparison has passed. Remove it only after the operator decides to cut over.
 
+## Approved feed
+
+The listener only consumes jobs already in the local queue. To put approved work there, write a private manifest and run the local feed command. The command never invents tasks, reads chat, selects GitHub issues, or changes approval state. It is not added to any MCP inventory.
+
+The manifest is a regular file owned by the current user and not group- or world-writable. Schema `brigade.grokbot.feed.v1` requires `approved: true`, a non-empty operator label, and an `entries` array. Each entry has an `idempotency_key` plus the existing Grok Bot job `spec`.
+
+```bash
+brigade run cloud grokbot feed --target . --manifest /path/to/approved-feed.json
+brigade run cloud grokbot feed --target . --manifest /path/to/approved-feed.json --apply --limit 1
+```
+
+The first command validates only and writes no queue state. `--apply` is required to enqueue. `--limit` bounds newly created jobs from 1 through 10 and defaults to 1. Known idempotency records do not consume the limit. The feed stops on the first invalid entry and performs no enqueue when validation fails. Output is counts and safe job projections only.
+
+The command does not schedule itself. systemd, cron, OpenClaw, or another operator may run an approved manifest later. Repeated runs are safe through the existing idempotency store.
+
 ## Current limits
 
 `setup` writes non-secret configuration and bearer references only. The operator still provisions Grok Bot routines and secrets. This work does not commission a Grok Bot and does not prove weekly quota attribution.

--- a/docs/phase-grokbot-approved-feed.md
+++ b/docs/phase-grokbot-approved-feed.md
@@ -1,0 +1,99 @@
+# Grok Bot approved feed
+
+## Status
+
+Approved by the operator on 2026-08-25 as part of the first-day Grok Bot
+reconciliation.
+
+## Problem
+
+The native Grok Bot adapter safely exposes a bounded queue, but it only
+consumes jobs. Hourly Repository Scout and Implementation Worker routines ran
+without producing work because no approved production envelope entered the
+queue after commissioning.
+
+## Decision
+
+Add a local-only `brigade run cloud grokbot feed` command that reads an
+explicit private manifest and enqueues a bounded number of approved envelopes.
+It never invents tasks, reads chat, selects GitHub issues, or changes approval
+state.
+
+The manifest contains:
+
+- schema `brigade.grokbot.feed.v1`
+- `approved: true`
+- a non-empty operator label
+- an array of entries, each with an `idempotency_key` and the existing Grok Bot
+  job `spec`
+
+The command defaults to validation-only. `--apply` is required to enqueue.
+`--limit` bounds newly created jobs from 1 through 10 and defaults to 1.
+Existing idempotency records do not consume the limit. The feed stops on the
+first invalid entry and performs no enqueue when validation fails.
+
+## Boundaries
+
+- Queue authority stays local. No feed tool is added to any MCP inventory.
+- Existing job-envelope validation remains authoritative.
+- The feed file must be a regular file owned by the current user and not group-
+  or world-writable.
+- Output includes only safe job projections and counts. It never prints
+  instructions, verification commands, ownership paths, or credentials.
+- The command does not schedule itself. systemd, cron, OpenClaw, or another
+  operator may run an approved manifest later.
+- Repeated runs are safe through the existing idempotency store.
+
+## Failure behavior
+
+- Malformed manifests, unsafe file permissions, duplicate feed keys, invalid
+  limits, and invalid job specs fail before queue mutation.
+- In validation mode, the command reports how many entries are valid and how
+  many are already known.
+- During apply, an unexpected queue error stops the feed and reports only the
+  entry index and a generic error.
+
+## File map
+
+- Create `src/brigade/grokbot_feed.py` for feed schema, validation, and apply
+  logic.
+- Modify `src/brigade/cli/run_cloud.py` to add the `feed` parser and dispatch.
+- Create `tests/test_grokbot_feed.py` for manifest, permission, validation,
+  idempotency, limit, redaction, and CLI contracts.
+- Modify `docs/grokbot-mcp.md` for the operator workflow and scheduling
+  boundary.
+
+## Implementation sequence
+
+1. Write failing preflight tests for a valid manifest, wrong schema, missing
+   approval, duplicate keys, unsafe permissions, invalid limits, and an invalid
+   later job. Each error case must leave the queue untouched.
+2. Implement `FeedError`, manifest loading, permission checks, and full
+   preflight validation by reusing the existing job-envelope validator without
+   writing queue state.
+3. Write failing apply tests for bounded creation, idempotent continuation, and
+   redacted results.
+4. Implement apply by completing preflight first and then calling the existing
+   queue enqueue operation in manifest order until the new-job limit is met.
+5. Write CLI tests, expose
+   `feed --manifest PATH --limit N [--apply] [--json]`, and document the
+   one-shot workflow plus external scheduling boundary.
+
+## Acceptance
+
+1. A valid manifest can be checked without writing queue state.
+2. `--apply --limit 1` creates only the first unknown job.
+3. A repeated run skips the known entry and creates the next unknown job.
+4. Invalid later entries prevent all writes.
+5. CLI and JSON output remain free of private task context.
+6. Existing Grok Bot queue, MCP, and operations tests stay green.
+
+## Verification
+
+Run these checks through the Brigade work loop:
+
+```bash
+pytest -q tests/test_grokbot_feed.py tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py tests/test_grokbot_ops.py
+ruff check src/brigade/grokbot_feed.py src/brigade/cli/run_cloud.py tests/test_grokbot_feed.py
+git diff --check
+```

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -72,6 +72,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_enqueue.add_argument("--spec", type=Path, required=True, help="Path to the private task envelope JSON file.")
     p_enqueue.add_argument("--idempotency-key", required=True)
 
+    p_feed = grokbot_sub.add_parser("feed", help="Validate or enqueue an approved Grok Bot feed manifest.")
+    add_target(p_feed)
+    p_feed.add_argument("--manifest", type=Path, required=True, help="Path to the approved private feed manifest.")
+    p_feed.add_argument("--limit", type=int, default=1, help="Maximum newly created jobs (1-10). Defaults to 1.")
+    p_feed.add_argument("--apply", action="store_true", help="Enqueue after validation. Default is validate only.")
+
     for name, help_text in (("claim", "Claim a queued job."), ("renew", "Renew a current job lease.")):
         command = grokbot_sub.add_parser(name, help=help_text)
         add_target(command)
@@ -272,6 +278,8 @@ def _dispatch_grokbot(args, target: Path) -> int:
     command = args.grokbot_command
     if command in {"setup", "doctor", "canary", "install-service"}:
         return _dispatch_grokbot_ops(args, target)
+    if command == "feed":
+        return _dispatch_grokbot_feed(args, target)
     if command == "serve":
         from .. import grokbot_mcp
 
@@ -336,6 +344,40 @@ def _dispatch_grokbot(args, target: Path) -> int:
         return 0
     _print_grokbot_result(result)
     return 0
+
+
+def _dispatch_grokbot_feed(args, target: Path) -> int:
+    """Validate or apply an approved feed without printing private task context."""
+    from .. import grokbot_feed
+
+    try:
+        if args.apply:
+            result = grokbot_feed.apply(target, args.manifest, limit=args.limit)
+        else:
+            result = grokbot_feed.preflight(target, args.manifest, limit=args.limit)
+    except grokbot_feed.FeedError as exc:
+        if exc.reason == "queue-error" and exc.index is not None:
+            print(f"error: queue-error index={exc.index}", file=sys.stderr)
+        else:
+            print(f"error: {exc.reason}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    _print_feed_result(result)
+    return 0
+
+
+def _print_feed_result(result: dict) -> None:
+    """Render feed counts and safe job handles only."""
+    parts = [f"valid={result['valid']}", f"known={result['known']}", f"limit={result['limit']}"]
+    if "created" in result:
+        parts.insert(2, f"created={result['created']}")
+        parts.insert(3, f"skipped={result['skipped']}")
+    print("grokbot feed: " + " ".join(parts))
+    for job in result.get("jobs", []):
+        print(f"job {job['job_id']} state={job['state']}")
 
 
 def _dispatch_grokbot_ops(args, target: Path) -> int:

--- a/src/brigade/grokbot_feed.py
+++ b/src/brigade/grokbot_feed.py
@@ -37,26 +37,14 @@ def preflight(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[
     """Validate a feed manifest without creating or mutating queue state."""
     limit = _validate_limit(limit)
     payload = load_manifest(manifest)
-    known = 0
-    for index, entry in enumerate(payload["entries"]):
-        try:
-            key = grokbot_jobs._validate_idempotency_key(entry["idempotency_key"])
-            spec = grokbot_jobs._validate_spec(entry["spec"])
-        except grokbot_jobs.GrokbotJobError as exc:
-            raise FeedError(exc.reason, index=index) from exc
-        existing = _existing_idempotency(target, key)
-        if existing is None:
-            continue
-        if existing["task_hash"] != grokbot_jobs._task_hash(spec):
-            raise FeedError("idempotency-conflict", index=index)
-        known += 1
-    return {"valid": len(payload["entries"]), "known": known, "limit": limit}
+    return _preview(target, payload, limit)
 
 
 def apply(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[str, Any]:
     """Enqueue unknown feed entries after a complete preflight succeeds."""
-    preview = preflight(target, manifest, limit=limit)
+    limit = _validate_limit(limit)
     payload = load_manifest(manifest)
+    preview = _preview(target, payload, limit)
     jobs: list[dict[str, Any]] = []
     created = 0
     skipped = 0
@@ -67,7 +55,9 @@ def apply(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[str,
             spec = grokbot_jobs._validate_spec(entry["spec"])
             key = grokbot_jobs._validate_idempotency_key(entry["idempotency_key"])
             handle = grokbot_jobs.enqueue(target, spec, key)
-        except grokbot_jobs.GrokbotJobError as exc:
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:
             raise FeedError("queue-error", index=index) from exc
         jobs.append(
             {
@@ -92,10 +82,9 @@ def apply(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[str,
 
 def load_manifest(path: Path) -> dict[str, Any]:
     """Load a private feed file after checking ownership and permissions."""
-    _assert_safe_manifest(path)
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        payload = json.loads(_read_manifest_snapshot(path))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise FeedError("malformed-manifest") from exc
     if not isinstance(payload, dict):
         raise FeedError("malformed-manifest")
@@ -126,6 +115,23 @@ def load_manifest(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _preview(target: Path, payload: dict[str, Any], limit: int) -> dict[str, Any]:
+    known = 0
+    for index, entry in enumerate(payload["entries"]):
+        try:
+            key = grokbot_jobs._validate_idempotency_key(entry["idempotency_key"])
+            spec = grokbot_jobs._validate_spec(entry["spec"])
+        except grokbot_jobs.GrokbotJobError as exc:
+            raise FeedError(exc.reason, index=index) from exc
+        existing = _existing_idempotency(target, key)
+        if existing is None:
+            continue
+        if existing["task_hash"] != grokbot_jobs._task_hash(spec):
+            raise FeedError("idempotency-conflict", index=index)
+        known += 1
+    return {"valid": len(payload["entries"]), "known": known, "limit": limit}
+
+
 def _validate_limit(limit: object) -> int:
     if type(limit) is not int or not MIN_LIMIT <= limit <= MAX_LIMIT:
         raise FeedError("invalid-limit")
@@ -138,34 +144,83 @@ def _bounded_label(value: object) -> str:
     return value
 
 
-def _assert_safe_manifest(path: Path) -> None:
+def _read_manifest_snapshot(path: Path) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    else:
+        try:
+            info = Path(path).lstat()
+        except OSError as exc:
+            raise FeedError("unsafe-manifest") from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise FeedError("unsafe-manifest")
+    descriptor: int | None = None
     try:
-        info = path.lstat()
-    except FileNotFoundError as exc:
+        descriptor = os.open(os.fspath(path), flags)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise FeedError("unsafe-manifest")
+        owner_uid = getattr(os, "getuid", None)
+        if owner_uid is not None and info.st_uid != owner_uid():
+            raise FeedError("unsafe-manifest")
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            raise FeedError("unsafe-manifest")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks)
+    except FeedError:
+        raise
+    except OSError as exc:
         raise FeedError("unsafe-manifest") from exc
-    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
-        raise FeedError("unsafe-manifest")
-    owner_uid = getattr(os, "getuid", None)
-    if owner_uid is not None and info.st_uid != owner_uid():
-        raise FeedError("unsafe-manifest")
-    if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
-        raise FeedError("unsafe-manifest")
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                raise FeedError("unsafe-manifest") from exc
 
 
 def _existing_idempotency(target: Path, key: str) -> dict[str, Any] | None:
-    digest = grokbot_jobs._idempotency_key_hash(key).removeprefix("sha256:")
-    path = Path(target).expanduser() / ".brigade" / "cloud" / "grokbot" / "idempotency" / f"{digest}.json"
+    name = f"{grokbot_jobs._idempotency_key_hash(key).removeprefix('sha256:')}.json"
+    descriptor: int | None = None
     try:
-        info = path.lstat()
-    except FileNotFoundError:
-        return None
-    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
-        raise FeedError("corrupt-storage")
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise FeedError("corrupt-storage") from exc
-    try:
+        if os.name != "posix":
+            directory = grokbot_jobs._Directory(
+                Path(target).expanduser() / ".brigade" / "cloud" / "grokbot" / "idempotency",
+                None,
+            )
+        else:
+            descriptor = grokbot_jobs._open_directory_path(Path(target).expanduser().absolute())
+            for component in (".brigade", "cloud", "grokbot", "idempotency"):
+                try:
+                    child = grokbot_jobs.os.open(component, grokbot_jobs._directory_flags(), dir_fd=descriptor)
+                except FileNotFoundError:
+                    return None
+                previous = descriptor
+                descriptor = child
+                grokbot_jobs.os.close(previous)
+                grokbot_jobs._assert_directory_descriptor(descriptor)
+            directory = grokbot_jobs._Directory(
+                Path(target) / ".brigade" / "cloud" / "grokbot" / "idempotency",
+                descriptor,
+            )
+        payload = grokbot_jobs._read_json_file(directory, name, missing_ok=True)
+        if payload is None:
+            return None
         return grokbot_jobs._validate_idempotency_record(payload)
     except grokbot_jobs.GrokbotJobError as exc:
         raise FeedError(exc.reason) from exc
+    except OSError as exc:
+        raise FeedError("unsafe-storage") from exc
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                raise FeedError("unsafe-storage") from exc

--- a/src/brigade/grokbot_feed.py
+++ b/src/brigade/grokbot_feed.py
@@ -1,0 +1,171 @@
+"""Local-only approved feed for the Grok Bot queue.
+
+The feed never invents work. It reads an explicit private manifest, validates
+every entry against the existing job-envelope rules, and optionally enqueues a
+bounded number of unknown jobs through the existing queue primitives.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+from . import grokbot_jobs
+
+FEED_SCHEMA = "brigade.grokbot.feed.v1"
+REQUIRED_MANIFEST_KEYS = frozenset({"schema", "approved", "label", "entries"})
+REQUIRED_ENTRY_KEYS = frozenset({"idempotency_key", "spec"})
+MIN_LIMIT = 1
+MAX_LIMIT = 10
+DEFAULT_LIMIT = 1
+LABEL_MAXIMUM = 160
+
+
+class FeedError(ValueError):
+    """A rejected feed request with a stable machine-readable reason."""
+
+    def __init__(self, reason: str, index: int | None = None):
+        self.reason = reason
+        self.index = index
+        super().__init__(reason)
+
+
+def preflight(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[str, Any]:
+    """Validate a feed manifest without creating or mutating queue state."""
+    limit = _validate_limit(limit)
+    payload = load_manifest(manifest)
+    known = 0
+    for index, entry in enumerate(payload["entries"]):
+        try:
+            key = grokbot_jobs._validate_idempotency_key(entry["idempotency_key"])
+            spec = grokbot_jobs._validate_spec(entry["spec"])
+        except grokbot_jobs.GrokbotJobError as exc:
+            raise FeedError(exc.reason, index=index) from exc
+        existing = _existing_idempotency(target, key)
+        if existing is None:
+            continue
+        if existing["task_hash"] != grokbot_jobs._task_hash(spec):
+            raise FeedError("idempotency-conflict", index=index)
+        known += 1
+    return {"valid": len(payload["entries"]), "known": known, "limit": limit}
+
+
+def apply(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[str, Any]:
+    """Enqueue unknown feed entries after a complete preflight succeeds."""
+    preview = preflight(target, manifest, limit=limit)
+    payload = load_manifest(manifest)
+    jobs: list[dict[str, Any]] = []
+    created = 0
+    skipped = 0
+    for index, entry in enumerate(payload["entries"]):
+        if created >= preview["limit"]:
+            break
+        try:
+            spec = grokbot_jobs._validate_spec(entry["spec"])
+            key = grokbot_jobs._validate_idempotency_key(entry["idempotency_key"])
+            handle = grokbot_jobs.enqueue(target, spec, key)
+        except grokbot_jobs.GrokbotJobError as exc:
+            raise FeedError("queue-error", index=index) from exc
+        jobs.append(
+            {
+                "job_id": handle["job_id"],
+                "state": handle["state"],
+                "idempotent": handle["idempotent"],
+            }
+        )
+        if handle["idempotent"]:
+            skipped += 1
+        else:
+            created += 1
+    return {
+        "valid": preview["valid"],
+        "known": preview["known"],
+        "limit": preview["limit"],
+        "created": created,
+        "skipped": skipped,
+        "jobs": jobs,
+    }
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    """Load a private feed file after checking ownership and permissions."""
+    _assert_safe_manifest(path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FeedError("malformed-manifest") from exc
+    if not isinstance(payload, dict):
+        raise FeedError("malformed-manifest")
+    if set(payload) != REQUIRED_MANIFEST_KEYS:
+        if payload.get("schema") != FEED_SCHEMA:
+            raise FeedError("invalid-schema")
+        if payload.get("approved") is not True:
+            raise FeedError("not-approved")
+        raise FeedError("malformed-manifest")
+    if payload["schema"] != FEED_SCHEMA:
+        raise FeedError("invalid-schema")
+    if payload["approved"] is not True:
+        raise FeedError("not-approved")
+    _bounded_label(payload["label"])
+    entries = payload["entries"]
+    if not isinstance(entries, list):
+        raise FeedError("malformed-manifest")
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict) or set(entry) != REQUIRED_ENTRY_KEYS:
+            raise FeedError("invalid-entry", index=index)
+        key = entry["idempotency_key"]
+        if not isinstance(key, str):
+            raise FeedError("invalid-idempotency-key", index=index)
+        if key in seen:
+            raise FeedError("duplicate-key", index=index)
+        seen.add(key)
+    return payload
+
+
+def _validate_limit(limit: object) -> int:
+    if type(limit) is not int or not MIN_LIMIT <= limit <= MAX_LIMIT:
+        raise FeedError("invalid-limit")
+    return limit
+
+
+def _bounded_label(value: object) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > LABEL_MAXIMUM or "\x00" in value:
+        raise FeedError("invalid-label")
+    return value
+
+
+def _assert_safe_manifest(path: Path) -> None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError as exc:
+        raise FeedError("unsafe-manifest") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise FeedError("unsafe-manifest")
+    owner_uid = getattr(os, "getuid", None)
+    if owner_uid is not None and info.st_uid != owner_uid():
+        raise FeedError("unsafe-manifest")
+    if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise FeedError("unsafe-manifest")
+
+
+def _existing_idempotency(target: Path, key: str) -> dict[str, Any] | None:
+    digest = grokbot_jobs._idempotency_key_hash(key).removeprefix("sha256:")
+    path = Path(target).expanduser() / ".brigade" / "cloud" / "grokbot" / "idempotency" / f"{digest}.json"
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise FeedError("corrupt-storage")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FeedError("corrupt-storage") from exc
+    try:
+        return grokbot_jobs._validate_idempotency_record(payload)
+    except grokbot_jobs.GrokbotJobError as exc:
+        raise FeedError(exc.reason) from exc

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -319,6 +320,90 @@ def test_apply_stops_on_unexpected_queue_error_with_generic_reason(tmp_path: Pat
     assert exc.value.reason == "queue-error"
     assert exc.value.index == 1
     assert len(_job_files(tmp_path)) == 1
+
+
+def test_apply_uses_one_in_memory_snapshot_when_the_manifest_is_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+    opened = {"n": 0, "flags": 0}
+    real_open = grokbot_feed.os.open
+
+    def open_and_replace(path, flags, *args, **kwargs):
+        handle = real_open(path, flags, *args, **kwargs)
+        if kwargs.get("dir_fd") is not None:
+            return handle
+        try:
+            opened_path = Path(os.fspath(path)).resolve()
+        except OSError:
+            return handle
+        if opened_path != manifest.resolve():
+            return handle
+        opened["n"] += 1
+        opened["flags"] = flags
+        replacement = tmp_path / "feed.replaced.json"
+        _write_manifest(replacement, _manifest(_entry("task-z", _spec(label="Replaced"))))
+        os.replace(replacement, manifest)
+        return handle
+
+    monkeypatch.setattr(grokbot_feed.os, "open", open_and_replace)
+
+    result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+    assert opened["n"] == 1
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        assert opened["flags"] & nofollow
+    assert result["valid"] == 2
+    assert result["created"] == 1
+    assert result["jobs"][0]["idempotent"] is False
+    record = json.loads(_job_files(tmp_path)[0].read_text(encoding="utf-8"))
+    assert record["spec"]["label"] == "First"
+    _assert_redacted(result)
+
+
+def test_preflight_rejects_unsafe_idempotency_storage_without_leaking_paths(tmp_path: Path):
+    grokbot_jobs.enqueue(tmp_path, _spec(label="First"), "task-a")
+    before = {path.name for path in _job_files(tmp_path)}
+    record = next((_queue_root(tmp_path) / "idempotency").glob("*.json"))
+    destination = tmp_path / "outside.json"
+    destination.write_text("{}", encoding="utf-8")
+    record.unlink()
+    record.symlink_to(destination)
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a", _spec(label="First"))))
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, manifest)
+
+    assert exc.value.reason == "unsafe-storage"
+    assert str(record) not in str(exc.value)
+    assert str(destination) not in str(exc.value)
+    assert str(tmp_path) not in str(exc.value)
+    assert {path.name for path in _job_files(tmp_path)} == before
+
+
+def test_apply_translates_oserror_from_enqueue_to_queue_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    def boom(target: Path, spec: dict, idempotency_key: str, now=None):
+        raise OSError(13, "Permission denied", str(tmp_path / "secret-queue.json"))
+
+    monkeypatch.setattr(grokbot_jobs, "enqueue", boom)
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+    assert exc.value.reason == "queue-error"
+    assert exc.value.index == 0
+    assert "secret-queue.json" not in str(exc.value)
+    assert "Permission denied" not in str(exc.value)
+    assert not _queue_root(tmp_path).exists()
 
 
 def _run_feed(target: Path, *command: str) -> int:

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -1,0 +1,429 @@
+"""Approved Grok Bot feed: local-only manifest validation and bounded apply."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, grokbot_feed, grokbot_jobs
+
+
+SECRET_INSTRUCTIONS = "SECRET_INSTRUCTION_DO_NOT_PRINT"
+SECRET_VERIFY = "SECRET_VERIFY_CMD"
+SECRET_OWNERSHIP = "SECRET_OWNERSHIP_PATH/file.py"
+
+
+def _spec(*, label: str = "Approved worker task") -> dict[str, object]:
+    return {
+        "label": label,
+        "role": "implementation-worker",
+        "repository": "example/brigade",
+        "base_ref": "main",
+        "ownership_paths": [SECRET_OWNERSHIP],
+        "instructions": SECRET_INSTRUCTIONS,
+        "verification_commands": [SECRET_VERIFY],
+        "artifact": {"kind": "draft-pr"},
+        "timeout_seconds": 900,
+    }
+
+
+def _manifest(*entries: dict[str, object], approved: bool = True, label: str = "operator-day-1") -> dict[str, object]:
+    return {
+        "schema": "brigade.grokbot.feed.v1",
+        "approved": approved,
+        "label": label,
+        "entries": list(entries),
+    }
+
+
+def _entry(key: str, spec: dict[str, object] | None = None) -> dict[str, object]:
+    return {"idempotency_key": key, "spec": spec if spec is not None else _spec()}
+
+
+def _write_manifest(path: Path, payload: dict[str, object], *, mode: int = 0o600) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(mode)
+    return path
+
+
+def _queue_root(target: Path) -> Path:
+    return target / ".brigade" / "cloud" / "grokbot"
+
+
+def _job_files(target: Path) -> list[Path]:
+    jobs = _queue_root(target) / "jobs"
+    if not jobs.exists():
+        return []
+    return sorted(jobs.glob("grokbot-*.json"))
+
+
+def test_preflight_accepts_a_valid_manifest_without_writing_queue_state(tmp_path: Path):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    result = grokbot_feed.preflight(tmp_path, manifest)
+
+    assert result["valid"] == 2
+    assert result["known"] == 0
+    assert result["limit"] == 1
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_preflight_counts_known_idempotency_records_without_writing(tmp_path: Path):
+    grokbot_jobs.enqueue(tmp_path, _spec(label="First"), "task-a")
+    before = {path.name for path in _job_files(tmp_path)}
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    result = grokbot_feed.preflight(tmp_path, manifest)
+
+    assert result["valid"] == 2
+    assert result["known"] == 1
+    assert {path.name for path in _job_files(tmp_path)} == before
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        (
+            {
+                "schema": "brigade.grokbot.feed.v0",
+                "approved": True,
+                "label": "operator-day-1",
+                "entries": [_entry("task-a")],
+            },
+            "invalid-schema",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.feed.v1",
+                "label": "operator-day-1",
+                "entries": [_entry("task-a")],
+            },
+            "not-approved",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.feed.v1",
+                "approved": False,
+                "label": "operator-day-1",
+                "entries": [_entry("task-a")],
+            },
+            "not-approved",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.feed.v1",
+                "approved": True,
+                "label": "",
+                "entries": [_entry("task-a")],
+            },
+            "invalid-label",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.feed.v1",
+                "approved": True,
+                "label": "operator-day-1",
+                "entries": [_entry("task-a"), _entry("task-a")],
+            },
+            "duplicate-key",
+        ),
+    ],
+)
+def test_preflight_rejects_malformed_manifests_without_writing_queue_state(
+    tmp_path: Path, payload: dict[str, object], reason: str
+):
+    manifest = _write_manifest(tmp_path / "feed.json", payload)
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, manifest)
+
+    assert exc.value.reason == reason
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_preflight_rejects_group_writable_manifest_without_writing(tmp_path: Path):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a")),
+        mode=0o660,
+    )
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, manifest)
+
+    assert exc.value.reason == "unsafe-manifest"
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_preflight_rejects_world_writable_manifest_without_writing(tmp_path: Path):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a")),
+        mode=0o602,
+    )
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, manifest)
+
+    assert exc.value.reason == "unsafe-manifest"
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_preflight_rejects_symlink_manifest_without_writing(tmp_path: Path):
+    real = _write_manifest(tmp_path / "real.json", _manifest(_entry("task-a")))
+    link = tmp_path / "feed.json"
+    link.symlink_to(real)
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, link)
+
+    assert exc.value.reason == "unsafe-manifest"
+    assert not _queue_root(tmp_path).exists()
+
+
+@pytest.mark.parametrize("limit", [0, 11, -1, True, 1.5, "1"])
+def test_preflight_rejects_invalid_limits_without_writing(tmp_path: Path, limit: object):
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, manifest, limit=limit)  # type: ignore[arg-type]
+
+    assert exc.value.reason == "invalid-limit"
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_preflight_rejects_invalid_later_job_without_writing(tmp_path: Path):
+    later = _spec(label="Broken later job")
+    later.pop("instructions")
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", later)),
+    )
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, manifest)
+
+    assert exc.value.reason == "missing-key"
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_preflight_rejects_idempotency_conflict_without_writing(tmp_path: Path):
+    grokbot_jobs.enqueue(tmp_path, _spec(label="First"), "task-a")
+    before = {path.name for path in _job_files(tmp_path)}
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="Different task"))),
+    )
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.preflight(tmp_path, manifest)
+
+    assert exc.value.reason == "idempotency-conflict"
+    assert {path.name for path in _job_files(tmp_path)} == before
+
+
+def _assert_redacted(payload: object) -> None:
+    dumped = json.dumps(payload)
+    assert SECRET_INSTRUCTIONS not in dumped
+    assert SECRET_VERIFY not in dumped
+    assert SECRET_OWNERSHIP not in dumped
+    if isinstance(payload, dict):
+        assert "instructions" not in dumped
+        assert "verification_commands" not in dumped
+        assert "ownership_paths" not in dumped
+
+
+def test_apply_limit_1_creates_only_the_first_unknown_job(tmp_path: Path):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+    assert result["created"] == 1
+    assert result["skipped"] == 0
+    assert result["known"] == 0
+    assert result["valid"] == 2
+    assert len(result["jobs"]) == 1
+    assert result["jobs"][0]["state"] == "queued"
+    assert result["jobs"][0]["idempotent"] is False
+    assert len(_job_files(tmp_path)) == 1
+    _assert_redacted(result)
+
+
+def test_apply_repeated_run_skips_known_and_creates_next_unknown(tmp_path: Path):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+    first = grokbot_feed.apply(tmp_path, manifest, limit=1)
+    first_id = first["jobs"][0]["job_id"]
+
+    result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+    assert result["created"] == 1
+    assert result["skipped"] == 1
+    assert result["known"] == 1
+    assert result["valid"] == 2
+    assert [job["job_id"] for job in result["jobs"]][0] == first_id
+    assert result["jobs"][0]["idempotent"] is True
+    assert result["jobs"][1]["idempotent"] is False
+    assert result["jobs"][1]["job_id"] != first_id
+    assert len(_job_files(tmp_path)) == 2
+    _assert_redacted(result)
+
+
+def test_apply_invalid_later_entry_prevents_all_writes(tmp_path: Path):
+    later = _spec(label="Broken later job")
+    later.pop("instructions")
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", later)),
+    )
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+    assert exc.value.reason == "missing-key"
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_apply_stops_on_unexpected_queue_error_with_generic_reason(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+    calls = {"n": 0}
+    original_enqueue = grokbot_jobs.enqueue
+
+    def boom(target: Path, spec: dict, idempotency_key: str, now=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return original_enqueue(target, spec, idempotency_key, now=now)
+        raise grokbot_jobs.GrokbotJobError("unsafe-storage")
+
+    monkeypatch.setattr(grokbot_jobs, "enqueue", boom)
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.apply(tmp_path, manifest, limit=2)
+
+    assert exc.value.reason == "queue-error"
+    assert exc.value.index == 1
+    assert len(_job_files(tmp_path)) == 1
+
+
+def _run_feed(target: Path, *command: str) -> int:
+    return cli.main(["run", "cloud", "grokbot", "feed", *command, "--target", str(target)])
+
+
+def test_cli_feed_defaults_to_validation_only(tmp_path: Path, capsys):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest)) == 0
+    captured = capsys.readouterr()
+    assert "valid=2" in captured.out
+    assert "known=0" in captured.out
+    assert "created=" not in captured.out
+    assert captured.err == ""
+    assert SECRET_INSTRUCTIONS not in captured.out
+    assert SECRET_VERIFY not in captured.out
+    assert SECRET_OWNERSHIP not in captured.out
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_cli_feed_apply_limit_1_then_repeats_to_the_next_unknown(tmp_path: Path, capsys):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply", "--limit", "1") == 0
+    first = capsys.readouterr()
+    assert "created=1" in first.out
+    assert "skipped=0" in first.out
+    assert SECRET_INSTRUCTIONS not in first.out
+    first_id = [part for part in first.out.split() if part.startswith("grokbot-")][0]
+    assert len(_job_files(tmp_path)) == 1
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply", "--limit", "1") == 0
+    second = capsys.readouterr()
+    assert "created=1" in second.out
+    assert "skipped=1" in second.out
+    assert first_id in second.out
+    assert SECRET_VERIFY not in second.out
+    assert len(_job_files(tmp_path)) == 2
+
+
+def test_cli_feed_json_stays_free_of_private_task_context(tmp_path: Path, capsys):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply", "--limit", "1", "--json") == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["created"] == 1
+    assert payload["jobs"][0]["state"] == "queued"
+    _assert_redacted(payload)
+
+
+def test_cli_feed_rejects_invalid_later_entry_without_writing(tmp_path: Path, capsys):
+    later = _spec(label="Broken later job")
+    later.pop("instructions")
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", later)),
+    )
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply", "--limit", "1") == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: missing-key"
+    assert SECRET_INSTRUCTIONS not in captured.err
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_cli_feed_reports_generic_queue_error_with_index(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+    original_enqueue = grokbot_jobs.enqueue
+    calls = {"n": 0}
+
+    def boom(target: Path, spec: dict, idempotency_key: str, now=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return original_enqueue(target, spec, idempotency_key, now=now)
+        raise grokbot_jobs.GrokbotJobError("unsafe-storage")
+
+    monkeypatch.setattr(grokbot_jobs, "enqueue", boom)
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply", "--limit", "2") == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: queue-error index=1"
+    assert "unsafe-storage" not in captured.err
+    assert SECRET_INSTRUCTIONS not in captured.err
+
+
+def test_cli_feed_rejects_invalid_limit(tmp_path: Path, capsys):
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--limit", "0") == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: invalid-limit"
+    assert not _queue_root(tmp_path).exists()


### PR DESCRIPTION
Closes #1172.

## What changed

- Add `brigade run cloud grokbot feed` as a local-only producer for approved queue work.
- Validate an explicit private manifest before any queue mutation.
- Cap new jobs, preserve idempotent continuation, and keep output free of task instructions and local paths.
- Document the scheduling boundary and the operator-owned `--apply` step.

## Safety boundary

- Validation is the default. Queue mutation requires `--apply`.
- The manifest is read once through a descriptor, checked for ownership and mode, then used as an immutable snapshot.
- Existing Grok Bot queue validation and enqueue code remains authoritative.
- No producer or approval tool is exposed through MCP.

## Verification

- Focused Grok Bot suite: 141 passed, 3 skipped.
- Ruff check and format check passed.
- Mypy, version sync, managed snapshot, template snapshot, and `git diff --check` passed.
- The branch-history content guard passed.
- `./scripts/verify` reached 46% before its 20-minute local timeout under concurrent test load. Its first failure reproduced on `origin/main`: pytest placed temporary files under the home-level Brigade workspace. The exact test passes with `TMPDIR=/tmp`. Clean-runner CI is required before merge.

## Review focus

- The one-read manifest snapshot and descriptor checks.
- Descriptor-safe idempotency lookup and redacted apply errors.
