### PR TITLE
feat(fleet): track external harness sessions

### DIFF
--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -106,6 +106,21 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_claims.add_argument("--all", action="store_true", help="Include expired claims.")
     p_claims.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
     p_claims.add_argument(
+        "--acquire",
+        metavar="TARGET",
+        default=None,
+        help=(
+            "Acquire TARGET for an external harness session. Records opaque --harness/--session labels "
+            "(optional --role/--job) and prints the fencing holder once."
+        ),
+    )
+    p_claims.add_argument(
+        "--heartbeat",
+        metavar="TARGET",
+        default=None,
+        help="Renew the live claim on TARGET. Requires the fencing --holder from --acquire.",
+    )
+    p_claims.add_argument(
         "--release",
         metavar="TARGET",
         default=None,
@@ -113,8 +128,25 @@ def register(sub: argparse._SubParsersAction) -> None:
             "Release the hub claim on TARGET, a claim key as listed by this command (a claim left behind by a "
             "crashed run). Refused unless this node holds it and the run that took it is verifiably dead: the "
             "claim's recorded run directory resolves to a workspace on this machine whose run lock has no live "
-            "owner (with --path, that workspace must be the one given). See --force."
+            "owner (with --path, that workspace must be the one given). See --force. With --holder, release "
+            "the exact session that acquired the row instead of the operator recovery path."
         ),
