### PR TITLE
fix(memory): fail closed on unresolved care closeouts

### DIFF
--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -89,12 +89,13 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 `brigade memory care closeout` records review completion, but it cannot convert a partial or failed care chain into `reviewed`:
 
 - With a nonempty refresh queue and no `--defer`, closeout refuses (exit 1), writes nothing, and reports the unresolved candidate count. JSON mode emits a `status: blocked` payload; human mode prints the error to stderr.
+- Closeout also refuses (exit 1, nothing written) when the refresh queue file is absent or fails validation; it never treats a missing or malformed queue as empty.
 - `--defer` is the explicit escape hatch for unresolved work and requires a nonblank `--reason`; blank reasons are refused so automation cannot silently suppress work.
 - An empty queue may close `reviewed`.
 
-Deferred and reviewed closeouts both record the queue's source fingerprints so `memory care status` can tell open from quieted issues.
+Only deferred closeouts record the queue's source fingerprints, so `memory care status` can tell open from quieted issues. Reviewed closeouts record an empty fingerprint list.
 
-Closeout receipts written before the #closeout-guard could carry `status: reviewed` with unresolved candidates still in the queue. `memory care status` ignores those legacy receipts instead of quieting their fingerprints: only a `reviewed` closeout with zero candidates and no fingerprints, or a `deferred` closeout with a nonblank reason, quiets matching queue entries. When the latest receipt is ignored, status JSON reports why in `latest_closeout_ignored_reason`.
+Receipts with malformed fields are ignored rather than honored: only a `reviewed` closeout with zero candidates and no fingerprints, or a `deferred` closeout with well-formed fingerprints and a nonblank string reason, quiets matching queue entries (#1191). When the latest receipt is ignored, status JSON reports why in `latest_closeout_ignored_reason`.
 
 ## Boundary
 

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -84,6 +84,16 @@ Before 0.9.1, scans wrote to `memory/cards/decay/`. Readers still fall back to t
 
 Queue entries include card identity, issue type, severity, priority, safe summary, evidence references, suggested refresh action, acceptance criteria, source item key, source fingerprint, and safe fix-plan metadata when available. `brigade memory care import-issues` imports those entries as source `memory-care` task imports with dedupe and dismissed-until-changed behavior.
 
+## Closeout
+
+`brigade memory care closeout` records review completion, but it cannot convert a partial or failed care chain into `reviewed`:
+
+- With a nonempty refresh queue and no `--defer`, closeout refuses (exit 1), writes nothing, and reports the unresolved candidate count. JSON mode emits a `status: blocked` payload; human mode prints the error to stderr.
+- `--defer` is the explicit escape hatch for unresolved work and requires a nonblank `--reason`; blank reasons are refused so automation cannot silently suppress work.
+- An empty queue may close `reviewed`.
+
+Deferred and reviewed closeouts both record the queue's source fingerprints so `memory care status` can tell open from quieted issues.
+
 ## Boundary
 
 Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md). Opt-in `brigade care install` can install target-namespaced systemd user timers on Linux or launchd agents on macOS without Brigade owning a daemon.

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -94,6 +94,8 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 
 Deferred and reviewed closeouts both record the queue's source fingerprints so `memory care status` can tell open from quieted issues.
 
