### PR TITLE
fix: reject fleet control characters and suppress health Server banner

### DIFF
--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -11,6 +11,14 @@ DEFAULT_PORT = 3774
 DEFAULT_DB_REL_PATH = Path(".brigade") / "fleet-hub.db"
 
 
+def _safe_table_cell(value: object) -> str:
+    """Render a table cell so stored non-printables cannot drive the terminal."""
+    text = str(value)
+    if text.isprintable():
+        return text
+    return "".join(ch if ch.isprintable() else ascii(ch)[1:-1] for ch in text)
+
+
 def _format_age(ts: object, *, now: datetime | None = None) -> str:
     """Human-readable age of an ISO-8601 timestamp ("42s", "3m", "2h", "5d")."""
     if not isinstance(ts, str) or not ts:
@@ -224,10 +232,10 @@ def _dispatch_nodes_list(args: argparse.Namespace) -> int:
         revoked = node.get("revoked_at")
         rows.append(
             [
-                str(node.get("node_id") or "-"),
-                str(node.get("label") or "-"),
-                _format_age(node.get("created_at")),
-                f"revoked {_format_age(revoked)} ago" if revoked else "active",
+                _safe_table_cell(str(node.get("node_id") or "-")),
+                _safe_table_cell(str(node.get("label") or "-")),
+                _safe_table_cell(_format_age(node.get("created_at"))),
+                _safe_table_cell(f"revoked {_format_age(revoked)} ago" if revoked else "active"),
             ]
         )
     widths = [max(len(h), *(len(r[i]) for r in rows)) if rows else len(h) for i, h in enumerate(headers)]
@@ -289,12 +297,12 @@ def _dispatch_status(args: argparse.Namespace) -> int:
         seat = "/".join(filter(None, [run_row.get("seat"), run_row.get("harness")])) or "-"
         rows.append(
             [
-                str(run_row.get("node_id") or "-")[:12],
-                str(run_row.get("repo") or "-"),
-                str(run_row.get("run_id") or "-"),
-                seat,
-                str(run_row.get("state") or "-"),
-                _format_age(run_row.get("ts")),
+                _safe_table_cell(str(run_row.get("node_id") or "-"))[:12],
+                _safe_table_cell(str(run_row.get("repo") or "-")),
+                _safe_table_cell(str(run_row.get("run_id") or "-")),
+                _safe_table_cell(seat),
+                _safe_table_cell(str(run_row.get("state") or "-")),
+                _safe_table_cell(_format_age(run_row.get("ts"))),
             ]
         )
     widths = [max(len(h), *(len(r[i]) for r in rows)) if rows else len(h) for i, h in enumerate(headers)]
@@ -541,11 +549,11 @@ def _dispatch_claims(args: argparse.Namespace) -> int:
             expires += " (expired)"
         rows.append(
             [
-                str(claim.get("target") or "-"),
-                str(claim.get("owner_node") or "-")[:12],
-                str(claim.get("owner_conductor") or "-"),
-                _format_age(claim.get("acquired_at")),
-                expires,
+                _safe_table_cell(str(claim.get("target") or "-")),
+                _safe_table_cell(str(claim.get("owner_node") or "-"))[:12],
+                _safe_table_cell(str(claim.get("owner_conductor") or "-")),
+                _safe_table_cell(_format_age(claim.get("acquired_at"))),
+                _safe_table_cell(expires),
             ]
         )
     widths = [max(len(h), *(len(r[i]) for r in rows)) if rows else len(h) for i, h in enumerate(headers)]

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -230,6 +230,20 @@ class FleetHubConflict(FleetHubError):
     """The request conflicts with current hub state (HTTP 409)."""
 
 
+class FleetHubUnprocessable(FleetHubError):
+    """A field failed semantic validation (HTTP 422), e.g. control characters."""
+
+
+def _contains_controls(value: str) -> bool:
+    """True when ``value`` contains a C0 or C1 control character (including DEL)."""
+    return any(ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F for ch in value)
+
+
+def _reject_controls(value: str, field: str, *, kind: str) -> None:
+    if _contains_controls(value):
+        raise FleetHubUnprocessable(f"{kind} field {field!r} must not contain control characters")
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -399,11 +413,14 @@ def _validate_event(raw: Any) -> dict[str, Any]:
         if kind is str:
             if not isinstance(value, str) or not value.strip():
                 raise FleetHubError(f"event field {field!r} must be a non-empty string")