+    )
+    p_claims.add_argument("--harness", default=None, help="Opaque harness label for --acquire or --outcome.")
+    p_claims.add_argument("--role", default=None, help="Opaque role label for --acquire or --outcome.")
+    p_claims.add_argument("--job", default=None, help="Opaque job label for --acquire or --outcome.")
+    p_claims.add_argument("--session", default=None, help="Opaque session label for --acquire or --outcome.")
+    p_claims.add_argument(
+        "--holder",
+        default=None,
+        help="Fencing token printed by --acquire. Required for --heartbeat and session --release.",
+    )
+    p_claims.add_argument("--ttl", type=int, default=None, help="Claim TTL in seconds for --acquire or --heartbeat.")
+    p_claims.add_argument(
+        "--outcome",
+        default=None,
+        choices=("external.completed", "external.failed", "external.canceled"),
+        help="With --release --holder: release first, then publish this terminal event when the holder matches.",
     )
     p_claims.add_argument(
         "--path",
@@ -291,10 +323,11 @@ def _dispatch_status(args: argparse.Namespace) -> int:
     if args.json:
         print(_json.dumps({"runs": runs}, indent=2, sort_keys=True))
         return 0
-    headers = ("node", "repo", "run_id", "seat/harness", "state", "age")
+    headers = ("node", "repo", "run_id", "seat/harness", "state", "exit", "age")
     rows = []
     for run_row in runs:
         seat = "/".join(filter(None, [run_row.get("seat"), run_row.get("harness")])) or "-"
+        exit_status = run_row.get("exit_status")
         rows.append(
             [
                 _safe_table_cell(str(run_row.get("node_id") or "-"))[:12],
@@ -302,6 +335,7 @@ def _dispatch_status(args: argparse.Namespace) -> int:
                 _safe_table_cell(str(run_row.get("run_id") or "-")),
                 _safe_table_cell(seat),
                 _safe_table_cell(str(run_row.get("state") or "-")),
+                _safe_table_cell("-" if exit_status is None else str(exit_status)),
                 _safe_table_cell(_format_age(run_row.get("ts"))),
             ]
         )
@@ -367,6 +401,9 @@ def _print_claim_failure(decision, *, what: str) -> bool:
         if "'holder'" in detail or "'scope'" in detail or "'action'" in detail:
             detail += " (this fleet hub predates token-less release; upgrade it)"
         print(f"error: fleet hub claim {what} failed: {detail}", file=sys.stderr)
+        return True
+    if decision.reason == "invalid":
+        print(f"error: {decision.detail}", file=sys.stderr)
         return True
     return False
 
@@ -521,14 +558,213 @@ def _release_claim(raw_target: str, *, as_path: bool, node_override: str | None,
     return 0
 
 
+def _session_labels(args: argparse.Namespace) -> dict[str, str | None]:
+    return {
+        "harness": args.harness,
+        "role": args.role,
+        "job": args.job,
+        "session": args.session,
+    }
+
+
+def _acquire_session(
+    target: str,
+    *,
+    harness: str | None,
+    role: str | None,
+    job: str | None,
+    session: str | None,
+    holder: str | None,
+    ttl: int | None,
+    as_json: bool,
+) -> int:
+    import json as _json
+
+    from .. import fleet_client
+
+    if not harness or not session:
+        print("error: --acquire requires --harness and --session", file=sys.stderr)
+        return 2
+    try:
+        fleet_client.validated_opaque_labels(harness=harness, role=role, job=job, session=session)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    decision = fleet_client.acquire_claim(
+        target,
+        holder=holder,
+        harness=harness,
+        role=role,
+        job=job,
+        session=session,
+        ttl_seconds=ttl if ttl is not None else fleet_client.DEFAULT_CLAIM_TTL_SECONDS,
+    )
+    if _print_claim_failure(decision, what="acquire"):
+        return 1
+    if as_json:
+        print(
+            _json.dumps(
+                {
+                    "target": target,
+                    "granted": decision.granted,
+                    "holder": decision.holder,
+                    "claim": decision.claim,
+                    "owner": decision.owner,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    if decision.granted:
+        if not as_json:
+            print(f"acquired claim on {target!r} harness {harness} session {session}")
+            print("holder token (shown once; the hub never lists it; pass it to --heartbeat / --release):")
+            print(decision.holder or "")
+        return 0
+    if not as_json:
+        owner = (decision.owner or {}).get("owner_node") or "-"
+        print(f"error: claim on {target!r} is held by node {owner}", file=sys.stderr)
+    return 1
+
+
+def _heartbeat_session(target: str, *, holder: str | None, ttl: int | None, as_json: bool) -> int:
+    import json as _json
+
+    from .. import fleet_client
+
+    if not holder:
+        print("error: --heartbeat requires --holder", file=sys.stderr)
+        return 2
+    decision = fleet_client.renew_claim(
+        target,
+        holder=holder,
+        ttl_seconds=ttl if ttl is not None else fleet_client.DEFAULT_CLAIM_TTL_SECONDS,
+    )
+    if _print_claim_failure(decision, what="renew"):
+        return 1
+    if as_json:
+        print(
+            _json.dumps(
+                {"target": target, "renewed": decision.granted, "claim": decision.claim, "owner": decision.owner},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    if decision.granted:
+        if not as_json:
+            print(f"renewed claim on {target!r}")
+        return 0
+    if not as_json:
+        print(
+            f"error: claim on {target!r} is held or the holder token does not match",
+            file=sys.stderr,
+        )
+    return 1
+
+
+def _release_session(
+    target: str,
+    *,
+    holder: str,
+    outcome: str | None,
+    harness: str | None,
+    role: str | None,
+    job: str | None,
+    session: str | None,
+    as_json: bool,
+) -> int:
+    import json as _json
+
+    from .. import fleet_client
+
+    if outcome is not None and (not harness or not session):
+        print("error: --outcome requires --harness and --session", file=sys.stderr)
+        return 2
+    try:
+        labels = (
+            fleet_client.validated_opaque_labels(harness=harness, role=role, job=job, session=session)
+            if outcome is not None
+            else {"harness": harness, "role": role, "job": job, "session": session}
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    harness, role, job, session = labels["harness"], labels["role"], labels["job"], labels["session"]
+    decision = fleet_client.release_claim(target, holder=holder)
+    if _print_claim_failure(decision, what="release"):
+        return 1
+    published = None
+    if decision.granted and outcome is not None:
+        if harness is None or session is None:
+            print("error: --outcome requires --harness and --session", file=sys.stderr)
+            return 2
+        fleet_client.report_external_event(
+            target=target, harness=harness, role=role, job=job, session=session, state=outcome
+        )
+        published = outcome
+    if as_json:
+        print(
+            _json.dumps(
+                {
+                    "target": target,
+                    "released": decision.granted,
+                    "forced": False,
+                    "claim": decision.claim,
+                    "owner": decision.owner,
+                    "outcome": published,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    if decision.granted:
+        if not as_json:
+            print(f"released claim on {target!r}")
+        return 0
+    if not as_json:
+        print(
+            f"error: claim on {target!r} is held or the holder token does not match",
+            file=sys.stderr,
+        )
+    return 1
+
+
 def _dispatch_claims(args: argparse.Namespace) -> int:
     import json as _json
 
     from .. import fleet_client
 
+    actions = [name for name in ("acquire", "heartbeat", "release") if getattr(args, name) is not None]
+    if len(actions) > 1:
+        print("error: --acquire, --heartbeat, and --release are mutually exclusive", file=sys.stderr)
+        return 2
     if args.release is None and (args.force or args.path or args.node is not None):
         print("error: --force, --path, and --node require --release <target>", file=sys.stderr)
         return 2
+    if args.holder is not None and (args.force or args.path or args.node is not None):
+        print("error: --holder cannot be combined with --force, --path, or --node", file=sys.stderr)
+        return 2
+    if args.outcome is not None and (args.release is None or args.holder is None):
+        print("error: --outcome requires --release <target> and --holder", file=sys.stderr)
+        return 2
+    if args.acquire is not None:
+        return _acquire_session(
+            args.acquire,
+            holder=args.holder,
+            ttl=args.ttl,
+            as_json=args.json,
+            **_session_labels(args),
+        )
+    if args.heartbeat is not None:
+        return _heartbeat_session(args.heartbeat, holder=args.holder, ttl=args.ttl, as_json=args.json)
+    if args.release is not None and args.holder is not None:
+        return _release_session(
+            args.release,
+            holder=args.holder,
+            outcome=args.outcome,
+            as_json=args.json,
+            **_session_labels(args),
+        )
     if args.release is not None:
         return _release_claim(
             args.release, as_path=args.path, node_override=args.node, force=args.force, as_json=args.json
@@ -541,7 +777,7 @@ def _dispatch_claims(args: argparse.Namespace) -> int:
     if args.json:
         print(_json.dumps({"claims": claims}, indent=2, sort_keys=True))
         return 0
-    headers = ("target", "node", "conductor", "acquired", "expires")
+    headers = ("target", "node", "conductor", "harness", "session", "acquired", "expires")
     rows = []
     for claim in claims:
         expires = str(claim.get("expires_at") or "-")
@@ -552,6 +788,8 @@ def _dispatch_claims(args: argparse.Namespace) -> int:
                 _safe_table_cell(str(claim.get("target") or "-")),
                 _safe_table_cell(str(claim.get("owner_node") or "-"))[:12],
                 _safe_table_cell(str(claim.get("owner_conductor") or "-")),
+                _safe_table_cell(str(claim.get("harness") or "-")),
+                _safe_table_cell(str(claim.get("session") or "-")),
                 _safe_table_cell(_format_age(claim.get("acquired_at"))),
                 _safe_table_cell(expires),
             ]

--- a/src/brigade/fleet_client.py
+++ b/src/brigade/fleet_client.py
@@ -83,6 +83,8 @@ import urllib.request
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -608,6 +610,40 @@ def report_journal_event(envelope: dict[str, Any], *, journal_path: Path | None 
     return report_event(event, base_path=journal_path)
 
 
+def report_external_event(
+    *,
+    target: str,
+    harness: str,
+    role: str | None = None,
+    job: str | None = None,
+    session: str,
+    state: str,
+) -> bool:
+    """Best-effort lifecycle event for an external harness session.
+
+    The hub receives only the opaque identity labels needed to locate the
+    session. Queue payloads, artifacts, headers, and credentials never enter
+    the event. ``session`` contributes to the digest but is deliberately not
+    a hub event field; the claim row is its lookup surface.
+    """
+    try:
+        labels = validated_opaque_labels(harness=harness, role=role, job=job, session=session)
+        event = {
+            "run_id": labels["job"] or labels["session"] or session,
+            "repo": target,
+            "seat": labels["role"],
+            "harness": labels["harness"],
+            "state": state,
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "sequence": time.time_ns(),
+        }
+        digest_input = json.dumps({**event, "session": labels["session"]}, sort_keys=True, separators=(",", ":"))
+        event["digest"] = sha256(digest_input.encode("utf-8")).hexdigest()
+    except Exception:
+        return False
+    return report_event(event)
+
+
 def fetch_status(*, hub_url: str | None = None, include_all: bool = False) -> list[dict[str, Any]]:
     """GET /status from the hub; raises FleetClientError when unreachable."""
     config = load_fleet_config()
@@ -632,10 +668,35 @@ def fetch_status(*, hub_url: str | None = None, include_all: bool = False) -> li
 # never the literal "unknown" (two identity-less machines must not both be
 # granted the same target).
 _CLAIM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+OPAQUE_LABEL_MAX_CHARS = 128
+OPAQUE_LABEL_FIELDS = ("harness", "role", "job", "session")
+EXTERNAL_OUTCOMES = frozenset({"external.completed", "external.failed", "external.canceled"})
 
 
 def _node_id_is_claimable(node_id: str) -> bool:
     return node_id != "unknown" and bool(_CLAIM_ID_RE.match(node_id))
+
+
+def _contains_controls(value: str) -> bool:
+    return any(ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F for ch in value)
+
+
+def validate_opaque_label(field: str, value: str | None) -> str | None:
+    """Return a stripped opaque label, or None when omitted. Raises ValueError."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or len(value) > OPAQUE_LABEL_MAX_CHARS:
+        raise ValueError(
+            f"claim field {field!r} must be a non-empty string at most {OPAQUE_LABEL_MAX_CHARS} characters"
+        )
+    if _contains_controls(value):
+        raise ValueError(f"claim field {field!r} must not contain control characters")
+    return value.strip()
+
+
+def validated_opaque_labels(**labels: str | None) -> dict[str, str | None]:
+    """Validate the acquire-only identity labels. Extra keys are ignored."""
+    return {field: validate_opaque_label(field, labels.get(field)) for field in OPAQUE_LABEL_FIELDS}
 
 
 @dataclass(frozen=True)
@@ -763,6 +824,10 @@ def _claim_op(
     lock: Mapping[str, str] | None = None,
     supersede: Mapping[str, str] | None = None,
     acquired_at: str | None = None,
+    harness: str | None = None,
+    role: str | None = None,
+    job: str | None = None,
+    session: str | None = None,
 ) -> ClaimDecision:
     """One claim request; never raises for network or hub failures.
 
@@ -798,6 +863,13 @@ def _claim_op(
             body["acquired_at"] = acquired_at
         if conductor:
             body["conductor"] = conductor
+        try:
+            labels = validated_opaque_labels(harness=harness, role=role, job=job, session=session)
+        except ValueError as exc:
+            return ClaimDecision(granted=False, reason="invalid", detail=str(exc), holder=holder)
+        for field, value in labels.items():
+            if value is not None:
+                body[field] = value
         tok = token or config["token"]
         status, payload = _run_with_deadline(
             lambda: _post_claim_blocking(hub, tok, body, timeout=CLAIM_TIMEOUT_SECONDS),
@@ -837,6 +909,10 @@ def acquire_claim(
     holder: str | None = None,
     lock_owner: Mapping[str, object] | None = None,
     supersede_dead_owner: Mapping[str, object] | None = None,
+    harness: str | None = None,
+    role: str | None = None,
+    job: str | None = None,
+    session: str | None = None,
     **kwargs: Any,
 ) -> ClaimDecision:
     """Acquire ``target``; a fresh fencing token is minted unless ``holder``
@@ -860,6 +936,10 @@ def acquire_claim(
         scope="node" if supersede is not None else "holder",
         lock=lease_from_lock_owner(lock_owner),
         supersede=supersede,
+        harness=harness,
+        role=role,
+        job=job,
+        session=session,
         **kwargs,
     )
 

--- a/src/brigade/fleet_dashboard.py
+++ b/src/brigade/fleet_dashboard.py
@@ -41,7 +41,17 @@ DEFAULT_SORT = "attention"
 FILTER_KEYS = ("node", "repo", "seat", "state")
 _MAX_FILTER_LEN = 128
 
-TERMINAL_STATES = frozenset({"run.completed", "run.failed", "run.interrupted"})
+TERMINAL_STATES = frozenset(
+    {
+        "run.completed",
+        "run.failed",
+        "run.interrupted",
+        "verify.completed",
+        "external.completed",
+        "external.failed",
+        "external.canceled",
+    }
+)
 _AWAITING_STATES = frozenset({"run.paused", "approval.requested", "approval.held"})
 
 # Attention buckets in display rank: what needs a human sorts first.
@@ -144,11 +154,17 @@ def _parse_stamp(value: object) -> datetime | None:
     return parsed
 
 
-def bucket_for(state: str, *, age_seconds: float | None) -> str:
+def bucket_for(state: str, *, age_seconds: float | None, exit_status: int | None = None) -> str:
     """Map a run_event type plus its age to an attention bucket."""
-    if state == "run.completed":
+    if state == "verify.completed":
+        if exit_status == 130:
+            return "interrupted"
+        if exit_status not in (None, 0):
+            return "failed"
         return "succeeded"
-    if state == "run.interrupted":
+    if state in {"run.completed", "external.completed"}:
+        return "succeeded"
+    if state in {"run.interrupted", "external.canceled"}:
         return "interrupted"
     if state == "run.failed" or state.endswith(".failed"):
         return "failed"
@@ -182,6 +198,8 @@ def build_rows(
         if started is not None:
             end = now if live or last is None else last
             elapsed = max(0.0, (end - started).total_seconds())
+        raw_exit = run.get("exit_status")
+        exit_status = raw_exit if isinstance(raw_exit, int) and not isinstance(raw_exit, bool) else None
         rows.append(
             RunRow(
                 node_id=node_id,
@@ -190,7 +208,7 @@ def build_rows(
                 seat=str(run.get("seat") or ""),
                 harness=str(run.get("harness") or ""),
                 state=state,
-                bucket=bucket_for(state, age_seconds=age if live else None),
+                bucket=bucket_for(state, age_seconds=age if live else None, exit_status=exit_status),
                 last_ts=last_ts,
                 age_seconds=age,
                 started_epoch=started.timestamp() if started is not None and live else None,
@@ -253,6 +271,10 @@ class ClaimRow:
     target: str
     owner_node: str
     owner_conductor: str
+    harness: str
+    role: str
+    job: str
+    session: str
     ttl_remaining: float | None
     expired: bool
 
@@ -268,6 +290,10 @@ def build_claims(claims: list[dict[str, Any]], *, now: datetime) -> list[ClaimRo
                 target=str(claim.get("target") or ""),
                 owner_node=str(claim.get("owner_node") or ""),
                 owner_conductor=str(claim.get("owner_conductor") or ""),
+                harness=str(claim.get("harness") or ""),
+                role=str(claim.get("role") or ""),
+                job=str(claim.get("job") or ""),
+                session=str(claim.get("session") or ""),
                 ttl_remaining=remaining,
                 expired=expired,
             )
@@ -331,6 +357,10 @@ def _claim_text(claim: ClaimRow) -> str:
     who = short_node(claim.owner_node)
     if claim.owner_conductor:
         who += f" · {claim.owner_conductor}"
+    if claim.harness:
+        who += f" · {claim.harness}"
+    if claim.session:
+        who += f" · {claim.session}"
     if claim.expired:
         return f"{who} (expired)"
     if claim.ttl_remaining is None:

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -154,9 +154,22 @@ EVENT_FIELDS = {
     "digest": str,
 }
 OPTIONAL_STR_FIELDS = ("repo", "seat", "harness")
+OPTIONAL_EVENT_STR_FIELDS = ("capability_fingerprint",)
+OPTIONAL_EVENT_INT_FIELDS = ("exit_status",)
 
-# Terminal run_event.v1 lifecycle types (see run_events.EVENT_TYPES).
-TERMINAL_STATES = frozenset({"run.completed", "run.failed", "run.interrupted"})
+# Terminal run_event.v1 lifecycle types (see run_events.EVENT_TYPES), plus
+# verify/external completions so finished sessions leave the live status view.
+TERMINAL_STATES = frozenset(
+    {
+        "run.completed",
+        "run.failed",
+        "run.interrupted",
+        "verify.completed",
+        "external.completed",
+        "external.failed",
+        "external.canceled",
+    }
+)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS events (
@@ -169,6 +182,8 @@ CREATE TABLE IF NOT EXISTS events (
     harness TEXT,
     state TEXT NOT NULL,
     ts TEXT NOT NULL,
+    exit_status INTEGER,
+    capability_fingerprint TEXT,
     received_at TEXT NOT NULL,
     PRIMARY KEY (node_id, run_id, sequence, digest)
 );
@@ -188,6 +203,10 @@ CREATE TABLE IF NOT EXISTS claims (
     target TEXT NOT NULL PRIMARY KEY,
     owner_node TEXT NOT NULL,
     owner_conductor TEXT,
+    harness TEXT,
+    role TEXT,
+    job TEXT,
+    session TEXT,
     holder_token TEXT NOT NULL,
     acquired_at TEXT NOT NULL,
     renewed_at TEXT NOT NULL,
@@ -198,7 +217,16 @@ CREATE TABLE IF NOT EXISTS claims (
     lock_run_dir TEXT
 );
 """
-_CLAIMS_LEASE_COLUMNS = ("lock_token", "lock_acquired_at", "lock_run_dir")
+_CLAIMS_ADDITIVE_COLUMNS = (
+    "harness",
+    "role",
+    "job",
+    "session",
+    "lock_token",
+    "lock_acquired_at",
+    "lock_run_dir",
+)
+_EVENTS_ADDITIVE_COLUMNS = ("exit_status", "capability_fingerprint")
 
 # Per-node credentials (schema v4, issue #1150): node_id -> SHA-256 of the
 # node's bearer token. The plaintext token is returned once by the add
@@ -216,6 +244,8 @@ CREATE TABLE IF NOT EXISTS nodes (
 # Bounded so a hostile client cannot bloat the row; a lease token is a uuid4
 # hex and an ISO-8601 stamp, a run_dir a filesystem path.
 LEASE_FIELD_MAX_CHARS = 1024
+OPAQUE_LABEL_MAX_CHARS = 128
+OPAQUE_LABEL_FIELDS = ("harness", "role", "job", "session")
 
 
 class FleetHubError(RuntimeError):
@@ -259,7 +289,11 @@ def _claims_table_needs_migration(claims_columns: set[str]) -> bool:
         return True
     if "holder_token" not in claims_columns:
         return True
-    return any(column not in claims_columns for column in _CLAIMS_LEASE_COLUMNS)
+    return any(column not in claims_columns for column in _CLAIMS_ADDITIVE_COLUMNS)
+
+
+def _events_columns(conn: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in conn.execute("PRAGMA table_info(events)").fetchall()}
 
 
 # Intra-process serialization for the claims migration, in addition to the
@@ -318,7 +352,7 @@ def _migrate_claims_table(conn: sqlite3.Connection) -> None:
         # v2 -> v3: the lease columns are nullable, so live claims survive
         # the upgrade (they can never be superseded, only released/expired).
         if claims_columns:
-            for column in _CLAIMS_LEASE_COLUMNS:
+            for column in _CLAIMS_ADDITIVE_COLUMNS:
                 if column in claims_columns:
                     continue
                 try:
@@ -387,6 +421,11 @@ def init_db(db_path: Path) -> sqlite3.Connection:
         conn.execute("PRAGMA busy_timeout=5000")
         _refuse_newer_schema(conn, resolved)
         conn.execute(_SCHEMA)
+        for column in _EVENTS_ADDITIVE_COLUMNS:
+            if column not in _events_columns(conn):
+                conn.execute(
+                    f"ALTER TABLE events ADD COLUMN {column} {'INTEGER' if column == 'exit_status' else 'TEXT'}"
+                )
         if _claims_table_needs_migration(_claims_columns(conn)):
             with _migration_lock(db_path):
                 # Re-check under the lock: the thread that held it first has
@@ -422,6 +461,16 @@ def _validate_event(raw: Any) -> dict[str, Any]:
         if isinstance(value, str):
             _reject_controls(value, field, kind="event")
         event[field] = value if isinstance(value, str) and value.strip() else None
+    for field in OPTIONAL_EVENT_STR_FIELDS:
+        value = raw.get(field)
+        if isinstance(value, str):
+            _reject_controls(value, field, kind="event")
+        event[field] = value if isinstance(value, str) and value.strip() else None
+    for field in OPTIONAL_EVENT_INT_FIELDS:
+        value = raw.get(field)
+        if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value < 0):
+            raise FleetHubError(f"event field {field!r} must be a non-negative integer")
+        event[field] = value
     return event
 
 
@@ -454,8 +503,8 @@ def store_events(conn: sqlite3.Connection, raw_events: Any, *, caller_node: str 
     for event in events:
         cursor = conn.execute(
             "INSERT OR IGNORE INTO events "
-            "(node_id, run_id, sequence, digest, repo, seat, harness, state, ts, received_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "(node_id, run_id, sequence, digest, repo, seat, harness, state, ts, exit_status, "
+            "capability_fingerprint, received_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 event["node_id"],
                 event["run_id"],
@@ -466,6 +515,8 @@ def store_events(conn: sqlite3.Connection, raw_events: Any, *, caller_node: str 
                 event["harness"],
                 event["state"],
                 event["ts"],
+                event["exit_status"],
+                event["capability_fingerprint"],
                 received_at,
             ),
         )
@@ -485,7 +536,7 @@ def latest_status(conn: sqlite3.Connection, *, include_all: bool = False) -> lis
     larger digest, so the view never shows a run twice.
     """
     rows = conn.execute(
-        "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest FROM ("
+        "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, capability_fingerprint FROM ("
         "  SELECT e.*, ROW_NUMBER() OVER ("
         "    PARTITION BY node_id, run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
         "  ) AS rn FROM events e"
@@ -506,6 +557,8 @@ def latest_status(conn: sqlite3.Connection, *, include_all: bool = False) -> lis
                 "ts": row[6],
                 "sequence": row[7],
                 "digest": row[8],
+                "exit_status": row[9],
+                "capability_fingerprint": row[10],
             }
         )
     return result
@@ -585,6 +638,21 @@ def _validate_claim_request(raw: Any) -> dict[str, Any]:
     if isinstance(conductor, str):
         _reject_controls(conductor, "conductor", kind="claim")
     request["conductor"] = conductor.strip() if isinstance(conductor, str) and conductor.strip() else None
+    labels: dict[str, str | None] = {}
+    for field in OPAQUE_LABEL_FIELDS:
+        value = raw.get(field)
+        if value is not None and action != "acquire":
+            raise FleetHubError(f"claim field {field!r} is only valid for acquire")
+        if value is not None and (
+            not isinstance(value, str) or not value.strip() or len(value) > OPAQUE_LABEL_MAX_CHARS
+        ):
+            raise FleetHubError(
+                f"claim field {field!r} must be a non-empty string at most {OPAQUE_LABEL_MAX_CHARS} characters"
+            )
+        if isinstance(value, str):
+            _reject_controls(value, field, kind="claim")
+        labels[field] = value.strip() if isinstance(value, str) and value.strip() else None
+    request["labels"] = labels
     ttl = raw.get("ttl_seconds", DEFAULT_CLAIM_TTL_SECONDS)
     if not isinstance(ttl, int) or isinstance(ttl, bool) or not CLAIM_TTL_MIN_SECONDS <= ttl <= CLAIM_TTL_MAX_SECONDS:
         raise FleetHubError(
@@ -645,21 +713,27 @@ def _claim_payload(row: tuple[Any, ...]) -> dict[str, Any]:
         "target": row[0],
         "owner_node": row[1],
         "owner_conductor": row[2],
-        "acquired_at": row[3],
-        "renewed_at": row[4],
-        "ttl_seconds": row[5],
-        "expires_at": _epoch_to_iso(row[6]),
+        "harness": row[3],
+        "role": row[4],
+        "job": row[5],
+        "session": row[6],
+        "acquired_at": row[7],
+        "renewed_at": row[8],
+        "ttl_seconds": row[9],
+        "expires_at": _epoch_to_iso(row[10]),
     }
 
 
 # Payload columns only: holder_token is a fencing capability and is never
 # serialized to callers (it would let anyone forge a renew/release).
-_CLAIM_COLUMNS = "target, owner_node, owner_conductor, acquired_at, renewed_at, ttl_seconds, expires_at"
+_CLAIM_COLUMNS = (
+    "target, owner_node, owner_conductor, harness, role, job, session, acquired_at, renewed_at, ttl_seconds, expires_at"
+)
 
 
 def _fetch_claim(conn: sqlite3.Connection, target: str) -> tuple[Any, ...] | None:
     """Row as (_CLAIM_COLUMNS..., holder_token, lock_token, lock_acquired_at,
-    lock_run_dir); the fencing token is index 7, the lease token index 8."""
+    lock_run_dir); the fencing token is index 11, the lease token index 12."""
     return conn.execute(
         f"SELECT {_CLAIM_COLUMNS}, holder_token, lock_token, lock_acquired_at, lock_run_dir "
         "FROM claims WHERE target = ?",
@@ -713,15 +787,16 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
     holder = request["holder"]
     ttl = request["ttl_seconds"]
     scope = request["scope"]
+    labels = request["labels"]
     now = _now_epoch()
     now_iso = _epoch_to_iso(now)
     if request["action"] == "inspect":
         row = _fetch_claim(conn, target)
-        if row is None or row[6] <= now:
+        if row is None or row[10] <= now:
             return 200, {"inspected": True, "claim": None, "owned": False}
         inspected: dict[str, Any] = {"inspected": True, "claim": _claim_payload(row), "owned": row[1] == node}
         if row[1] == node:
-            inspected["lock_run_dir"] = row[10]
+            inspected["lock_run_dir"] = row[14]
         return 200, inspected
     if request["action"] == "acquire":
         # One write transaction: the prune, the prior-row read that the
@@ -735,12 +810,17 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         supersede = request["supersede"] or {"token": None, "acquired_at": None}
         cursor = conn.execute(
             "INSERT INTO claims "
-            "(target, owner_node, owner_conductor, holder_token, lock_token, lock_acquired_at, lock_run_dir, "
+            "(target, owner_node, owner_conductor, harness, role, job, session, holder_token, "
+            "lock_token, lock_acquired_at, lock_run_dir, "
             "acquired_at, renewed_at, ttl_seconds, expires_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(target) DO UPDATE SET "
             "owner_node = excluded.owner_node, "
             "owner_conductor = excluded.owner_conductor, "
+            "harness = excluded.harness, "
+            "role = excluded.role, "
+            "job = excluded.job, "
+            "session = excluded.session, "
             "holder_token = excluded.holder_token, "
             "lock_token = excluded.lock_token, "
             "lock_acquired_at = excluded.lock_acquired_at, "
@@ -761,6 +841,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
                 target,
                 node,
                 conductor,
+                labels["harness"],
+                labels["role"],
+                labels["job"],
+                labels["session"],
                 holder,
                 lock["token"],
                 lock["acquired_at"],
@@ -780,9 +864,21 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         conn.commit()
         if cursor.rowcount == 1:
             row = _fetch_claim(conn, target)
-            written = (target, node, conductor, now_iso, now_iso, ttl, now + ttl)
+            written = (
+                target,
+                node,
+                conductor,
+                labels["harness"],
+                labels["role"],
+                labels["job"],
+                labels["session"],
+                now_iso,
+                now_iso,
+                ttl,
+                now + ttl,
+            )
             granted: dict[str, Any] = {"granted": True, "claim": _claim_payload(row if row is not None else written)}
-            if prior is not None and prior[7] != holder:
+            if prior is not None and prior[11] != holder:
                 granted["superseded"] = _claim_payload(prior)
             return 200, granted
         row = _fetch_claim(conn, target)
@@ -801,10 +897,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         conn.commit()
         if cursor.rowcount == 1:
             row = _fetch_claim(conn, target)
-            written = (target, node, conductor, now_iso, now_iso, ttl, now + ttl)
+            written = (target, node, conductor, None, None, None, None, now_iso, now_iso, ttl, now + ttl)
             return 200, {"renewed": True, "claim": _claim_payload(row if row is not None else written)}
         row = _fetch_claim(conn, target)
-        if row is not None and row[6] > now and (row[7] != holder or row[1] != node):
+        if row is not None and row[10] > now and (row[11] != holder or row[1] != node):
             return 409, {
                 "renewed": False,
                 "error": f"target {target!r} is held by {row[1]}",
@@ -851,7 +947,7 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         if scope != "force" and row[1] != node:
             error = f"target {target!r} is held by {row[1]}, not {node}"
         else:
-            error = f"target {target!r} was re-acquired since it was inspected (now acquired {row[3]})"
+            error = f"target {target!r} was re-acquired since it was inspected (now acquired {row[7]})"
         return 409, {"released": False, "error": error, "owner": _claim_payload(row)}
     return 200, {"released": False}
 
@@ -862,7 +958,7 @@ def list_claims(conn: sqlite3.Connection, *, include_all: bool = False) -> list[
     rows = conn.execute(f"SELECT {_CLAIM_COLUMNS} FROM claims ORDER BY target").fetchall()
     result = []
     for row in rows:
-        expired = row[6] <= now
+        expired = row[10] <= now
         if expired and not include_all:
             continue
         payload = _claim_payload(row)

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -7,6 +7,7 @@ identity, target, role, or lease duration.
 
 from __future__ import annotations
 
+import hashlib
 import hmac
 import ipaddress
 import json
@@ -17,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from . import grokbot_jobs
+from . import fleet_client, grokbot_jobs
 
 
 DEFAULT_BIND = "127.0.0.1:8766"
@@ -26,6 +27,9 @@ LEASE_SECONDS = 300
 MAX_LISTED_JOBS = 100
 SDK_LOOPBACK_ALLOWED_HOSTS = ("localhost", "localhost:*", "127.0.0.1", "127.0.0.1:*", "::1", "[::1]:*")
 INSTANCES = frozenset({"operator", "repository-scout", "implementation-worker"})
+_FLEET_HOLDER_DOMAIN = b"brigade.grokbot.fleet-holder"
+_FLEET_SESSION_DOMAIN = b"brigade.grokbot.fleet-session"
+_FLEET_BEST_EFFORT = frozenset({"no-hub", "no-identity", "hub-unavailable"})
 ENVIRONMENT_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,127}$")
 
 OPERATOR_TOOLS = frozenset(
@@ -183,33 +187,114 @@ class GrokbotAdapter:
             return operation(self.config.target, job_id)
         if name == "grokbot_queue_claim":
             job = self._eligible_job(arguments, allowed={"job_id", "lease_id"})
-            return grokbot_jobs.claim_execution_context(
-                self.config.target, job["job_id"], self.config.bot_id, _lease_id(arguments), LEASE_SECONDS
-            )
+            lease_id = _lease_id(arguments)
+            holder, session = fleet_holder(job["job_id"], lease_id), fleet_session(job["job_id"], lease_id)
+            decision = self._fleet_acquire(job["job_id"], holder, session)
+            if _fleet_refused(decision):
+                raise AdapterError()
+            try:
+                result = grokbot_jobs.claim_execution_context(
+                    self.config.target, job["job_id"], self.config.bot_id, lease_id, LEASE_SECONDS
+                )
+            except Exception:
+                if decision.granted:
+                    self._fleet_release(holder)
+                raise
+            self._fleet_event(job["job_id"], session, "external.claimed")
+            return result
         if name == "grokbot_queue_renew":
             job_id, lease_id = _job_id(arguments, {"job_id", "lease_id"}), _lease_id(arguments)
-            return grokbot_jobs.renew(self.config.target, job_id, self.config.bot_id, lease_id, LEASE_SECONDS)
+            holder, session = fleet_holder(job_id, lease_id), fleet_session(job_id, lease_id)
+            decision = self._fleet_renew(holder)
+            if not decision.granted and decision.reason == "missing":
+                decision = self._fleet_acquire(job_id, holder, session)
+            if _fleet_refused(decision):
+                raise AdapterError()
+            try:
+                result = grokbot_jobs.renew(self.config.target, job_id, self.config.bot_id, lease_id, LEASE_SECONDS)
+            except Exception:
+                if decision.granted:
+                    self._fleet_release(holder)
+                raise
+            self._fleet_event(job_id, session, "external.heartbeat")
+            return result
         if name in {"grokbot_queue_start", "grokbot_queue_fail", "grokbot_queue_ack_cancel"}:
             job_id, lease_id = _job_id(arguments, {"job_id", "lease_id"}), _lease_id(arguments)
+            holder, session = fleet_holder(job_id, lease_id), fleet_session(job_id, lease_id)
             if name.endswith("start"):
-                return grokbot_jobs.transition(self.config.target, job_id, self.config.bot_id, lease_id, "running")
+                result = grokbot_jobs.transition(self.config.target, job_id, self.config.bot_id, lease_id, "running")
+                self._fleet_event(job_id, session, "external.running")
+                return result
             if name.endswith("fail"):
-                return grokbot_jobs.transition(self.config.target, job_id, self.config.bot_id, lease_id, "failed")
-            return grokbot_jobs.acknowledge_cancel(self.config.target, job_id, self.config.bot_id, lease_id)
+                result = grokbot_jobs.transition(self.config.target, job_id, self.config.bot_id, lease_id, "failed")
+                self._fleet_event(job_id, session, "external.failed")
+                self._fleet_release(holder)
+                return result
+            result = grokbot_jobs.acknowledge_cancel(self.config.target, job_id, self.config.bot_id, lease_id)
+            self._fleet_event(job_id, session, "external.canceled")
+            self._fleet_release(holder)
+            return result
         if name == "grokbot_queue_complete":
             job = self._eligible_job(arguments, allowed={"job_id", "lease_id", "artifact"})
             artifact = arguments.get("artifact")
             if not isinstance(artifact, dict):
                 raise AdapterError()
-            return grokbot_jobs.transition(
+            lease_id = _lease_id(arguments)
+            holder, session = fleet_holder(job["job_id"], lease_id), fleet_session(job["job_id"], lease_id)
+            result = grokbot_jobs.transition(
                 self.config.target,
                 job["job_id"],
                 self.config.bot_id,
-                _lease_id(arguments),
+                lease_id,
                 "completed",
                 artifact=artifact,
             )
+            self._fleet_event(job["job_id"], session, "external.completed")
+            self._fleet_release(holder)
+            return result
         raise AdapterError()
+
+    def _fleet_target(self) -> str:
+        return fleet_client.resolve_claim_target(self.config.target)
+
+    def _fleet_acquire(self, job_id: str, holder: str, session: str) -> fleet_client.ClaimDecision:
+        try:
+            return fleet_client.acquire_claim(
+                self._fleet_target(),
+                holder=holder,
+                ttl_seconds=LEASE_SECONDS,
+                harness="grokbot",
+                role=self.config.instance,
+                job=job_id,
+                session=session,
+            )
+        except Exception:
+            return fleet_client.ClaimDecision(granted=False, reason="hub-unavailable", holder=holder)
+
+    def _fleet_renew(self, holder: str) -> fleet_client.ClaimDecision:
+        try:
+            return fleet_client.renew_claim(self._fleet_target(), holder=holder, ttl_seconds=LEASE_SECONDS)
+        except Exception:
+            return fleet_client.ClaimDecision(granted=False, reason="hub-unavailable", holder=holder)
+
+    def _fleet_release(self, holder: str) -> None:
+        try:
+            fleet_client.release_claim(self._fleet_target(), holder=holder)
+        except Exception:
+            return
+
+    def _fleet_event(self, job_id: str, session: str, state: str) -> None:
+        try:
+            fleet_client.report_external_event(
+                target=self._fleet_target(),
+                harness="grokbot",
+                role=self.config.instance,
+                job=job_id,
+                session=session,
+                state=state,
+            )
+        except Exception:
+            return
 
     def _eligible_job(self, arguments: dict[str, Any], allowed: set[str] | None = None) -> dict[str, Any]:
         job_id = _job_id(arguments, allowed or {"job_id"})
@@ -467,6 +552,25 @@ def _lease_id(arguments: dict[str, Any]) -> str:
     if not isinstance(lease_id, str):
         raise AdapterError()
     return lease_id
+
+
+def _fleet_derivation_message(job_id: str, lease_id: str) -> bytes:
+    """Length-prefixed so job_id and lease_id cannot collide across concatenations."""
+    return f"{len(job_id)}:{job_id}:{len(lease_id)}:{lease_id}".encode("utf-8")
+
+
+def fleet_holder(job_id: str, lease_id: str) -> str:
+    """Full fencing token derived from the job-scoped queue lease, never the lease itself."""
+    return hmac.new(_FLEET_HOLDER_DOMAIN, _fleet_derivation_message(job_id, lease_id), hashlib.sha256).hexdigest()
+
+
+def fleet_session(job_id: str, lease_id: str) -> str:
+    """Opaque non-capability session label, domain-separated from the holder."""
+    return hmac.new(_FLEET_SESSION_DOMAIN, _fleet_derivation_message(job_id, lease_id), hashlib.sha256).hexdigest()[:32]
+
+
+def _fleet_refused(decision: fleet_client.ClaimDecision) -> bool:
+    return not decision.granted and decision.reason not in _FLEET_BEST_EFFORT
 
 
 def _valid_tool_arguments(name: object, arguments: object) -> bool:

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -687,6 +687,35 @@ def _safe_finalize_verify_receipt(
         return receipt, rc
 
 
+def _report_fleet_completion(target: Path, receipt: dict[str, Any], rc: int) -> None:
+    """Publish one redacted verify receipt outcome through Fleet's spool path."""
+    try:
+        from .. import fleet_client, outcome_cmd
+
+        digests = receipt.get("digests")
+        digest = digests.get("receipt_sha256") if isinstance(digests, dict) else None
+        run_id = receipt.get("run_id")
+        completed_at = receipt.get("completed_at")
+        if not all(isinstance(value, str) and value for value in (digest, run_id, completed_at)):
+            return
+        fleet_client.report_event(
+            {
+                "run_id": run_id,
+                "repo": target.name,
+                "harness": "brigade-work",
+                "state": "verify.completed",
+                "ts": completed_at,
+                "sequence": 0,
+                "digest": digest,
+                "exit_status": 128 + (-rc) if rc < 0 else rc,
+                "capability_fingerprint": outcome_cmd.capability_fingerprint(outcome_cmd.context_manifest()),
+            },
+            base_path=target,
+        )
+    except Exception:
+        return
+
+
 VERIFY_RUNS_KEEP = config.DEFAULT_VERIFY_RUNS_KEEP
 
 VERIFY_ARCHIVE_INDEX_NAME = "index.jsonl"
@@ -1698,6 +1727,7 @@ def _run_verify_commands(
             )
             finalized = True
     assert receipt is not None
+    _report_fleet_completion(target, receipt, rc)
     return receipt, rc
 
 
@@ -1756,6 +1786,7 @@ def _write_reused_receipt(
         _prune_verify_runs(target)
     except Exception:
         pass
+    _report_fleet_completion(target, receipt, 0)
     return receipt, 0
 
 

--- a/tests/test_fleet_claim_release.py
+++ b/tests/test_fleet_claim_release.py
@@ -273,6 +273,7 @@ class TestHubScopes:
         status, payload = _post(url, token, release)
         assert status == 409 and payload["released"] is False
         assert "re-acquired" in payload["error"] and payload["owner"]["owner_conductor"] == "new-run"
+        assert f"now acquired {payload['owner']['acquired_at']}" in payload["error"]
         assert _post(url, token, _claim("renew", holder="fresh"))[1]["renewed"] is True
         # The current row's acquired_at releases it; force is fenced too when given.
         current = _post(url, token, inspect)[1]["claim"]["acquired_at"]
@@ -703,7 +704,10 @@ class TestReleaseCli:
 
         monkeypatch.setattr(fleet_client, "inspect_claim", inspect_then_new_run)
         assert cli.main(["fleet", "claims", "--release", "api"]) == 1
-        assert "re-acquired since it was inspected" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "re-acquired since it was inspected" in err
+        fresh = fleet_client.fetch_claims()[0]
+        assert fresh["acquired_at"] in err
         # 409, nothing deleted: the fresh run's claim survives and renews.
         assert [c["owner_conductor"] for c in fleet_client.fetch_claims()] == ["new-run"]
         assert _post(url, token, _claim("renew", target="api", holder="fresh"))[1]["renewed"] is True

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -257,6 +257,59 @@ class TestHeartbeatCredentialRefusal:
 
 
 class TestHubClaims:
+    def test_acquire_preserves_validated_external_harness_labels(self, hub):
+        url, token, _db = hub
+        status, payload = _post(
+            url,
+            token,
+            _claim(
+                harness="grokbot",
+                role="implementation-worker",
+                job="grokbot-" + "a" * 24,
+                session="lease-a",
+            ),
+        )
+
+        assert status == 200 and payload["granted"] is True
+        claim = payload["claim"]
+        assert {key: claim[key] for key in ("harness", "role", "job", "session")} == {
+            "harness": "grokbot",
+            "role": "implementation-worker",
+            "job": "grokbot-" + "a" * 24,
+            "session": "lease-a",
+        }
+        assert "holder_token" not in claim
+        listed = _get(url, "/claims", token)[1]["claims"]
+        assert len(listed) == 1
+        assert {key: listed[0][key] for key in ("harness", "role", "job", "session")} == {
+            "harness": "grokbot",
+            "role": "implementation-worker",
+            "job": "grokbot-" + "a" * 24,
+            "session": "lease-a",
+        }
+
+    def test_acquire_rejects_invalid_opaque_labels(self, hub):
+        url, token, _db = hub
+        for field, value, status in (
+            ("harness", " ", 400),
+            ("role", "x" * 129, 400),
+            ("job", "job\x1b[31m", 422),
+            ("session", "lease\x07", 422),
+        ):
+            code, payload = _post(url, token, _claim(**{field: value}))
+            assert code == status, (field, value, code, payload)
+            assert field in payload["error"] or "control" in payload["error"]
+        assert _get(url, "/claims", token)[1]["claims"] == []
+
+    def test_opaque_labels_are_acquire_only(self, hub):
+        url, token, _db = hub
+        assert _post(url, token, _claim(harness="grokbot", session="lease-a"))[0] == 200
+        for action in ("renew", "release"):
+            status, payload = _post(url, token, _claim(action, harness="grokbot"))
+            assert status == 400, action
+            assert "harness" in payload["error"]
+        assert _get(url, "/claims", token)[1]["claims"][0]["harness"] == "grokbot"
+
     def test_claims_require_auth(self, hub):
         url, _token, _db = hub
         assert _post(url, "", _claim())[0] == 401
@@ -854,6 +907,32 @@ class TestClientClaims:
             assert fleet_client.fetch_claims(include_all=True) == [], "released claim was resurrected"
             time.sleep(0.02)
 
+    def test_client_rejects_invalid_opaque_labels_without_posting(self, hub, monkeypatch):
+        url, token, _db = hub
+        monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", url)
+        monkeypatch.setenv("BRIGADE_FLEET_TOKEN", token)
+        posted: list[dict[str, object]] = []
+        real = fleet_client._post_claim_blocking
+
+        def capture(hub_url, tok, body, *, timeout):
+            posted.append(body)
+            return real(hub_url, tok, body, timeout=timeout)
+
+        monkeypatch.setattr(fleet_client, "_post_claim_blocking", capture)
+        for kwargs in (
+            {"harness": " "},
+            {"role": "x" * 129},
+            {"job": "job\x1b[31m"},
+            {"session": "lease\x07"},
+        ):
+            decision = fleet_client.acquire_claim("repo-a", node_id=NODE_A, **kwargs)
+            assert decision.granted is False
+            assert decision.reason != "ok"
+        assert posted == []
+        assert fleet_client.acquire_claim("repo-a", node_id=NODE_A, harness="grokbot", session="lease-a").granted
+        assert posted[-1]["harness"] == "grokbot"
+        assert posted[-1]["session"] == "lease-a"
+
     def test_resolve_claim_target_uses_workspace_name(self, tmp_path, monkeypatch):
         from brigade import node as node_mod
 
@@ -934,6 +1013,367 @@ class TestFleetClaimsCli:
         monkeypatch.delenv("BRIGADE_FLEET_HUB_URL", raising=False)
         assert cli.main(["fleet", "claims"]) == 1
         assert "no fleet hub configured" in capsys.readouterr().err
+
+    def _session_env(self, hub, tmp_path, monkeypatch):
+        url, token, _db = hub
+        home = tmp_path / "home"
+        monkeypatch.setenv("BRIGADE_HOME", str(home))
+        _plant_home_identity(home, NODE_A)
+        monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", url)
+        monkeypatch.setenv("BRIGADE_FLEET_TOKEN", token)
+        return url, token
+
+    def test_acquire_heartbeat_and_holder_release_fence_the_session(self, hub, tmp_path, monkeypatch, capsys):
+        from brigade import cli
+
+        self._session_env(hub, tmp_path, monkeypatch)
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--acquire",
+                    "repo-a",
+                    "--harness",
+                    "t3",
+                    "--session",
+                    "sess-1",
+                    "--role",
+                    "coder",
+                    "--job",
+                    "job-1",
+                    "--holder",
+                    "holder-a",
+                    "--json",
+                ]
+            )
+            == 0
+        )
+        acquired = json.loads(capsys.readouterr().out)
+        assert acquired["granted"] is True
+        assert acquired["holder"] == "holder-a"
+        assert {key: acquired["claim"][key] for key in ("harness", "role", "job", "session")} == {
+            "harness": "t3",
+            "role": "coder",
+            "job": "job-1",
+            "session": "sess-1",
+        }
+        assert "holder_token" not in acquired["claim"]
+        assert cli.main(["fleet", "claims", "--heartbeat", "repo-a", "--holder", "holder-b"]) == 1
+        assert "held" in capsys.readouterr().err or "holder" in capsys.readouterr().err
+        assert cli.main(["fleet", "claims", "--heartbeat", "repo-a", "--holder", "holder-a", "--json"]) == 0
+        assert json.loads(capsys.readouterr().out)["renewed"] is True
+        assert cli.main(["fleet", "claims", "--release", "repo-a", "--holder", "holder-b"]) == 1
+        assert _get(hub[0], "/claims", hub[1])[1]["claims"]
+        assert cli.main(["fleet", "claims", "--release", "repo-a", "--holder", "holder-a", "--json"]) == 0
+        released = json.loads(capsys.readouterr().out)
+        assert released["released"] is True
+        assert released.get("forced") is not True
+        assert _get(hub[0], "/claims", hub[1])[1]["claims"] == []
+
+    def test_holder_release_reports_terminal_outcome_without_queue_content(self, hub, tmp_path, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token = self._session_env(hub, tmp_path, monkeypatch)
+        events: list[dict[str, object]] = []
+        monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: events.append(kwargs) or True)
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--acquire",
+                    "repo-a",
+                    "--harness",
+                    "cursor-cloud",
+                    "--session",
+                    "sess-2",
+                    "--holder",
+                    "holder-c",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--release",
+                    "repo-a",
+                    "--holder",
+                    "holder-c",
+                    "--outcome",
+                    "external.completed",
+                    "--harness",
+                    "cursor-cloud",
+                    "--session",
+                    "sess-2",
+                    "--json",
+                ]
+            )
+            == 0
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["released"] is True
+        assert events == [
+            {
+                "target": "repo-a",
+                "harness": "cursor-cloud",
+                "role": None,
+                "job": None,
+                "session": "sess-2",
+                "state": "external.completed",
+            }
+        ]
+        assert "prompt" not in json.dumps(events)
+        assert "holder-c" not in json.dumps(events)
+        listed = _get(url, "/claims", token)[1]["claims"]
+        assert listed == []
+
+    def test_wrong_holder_outcome_releases_nothing_and_publishes_nothing(self, hub, tmp_path, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token = self._session_env(hub, tmp_path, monkeypatch)
+        events: list[dict[str, object]] = []
+        monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: events.append(kwargs) or True)
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--acquire",
+                    "repo-a",
+                    "--harness",
+                    "t3",
+                    "--session",
+                    "sess-3",
+                    "--holder",
+                    "holder-c",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--release",
+                    "repo-a",
+                    "--holder",
+                    "holder-wrong",
+                    "--outcome",
+                    "external.failed",
+                    "--harness",
+                    "t3",
+                    "--session",
+                    "sess-3",
+                    "--json",
+                ]
+            )
+            == 1
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["released"] is False
+        assert payload.get("outcome") in (None, "external.failed")
+        assert events == []
+        listed = _get(url, "/claims", token)[1]["claims"]
+        assert [claim["session"] for claim in listed] == ["sess-3"]
+
+    def test_holder_release_reports_outcome_only_after_granted_release(self, hub, tmp_path, monkeypatch, capsys):
+        from brigade import cli
+
+        self._session_env(hub, tmp_path, monkeypatch)
+        order: list[str] = []
+        real_release = fleet_client.release_claim
+
+        def release(target, **kwargs):
+            order.append("release")
+            return real_release(target, **kwargs)
+
+        monkeypatch.setattr(fleet_client, "release_claim", release)
+        monkeypatch.setattr(
+            fleet_client,
+            "report_external_event",
+            lambda **kwargs: order.append("event") or True,
+        )
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--acquire",
+                    "repo-a",
+                    "--harness",
+                    "cursor-cloud",
+                    "--session",
+                    "sess-4",
+                    "--holder",
+                    "holder-d",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--release",
+                    "repo-a",
+                    "--holder",
+                    "holder-d",
+                    "--outcome",
+                    "external.completed",
+                    "--harness",
+                    "cursor-cloud",
+                    "--session",
+                    "sess-4",
+                    "--json",
+                ]
+            )
+            == 0
+        )
+        assert order == ["release", "event"]
+
+    def test_holder_release_rejects_invalid_opaque_labels_without_releasing(self, hub, tmp_path, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token = self._session_env(hub, tmp_path, monkeypatch)
+        events: list[dict[str, object]] = []
+        monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: events.append(kwargs) or True)
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--acquire",
+                    "repo-a",
+                    "--harness",
+                    "cursor-cloud",
+                    "--session",
+                    "sess-5",
+                    "--holder",
+                    "holder-e",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        invalid = (
+            ("--harness", "x" * 129),
+            ("--session", "sess\x07"),
+            ("--role", "x" * 129),
+            ("--job", "job\x1b[31m"),
+        )
+        for flag, value in invalid:
+            argv = [
+                "fleet",
+                "claims",
+                "--release",
+                "repo-a",
+                "--holder",
+                "holder-e",
+                "--outcome",
+                "external.completed",
+                "--harness",
+                "cursor-cloud",
+                "--session",
+                "sess-5",
+                flag,
+                value,
+            ]
+            assert cli.main(argv) == 2
+            err = capsys.readouterr().err
+            assert "control" in err or "at most" in err or "non-empty" in err
+        assert events == []
+        listed = _get(url, "/claims", token)[1]["claims"]
+        assert [claim["session"] for claim in listed] == ["sess-5"]
+
+    def test_holder_release_uses_normalized_opaque_labels(self, hub, tmp_path, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token = self._session_env(hub, tmp_path, monkeypatch)
+        events: list[dict[str, object]] = []
+        monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: events.append(kwargs) or True)
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--acquire",
+                    "repo-a",
+                    "--harness",
+                    "cursor-cloud",
+                    "--session",
+                    "sess-6",
+                    "--role",
+                    "worker",
+                    "--job",
+                    "job-6",
+                    "--holder",
+                    "holder-f",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "claims",
+                    "--release",
+                    "repo-a",
+                    "--holder",
+                    "holder-f",
+                    "--outcome",
+                    "external.completed",
+                    "--harness",
+                    "  cursor-cloud  ",
+                    "--session",
+                    "  sess-6  ",
+                    "--role",
+                    "  worker  ",
+                    "--job",
+                    "  job-6  ",
+                    "--json",
+                ]
+            )
+            == 0
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["released"] is True
+        assert payload["outcome"] == "external.completed"
+        assert events == [
+            {
+                "target": "repo-a",
+                "harness": "cursor-cloud",
+                "role": "worker",
+                "job": "job-6",
+                "session": "sess-6",
+                "state": "external.completed",
+            }
+        ]
+        assert _get(url, "/claims", token)[1]["claims"] == []
+
+    def test_claims_table_renders_external_harness_labels(self, hub, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token, _db = hub
+        monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", url)
+        monkeypatch.setenv("BRIGADE_FLEET_TOKEN", token)
+        _post(url, token, _claim(harness="grokbot", role="implementation-worker", job="job-9", session="lease-z"))
+        assert cli.main(["fleet", "claims"]) == 0
+        out = capsys.readouterr().out
+        header = out.splitlines()[0]
+        assert "harness" in header and "session" in header
+        assert "grokbot" in out and "lease-z" in out
+        assert "holder_token" not in out
 
 
 class TestDispatchWiring:

--- a/tests/test_fleet_dashboard.py
+++ b/tests/test_fleet_dashboard.py
@@ -202,6 +202,63 @@ class TestBoards:
         repo_c = by_repo["repo-c"]
         assert "idle" in repo_c and "succeeded" in repo_c
 
+    def test_claims_and_boards_render_external_labels_and_hide_finished_verify(self, hub):
+        now = datetime.now(timezone.utc).isoformat()
+        events = [
+            {
+                **_event(NODE_A, "ext-1", 1, "external.claimed", repo="repo-x", harness="grokbot", ts=now),
+                "seat": "implementation-worker",
+            },
+            {
+                **_event(NODE_A, "vr-1", 1, "verify.completed", repo="repo-x", harness="brigade-work", ts=now),
+                "exit_status": 0,
+                "capability_fingerprint": "fp-1",
+            },
+        ]
+        status, _headers, text = _request(hub, "POST", "/events", headers=_bearer(), body=events)
+        assert status == 200, text
+        claim = {
+            "action": "acquire",
+            "target": "repo-x",
+            "node_id": NODE_A,
+            "holder": "holder-secret",
+            "harness": "grokbot",
+            "role": "implementation-worker",
+            "job": "job-x",
+            "session": "lease-x",
+        }
+        status, _headers, text = _request(hub, "POST", "/claims", headers=_bearer(), body=claim)
+        assert status == 200, text
+        _status, _headers, text = _request(hub, "GET", "/", headers=_bearer())
+        assert "repo-x" in text
+        assert "grokbot" in text and "lease-x" in text
+        assert "holder-secret" not in text
+        assert "vr-1" not in text
+        _status, _headers, all_text = _request(hub, "GET", "/?all=1", headers=_bearer())
+        assert "vr-1" in all_text
+        assert "succeeded" in all_text
+        assert "holder-secret" not in all_text
+
+    def test_finished_verify_buckets_use_exit_status(self, hub):
+        now = datetime.now(timezone.utc).isoformat()
+        events = [
+            {
+                **_event(NODE_A, "vr-fail", 1, "verify.completed", repo="repo-fail", harness="brigade-work", ts=now),
+                "exit_status": 1,
+            },
+            {
+                **_event(NODE_A, "vr-int", 1, "verify.completed", repo="repo-int", harness="brigade-work", ts=now),
+                "exit_status": 130,
+            },
+        ]
+        status, _headers, text = _request(hub, "POST", "/events", headers=_bearer(), body=events)
+        assert status == 200, text
+        _status, _headers, all_text = _request(hub, "GET", "/?all=1", headers=_bearer())
+        fail_row = next(row for row in all_text.split("<tr") if "vr-fail" in row)
+        int_row = next(row for row in all_text.split("<tr") if "vr-int" in row)
+        assert 'data-bucket="failed"' in fail_row
+        assert 'data-bucket="interrupted"' in int_row
+
     def test_empty_hub_renders(self, hub):
         _status, _headers, text = _request(hub, "GET", "/", headers=_bearer())
         assert "No fleet events recorded yet." in text
@@ -300,6 +357,10 @@ class TestPureRendering:
         assert fleet_dashboard.bucket_for("run.dispatch.observed", age_seconds=0) == "running"
         assert fleet_dashboard.bucket_for("run.dispatch.observed", age_seconds=3600) == "stale"
         assert fleet_dashboard.bucket_for("run.paused", age_seconds=3600) == "awaiting approval"
+        assert fleet_dashboard.bucket_for("verify.completed", age_seconds=0, exit_status=0) == "succeeded"
+        assert fleet_dashboard.bucket_for("verify.completed", age_seconds=0, exit_status=130) == "interrupted"
+        assert fleet_dashboard.bucket_for("verify.completed", age_seconds=0, exit_status=1) == "failed"
+        assert fleet_dashboard.bucket_for("verify.completed", age_seconds=0, exit_status=137) == "failed"
 
     def test_parse_query_sanitises(self):
         query = fleet_dashboard.parse_query("sort=bogus&node=" + "x" * 500 + "&attention=yes&all=0", view="nope")

--- a/tests/test_fleet_sync.py
+++ b/tests/test_fleet_sync.py
@@ -161,6 +161,29 @@ class TestHub:
         assert len(_get(url, "/status?all=true", token)[1]["runs"]) == 1
         assert len(_get(url, "/status?x=1&all=1", token)[1]["runs"]) == 1
 
+    def test_verify_and_external_completion_are_terminal_and_drop_secrets(self, hub):
+        url, token, _db = hub
+        verify = {
+            **_event(run_id="vr1", state="verify.completed", digest="dv"),
+            "exit_status": 0,
+            "capability_fingerprint": "fp-verify",
+            "token": "secret-token",
+            "headers": {"Authorization": "Bearer leaked"},
+            "artifact": {"diff": "NOPE"},
+        }
+        external = {**_event(run_id="ex1", state="external.completed", digest="de"), "prompt": "do not store"}
+        assert _post(url, token, [verify, external])[0] == 200
+        assert _get(url, "/status", token)[1]["runs"] == []
+        rows = {row["run_id"]: row for row in _get(url, "/status?all=1", token)[1]["runs"]}
+        assert rows["vr1"]["exit_status"] == 0
+        assert rows["vr1"]["capability_fingerprint"] == "fp-verify"
+        assert rows["ex1"]["state"] == "external.completed"
+        dumped = json.dumps(list(rows.values()))
+        assert "secret-token" not in dumped
+        assert "Bearer leaked" not in dumped
+        assert "NOPE" not in dumped
+        assert "do not store" not in dumped
+
     def test_batch_with_one_bad_event_stores_nothing(self, hub):
         url, token, db = hub
         status, _payload = _post(url, token, [_event(seq=1), {"node_id": "x"}])
@@ -585,6 +608,21 @@ class TestCli:
         out = capsys.readouterr().out
         assert "repo-a" in out and "worker/claude" in out and "run.created" in out
         assert out.splitlines()[0].split()[-1] == "age"
+
+    def test_status_table_shows_verify_exit_without_receipt_body(self, hub, monkeypatch, capsys):
+        from brigade import cli
+
+        url, token, _db = hub
+        monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", url)
+        monkeypatch.setenv("BRIGADE_FLEET_TOKEN", token)
+        event = {**_event(run_id="vr-status", state="verify.completed"), "exit_status": 3}
+        assert _post(url, token, event)[0] == 200
+        assert cli.main(["fleet", "status", "--all"]) == 0
+        out = capsys.readouterr().out
+        header = out.splitlines()[0]
+        assert "exit" in header
+        assert "verify.completed" in out and "3" in out
+        assert "commands" not in out and "stdout" not in out
 
     def test_status_table_renders_legacy_nonprintables_inert(self, hub, monkeypatch, capsys):
         from brigade import cli

--- a/tests/test_grokbot_mcp.py
+++ b/tests/test_grokbot_mcp.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, grokbot_jobs, grokbot_mcp
+from brigade import cli, fleet_client, grokbot_jobs, grokbot_mcp
 
 
 def _spec(role: str) -> dict[str, object]:
@@ -103,6 +103,459 @@ def test_workers_only_list_claim_and_read_their_configured_role(tmp_path: Path):
     assert "PRIVATE_INSTRUCTIONS_MUST_NOT_LEAK" not in json.dumps(listed)
     assert "execution_context" not in worker.call_tool("grokbot_queue_status", {"job_id": implementation})
     assert grokbot_jobs.get_job(tmp_path, implementation)["role"] == "implementation-worker"
+
+
+def test_worker_lifecycle_is_mirrored_to_the_fleet_without_queue_content(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def claim(target, **kwargs):
+        calls.append(("claim", {"target": target, **kwargs}))
+        return fleet_client.ClaimDecision(granted=True, reason="ok", holder=str(kwargs["holder"]))
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", claim)
+
+    def renew(target, **kwargs):
+        calls.append(("renew", {"target": target, **kwargs}))
+        return fleet_client.ClaimDecision(granted=True, reason="ok", holder=str(kwargs["holder"]))
+
+    monkeypatch.setattr(fleet_client, "renew_claim", renew)
+    monkeypatch.setattr(
+        fleet_client, "release_claim", lambda target, **kwargs: calls.append(("release", {"target": target, **kwargs}))
+    )
+    monkeypatch.setattr(
+        fleet_client,
+        "report_external_event",
+        lambda **kwargs: calls.append(("event", kwargs)),
+        raising=False,
+    )
+
+    adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-a"})
+    adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": "lease-a"})
+    adapter.call_tool("grokbot_queue_start", {"job_id": job_id, "lease_id": "lease-a"})
+    adapter.call_tool("grokbot_queue_fail", {"job_id": job_id, "lease_id": "lease-a"})
+
+    claim_call = next(payload for kind, payload in calls if kind == "claim")
+    holder = grokbot_mcp.fleet_holder(job_id, "lease-a")
+    session = grokbot_mcp.fleet_session(job_id, "lease-a")
+    assert holder != "lease-a" and session != "lease-a" and holder != session
+    assert {key: claim_call[key] for key in ("harness", "role", "job", "session", "holder")} == {
+        "harness": "grokbot",
+        "role": "implementation-worker",
+        "job": job_id,
+        "session": session,
+        "holder": holder,
+    }
+    events = [payload for kind, payload in calls if kind == "event"]
+    assert [payload["state"] for payload in events] == [
+        "external.claimed",
+        "external.heartbeat",
+        "external.running",
+        "external.failed",
+    ]
+    assert all(payload["session"] == session for payload in events)
+    dumped_events = json.dumps(events)
+    assert "lease-a" not in dumped_events
+    assert holder not in dumped_events
+    assert [kind for kind, _payload in calls].count("release") == 1
+    assert next(payload for kind, payload in calls if kind == "release")["holder"] == holder
+    assert "PRIVATE_INSTRUCTIONS_MUST_NOT_LEAK" not in json.dumps(calls)
+
+
+def test_complete_and_cancel_ack_release_the_fleet_claim(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def claim(target, **kwargs):
+        calls.append(("claim", {"target": target, **kwargs}))
+        return fleet_client.ClaimDecision(granted=True, reason="ok", holder=str(kwargs["holder"]))
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", claim)
+    monkeypatch.setattr(
+        fleet_client,
+        "release_claim",
+        lambda target, **kwargs: calls.append(("release", {"target": target, **kwargs})),
+    )
+    monkeypatch.setattr(
+        fleet_client,
+        "report_external_event",
+        lambda **kwargs: calls.append(("event", kwargs)),
+        raising=False,
+    )
+
+    adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-b"})
+    adapter.call_tool("grokbot_queue_start", {"job_id": job_id, "lease_id": "lease-b"})
+    adapter.call_tool(
+        "grokbot_queue_complete",
+        {
+            "job_id": job_id,
+            "lease_id": "lease-b",
+            "artifact": {
+                "kind": "draft-pr",
+                "url": "https://github.com/example/brigade/pull/1",
+                "branch": "feat/SECRET_ARTIFACT",
+            },
+        },
+    )
+    assert [payload["state"] for kind, payload in calls if kind == "event"] == [
+        "external.claimed",
+        "external.running",
+        "external.completed",
+    ]
+    assert [kind for kind, _payload in calls].count("release") == 1
+    dumped = json.dumps(calls)
+    assert "SECRET_ARTIFACT" not in dumped
+    assert "PRIVATE_INSTRUCTIONS_MUST_NOT_LEAK" not in dumped
+    assert "hub_url" not in dumped
+    assert "token" not in dumped
+    assert "bearer" not in dumped
+
+    canceled = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "cancel-job")["job_id"]
+    adapter.call_tool("grokbot_queue_claim", {"job_id": canceled, "lease_id": "lease-c"})
+    grokbot_jobs.cancel(tmp_path, canceled)
+    adapter.call_tool("grokbot_queue_ack_cancel", {"job_id": canceled, "lease_id": "lease-c"})
+    assert [payload["state"] for kind, payload in calls if kind == "event"][-1] == "external.canceled"
+    assert [kind for kind, _payload in calls].count("release") == 2
+
+
+def test_fleet_holder_and_session_are_domain_separated_from_the_queue_lease():
+    holder = grokbot_mcp.fleet_holder("job-a", "lease-a")
+    session = grokbot_mcp.fleet_session("job-a", "lease-a")
+    assert holder == grokbot_mcp.fleet_holder("job-a", "lease-a")
+    assert session == grokbot_mcp.fleet_session("job-a", "lease-a")
+    assert holder != session
+    assert "lease-a" not in holder
+    assert "lease-a" not in session
+    assert "job-a" not in holder
+    assert "job-a" not in session
+    assert grokbot_mcp.fleet_holder("job-a", "lease-b") != holder
+    assert grokbot_mcp.fleet_session("job-a", "lease-b") != session
+    assert len(holder) == 64
+    assert 0 < len(session) < len(holder)
+
+
+def test_same_lease_id_on_different_jobs_derives_distinct_fleet_identities():
+    lease_id = "shared-lease"
+    holder_a = grokbot_mcp.fleet_holder("job-a", lease_id)
+    holder_b = grokbot_mcp.fleet_holder("job-b", lease_id)
+    session_a = grokbot_mcp.fleet_session("job-a", lease_id)
+    session_b = grokbot_mcp.fleet_session("job-b", lease_id)
+    assert holder_a != holder_b
+    assert session_a != session_b
+    assert holder_a == grokbot_mcp.fleet_holder("job-a", lease_id)
+    assert session_a == grokbot_mcp.fleet_session("job-a", lease_id)
+    assert holder_a != session_a
+    assert holder_b != session_b
+
+
+def test_same_lease_id_on_different_jobs_cannot_share_or_release_fleet_claims(tmp_path: Path, monkeypatch):
+    first = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "first-job")["job_id"]
+    second = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "second-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    held: list[str] = []
+    releases: list[str] = []
+
+    def claim(target, **kwargs):
+        holder = str(kwargs["holder"])
+        if held and held[0] != holder:
+            return fleet_client.ClaimDecision(granted=False, reason="held", holder=holder)
+        if not held:
+            held.append(holder)
+        return fleet_client.ClaimDecision(granted=True, reason="ok", holder=holder)
+
+    def release(target, **kwargs):
+        holder = str(kwargs["holder"])
+        releases.append(holder)
+        if held and held[0] == holder:
+            held.clear()
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", claim)
+    monkeypatch.setattr(fleet_client, "release_claim", release)
+    monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: None, raising=False)
+
+    adapter.call_tool("grokbot_queue_claim", {"job_id": first, "lease_id": "shared-lease"})
+    with pytest.raises(grokbot_mcp.AdapterError):
+        adapter.call_tool("grokbot_queue_claim", {"job_id": second, "lease_id": "shared-lease"})
+    assert grokbot_jobs.get_job(tmp_path, first)["state"] == "claimed"
+    assert grokbot_jobs.get_job(tmp_path, second)["state"] == "queued"
+    first_holder = grokbot_mcp.fleet_holder(first, "shared-lease")
+    second_holder = grokbot_mcp.fleet_holder(second, "shared-lease")
+    first_session = grokbot_mcp.fleet_session(first, "shared-lease")
+    second_session = grokbot_mcp.fleet_session(second, "shared-lease")
+    assert first_holder != second_holder
+    assert first_session != second_session
+    assert held == [first_holder]
+
+    with pytest.raises(grokbot_mcp.AdapterError):
+        adapter.call_tool("grokbot_queue_fail", {"job_id": second, "lease_id": "shared-lease"})
+    assert releases == []
+    assert held == [first_holder]
+    assert grokbot_jobs.get_job(tmp_path, first)["state"] == "claimed"
+    assert grokbot_jobs.get_job(tmp_path, second)["state"] == "queued"
+
+    adapter.call_tool("grokbot_queue_fail", {"job_id": first, "lease_id": "shared-lease"})
+    assert releases == [first_holder]
+    assert held == []
+
+
+def test_known_fleet_refusal_does_not_claim_or_emit(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    for reason in ("held", "auth-failed", "invalid", "missing"):
+        calls: list[tuple[str, dict[str, object]]] = []
+
+        def refuse(target, *, _reason=reason, **kwargs):
+            return fleet_client.ClaimDecision(granted=False, reason=_reason, holder=str(kwargs["holder"]))
+
+        def record_event(*, _calls=calls, **kwargs):
+            _calls.append(("event", kwargs))
+
+        monkeypatch.setattr(fleet_client, "acquire_claim", refuse)
+        monkeypatch.setattr(fleet_client, "report_external_event", record_event, raising=False)
+        with pytest.raises(grokbot_mcp.AdapterError):
+            adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-refuse"})
+        assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "queued"
+        assert calls == []
+
+
+def test_best_effort_fleet_gaps_still_claim_the_queue(tmp_path: Path, monkeypatch):
+    for reason in ("no-hub", "no-identity", "hub-unavailable"):
+        job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), f"{reason}-job")["job_id"]
+        adapter = _adapter(tmp_path)
+
+        def gap(target, *, _reason=reason, **kwargs):
+            return fleet_client.ClaimDecision(granted=False, reason=_reason, holder=str(kwargs["holder"]))
+
+        monkeypatch.setattr(fleet_client, "acquire_claim", gap)
+        claimed = adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": f"lease-{reason}"})
+        assert claimed["state"] == "claimed"
+        assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
+
+
+def test_known_fleet_renew_refusal_does_not_heartbeat_or_extend_the_lease(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    monkeypatch.setattr(
+        fleet_client,
+        "acquire_claim",
+        lambda target, **kwargs: fleet_client.ClaimDecision(granted=True, reason="ok", holder=str(kwargs["holder"])),
+    )
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: events.append(kwargs), raising=False)
+    adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-renew"})
+    events.clear()
+    before = grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"]
+    monkeypatch.setattr(
+        fleet_client,
+        "renew_claim",
+        lambda target, **kwargs: fleet_client.ClaimDecision(granted=False, reason="held", holder=str(kwargs["holder"])),
+    )
+    with pytest.raises(grokbot_mcp.AdapterError):
+        adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": "lease-renew"})
+    assert grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"] == before
+    assert events == []
+
+
+def test_queue_renew_failure_releases_a_granted_fleet_claim(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def granted(target, **kwargs):
+        calls.append(("granted", {"target": target, **kwargs}))
+        return fleet_client.ClaimDecision(granted=True, reason="ok", holder=str(kwargs["holder"]))
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", granted)
+    monkeypatch.setattr(fleet_client, "renew_claim", granted)
+    monkeypatch.setattr(
+        fleet_client,
+        "release_claim",
+        lambda target, **kwargs: calls.append(("release", {"target": target, **kwargs})),
+    )
+    monkeypatch.setattr(
+        fleet_client,
+        "report_external_event",
+        lambda **kwargs: calls.append(("event", kwargs)),
+        raising=False,
+    )
+    adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-renew-rollback"})
+    before = grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"]
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "renew",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(grokbot_jobs.GrokbotJobError("lease-conflict")),
+    )
+    with pytest.raises(grokbot_mcp.AdapterError):
+        adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": "lease-renew-rollback"})
+    assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
+    assert grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"] == before
+    assert [kind for kind, _payload in calls if kind == "release"] == ["release"]
+    assert next(payload for kind, payload in calls if kind == "release")["holder"] == grokbot_mcp.fleet_holder(
+        job_id, "lease-renew-rollback"
+    )
+    assert [payload["state"] for kind, payload in calls if kind == "event"] == ["external.claimed"]
+
+
+def test_fleet_outage_then_missing_renew_recovers_via_acquire(tmp_path: Path, monkeypatch):
+    for reason in ("no-hub", "no-identity", "hub-unavailable"):
+        job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), f"{reason}-recover")["job_id"]
+        adapter = _adapter(tmp_path)
+        calls: list[tuple[str, dict[str, object]]] = []
+        lease_id = f"lease-{reason}-recover"
+
+        def gap_then_grant(target, *, _reason=reason, _calls=calls, **kwargs):
+            _calls.append(("acquire", {"target": target, **kwargs}))
+            if len([kind for kind, _payload in _calls if kind == "acquire"]) == 1:
+                return fleet_client.ClaimDecision(granted=False, reason=_reason, holder=str(kwargs["holder"]))
+            return fleet_client.ClaimDecision(granted=True, reason="ok", holder=str(kwargs["holder"]))
+
+        def missing_renew(target, *, _calls=calls, **kwargs):
+            _calls.append(("renew", {"target": target, **kwargs}))
+            return fleet_client.ClaimDecision(granted=False, reason="missing", holder=str(kwargs["holder"]))
+
+        def record_event(*, _calls=calls, **kwargs):
+            _calls.append(("event", kwargs))
+
+        monkeypatch.setattr(fleet_client, "acquire_claim", gap_then_grant)
+        monkeypatch.setattr(fleet_client, "renew_claim", missing_renew)
+        monkeypatch.setattr(fleet_client, "report_external_event", record_event, raising=False)
+        adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": lease_id})
+        result = adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": lease_id})
+        assert result["state"] == "claimed"
+        assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
+        assert [kind for kind, _payload in calls if kind == "renew"] == ["renew"]
+        acquire_calls = [payload for kind, payload in calls if kind == "acquire"]
+        assert len(acquire_calls) == 2
+        recovered = acquire_calls[1]
+        assert recovered["holder"] == grokbot_mcp.fleet_holder(job_id, lease_id)
+        assert recovered["session"] == grokbot_mcp.fleet_session(job_id, lease_id)
+        assert recovered["job"] == job_id
+        assert [payload["state"] for kind, payload in calls if kind == "event"] == [
+            "external.claimed",
+            "external.heartbeat",
+        ]
+
+
+def test_fleet_outage_then_missing_renew_allows_best_effort_acquire(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "best-effort-recover")["job_id"]
+    adapter = _adapter(tmp_path)
+    events: list[dict[str, object]] = []
+
+    def gap(target, **kwargs):
+        return fleet_client.ClaimDecision(granted=False, reason="no-hub", holder=str(kwargs["holder"]))
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", gap)
+    monkeypatch.setattr(
+        fleet_client,
+        "renew_claim",
+        lambda target, **kwargs: fleet_client.ClaimDecision(
+            granted=False, reason="missing", holder=str(kwargs["holder"])
+        ),
+    )
+    monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: events.append(kwargs), raising=False)
+    adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-best-effort"})
+    events.clear()
+    monkeypatch.setattr(
+        fleet_client,
+        "acquire_claim",
+        lambda target, **kwargs: fleet_client.ClaimDecision(
+            granted=False, reason="hub-unavailable", holder=str(kwargs["holder"])
+        ),
+    )
+    result = adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": "lease-best-effort"})
+    assert result["state"] == "claimed"
+    assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
+    assert [payload["state"] for payload in events] == ["external.heartbeat"]
+
+
+def test_fleet_outage_then_missing_renew_refuses_known_acquire_refusal(tmp_path: Path, monkeypatch):
+    for reason in ("held", "auth-failed", "invalid", "missing"):
+        job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), f"{reason}-refuse")["job_id"]
+        adapter = _adapter(tmp_path)
+        events: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            fleet_client,
+            "acquire_claim",
+            lambda target, **kwargs: fleet_client.ClaimDecision(
+                granted=False, reason="no-hub", holder=str(kwargs["holder"])
+            ),
+        )
+
+        def record_event(*, _events=events, **kwargs):
+            _events.append(kwargs)
+
+        monkeypatch.setattr(fleet_client, "report_external_event", record_event, raising=False)
+        adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": f"lease-{reason}-refuse"})
+        events.clear()
+        before = grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"]
+        monkeypatch.setattr(
+            fleet_client,
+            "renew_claim",
+            lambda target, **kwargs: fleet_client.ClaimDecision(
+                granted=False, reason="missing", holder=str(kwargs["holder"])
+            ),
+        )
+        monkeypatch.setattr(
+            fleet_client,
+            "acquire_claim",
+            lambda target, *, _reason=reason, **kwargs: fleet_client.ClaimDecision(
+                granted=False, reason=_reason, holder=str(kwargs["holder"])
+            ),
+        )
+        with pytest.raises(grokbot_mcp.AdapterError):
+            adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": f"lease-{reason}-refuse"})
+        assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
+        assert grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"] == before
+        assert events == []
+
+
+def test_queue_claim_failure_releases_a_granted_fleet_claim(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def claim(target, **kwargs):
+        calls.append(("claim", {"target": target, **kwargs}))
+        return fleet_client.ClaimDecision(granted=True, reason="ok", holder=str(kwargs["holder"]))
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", claim)
+    monkeypatch.setattr(
+        fleet_client,
+        "release_claim",
+        lambda target, **kwargs: calls.append(("release", {"target": target, **kwargs})),
+    )
+    monkeypatch.setattr(
+        fleet_client,
+        "report_external_event",
+        lambda **kwargs: calls.append(("event", kwargs)),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "claim_execution_context",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(grokbot_jobs.GrokbotJobError("lease-conflict")),
+    )
+    with pytest.raises(grokbot_mcp.AdapterError):
+        adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-rollback"})
+    assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "queued"
+    assert [kind for kind, _payload in calls] == ["claim", "release"]
+    assert calls[1][1]["holder"] == grokbot_mcp.fleet_holder(job_id, "lease-rollback")
+
+
+def test_fleet_outage_does_not_fail_queue_claim(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("hub down")
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", boom)
+    monkeypatch.setattr(fleet_client, "report_external_event", boom, raising=False)
+    claimed = adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-d"})
+    assert claimed["state"] == "claimed"
+    assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
 
 
 def test_worker_inputs_cannot_select_target_role_bot_identity_or_lease_duration(tmp_path: Path):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from brigade import cli
+from brigade import fleet_client
 from brigade import graphtrail_delta
 from brigade import localio
 from brigade import receipts_cmd
@@ -52,6 +53,114 @@ def test_verify_run_marks_parser_rejected_command_as_rejected_not_failed(tmp_pat
     assert outcome_cmd.capture(target=tmp_path, artifact_id="brigade-work", json_output=True) == 0
     record = json.loads(capsys.readouterr().out)["record"]
     assert record["signal_value"] == 0
+
+
+def test_verify_run_reports_a_redacted_fleet_completion_event(tmp_path, monkeypatch):
+    _init_git_repo_with_head(tmp_path)
+    reported: list[dict[str, object]] = []
+    monkeypatch.setattr(fleet_client, "report_event", lambda event, **_kwargs: reported.append(event) or True)
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["true"], timeout=60) == 0
+
+    assert len(reported) == 1
+    event = reported[0]
+    assert event["state"] == "verify.completed"
+    assert event["repo"] == tmp_path.name
+    assert event["harness"] == "brigade-work"
+    assert event["exit_status"] == 0
+    assert isinstance(event["capability_fingerprint"], str) and event["capability_fingerprint"]
+    assert {"commands", "stdout", "stderr", "token", "credential", "headers", "artifacts"}.isdisjoint(event)
+
+
+def test_verify_run_reports_failed_completion_exit_status(tmp_path, monkeypatch):
+    _init_git_repo_with_head(tmp_path)
+    reported: list[dict[str, object]] = []
+    monkeypatch.setattr(fleet_client, "report_event", lambda event, **_kwargs: reported.append(event) or True)
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["false"], timeout=60) == 1
+
+    assert len(reported) == 1
+    event = reported[0]
+    assert event["state"] == "verify.completed"
+    assert event["exit_status"] == 1
+    assert {"commands", "stdout", "stderr", "token", "credential", "headers", "artifacts"}.isdisjoint(event)
+
+
+def test_verify_run_reports_canceled_completion_as_interrupted_exit(tmp_path, monkeypatch):
+    from brigade.work_cmd import verification as verify_mod
+
+    _init_git_repo_with_head(tmp_path)
+    reported: list[dict[str, object]] = []
+    monkeypatch.setattr(fleet_client, "report_event", lambda event, **_kwargs: reported.append(event) or True)
+
+    def interrupted_child_runner(execution_argv, *, cwd, env, timeout):
+        return verify_mod._VERIFY_INTERRUPTED_COMMAND_STATUS, None, "", ""
+
+    monkeypatch.setattr(verify_mod, "_run_verify_child_process", interrupted_child_runner)
+    rc = work_cmd.verify_run(
+        target=tmp_path,
+        commands=[[sys.executable, "-c", "print(1)"]],
+        timeout=30,
+        json_output=True,
+    )
+    assert rc == 130
+    assert len(reported) == 1
+    event = reported[0]
+    assert event["state"] == "verify.completed"
+    assert event["exit_status"] == 130
+
+
+def test_verify_fleet_completion_encodes_negative_returncode_as_128_plus_signal(tmp_path, monkeypatch):
+    from brigade.work_cmd import verification as verify_mod
+
+    reported: list[dict[str, object]] = []
+    monkeypatch.setattr(fleet_client, "report_event", lambda event, **_kwargs: reported.append(event) or True)
+    receipt = {
+        "run_id": "vr-neg",
+        "completed_at": "2026-08-26T12:00:00+00:00",
+        "digests": {"receipt_sha256": "a" * 64},
+    }
+    verify_mod._report_fleet_completion(tmp_path, receipt, -9)
+    assert reported[0]["state"] == "verify.completed"
+    assert reported[0]["exit_status"] == 137
+
+
+def test_verify_run_spools_completion_and_flush_drains_it(tmp_path, monkeypatch):
+    import threading
+
+    from brigade import fleet_hub
+    from brigade import node as node_mod
+
+    _init_git_repo_with_head(tmp_path)
+    home = tmp_path / "home"
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    identity = node_mod.NodeIdentity(node_id="node-verify", hostname="fleet-test", roles=(), platform="test")
+    path = node_mod.node_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(node_mod._format_node_toml(identity), encoding="utf-8")
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:9")
+    monkeypatch.setenv("BRIGADE_FLEET_TOKEN", "test-token-12345")
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["true"], timeout=60) == 0
+    spool_files = list((fleet_client.brigade_home() / "fleet-spool").glob("*.jsonl"))
+    assert len(spool_files) == 1
+    event = json.loads(spool_files[0].read_text().splitlines()[0])
+    assert event["state"] == "verify.completed"
+    assert event["exit_status"] == 0
+    assert {"commands", "stdout", "token", "headers", "artifacts"}.isdisjoint(event)
+
+    db = tmp_path / "hub" / "fleet.db"
+    hub = fleet_hub.make_server("127.0.0.1", 0, db, "test-token-12345", allow_admin_writes=True)
+    thread = threading.Thread(target=hub.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{hub.server_address[1]}"
+        monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", url)
+        assert fleet_client.flush_spool(spool_files[0].stem, hub_url=url, token="test-token-12345") == 1
+        assert list((fleet_client.brigade_home() / "fleet-spool").glob("*.jsonl")) == []
+    finally:
+        hub.shutdown()
+        hub.server_close()
 
 
 _PYTHON_MISSING_PYTHON3_SUGGESTION = (


### PR DESCRIPTION
## Summary

- add holder-fenced acquire, heartbeat, and release operations for external harness sessions
- mirror Grok Bot queue lifecycle into Fleet Hub without giving cloud workers hub credentials or publishing queue payloads
- publish redacted `verify.completed` events and show external harness state in Fleet status and the dashboard

## Safety

- Fleet holder tokens remain write-only and never appear in claim listings or event payloads
- public session labels use a domain-separated, job-scoped derivation from queue leases
- hub outages use the existing spool and flush path, while known authorization and claim refusals stop queue mutation

## Verification

- `./scripts/verify`
- `9194 passed, 8 skipped, 68 subtests passed`
- Brigade receipt `20260826-130628-work-verify-9bcbc1`

Fixes #1179