+Closeout receipts written before the #closeout-guard could carry `status: reviewed` with unresolved candidates still in the queue. `memory care status` ignores those legacy receipts instead of quieting their fingerprints: only a `reviewed` closeout with zero candidates and no fingerprints, or a `deferred` closeout with a nonblank reason, quiets matching queue entries. When the latest receipt is ignored, status JSON reports why in `latest_closeout_ignored_reason`.
+
 ## Boundary
 
 Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md). Opt-in `brigade care install` can install target-namespaced systemd user timers on Linux or launchd agents on macOS without Brigade owning a daemon.

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -1684,6 +1684,35 @@ def closeout(*, target: Path, reason: str | None = None, defer: bool = False, js
         return 2
     cards_value = queue.get("cards") if isinstance(queue, dict) else None
     cards = cards_value if isinstance(cards_value, list) else []
+    reason_text = (reason or "").strip()
+    if defer and not reason_text:
+        message = "error: deferred memory-care closeout requires a nonblank --reason"
+        if json_output:
+            print(
+                json.dumps(
+                    {"status": "blocked", "error": message, "candidate_count": len(cards)}, indent=2, sort_keys=True
+                )
+            )
+        else:
+            print(message, file=sys.stderr)
+        return 1
+    if not defer and cards:
+        message = (
+            f"error: memory-care refresh queue has {len(cards)} unresolved candidate(s); "
+            "closeout cannot mark them reviewed. Use --defer with a nonblank --reason to "
+            "defer explicitly, or resolve the queue first."
+        )
+        if json_output:
+            print(
+                json.dumps(
+                    {"status": "blocked", "error": message, "candidate_count": len(cards)},
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(message, file=sys.stderr)
+        return 1
     fingerprints = [
         str(card.get("source_fingerprint"))
         for card in cards
@@ -1694,7 +1723,7 @@ def closeout(*, target: Path, reason: str | None = None, defer: bool = False, js
         "closeout_id": closeout_id,
         "created_at": _utc_iso(),
         "status": "deferred" if defer else "reviewed",
-        "reason": reason or "",
+        "reason": reason_text,
         "candidate_count": len(cards),
         "source_fingerprints": fingerprints,
         "safe_summary": f"{len(cards)} memory-care candidate(s) {'deferred' if defer else 'reviewed'}",

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -1675,25 +1675,30 @@ def _latest_closeout(target: Path) -> dict[str, Any] | None:
 def _closeout_quiet_set(closeout: dict[str, Any] | None) -> tuple[set[str], str | None]:
     """Return (fingerprints to quiet, reason the receipt was ignored).
 
-    Before 15d54523, closeouts could write status=reviewed with unresolved
-    candidates still in the queue. Such legacy receipts are not honored:
+    Closeouts could historically write status=reviewed with unresolved
+    candidates still in the queue (#1191). Such receipts are not honored:
     only a reviewed closeout with no candidates/fingerprints, or a deferred
-    closeout with a nonblank reason, may quiet matching queue fingerprints.
+    closeout with a nonblank string reason, may quiet matching queue
+    fingerprints. Malformed receipts are ignored with a reported reason.
     """
     if not isinstance(closeout, dict):
         return set(), None
+    raw_fingerprints = closeout.get("source_fingerprints")
+    if not isinstance(raw_fingerprints, list) or any(
+        not isinstance(item, str) or not item.strip() for item in raw_fingerprints
+    ):
+        return set(), "closeout receipt has malformed source_fingerprints; not quieting queue fingerprints"
+    fingerprints = set(raw_fingerprints)
     status = str(closeout.get("status") or "")
-    fingerprints = {
-        item for item in (closeout.get("source_fingerprints") or []) if isinstance(item, str) and item.strip()
-    }
     try:
         candidate_count = int(closeout.get("candidate_count") or 0)
     except (TypeError, ValueError):
         candidate_count = 0
     if status == "deferred":
-        if str(closeout.get("reason") or "").strip():
+        reason_value = closeout.get("reason")
+        if isinstance(reason_value, str) and reason_value.strip():
             return fingerprints, None
-        return set(), "deferred closeout has a blank reason; not quieting queue fingerprints"
+        return set(), "deferred closeout has a blank or non-string reason; not quieting queue fingerprints"
     if status == "reviewed" and candidate_count == 0 and not fingerprints:
         return set(), None
     if status == "reviewed":
@@ -1714,11 +1719,36 @@ def closeout(*, target: Path, reason: str | None = None, defer: bool = False, js
         return 2
     try:
         config = _config_or_default(target)
-        queue = _load_json_file(_queue_path(target, config))
+        queue_path = _queue_path(target, config)
+        queue = _load_json_file(queue_path)
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         print(f"error: cannot read memory-care queue: {exc}", file=sys.stderr)
         return 2
-    cards_value = queue.get("cards") if isinstance(queue, dict) else None
+    if not isinstance(queue, dict):
+        message = f"error: memory-care queue is missing or not a JSON object at {queue_path}; closeout refused"
+        if json_output:
+            print(json.dumps({"status": "blocked", "error": message, "candidate_count": 0}, indent=2, sort_keys=True))
+        else:
+            print(message, file=sys.stderr)
+        return 1
+    validation_errors = _validate_queue(queue, path=queue_path)
+    if validation_errors:
+        summary = "; ".join(validation_errors[:5])
+        message = f"error: memory-care queue failed validation; closeout refused. {summary}"
+        cards_value = queue.get("cards")
+        candidate_count = len(cards_value) if isinstance(cards_value, list) else 0
+        if json_output:
+            print(
+                json.dumps(
+                    {"status": "blocked", "error": message, "candidate_count": candidate_count},
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(message, file=sys.stderr)
+        return 1
+    cards_value = queue.get("cards")
     cards = cards_value if isinstance(cards_value, list) else []
     reason_text = (reason or "").strip()
     if defer and not reason_text:

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -1170,7 +1170,7 @@ def health(target: Path) -> dict[str, Any]:
     if queue_payload is None:
         checks.append({"status": "warn", "name": "memory_care_queue", "detail": f"missing at {queue_path}"})
     closeout = _latest_closeout(target)
-    closed = set(closeout.get("source_fingerprints", [])) if isinstance(closeout, dict) else set()
+    closed, closeout_ignored_reason = _closeout_quiet_set(closeout)
     top_issue = None
     queue_count = 0
     if isinstance(queue_payload, dict) and isinstance(queue_payload.get("cards"), list) and queue_payload["cards"]:
@@ -1271,6 +1271,7 @@ def health(target: Path) -> dict[str, Any]:
         },
         "archive_candidates": archive_candidates,
         "latest_closeout": closeout,
+        "latest_closeout_ignored_reason": closeout_ignored_reason,
         "search_recall": search_recall_status(target),
     }
 
@@ -1669,6 +1670,41 @@ def _latest_closeout(target: Path) -> dict[str, Any] | None:
             payloads.append(payload)
     payloads.sort(key=lambda item: str(item.get("created_at") or item.get("closeout_id") or ""), reverse=True)
     return payloads[0] if payloads else None
+
+
+def _closeout_quiet_set(closeout: dict[str, Any] | None) -> tuple[set[str], str | None]:
+    """Return (fingerprints to quiet, reason the receipt was ignored).
+
+    Before 15d54523, closeouts could write status=reviewed with unresolved
+    candidates still in the queue. Such legacy receipts are not honored:
+    only a reviewed closeout with no candidates/fingerprints, or a deferred
+    closeout with a nonblank reason, may quiet matching queue fingerprints.
+    """
+    if not isinstance(closeout, dict):
+        return set(), None
+    status = str(closeout.get("status") or "")
+    fingerprints = {
+        item for item in (closeout.get("source_fingerprints") or []) if isinstance(item, str) and item.strip()
+    }
+    try:
+        candidate_count = int(closeout.get("candidate_count") or 0)
+    except (TypeError, ValueError):
+        candidate_count = 0
+    if status == "deferred":
+        if str(closeout.get("reason") or "").strip():
+            return fingerprints, None
+        return set(), "deferred closeout has a blank reason; not quieting queue fingerprints"
+    if status == "reviewed" and candidate_count == 0 and not fingerprints:
+        return set(), None
+    if status == "reviewed":
+        return (
+            set(),
+            (
+                "legacy reviewed closeout carries "
+                f"{candidate_count} candidate(s) and {len(fingerprints)} fingerprint(s); not quieting"
+            ),
+        )
+    return set(), None
 
 
 def closeout(*, target: Path, reason: str | None = None, defer: bool = False, json_output: bool = False) -> int:

--- a/tests/test_context_learning_closeout_cmd.py
+++ b/tests/test_context_learning_closeout_cmd.py
@@ -740,14 +740,15 @@ def test_closeout_commands_and_acceptance_summary(tmp_path, capsys):
         "cards": [
             {
                 "card_id": "card-one",
-                "card_file": "memory/cards/card-one.md",
+                "file": "memory/cards/card-one.md",
                 "issue_type": "stale",
+                "safe_summary": "One stale memory card",
                 "source_fingerprint": "memory-fp-one",
             }
         ],
     }
     _write_json(tmp_path / "memory" / "cards" / "decay" / "refresh-queue.json", queue)
-    # A nonempty unresolved queue must not be closed as reviewed (#closeout-guard).
+    # A nonempty unresolved queue must not be closed as reviewed (issue #1191).
     assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=True) == 1
     blocked = json.loads(capsys.readouterr().out)
     assert blocked["status"] == "blocked"

--- a/tests/test_context_learning_closeout_cmd.py
+++ b/tests/test_context_learning_closeout_cmd.py
@@ -747,9 +747,34 @@ def test_closeout_commands_and_acceptance_summary(tmp_path, capsys):
         ],
     }
     _write_json(tmp_path / "memory" / "cards" / "decay" / "refresh-queue.json", queue)
-    assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=True) == 0
-    memory = json.loads(capsys.readouterr().out)
-    assert memory["source_fingerprints"] == ["memory-fp-one"]
+    # A nonempty unresolved queue must not be closed as reviewed (#closeout-guard).
+    assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=True) == 1
+    blocked = json.loads(capsys.readouterr().out)
+    assert blocked["status"] == "blocked"
+    assert blocked["candidate_count"] == 1
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+    assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=False) == 1
+    assert "unresolved" in capsys.readouterr().err
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+
+    # Explicit deferral stays available but requires a nonblank reason.
+    assert memory_cmd.closeout(target=tmp_path, defer=True, json_output=True) == 1
+    capsys.readouterr()
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+    assert memory_cmd.closeout(target=tmp_path, defer=True, reason="   ", json_output=False) == 1
+    capsys.readouterr()
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+    assert memory_cmd.closeout(target=tmp_path, defer=True, reason="waiting on card owner", json_output=True) == 0
+    deferred = json.loads(capsys.readouterr().out)
+    assert deferred["status"] == "deferred"
+    assert deferred["source_fingerprints"] == ["memory-fp-one"]
+
+    # An empty queue may still close reviewed.
+    _write_json(tmp_path / "memory" / "cards" / "decay" / "refresh-queue.json", {"version": 1, "cards": []})
+    assert memory_cmd.closeout(target=tmp_path, reason="queue drained", json_output=True) == 0
+    reviewed = json.loads(capsys.readouterr().out)
+    assert reviewed["status"] == "reviewed"
+    assert reviewed["source_fingerprints"] == []
 
     handoff_dir = tmp_path / ".claude" / "memory-handoffs"
     handoff_dir.mkdir(parents=True)

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -1282,8 +1282,9 @@ def test_memory_care_health_ignores_legacy_reviewed_closeout_with_candidates(tmp
                 "cards": [
                     {
                         "card_id": "card-one",
-                        "card_file": "memory/cards/card-one.md",
+                        "file": "memory/cards/card-one.md",
                         "issue_type": "stale",
+                        "safe_summary": "One stale memory card",
                         "source_fingerprint": "memory-fp-one",
                     }
                 ],
@@ -1327,6 +1328,117 @@ def test_memory_care_health_ignores_legacy_reviewed_closeout_with_candidates(tmp
     assert payload["queue_count"] == 0
     assert payload["latest_closeout_ignored_reason"] is None
     assert any(check["name"] == "memory_care_open_issues" and check["status"] == "ok" for check in payload["checks"])
+
+
+def _write_memory_care_queue(tmp_path, payload):
+    queue_path = tmp_path / ".brigade" / "memory-care" / "decay" / "refresh-queue.json"
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    queue_path.write_text(json.dumps(payload))
+
+
+def _valid_memory_care_card(**overrides):
+    card = {
+        "card_id": "card-one",
+        "file": "memory/cards/card-one.md",
+        "issue_type": "stale",
+        "safe_summary": "One stale memory card",
+        "source_fingerprint": "memory-fp-one",
+    }
+    card.update(overrides)
+    return card
+
+
+def test_memory_care_closeout_refuses_missing_or_invalid_queue(tmp_path, capsys):
+    # Absent queue file: refuse without writing a closeout.
+    assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=True) == 1
+    blocked = json.loads(capsys.readouterr().out)
+    assert blocked["status"] == "blocked"
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+
+    # Queue object missing the cards field.
+    _write_memory_care_queue(tmp_path, {"version": 1})
+    assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=True) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+
+    # Non-list cards field.
+    _write_memory_care_queue(tmp_path, {"version": 1, "cards": "not-a-list"})
+    assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=True) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+
+    # Card failing schema validation.
+    _write_memory_care_queue(
+        tmp_path,
+        {"version": 1, "cards": [_valid_memory_care_card(safe_summary="   ")]},
+    )
+    assert memory_cmd.closeout(target=tmp_path, reason="reviewed", json_output=False) == 1
+    assert capsys.readouterr().err
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+
+    # Deferral must hit the same guards.
+    assert memory_cmd.closeout(target=tmp_path, defer=True, reason="waiting", json_output=True) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+    assert not (tmp_path / ".brigade" / "memory-care" / "closeouts").exists()
+
+
+def test_memory_care_health_ignores_malformed_closeout_receipts(tmp_path):
+    _write_memory_care_queue(tmp_path, {"version": 1, "cards": [_valid_memory_care_card()]})
+
+    # Scalar source_fingerprints is malformed: the receipt is ignored.
+    _write_memory_care_closeout(
+        tmp_path,
+        "scalar-closeout",
+        {
+            "closeout_id": "scalar-closeout",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "status": "deferred",
+            "reason": "waiting on card owner",
+            "candidate_count": 1,
+            "source_fingerprints": "memory-fp-one",
+            "safe_summary": "1 memory-care candidate(s) deferred",
+        },
+    )
+    payload = memory_cmd.health(tmp_path)
+    assert payload["queue_count"] == 1
+    assert payload["latest_closeout_ignored_reason"]
+    assert any(check["name"] == "memory_care_open_issues" and check["status"] == "warn" for check in payload["checks"])
+
+    # A truthy non-string reason does not satisfy the deferred contract.
+    _write_memory_care_closeout(
+        tmp_path,
+        "numeric-reason-closeout",
+        {
+            "closeout_id": "numeric-reason-closeout",
+            "created_at": "2026-02-01T00:00:00+00:00",
+            "status": "deferred",
+            "reason": 42,
+            "candidate_count": 1,
+            "source_fingerprints": ["memory-fp-one"],
+            "safe_summary": "1 memory-care candidate(s) deferred",
+        },
+    )
+    payload = memory_cmd.health(tmp_path)
+    assert payload["queue_count"] == 1
+    assert payload["latest_closeout_ignored_reason"]
+
+    # Fingerprints containing non-string entries are also ignored.
+    _write_memory_care_closeout(
+        tmp_path,
+        "mixed-fingerprint-closeout",
+        {
+            "closeout_id": "mixed-fingerprint-closeout",
+            "created_at": "2026-03-01T00:00:00+00:00",
+            "status": "deferred",
+            "reason": "waiting on card owner",
+            "candidate_count": 2,
+            "source_fingerprints": ["memory-fp-one", 7],
+            "safe_summary": "2 memory-care candidate(s) deferred",
+        },
+    )
+    payload = memory_cmd.health(tmp_path)
+    assert payload["queue_count"] == 1
+    assert payload["latest_closeout_ignored_reason"]
 
 
 def test_memory_care_status_archive_candidates_are_read_only(tmp_path, monkeypatch, capsys):

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -1266,6 +1266,69 @@ def test_memory_care_status_archive_candidates_include_age_reviewed_and_evidence
     assert candidate["approval_required"] is True
 
 