+            _reject_controls(value, field, kind="event")
         elif not isinstance(value, int) or isinstance(value, bool) or value < 0:
             raise FleetHubError(f"event field {field!r} must be a non-negative integer")
         event[field] = value
     for field in OPTIONAL_STR_FIELDS:
         value = raw.get(field)
+        if isinstance(value, str):
+            _reject_controls(value, field, kind="event")
         event[field] = value if isinstance(value, str) and value.strip() else None
     return event
 
@@ -553,6 +570,8 @@ def _validate_claim_request(raw: Any) -> dict[str, Any]:
             continue
         if not isinstance(value, str) or not value.strip():
             raise FleetHubError(f"claim field {field!r} must be a non-empty string")
+        if field == "target":
+            _reject_controls(value, field, kind="claim")
         request[field] = value.strip()
     for field in ("node_id", "holder"):
         if request[field] is None:
@@ -563,6 +582,8 @@ def _validate_claim_request(raw: Any) -> dict[str, Any]:
                 "([A-Za-z0-9._-], max 128 chars, never the literal 'unknown')"
             )
     conductor = raw.get("conductor")
+    if isinstance(conductor, str):
+        _reject_controls(conductor, "conductor", kind="claim")
     request["conductor"] = conductor.strip() if isinstance(conductor, str) and conductor.strip() else None
     ttl = raw.get("ttl_seconds", DEFAULT_CLAIM_TTL_SECONDS)
     if not isinstance(ttl, int) or isinstance(ttl, bool) or not CLAIM_TTL_MIN_SECONDS <= ttl <= CLAIM_TTL_MAX_SECONDS:
@@ -979,6 +1000,7 @@ def make_handler(token: str, db_path: Path, *, allow_admin_writes: bool = False)
 
     class _Handler(BaseHTTPRequestHandler):
         server_version = "brigade-fleet-hub/1"
+        sys_version = ""
         # Idle-socket guard: a peer that connects and never sends a request
         # line cannot pin a handler thread forever (pre-auth).
         timeout = 30
@@ -1232,6 +1254,9 @@ def make_handler(token: str, db_path: Path, *, allow_admin_writes: bool = False)
                     status, body_payload = handle_node_request(conn, parsed)
             except FleetHubForbidden as exc:
                 self._send_json(403, {"error": str(exc)})
+                return
+            except FleetHubUnprocessable as exc:
+                self._send_json(422, {"error": str(exc)})
                 return
             except FleetHubError as exc:
                 self._send_json(400, {"error": str(exc)})

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -366,6 +366,32 @@ class TestHubClaims:
         assert _post(url, token, _claim(holder="unknown"))[0] == 400
         assert _post(url, token, _claim(holder="h 1"))[0] == 400
 
+    def test_control_characters_rejected_at_claim_ingestion(self, hub, tmp_path):
+        url, token, _db = hub
+        for field, value in (
+            ("target", "repo\x1b[31m"),
+            ("target", "repo\x07"),
+            ("target", "repo\x9b"),
+            ("conductor", "cond\x1b[31m"),
+            ("conductor", "cond\x80"),
+            ("conductor", "cond\x7f"),
+        ):
+            status, payload = _post(url, token, _claim(**{field: value}))
+            assert status == 422, (field, value)
+            assert "control" in payload["error"]
+        assert _get(url, "/claims", token)[1]["claims"] == []
+        # Existing identity / length caps stay 400; clean display fields still ingest.
+        status, payload = _post(url, token, _claim(node="x" * 200))
+        assert status == 400 and "node_id" in payload["error"]
+        assert _post(url, token, _claim(target="repo-clean", conductor="cond-1"))[0] == 200
+        conn = fleet_hub.init_db(tmp_path / "direct.db")
+        try:
+            with pytest.raises(fleet_hub.FleetHubUnprocessable):
+                fleet_hub.handle_claim(conn, _claim(target="repo\x1b"))
+            assert conn.execute("SELECT COUNT(*) FROM claims").fetchone()[0] == 0
+        finally:
+            conn.close()
+
     def test_claims_listing_filters_expired_unless_all(self, hub, clock):
         url, token, _db = hub
         _post(url, token, _claim(target="repo-a", ttl_seconds=100))
@@ -833,6 +859,43 @@ class TestFleetClaimsCli:
         out = capsys.readouterr().out
         assert "repo-a" in out and NODE_A[:12] in out and "cond-1" in out
         assert out.splitlines()[0].split()[0] == "target"
