### PR TITLE
fix(harness): report pending, not current, on conflict-free dry runs

### DIFF
--- a/src/brigade/harness_profile_cmd.py
+++ b/src/brigade/harness_profile_cmd.py
@@ -1985,9 +1985,12 @@ def _sync_profile(
             migration="legacy-v1" if migrated_from_legacy else None,
         ), bool(files_written or files_removed)
     receipt_state = "present" if profile.receipt_path.exists() else "missing"
+    # A conflict-free plan with planned writes is "safe to apply", not
+    # "already applied".  Only a fully applied profile is "current".
+    pending = any(item["action"] in {"create", "update", "remove"} for item in items)
     return _result(
         profile,
-        status="current" if ready else "conflict",
+        status="conflict" if conflicts else ("pending" if pending else "current"),
         ready=ready,
         items=items,
         conflicts=conflicts,
@@ -2268,9 +2271,12 @@ def _uninstall_profile(
                 _prune_created_directories(instruction_dirs + generated_plan["prune"], profile.user_root)
             )
     changed = bool(files_removed or files_written)
+    # Dry-run parity with sync: planned removals mean the profile is pending
+    # removal, not already gone.
+    pending = any(item["action"] in {"create", "update", "remove"} for item in items)
     return _result(
         profile,
-        status="conflict" if conflicts else ("updated" if changed else "current"),
+        status="conflict" if conflicts else ("updated" if changed else ("pending" if pending else "current")),
         ready=not conflicts,
         items=items,
         conflicts=conflicts,

--- a/tests/test_harness_user_scope.py
+++ b/tests/test_harness_user_scope.py
@@ -106,6 +106,54 @@ def test_sync_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
     assert not (home / ".codex").exists()
 
 
+def test_sync_dry_run_reports_pending_until_applied(tmp_path, monkeypatch, capsys):
+    """Issue #1170: a conflict-free dry run with planned writes is not "current"."""
+    from brigade import cli
+
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    base = _sync_base(workspace)
+
+    assert cli.main(base + ["--json"]) == 0
+    planned = json.loads(capsys.readouterr().out)["results"][0]
+    assert planned["status"] == "pending"
+    assert planned["ready"] is True
+    assert planned["receipt_state"] == "missing"
+    assert any(item["action"] in {"create", "update", "remove"} for item in planned["items"])
+    assert not (home / ".codex").exists()
+
+    assert cli.main(base + ["--write", "--json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(base + ["--json"]) == 0
+    applied = json.loads(capsys.readouterr().out)["results"][0]
+    assert applied["status"] == "current"
+    assert applied["receipt_state"] == "present"
+    assert all(item["action"] not in {"create", "update", "remove"} for item in applied["items"])
+
+
+def test_uninstall_dry_run_reports_pending_before_apply(tmp_path, monkeypatch, capsys):
+    """Issue #1170 dry-run parity for uninstall: planned removals are not "current"."""
+    from brigade import cli
+
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    assert cli.main(_sync_base(workspace) + ["--write", "--json"]) == 0
+    capsys.readouterr()
+    before = {path: path.read_bytes() for path in sorted((home / ".codex").rglob("*")) if path.is_file()}
+
+    assert cli.main(_uninstall_base(workspace) + ["--json"]) == 0
+    planned = json.loads(capsys.readouterr().out)["results"][0]
+    assert planned["status"] == "pending"
+    assert planned["ready"] is True
+    after = {path: path.read_bytes() for path in sorted((home / ".codex").rglob("*")) if path.is_file()}
+    assert after == before
+
+    assert cli.main(_uninstall_base(workspace) + ["--write", "--json"]) == 0
+    applied = json.loads(capsys.readouterr().out)["results"][0]
+    assert applied["status"] == "updated"
+
+
 def test_sync_write_then_resync_is_idempotent(tmp_path, monkeypatch, capsys):
     from brigade import cli
 

--- a/tests/test_harness_user_scope_slice2.py
+++ b/tests/test_harness_user_scope_slice2.py
@@ -176,6 +176,33 @@ def test_sync_dry_run_writes_nothing(tmp_path, monkeypatch, capsys, harness):
 
 
 @pytest.mark.parametrize("harness", SLICE2_HARNESSES)
+def test_sync_dry_run_reports_pending_until_applied(tmp_path, monkeypatch, capsys, harness):
+    """Issue #1170: a conflict-free dry run with planned writes is not "current"."""
+    from brigade import cli
+
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    base = _sync_base(workspace, harness)
+
+    assert cli.main(base + ["--json"]) == 0
+    planned = json.loads(capsys.readouterr().out)["results"][0]
+    assert planned["status"] == "pending"
+    assert planned["ready"] is True
+    assert planned["receipt_state"] == "missing"
+    assert any(item["action"] in {"create", "update", "remove"} for item in planned["items"])
+    assert _file_snapshot(home) == {}
+
+    assert cli.main(base + ["--write", "--json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(base + ["--json"]) == 0
+    applied = json.loads(capsys.readouterr().out)["results"][0]
+    assert applied["status"] == "current"
+    assert applied["receipt_state"] == "present"
+    assert all(item["action"] not in {"create", "update", "remove"} for item in applied["items"])
+
+
+@pytest.mark.parametrize("harness", SLICE2_HARNESSES)
 def test_sync_write_then_resync_is_idempotent(tmp_path, monkeypatch, capsys, harness):
     from brigade import cli
 


### PR DESCRIPTION
## Summary

`brigade harness sync --dry-run` could return `status: current` and `ready: true` while the same payload contained 125 missing items and `receipt_state: missing`, and while `sync --check` exited 1 calling the managed instruction missing. The non-write return path in `_sync_profile` derived status purely from conflicts, and pending writes are not conflicts.

The result now distinguishes safe-to-apply from already-applied:

- `conflict`: unsafe to apply (unchanged)
- `pending`: conflict-free but items plan create/update/remove (new)
- `current`: fully applied (now means it)
- `updated`: a write run applied something (unchanged)

`ready` remains the apply-readiness field (`not conflicts`) and still drives exit codes, per the contract discussion on the issue. `_uninstall_profile`'s non-write path had the identical flaw and gets the same fix.

Fixes #1170

## Test plan

- [x] New regression tests: dry-run reports `pending`/`receipt_state missing` before apply and `current`/`present` after, across codex (slice1) and all five slice2 harnesses including opencode; uninstall dry-run parity test
- [x] Targeted harness suites green via Brigade verify receipt (120 tests, exit 0)
- [x] ruff check / ruff format / mypy / version-sync / snapshot checks green
- [x] Full suite raw run: 8983 passed, coverage 83.69% (floor 78%); the 8 failures are environment-only on this VM (TMPDIR under home + enrolled fleet node identity) and reproduce identically on unmodified HEAD