+def _write_memory_care_closeout(tmp_path, closeout_id, payload):
+    root = tmp_path / ".brigade" / "memory-care" / "closeouts" / closeout_id
+    root.mkdir(parents=True)
+    (root / "closeout.json").write_text(json.dumps(payload))
+
+
+def test_memory_care_health_ignores_legacy_reviewed_closeout_with_candidates(tmp_path):
+    queue_path = tmp_path / ".brigade" / "memory-care" / "decay" / "refresh-queue.json"
+    queue_path.parent.mkdir(parents=True)
+    queue_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "cards": [
+                    {
+                        "card_id": "card-one",
+                        "card_file": "memory/cards/card-one.md",
+                        "issue_type": "stale",
+                        "source_fingerprint": "memory-fp-one",
+                    }
+                ],
+            }
+        )
+    )
+    _write_memory_care_closeout(
+        tmp_path,
+        "legacy-closeout",
+        {
+            "closeout_id": "legacy-closeout",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "status": "reviewed",
+            "reason": "",
+            "candidate_count": 3,
+            "source_fingerprints": ["memory-fp-one"],
+            "safe_summary": "3 memory-care candidate(s) reviewed",
+        },
+    )
+
+    payload = memory_cmd.health(tmp_path)
+    assert payload["queue_count"] == 1
+    assert payload["latest_closeout_ignored_reason"]
+    assert any(check["name"] == "memory_care_open_issues" and check["status"] == "warn" for check in payload["checks"])
+
+    # An explicit deferred closeout with a nonblank reason still quiets the match.
+    _write_memory_care_closeout(
+        tmp_path,
+        "deferred-closeout",
+        {
+            "closeout_id": "deferred-closeout",
+            "created_at": "2026-02-01T00:00:00+00:00",
+            "status": "deferred",
+            "reason": "waiting on card owner",
+            "candidate_count": 1,
+            "source_fingerprints": ["memory-fp-one"],
+            "safe_summary": "1 memory-care candidate(s) deferred",
+        },
+    )
+    payload = memory_cmd.health(tmp_path)
+    assert payload["queue_count"] == 0
+    assert payload["latest_closeout_ignored_reason"] is None
+    assert any(check["name"] == "memory_care_open_issues" and check["status"] == "ok" for check in payload["checks"])
+
+
 def test_memory_care_status_archive_candidates_are_read_only(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(memory_cmd, "_today", lambda: date(2026, 5, 28))
     _write_archive_candidate_care_config(tmp_path, stale_after_days=30)


### PR DESCRIPTION
Closes #1191.

## What changed

- Refuse reviewed closeout when the queue is missing, malformed, or nonempty.
- Require a nonblank reason for explicit deferral.
- Ignore legacy and malformed closeout receipts instead of hiding findings.
- Report why a closeout receipt was ignored in memory-care status.
- Add regressions for failed chains, malformed queues, and malformed receipts.

## Why

A failed scan/import/refresh chain could be followed by a successful closeout that marked every unresolved fingerprint reviewed. Memory-care status then reported a clean queue even though no review occurred.

## Verification

- 70 focused tests passed.
- Ruff check passed.
- Ruff formatting check passed.
- Independent review found no blocking findings.

## Operational note

Keep the managed memory-closeout timer disabled until this patch is installed and verified against the live queue.