+
+    def test_claims_table_renders_legacy_nonprintables_inert(self, hub, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token, db = hub
+        monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", url)
+        monkeypatch.setenv("BRIGADE_FLEET_TOKEN", token)
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute(
+                "INSERT INTO claims "
+                "(target, owner_node, owner_conductor, holder_token, acquired_at, renewed_at, "
+                "ttl_seconds, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "repo\x1b[31mred",
+                    NODE_A,
+                    "cond\x9b",
+                    "h1",
+                    "2026-08-23T12:00:00+00:00",
+                    "2026-08-23T12:00:00+00:00",
+                    900,
+                    4_000_000_000.0,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        assert cli.main(["fleet", "claims", "--json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["claims"][0]["target"] == "repo\x1b[31mred"
+        assert payload["claims"][0]["owner_conductor"] == "cond\x9b"
+        assert cli.main(["fleet", "claims"]) == 0
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "\x9b" not in out
+        assert "\\x1b[31mred" in out
+        assert "\\x9b" in out
 
     def test_claims_empty_and_no_hub(self, hub, tmp_path, monkeypatch, capsys):
         from brigade import cli

--- a/tests/test_fleet_nodes.py
+++ b/tests/test_fleet_nodes.py
@@ -454,6 +454,26 @@ class TestNodesCli:
         assert cli.main(["fleet", "nodes", "revoke", NODE_A, "--json"]) == 0
         assert json.loads(capsys.readouterr().out)["revoked"] is True
 
+    def test_nodes_table_renders_legacy_nonprintables_inert(self, hub, capsys):
+        from brigade import cli
+
+        url, db = hub
+        self._config(url)
+        _enroll(url, NODE_A, "clean")
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute("UPDATE nodes SET label = ? WHERE node_id = ?", ("lab\x1b[31mel", NODE_A))
+            conn.commit()
+        finally:
+            conn.close()
+        assert cli.main(["fleet", "nodes", "list", "--json"]) == 0
+        listed = json.loads(capsys.readouterr().out)["nodes"]
+        assert listed[0]["label"] == "lab\x1b[31mel"
+        assert cli.main(["fleet", "nodes", "list"]) == 0
+        table = capsys.readouterr().out
+        assert "\x1b" not in table
+        assert "\\x1b[31mel" in table
+
     def test_errors_are_reported_not_raised(self, hub, capsys):
         from brigade import cli
 

--- a/tests/test_fleet_sync.py
+++ b/tests/test_fleet_sync.py
@@ -106,8 +106,9 @@ class TestHub:
         handler = fleet_hub.make_handler("tok", Path("/nonexistent"))
         assert handler.server_version == "brigade-fleet-hub/1"
         assert handler.sys_version == ""
-        assert "Python" not in handler.version_string()
-        assert sys.version.split()[0] not in handler.version_string()
+        banner = f"{handler.server_version} {handler.sys_version}"
+        assert "Python" not in banner
+        assert sys.version.split()[0] not in banner
 
     def test_events_rejected_without_token(self, hub):
         url, _token, _db = hub

--- a/tests/test_fleet_sync.py
+++ b/tests/test_fleet_sync.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
+import sys
 import threading
 import urllib.request
 from pathlib import Path
@@ -89,6 +91,23 @@ class TestHub:
         status, payload = _get(url, "/health", None)
         assert status == 200
         assert payload["ok"] is True
+        assert payload == {"ok": True, "service": "brigade-fleet-hub"}
+
+    def test_health_server_header_omits_python_banner(self, hub):
+        url, _token, _db = hub
+        request = urllib.request.Request(url + "/health")
+        with urllib.request.urlopen(request, timeout=5) as response:
+            server = response.headers.get("Server", "")
+            payload = json.loads(response.read())
+        assert response.status == 200
+        assert payload == {"ok": True, "service": "brigade-fleet-hub"}
+        assert "Python" not in server
+        assert sys.version.split()[0] not in server
+        handler = fleet_hub.make_handler("tok", Path("/nonexistent"))
+        assert handler.server_version == "brigade-fleet-hub/1"
+        assert handler.sys_version == ""
+        assert "Python" not in handler.version_string()
+        assert sys.version.split()[0] not in handler.version_string()
 
     def test_events_rejected_without_token(self, hub):
         url, _token, _db = hub
@@ -566,6 +585,44 @@ class TestCli:
         assert "repo-a" in out and "worker/claude" in out and "run.created" in out
         assert out.splitlines()[0].split()[-1] == "age"
 
+    def test_status_table_renders_legacy_nonprintables_inert(self, hub, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token, db = hub
+        monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", url)
+        monkeypatch.setenv("BRIGADE_FLEET_TOKEN", token)
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute(
+                "INSERT INTO events "
+                "(node_id, run_id, sequence, digest, repo, seat, harness, state, ts, received_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    NODE_A,
+                    "r-legacy",
+                    1,
+                    "d1",
+                    "repo\x1b[31mred",
+                    "seat\x9b",
+                    "claude",
+                    "run.created",
+                    "2026-08-23T12:00:00+00:00",
+                    "2026-08-23T12:00:00+00:00",
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        assert cli.main(["fleet", "status", "--json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["runs"][0]["repo"] == "repo\x1b[31mred"
+        assert cli.main(["fleet", "status"]) == 0
+        out = capsys.readouterr().out
+        assert "\x1b" not in out
+        assert "\x9b" not in out
+        assert "\\x1b[31mred" in out
+        assert "\\x9b" in out
+
     def test_status_without_hub_is_error(self, tmp_path, monkeypatch, capsys):
         from brigade import cli
 
@@ -978,6 +1035,41 @@ class TestHubHardening:
         assert "database" in payload["error"]
         status, payload = _get(url, "/status", token)
         assert status == 200
+
+    def test_control_characters_rejected_at_event_ingestion(self, hub, tmp_path):
+        url, token, db = hub
+        crafted = (
+            {**_event(), "node_id": "node\x1b[31m"},
+            {**_event(), "run_id": "run\x07"},
+            {**_event(), "state": "run.\x9bstarted"},
+            {**_event(), "ts": "2026-08-23T12:00:00+00:00\x00"},
+            {**_event(), "digest": "d1\x1f"},
+            {**_event(), "repo": "repo\x1b[31mred"},
+            {**_event(), "seat": "worker\x80"},
+            {**_event(), "harness": "claude\x7f"},
+        )
+        for bad in crafted:
+            status, payload = _post(url, token, bad)
+            assert status == 422, bad
+            assert "control" in payload["error"]
+        conn = sqlite3.connect(str(db))
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 0
+        finally:
+            conn.close()
+        # Clean values still ingest; length-style emptiness stays 400.
+        assert _post(url, token, _event())[0] == 200
+        status, payload = _post(url, token, {**_event(seq=2), "repo": ""})
+        assert status == 200
+        status, payload = _post(url, token, {**_event(), "node_id": ""})
+        assert status == 400
+        conn = fleet_hub.init_db(tmp_path / "direct.db")
+        try:
+            with pytest.raises(fleet_hub.FleetHubUnprocessable):
+                fleet_hub.store_events(conn, {**_event(), "repo": "r\x1b"})
+            assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 0
+        finally:
+            conn.close()
 
 
 def test_conftest_clears_fleet_env():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1155

## What and why

Hub ingestion now rejects C0/C1 control characters in event and claim display fields with HTTP 422 (existing length caps unchanged). Fleet CLI tables render any already-stored non-printables as inert `repr`-style escapes so terminal sequences cannot drive an operator terminal. The unauthenticated `/health` handler sets `server_version` / `sys_version` to fixed neutral strings so the Server banner no longer leaks a Python implementation version; the JSON body stays `{"ok": true, "service": "brigade-fleet-hub"}`.

## Type of change

- [x] Bug fix / security hardening
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change

## Checklist

- [x] Focused pytest files pass locally (see verification)
- [x] Added regressions for ingestion 422, CLI table sanitizing, and `/health` Server banner
- [ ] CHANGELOG.md not updated (outside ownership paths for this job)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit message

## Verification

All four required commands passed on `fd8a4b7bedd73ae8a6bde2b960543f8ad577034e`.

```
$ python -m pytest -q tests/test_fleet_claims.py tests/test_fleet_nodes.py tests/test_fleet_sync.py
........................................................................ [ 52%]
..................................................................       [100%]
138 passed in 54.37s
```

```
$ ruff check src/brigade/fleet_hub.py src/brigade/cli/fleet.py tests/test_fleet_claims.py tests/test_fleet_nodes.py tests/test_fleet_sync.py
All checks passed!
```

```
$ ruff format --check src/brigade/fleet_hub.py src/brigade/cli/fleet.py tests/test_fleet_claims.py tests/test_fleet_nodes.py tests/test_fleet_sync.py
5 files already formatted
```

```
$ git diff --check
(no output; exit 0)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45c85c40-08a6-480d-b813-e27d7d8b08ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45c85c40-08a6-480d-b813-e27d7d8b08ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

