### PR TITLE
fix(fleet): fence claim acquire/renew with generation tombstones

### DIFF
--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -405,6 +405,13 @@ def _print_claim_failure(decision, *, what: str) -> bool:
     if decision.reason == "invalid":
         print(f"error: {decision.detail}", file=sys.stderr)
         return True
+    if decision.reason == "stale-generation":
+        print(
+            f"error: fleet claim {what} refused: stale generation"
+            + (f" ({decision.detail})" if decision.detail else ""),
+            file=sys.stderr,
+        )
+        return True
     return False
 
 
@@ -777,12 +784,13 @@ def _dispatch_claims(args: argparse.Namespace) -> int:
     if args.json:
         print(_json.dumps({"claims": claims}, indent=2, sort_keys=True))
         return 0
-    headers = ("target", "node", "conductor", "harness", "session", "acquired", "expires")
+    headers = ("target", "node", "conductor", "harness", "session", "gen", "acquired", "expires")
     rows = []
     for claim in claims:
         expires = str(claim.get("expires_at") or "-")
         if claim.get("expired"):
             expires += " (expired)"
+        generation = claim.get("generation")
         rows.append(
             [
                 _safe_table_cell(str(claim.get("target") or "-")),
@@ -790,6 +798,7 @@ def _dispatch_claims(args: argparse.Namespace) -> int:
                 _safe_table_cell(str(claim.get("owner_conductor") or "-")),
                 _safe_table_cell(str(claim.get("harness") or "-")),
                 _safe_table_cell(str(claim.get("session") or "-")),
+                _safe_table_cell("-" if generation is None else str(generation)),
                 _safe_table_cell(_format_age(claim.get("acquired_at"))),
                 _safe_table_cell(expires),
             ]

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -412,6 +412,13 @@ def _print_claim_failure(decision, *, what: str) -> bool:
             file=sys.stderr,
         )
         return True
+    if decision.reason == "storage-full":
+        print(
+            f"error: fleet claim {what} refused: durable fence limit reached"
+            + (f" ({decision.detail})" if decision.detail else ""),
+            file=sys.stderr,
+        )
+        return True
     return False
 
 

--- a/src/brigade/fleet_client.py
+++ b/src/brigade/fleet_client.py
@@ -709,9 +709,11 @@ class ClaimDecision:
     release), ``"no-hub"`` (no hub configured), ``"no-identity"`` (this node
     has no usable identity to claim with), ``"auth-failed"`` (the hub
     refused this node's credentials (HTTP 401/403), a stable outcome that
-    is never retried or fallen back from; see ``FleetClaimAuthError``), or
-    ``"hub-unavailable"`` (network/hub failure; callers fall back to the
-    local run lock).
+    is never retried or fallen back from; see ``FleetClaimAuthError``),
+    ``"stale-generation"`` (the hub refused this acquire/renew because a
+    later release tombstoned this holder or generation; terminal — do not
+    retry or re-acquire), or ``"hub-unavailable"`` (network/hub failure;
+    callers fall back to the local run lock).
     ``holder`` is the fencing token this operation used; renew and release
     must present the same token. ``superseded`` is the unexpired same-node
     claim a ``supersede_dead_owner`` acquire replaced (issue #1141); a
@@ -824,6 +826,7 @@ def _claim_op(
     lock: Mapping[str, str] | None = None,
     supersede: Mapping[str, str] | None = None,
     acquired_at: str | None = None,
+    generation: int | None = None,
     harness: str | None = None,
     role: str | None = None,
     job: str | None = None,
@@ -861,6 +864,8 @@ def _claim_op(
             body["supersede"] = dict(supersede)
         if acquired_at is not None:
             body["acquired_at"] = acquired_at
+        if generation is not None:
+            body["generation"] = int(generation)
         if conductor:
             body["conductor"] = conductor
         try:
@@ -894,6 +899,8 @@ def _claim_op(
         return ClaimDecision(
             granted=True, reason="ok", claim=claim, holder=holder, superseded=superseded, lock_run_dir=run_dir
         )
+    if payload.get("reason") == "stale-generation":
+        return ClaimDecision(granted=False, reason="stale-generation", owner=owner, detail=detail, holder=holder)
     if status in (200, 409):
         return ClaimDecision(
             granted=False, reason="held" if owner is not None else "missing", owner=owner, detail=detail, holder=holder
@@ -913,6 +920,7 @@ def acquire_claim(
     role: str | None = None,
     job: str | None = None,
     session: str | None = None,
+    generation: int | None = None,
     **kwargs: Any,
 ) -> ClaimDecision:
     """Acquire ``target``; a fresh fencing token is minted unless ``holder``
@@ -940,12 +948,27 @@ def acquire_claim(
         role=role,
         job=job,
         session=session,
+        generation=generation,
         **kwargs,
     )
 
 
-def renew_claim(target: str, *, holder: str, **kwargs: Any) -> ClaimDecision:
-    return _claim_op("renew", target, holder=holder, **kwargs)
+def renew_claim(
+    target: str,
+    *,
+    holder: str,
+    generation: int | None = None,
+    lock_owner: Mapping[str, object] | None = None,
+    **kwargs: Any,
+) -> ClaimDecision:
+    return _claim_op(
+        "renew",
+        target,
+        holder=holder,
+        generation=generation,
+        lock=lease_from_lock_owner(lock_owner),
+        **kwargs,
+    )
 
 
 def release_claim(
@@ -1150,12 +1173,33 @@ def repo_claim(
         "ttl_seconds": ttl_seconds,
         "lock_owner": lock_owner,
     }
+    generation: int | None = None
+
+    def _remember_generation(outcome: ClaimDecision) -> None:
+        nonlocal generation
+        claim = outcome.claim
+        if not outcome.granted or not isinstance(claim, dict):
+            return
+        value = claim.get("generation")
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
+            generation = value
+            acquire_kwargs["generation"] = value
+
     decision = acquire_claim(target, supersede_dead_owner=supersede_dead_owner, **acquire_kwargs)
+    _remember_generation(decision)
     if not decision.granted and decision.reason in ("hub-unavailable", "missing"):
         # One retry with the same fencing token: a lost response may have
         # committed the row (idempotent for this holder), and a 409 with no
         # owner means the target freed mid-request.
         decision = acquire_claim(target, supersede_dead_owner=supersede_dead_owner, **acquire_kwargs)
+        _remember_generation(decision)
+    if not decision.granted and decision.reason == "stale-generation":
+        _LOG.warning(
+            "fleet hub refused %s with stale generation; relying on the local run lock",
+            target,
+        )
+        yield decision
+        return
     if not decision.granted and decision.reason == "auth-failed":
         # Fail closed (#1161): bad credentials would turn "the hub refused"
         # into "every node runs unprotected on its local lock". No retry,
@@ -1210,7 +1254,21 @@ def repo_claim(
     def _renew_loop() -> None:
         warned_unavailable = False
         while not stop.wait(_claim_renew_interval(ttl_seconds)):
-            outcome = renew_claim(target, holder=holder, node_id=node_id, conductor=conductor, ttl_seconds=ttl_seconds)
+            outcome = renew_claim(
+                target,
+                holder=holder,
+                node_id=node_id,
+                conductor=conductor,
+                ttl_seconds=ttl_seconds,
+                generation=generation,
+                lock_owner=lock_owner,
+            )
+            if not outcome.granted and outcome.reason == "stale-generation":
+                _LOG.warning(
+                    "fleet claim heartbeat for %s saw a stale generation; not re-acquiring",
+                    target,
+                )
+                return
             if not outcome.granted and outcome.reason == "missing":
                 if stop.is_set():
                     # "missing" during shutdown is our own release landing
@@ -1225,7 +1283,14 @@ def repo_claim(
                 # still in flight.
                 pending_orphan_release.set()
                 outcome = acquire_claim(target, **acquire_kwargs)
+                if not outcome.granted and outcome.reason == "stale-generation":
+                    _LOG.warning(
+                        "fleet claim heartbeat for %s saw a stale generation; not re-acquiring",
+                        target,
+                    )
+                    return
             if outcome.granted:
+                _remember_generation(outcome)
                 warned_unavailable = False
                 continue
             if outcome.reason == "hub-unavailable":

--- a/src/brigade/fleet_client.py
+++ b/src/brigade/fleet_client.py
@@ -712,7 +712,9 @@ class ClaimDecision:
     is never retried or fallen back from; see ``FleetClaimAuthError``),
     ``"stale-generation"`` (the hub refused this acquire/renew because a
     later release tombstoned this holder or generation; terminal — do not
-    retry or re-acquire), or ``"hub-unavailable"`` (network/hub failure;
+    retry or re-acquire), ``"storage-full"`` (the hub refused a new durable
+    fence rather than evict an existing one; terminal — do not treat as
+    missing or re-acquire), or ``"hub-unavailable"`` (network/hub failure;
     callers fall back to the local run lock).
     ``holder`` is the fencing token this operation used; renew and release
     must present the same token. ``superseded`` is the unexpired same-node
@@ -901,6 +903,8 @@ def _claim_op(
         )
     if payload.get("reason") == "stale-generation":
         return ClaimDecision(granted=False, reason="stale-generation", owner=owner, detail=detail, holder=holder)
+    if payload.get("reason") == "storage-full":
+        return ClaimDecision(granted=False, reason="storage-full", owner=owner, detail=detail, holder=holder)
     if status in (200, 409):
         return ClaimDecision(
             granted=False, reason="held" if owner is not None else "missing", owner=owner, detail=detail, holder=holder
@@ -1263,10 +1267,11 @@ def repo_claim(
                 generation=generation,
                 lock_owner=lock_owner,
             )
-            if not outcome.granted and outcome.reason == "stale-generation":
+            if not outcome.granted and outcome.reason in {"stale-generation", "storage-full"}:
                 _LOG.warning(
-                    "fleet claim heartbeat for %s saw a stale generation; not re-acquiring",
+                    "fleet claim heartbeat for %s saw a %s; not re-acquiring",
                     target,
+                    outcome.reason,
                 )
                 return
             if not outcome.granted and outcome.reason == "missing":
@@ -1283,10 +1288,11 @@ def repo_claim(
                 # still in flight.
                 pending_orphan_release.set()
                 outcome = acquire_claim(target, **acquire_kwargs)
-                if not outcome.granted and outcome.reason == "stale-generation":
+                if not outcome.granted and outcome.reason in {"stale-generation", "storage-full"}:
                     _LOG.warning(
-                        "fleet claim heartbeat for %s saw a stale generation; not re-acquiring",
+                        "fleet claim heartbeat for %s saw a %s; not re-acquiring",
                         target,
+                        outcome.reason,
                     )
                     return
             if outcome.granted:

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -842,7 +842,7 @@ def _is_stale_against_tombstones(
         return True
     if holder is not None and any(row[2] == holder and row[3] == node for row in live):
         return True
-    if lease_stamp and any(row[3] == node and row[4] and lease_stamp <= row[4] for row in live):
+    if lease_stamp and any(row[3] == node and row[4] == lease_stamp for row in live):
         return True
     return False
 
@@ -861,8 +861,7 @@ def _row_lease_stamp(row: tuple[Any, ...]) -> str | None:
     lock_acquired_at = row[14] if len(row) > 14 else None
     if isinstance(lock_acquired_at, str) and lock_acquired_at.strip():
         return lock_acquired_at.strip()
-    acquired_at = row[7]
-    return acquired_at.strip() if isinstance(acquired_at, str) and acquired_at.strip() else None
+    return None
 
 
 def _write_claim_tombstone(

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -64,11 +64,14 @@ Endpoints:
   ``lock_run_dir`` so that node's CLI can find the run and check its lock
   is dead before a token-less release (never to other callers).
   Each live row carries a monotonic ``generation``. Release writes a
-  per-(target, holder, node) tombstone for that generation so a late
-  acquire or renew whose generation, holder, or lease stamp predates the
-  tombstone is refused with ``reason: "stale-generation"`` instead of
-  resurrecting the row (issue #1189). Schema v4 databases gain the
-  column and tombstone table additively.
+  per-(target, holder, node) tombstone for that generation and raises a
+  durable per-target generation floor (schema v5) so a late acquire or
+  renew whose generation, holder, or lease stamp is stale is refused with
+  ``reason: "stale-generation"`` instead of resurrecting the row (issue
+  #1189). The floor outlives claim TTL. Holder tombstones are capped per
+  target and node so no-row release spam cannot grow the database without
+  bound; the newest tombstones — including an in-flight acquire's fence —
+  are kept. Schema v4 databases migrate forward to v5.
   Trust boundary: ``node_id`` is bound to the node token that presents it,
   so a member can only act as itself; ``lock``, ``supersede`` and ``scope``
   remain caller-asserted intent that keeps *honest* clients from stealing
@@ -117,9 +120,13 @@ from urllib.parse import parse_qs, urlencode
 
 from . import fleet_dashboard
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 DEFAULT_PORT = 3774
 MAX_BODY_BYTES = 8 * 1024 * 1024
+# Newest holder tombstones kept per (target, node). The in-flight no-row
+# release fence is the newest row, so it survives the cap; older spam is
+# dropped. The generation floor is stored separately and is not capped.
+CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE = 16
 
 # Dashboard cookie (issue #1124): a derived, read-only capability, not the token.
 DASHBOARD_COOKIE = "brigade_fleet_view"
@@ -224,9 +231,9 @@ CREATE TABLE IF NOT EXISTS claims (
     generation INTEGER NOT NULL DEFAULT 1
 );
 """
-# Release tombstones (issue #1189): survive the claim DELETE so a late
-# acquire/renew cannot recreate the row. One row per released holder on a
-# node; expired with the claim TTL. Additive on schema v4.
+# Release tombstones (issue #1189 / schema v5): survive the claim DELETE so
+# a late acquire/renew cannot recreate the row. One row per released holder
+# on a node. Capped per (target, node); not expired with claim TTL.
 _TOMBSTONES_SCHEMA = """
 CREATE TABLE IF NOT EXISTS claim_tombstones (
     target TEXT NOT NULL,
@@ -237,6 +244,14 @@ CREATE TABLE IF NOT EXISTS claim_tombstones (
     released_at TEXT NOT NULL,
     expires_at REAL NOT NULL,
     PRIMARY KEY (target, holder_token, owner_node)
+);
+"""
+# Durable generation floor per target (schema v5). Survives claim TTL and
+# tombstone eviction so generation 1 cannot be reused after a release.
+_GENERATION_FLOORS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS claim_generation_floors (
+    target TEXT NOT NULL PRIMARY KEY,
+    generation INTEGER NOT NULL
 );
 """
 _CLAIMS_ADDITIVE_COLUMNS = (
@@ -393,6 +408,7 @@ def _migrate_claims_table(conn: sqlite3.Connection) -> None:
                     if "duplicate column" not in str(exc).lower():
                         raise
         conn.execute(_TOMBSTONES_SCHEMA)
+        conn.execute(_GENERATION_FLOORS_SCHEMA)
         conn.commit()
     except BaseException:
         conn.rollback()
@@ -464,8 +480,12 @@ def init_db(db_path: Path) -> sqlite3.Connection:
                 if _claims_table_needs_migration(_claims_columns(conn)):
                     _migrate_claims_table(conn)
         conn.execute(_TOMBSTONES_SCHEMA)
+        conn.execute(_GENERATION_FLOORS_SCHEMA)
+        _backfill_generation_floors(conn)
         conn.execute("CREATE INDEX IF NOT EXISTS events_run_seq ON events (node_id, run_id, sequence)")
         # v3 -> v4 is one additive table; IF NOT EXISTS is the whole migration.
+        # v4 -> v5 adds generation floors (and tombstones if a v4-on-this-branch
+        # hub already created them) without dropping live claims.
         conn.execute(_NODES_SCHEMA)
         conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
         conn.commit()
@@ -747,6 +767,45 @@ def _validate_lease(raw: Any, field: str) -> dict[str, str | None]:
     return lease
 
 
+def _backfill_generation_floors(conn: sqlite3.Connection) -> None:
+    """Raise each target's durable floor to the max generation already stored."""
+    conn.execute(
+        "INSERT INTO claim_generation_floors (target, generation) "
+        "SELECT target, MAX(generation) FROM claims GROUP BY target "
+        "ON CONFLICT(target) DO UPDATE SET "
+        "generation = MAX(claim_generation_floors.generation, excluded.generation)"
+    )
+    conn.execute(
+        "INSERT INTO claim_generation_floors (target, generation) "
+        "SELECT target, MAX(generation) FROM claim_tombstones GROUP BY target "
+        "ON CONFLICT(target) DO UPDATE SET "
+        "generation = MAX(claim_generation_floors.generation, excluded.generation)"
+    )
+
+
+def _generation_floor(conn: sqlite3.Connection, target: str) -> int:
+    row = conn.execute("SELECT generation FROM claim_generation_floors WHERE target = ?", (target,)).fetchone()
+    return _as_generation(row[0]) if row is not None else 0
+
+
+def _raise_generation_floor(conn: sqlite3.Connection, target: str, generation: int) -> None:
+    conn.execute(
+        "INSERT INTO claim_generation_floors (target, generation) VALUES (?, ?) "
+        "ON CONFLICT(target) DO UPDATE SET "
+        "generation = MAX(claim_generation_floors.generation, excluded.generation)",
+        (target, generation),
+    )
+
+
+def _prune_target_node_tombstones(conn: sqlite3.Connection, target: str, node: str) -> None:
+    conn.execute(
+        "DELETE FROM claim_tombstones WHERE rowid IN ("
+        "SELECT rowid FROM claim_tombstones WHERE target = ? AND owner_node = ? "
+        "ORDER BY released_at DESC, rowid DESC LIMIT -1 OFFSET ?)",
+        (target, node, CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE),
+    )
+
+
 def _as_generation(value: Any) -> int:
     if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
         return value
@@ -827,34 +886,32 @@ def _is_stale_against_tombstones(
     lease_stamp: str | None,
     prior: tuple[Any, ...] | None,
     tombstones: list[tuple[Any, ...]],
+    floor: int,
     now: float,
 ) -> bool:
-    live = [row for row in tombstones if row[6] > now]
-    if not live:
-        return False
     live_same_holder = (
         prior is not None and prior[10] > now and holder is not None and prior[12] == holder and prior[1] == node
     )
     if live_same_holder:
         return generation is not None and generation < _as_generation(prior[11])
-    max_gen = max(_as_generation(row[1]) for row in live)
-    if generation is not None and generation <= max_gen:
+    if generation is not None and generation <= floor:
         return True
-    if holder is not None and any(row[2] == holder and row[3] == node for row in live):
+    if holder is not None and any(row[2] == holder and row[3] == node for row in tombstones):
         return True
-    if lease_stamp and any(row[3] == node and row[4] == lease_stamp for row in live):
+    if lease_stamp and any(row[3] == node and row[4] == lease_stamp for row in tombstones):
         return True
     return False
 
 
-def _next_claim_generation(prior: tuple[Any, ...] | None, tombstones: list[tuple[Any, ...]], now: float) -> int:
-    floor = 0
-    live = [row for row in tombstones if row[6] > now]
-    if live:
-        floor = max(floor, max(_as_generation(row[1]) for row in live))
+def _next_claim_generation(
+    prior: tuple[Any, ...] | None, tombstones: list[tuple[Any, ...]], floor: int, now: float
+) -> int:
+    next_floor = floor
+    if tombstones:
+        next_floor = max(next_floor, max(_as_generation(row[1]) for row in tombstones))
     if prior is not None and prior[10] > now:
-        floor = max(floor, _as_generation(prior[11]))
-    return floor + 1
+        next_floor = max(next_floor, _as_generation(prior[11]))
+    return next_floor + 1
 
 
 def _row_lease_stamp(row: tuple[Any, ...]) -> str | None:
@@ -887,6 +944,8 @@ def _write_claim_tombstone(
         "expires_at = excluded.expires_at",
         (target, holder, node, generation, lease_stamp, now_iso, now + ttl),
     )
+    _raise_generation_floor(conn, target, generation)
+    _prune_target_node_tombstones(conn, target, node)
 
 
 def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None = None) -> tuple[int, dict[str, Any]]:
@@ -925,12 +984,13 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
     deleted (409 with the current row). Only ``force`` deletes unfenced.
 
     Release also writes a tombstone for the released (target, holder, node)
-    carrying that row's generation and lease stamp (issue #1189). A later
-    acquire or renew whose generation is not newer, whose holder matches the
-    tombstone, or whose lock ``acquired_at`` predates the tombstone stamp is
-    refused with ``reason: "stale-generation"``. A holder-scoped release
-    that finds no row still plants a tombstone so an in-flight acquire for
-    that holder cannot land after the release.
+    and raises the durable per-target generation floor (issue #1189). A
+    later acquire or renew whose generation is not newer than that floor,
+    whose holder matches a tombstone, or whose lock ``acquired_at`` matches
+    the released lease is refused with ``reason: "stale-generation"``. The
+    floor outlives claim TTL. A holder-scoped release that finds no row
+    still plants a tombstone (newest kept when the per-node cap is hit) so
+    an in-flight acquire for that holder cannot land after the release.
     """
     request = _validate_claim_request(raw)
     if caller_node is not None and request["node_id"] != caller_node:
@@ -960,9 +1020,9 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         # upsert see one state.
         conn.execute("BEGIN IMMEDIATE")
         conn.execute("DELETE FROM claims WHERE expires_at <= ?", (now,))
-        conn.execute("DELETE FROM claim_tombstones WHERE expires_at <= ?", (now,))
         prior = _fetch_claim(conn, target)
         tombstones = _fetch_tombstones(conn, target)
+        floor = _generation_floor(conn, target)
         if _is_stale_against_tombstones(
             node=node,
             holder=holder,
@@ -970,13 +1030,14 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             lease_stamp=_request_lease_stamp(request),
             prior=prior,
             tombstones=tombstones,
+            floor=floor,
             now=now,
         ):
             conn.commit()
             return 409, _stale_generation_payload("acquire", target)
         lock = request["lock"] or {"token": None, "acquired_at": None, "run_dir": None}
         supersede = request["supersede"] or {"token": None, "acquired_at": None}
-        next_generation = _next_claim_generation(prior, tombstones, now)
+        next_generation = _next_claim_generation(prior, tombstones, floor, now)
         cursor = conn.execute(
             "INSERT INTO claims "
             "(target, owner_node, owner_conductor, harness, role, job, session, holder_token, "
@@ -1035,6 +1096,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
                 supersede["acquired_at"],
             ),
         )
+        if cursor.rowcount == 1:
+            new_grant = prior is None or prior[10] <= now or prior[12] != holder or prior[1] != node
+            if new_grant:
+                _raise_generation_floor(conn, target, next_generation)
         conn.commit()
         if cursor.rowcount == 1:
             row = _fetch_claim(conn, target)
@@ -1072,6 +1137,7 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             lease_stamp=_request_lease_stamp(request),
             prior=prior,
             tombstones=_fetch_tombstones(conn, target),
+            floor=_generation_floor(conn, target),
             now=now,
         ):
             return 409, _stale_generation_payload("renew", target)

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -768,13 +768,11 @@ def _validate_lease(raw: Any, field: str) -> dict[str, str | None]:
 
 
 def _backfill_generation_floors(conn: sqlite3.Connection) -> None:
-    """Raise each target's durable floor to the max generation already stored."""
-    conn.execute(
-        "INSERT INTO claim_generation_floors (target, generation) "
-        "SELECT target, MAX(generation) FROM claims GROUP BY target "
-        "ON CONFLICT(target) DO UPDATE SET "
-        "generation = MAX(claim_generation_floors.generation, excluded.generation)"
-    )
+    """Raise each target's durable floor to the highest *released* generation.
+
+    Live claims are not a floor. A lost-row heartbeat must be able to
+    re-acquire the same generation; only a release (tombstone) retires it.
+    """
     conn.execute(
         "INSERT INTO claim_generation_floors (target, generation) "
         "SELECT target, MAX(generation) FROM claim_tombstones GROUP BY target "
@@ -1096,10 +1094,6 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
                 supersede["acquired_at"],
             ),
         )
-        if cursor.rowcount == 1:
-            new_grant = prior is None or prior[10] <= now or prior[12] != holder or prior[1] != node
-            if new_grant:
-                _raise_generation_floor(conn, target, next_generation)
         conn.commit()
         if cursor.rowcount == 1:
             row = _fetch_claim(conn, target)

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -682,9 +682,7 @@ def _validate_claim_request(raw: Any) -> dict[str, Any]:
         if field == "target":
             _reject_controls(value, field, kind="claim")
             if len(value.strip()) > CLAIM_TARGET_MAX_CHARS:
-                raise FleetHubError(
-                    f"claim field 'target' must be at most {CLAIM_TARGET_MAX_CHARS} characters"
-                )
+                raise FleetHubError(f"claim field 'target' must be at most {CLAIM_TARGET_MAX_CHARS} characters")
         request[field] = value.strip()
     for field in ("node_id", "holder"):
         if request[field] is None:

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -68,10 +68,11 @@ Endpoints:
   durable per-target generation floor (schema v5) so a late acquire or
   renew whose generation, holder, or lease stamp is stale is refused with
   ``reason: "stale-generation"`` instead of resurrecting the row (issue
-  #1189). The floor outlives claim TTL. Holder tombstones are capped per
-  target and node so no-row release spam cannot grow the database without
-  bound; the newest tombstones — including an in-flight acquire's fence —
-  are kept. Schema v4 databases migrate forward to v5.
+  #1189). The floor outlives claim TTL. Holder tombstones and live claims
+  share a durable fence budget; a new no-row fence that would exceed the
+  per-(target, node) or global cap is refused instead of evicting an
+  existing fence a delayed initial acquire could still match. Schema v4
+  databases migrate forward to v5.
   Trust boundary: ``node_id`` is bound to the node token that presents it,
   so a member can only act as itself; ``lock``, ``supersede`` and ``scope``
   remain caller-asserted intent that keeps *honest* clients from stealing
@@ -123,10 +124,13 @@ from . import fleet_dashboard
 SCHEMA_VERSION = 5
 DEFAULT_PORT = 3774
 MAX_BODY_BYTES = 8 * 1024 * 1024
-# Newest holder tombstones kept per (target, node). The in-flight no-row
-# release fence is the newest row, so it survives the cap; older spam is
-# dropped. The generation floor is stored separately and is not capped.
+# No-row release fences kept per (target, node). Overflow fails closed
+# rather than evicting a fence a delayed generation-less acquire can match.
+# Real releases may exceed this per-node cap; the global durable budget
+# still applies. The generation floor is stored separately.
 CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE = 16
+CLAIM_DURABLE_FENCE_LIMIT = 1024
+CLAIM_TARGET_MAX_CHARS = 256
 
 # Dashboard cookie (issue #1124): a derived, read-only capability, not the token.
 DASHBOARD_COOKIE = "brigade_fleet_view"
@@ -233,7 +237,7 @@ CREATE TABLE IF NOT EXISTS claims (
 """
 # Release tombstones (issue #1189 / schema v5): survive the claim DELETE so
 # a late acquire/renew cannot recreate the row. One row per released holder
-# on a node. Capped per (target, node); not expired with claim TTL.
+# on a node. Not expired with claim TTL; new rows fail closed at the cap.
 _TOMBSTONES_SCHEMA = """
 CREATE TABLE IF NOT EXISTS claim_tombstones (
     target TEXT NOT NULL,
@@ -677,6 +681,10 @@ def _validate_claim_request(raw: Any) -> dict[str, Any]:
             raise FleetHubError(f"claim field {field!r} must be a non-empty string")
         if field == "target":
             _reject_controls(value, field, kind="claim")
+            if len(value.strip()) > CLAIM_TARGET_MAX_CHARS:
+                raise FleetHubError(
+                    f"claim field 'target' must be at most {CLAIM_TARGET_MAX_CHARS} characters"
+                )
         request[field] = value.strip()
     for field in ("node_id", "holder"):
         if request[field] is None:
@@ -795,12 +803,28 @@ def _raise_generation_floor(conn: sqlite3.Connection, target: str, generation: i
     )
 
 
-def _prune_target_node_tombstones(conn: sqlite3.Connection, target: str, node: str) -> None:
-    conn.execute(
-        "DELETE FROM claim_tombstones WHERE rowid IN ("
-        "SELECT rowid FROM claim_tombstones WHERE target = ? AND owner_node = ? "
-        "ORDER BY released_at DESC, rowid DESC LIMIT -1 OFFSET ?)",
-        (target, node, CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE),
+def _durable_fence_count(conn: sqlite3.Connection) -> int:
+    tombstones = conn.execute("SELECT COUNT(*) FROM claim_tombstones").fetchone()[0]
+    claims = conn.execute("SELECT COUNT(*) FROM claims").fetchone()[0]
+    return int(tombstones) + int(claims)
+
+
+def _tombstone_row_exists(conn: sqlite3.Connection, target: str, holder: str, node: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM claim_tombstones WHERE target = ? AND holder_token = ? AND owner_node = ?",
+            (target, holder, node),
+        ).fetchone()
+        is not None
+    )
+
+
+def _target_node_tombstone_count(conn: sqlite3.Connection, target: str, node: str) -> int:
+    return int(
+        conn.execute(
+            "SELECT COUNT(*) FROM claim_tombstones WHERE target = ? AND owner_node = ?",
+            (target, node),
+        ).fetchone()[0]
     )
 
 
@@ -868,6 +892,16 @@ def _stale_generation_payload(action: str, target: str) -> dict[str, Any]:
     }
 
 
+def _storage_full_payload(action: str, target: str) -> dict[str, Any]:
+    key = "granted" if action == "acquire" else "released"
+    return {
+        key: False,
+        "error": f"fleet hub durable claim fence limit reached for {target!r}",
+        "reason": "storage-full",
+        "owner": None,
+    }
+
+
 def _request_lease_stamp(request: dict[str, Any]) -> str | None:
     lock = request.get("lock")
     if not isinstance(lock, dict):
@@ -930,7 +964,16 @@ def _write_claim_tombstone(
     ttl: int,
     now: float,
     now_iso: str,
-) -> None:
+    replacing_claim: bool,
+) -> bool:
+    """Write or refresh a fence. ``False`` when a *new* row would exceed a
+    cap: the caller must not evict an existing fence to make room."""
+    if not _tombstone_row_exists(conn, target, holder, node):
+        if _durable_fence_count(conn) >= CLAIM_DURABLE_FENCE_LIMIT:
+            return False
+        per_node = _target_node_tombstone_count(conn, target, node)
+        if not replacing_claim and per_node >= CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE:
+            return False
     conn.execute(
         "INSERT INTO claim_tombstones "
         "(target, holder_token, owner_node, generation, lease_stamp, released_at, expires_at) "
@@ -943,7 +986,7 @@ def _write_claim_tombstone(
         (target, holder, node, generation, lease_stamp, now_iso, now + ttl),
     )
     _raise_generation_floor(conn, target, generation)
-    _prune_target_node_tombstones(conn, target, node)
+    return True
 
 
 def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None = None) -> tuple[int, dict[str, Any]]:
@@ -987,8 +1030,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
     whose holder matches a tombstone, or whose lock ``acquired_at`` matches
     the released lease is refused with ``reason: "stale-generation"``. The
     floor outlives claim TTL. A holder-scoped release that finds no row
-    still plants a tombstone (newest kept when the per-node cap is hit) so
-    an in-flight acquire for that holder cannot land after the release.
+    still plants a tombstone so an in-flight acquire for that holder cannot
+    land after the release. A new fence that would exceed the per-node or
+    global durable cap answers ``reason: "storage-full"`` instead of
+    evicting an existing fence.
     """
     request = _validate_claim_request(raw)
     if caller_node is not None and request["node_id"] != caller_node:
@@ -1033,6 +1078,9 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         ):
             conn.commit()
             return 409, _stale_generation_payload("acquire", target)
+        if prior is None and _durable_fence_count(conn) >= CLAIM_DURABLE_FENCE_LIMIT:
+            conn.commit()
+            return 409, _storage_full_payload("acquire", target)
         lock = request["lock"] or {"token": None, "acquired_at": None, "run_dir": None}
         supersede = request["supersede"] or {"token": None, "acquired_at": None}
         next_generation = _next_claim_generation(prior, tombstones, floor, now)
@@ -1174,7 +1222,7 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             (target, holder, node),
         )
         if cursor.rowcount == 1:
-            _write_claim_tombstone(
+            if not _write_claim_tombstone(
                 conn,
                 target=target,
                 generation=_as_generation(prior[11]) if prior is not None else 1,
@@ -1184,7 +1232,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
                 ttl=int(prior[9]) if prior is not None else ttl,
                 now=now,
                 now_iso=now_iso,
-            )
+                replacing_claim=True,
+            ):
+                conn.rollback()
+                return 409, _storage_full_payload("release", target)
             conn.commit()
             return 200, {"released": True}
         if prior is not None:
@@ -1194,7 +1245,7 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
                 "error": f"target {target!r} is held by {prior[1]}",
                 "owner": _claim_payload(prior),
             }
-        _write_claim_tombstone(
+        if not _write_claim_tombstone(
             conn,
             target=target,
             generation=1,
@@ -1204,7 +1255,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             ttl=ttl,
             now=now,
             now_iso=now_iso,
-        )
+            replacing_claim=False,
+        ):
+            conn.rollback()
+            return 409, _storage_full_payload("release", target)
         conn.commit()
         return 200, {"released": False}
     # Token-less release (issue #1141): the caller's own node's row, or with
@@ -1221,7 +1275,7 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         (target, int(scope == "force"), node, expected_acquired_at, expected_acquired_at),
     )
     if cursor.rowcount == 1 and prior is not None:
-        _write_claim_tombstone(
+        if not _write_claim_tombstone(
             conn,
             target=target,
             generation=_as_generation(prior[11]),
@@ -1231,7 +1285,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             ttl=int(prior[9]),
             now=now,
             now_iso=now_iso,
-        )
+            replacing_claim=True,
+        ):
+            conn.rollback()
+            return 409, _storage_full_payload("release", target)
     conn.commit()
     if cursor.rowcount == 1:
         released: dict[str, Any] = {"released": True}

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -63,6 +63,12 @@ Endpoints:
   when the caller's ``node_id`` owns it the answer also carries
   ``lock_run_dir`` so that node's CLI can find the run and check its lock
   is dead before a token-less release (never to other callers).
+  Each live row carries a monotonic ``generation``. Release writes a
+  per-(target, holder, node) tombstone for that generation so a late
+  acquire or renew whose generation, holder, or lease stamp predates the
+  tombstone is refused with ``reason: "stale-generation"`` instead of
+  resurrecting the row (issue #1189). Schema v4 databases gain the
+  column and tombstone table additively.
   Trust boundary: ``node_id`` is bound to the node token that presents it,
   so a member can only act as itself; ``lock``, ``supersede`` and ``scope``
   remain caller-asserted intent that keeps *honest* clients from stealing
@@ -214,7 +220,23 @@ CREATE TABLE IF NOT EXISTS claims (
     expires_at REAL NOT NULL,
     lock_token TEXT,
     lock_acquired_at TEXT,
-    lock_run_dir TEXT
+    lock_run_dir TEXT,
+    generation INTEGER NOT NULL DEFAULT 1
+);
+"""
+# Release tombstones (issue #1189): survive the claim DELETE so a late
+# acquire/renew cannot recreate the row. One row per released holder on a
+# node; expired with the claim TTL. Additive on schema v4.
+_TOMBSTONES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS claim_tombstones (
+    target TEXT NOT NULL,
+    holder_token TEXT NOT NULL,
+    owner_node TEXT NOT NULL,
+    generation INTEGER NOT NULL,
+    lease_stamp TEXT,
+    released_at TEXT NOT NULL,
+    expires_at REAL NOT NULL,
+    PRIMARY KEY (target, holder_token, owner_node)
 );
 """
 _CLAIMS_ADDITIVE_COLUMNS = (
@@ -289,6 +311,8 @@ def _claims_table_needs_migration(claims_columns: set[str]) -> bool:
         return True
     if "holder_token" not in claims_columns:
         return True
+    if "generation" not in claims_columns:
+        return True
     return any(column not in claims_columns for column in _CLAIMS_ADDITIVE_COLUMNS)
 
 
@@ -362,6 +386,13 @@ def _migrate_claims_table(conn: sqlite3.Connection) -> None:
                     # wanted, not an error.
                     if "duplicate column" not in str(exc).lower():
                         raise
+            if "generation" not in claims_columns:
+                try:
+                    conn.execute("ALTER TABLE claims ADD COLUMN generation INTEGER NOT NULL DEFAULT 1")
+                except sqlite3.OperationalError as exc:
+                    if "duplicate column" not in str(exc).lower():
+                        raise
+        conn.execute(_TOMBSTONES_SCHEMA)
         conn.commit()
     except BaseException:
         conn.rollback()
@@ -432,6 +463,7 @@ def init_db(db_path: Path) -> sqlite3.Connection:
                 # usually done the work already.
                 if _claims_table_needs_migration(_claims_columns(conn)):
                     _migrate_claims_table(conn)
+        conn.execute(_TOMBSTONES_SCHEMA)
         conn.execute("CREATE INDEX IF NOT EXISTS events_run_seq ON events (node_id, run_id, sequence)")
         # v3 -> v4 is one additive table; IF NOT EXISTS is the whole migration.
         conn.execute(_NODES_SCHEMA)
@@ -672,9 +704,16 @@ def _validate_claim_request(raw: Any) -> dict[str, Any]:
         # fresh run acquired after the caller looked. Only "force" may
         # delete unfenced.
         raise FleetHubError("claim field 'acquired_at' is required for a token-less node-scoped release")
+    generation = raw.get("generation")
+    if generation is not None:
+        if action not in ("acquire", "renew"):
+            raise FleetHubError("claim field 'generation' is only valid for acquire or renew")
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 1:
+            raise FleetHubError("claim field 'generation' must be a positive integer")
+    request["generation"] = generation
     lock = raw.get("lock")
-    if lock is not None and action != "acquire":
-        raise FleetHubError("claim field 'lock' is only valid for acquire")
+    if lock is not None and action not in ("acquire", "renew"):
+        raise FleetHubError("claim field 'lock' is only valid for acquire or renew")
     request["lock"] = _validate_lease(lock, "lock") if lock is not None else None
     supersede = raw.get("supersede")
     if action == "acquire" and scope == "node":
@@ -708,6 +747,12 @@ def _validate_lease(raw: Any, field: str) -> dict[str, str | None]:
     return lease
 
 
+def _as_generation(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
+        return value
+    return 1
+
+
 def _claim_payload(row: tuple[Any, ...]) -> dict[str, Any]:
     return {
         "target": row[0],
@@ -721,24 +766,128 @@ def _claim_payload(row: tuple[Any, ...]) -> dict[str, Any]:
         "renewed_at": row[8],
         "ttl_seconds": row[9],
         "expires_at": _epoch_to_iso(row[10]),
+        "generation": _as_generation(row[11] if len(row) > 11 else None),
     }
 
 
 # Payload columns only: holder_token is a fencing capability and is never
 # serialized to callers (it would let anyone forge a renew/release).
 _CLAIM_COLUMNS = (
-    "target, owner_node, owner_conductor, harness, role, job, session, acquired_at, renewed_at, ttl_seconds, expires_at"
+    "target, owner_node, owner_conductor, harness, role, job, session, "
+    "acquired_at, renewed_at, ttl_seconds, expires_at, generation"
 )
 
 
 def _fetch_claim(conn: sqlite3.Connection, target: str) -> tuple[Any, ...] | None:
     """Row as (_CLAIM_COLUMNS..., holder_token, lock_token, lock_acquired_at,
-    lock_run_dir); the fencing token is index 11, the lease token index 12."""
+    lock_run_dir); generation is index 11, the fencing token is index 12,
+    the lease token index 13."""
     return conn.execute(
         f"SELECT {_CLAIM_COLUMNS}, holder_token, lock_token, lock_acquired_at, lock_run_dir "
         "FROM claims WHERE target = ?",
         (target,),
     ).fetchone()
+
+
+def _fetch_tombstones(conn: sqlite3.Connection, target: str) -> list[tuple[Any, ...]]:
+    """Rows as (target, generation, holder_token, owner_node, lease_stamp,
+    released_at, expires_at)."""
+    return list(
+        conn.execute(
+            "SELECT target, generation, holder_token, owner_node, lease_stamp, released_at, expires_at "
+            "FROM claim_tombstones WHERE target = ?",
+            (target,),
+        ).fetchall()
+    )
+
+
+def _stale_generation_payload(action: str, target: str) -> dict[str, Any]:
+    key = "granted" if action == "acquire" else "renewed"
+    return {
+        key: False,
+        "error": f"claim generation on {target!r} is stale",
+        "reason": "stale-generation",
+        "owner": None,
+    }
+
+
+def _request_lease_stamp(request: dict[str, Any]) -> str | None:
+    lock = request.get("lock")
+    if not isinstance(lock, dict):
+        return None
+    stamp = lock.get("acquired_at")
+    return stamp.strip() if isinstance(stamp, str) and stamp.strip() else None
+
+
+def _is_stale_against_tombstones(
+    *,
+    node: str,
+    holder: str | None,
+    generation: int | None,
+    lease_stamp: str | None,
+    prior: tuple[Any, ...] | None,
+    tombstones: list[tuple[Any, ...]],
+    now: float,
+) -> bool:
+    live = [row for row in tombstones if row[6] > now]
+    if not live:
+        return False
+    live_same_holder = (
+        prior is not None and prior[10] > now and holder is not None and prior[12] == holder and prior[1] == node
+    )
+    if live_same_holder:
+        return generation is not None and generation < _as_generation(prior[11])
+    max_gen = max(_as_generation(row[1]) for row in live)
+    if generation is not None and generation <= max_gen:
+        return True
+    if holder is not None and any(row[2] == holder and row[3] == node for row in live):
+        return True
+    if lease_stamp and any(row[3] == node and row[4] and lease_stamp <= row[4] for row in live):
+        return True
+    return False
+
+
+def _next_claim_generation(prior: tuple[Any, ...] | None, tombstones: list[tuple[Any, ...]], now: float) -> int:
+    floor = 0
+    live = [row for row in tombstones if row[6] > now]
+    if live:
+        floor = max(floor, max(_as_generation(row[1]) for row in live))
+    if prior is not None and prior[10] > now:
+        floor = max(floor, _as_generation(prior[11]))
+    return floor + 1
+
+
+def _row_lease_stamp(row: tuple[Any, ...]) -> str | None:
+    lock_acquired_at = row[14] if len(row) > 14 else None
+    if isinstance(lock_acquired_at, str) and lock_acquired_at.strip():
+        return lock_acquired_at.strip()
+    acquired_at = row[7]
+    return acquired_at.strip() if isinstance(acquired_at, str) and acquired_at.strip() else None
+
+
+def _write_claim_tombstone(
+    conn: sqlite3.Connection,
+    *,
+    target: str,
+    generation: int,
+    holder: str,
+    node: str,
+    lease_stamp: str | None,
+    ttl: int,
+    now: float,
+    now_iso: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO claim_tombstones "
+        "(target, holder_token, owner_node, generation, lease_stamp, released_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT(target, holder_token, owner_node) DO UPDATE SET "
+        "generation = MAX(claim_tombstones.generation, excluded.generation), "
+        "lease_stamp = excluded.lease_stamp, "
+        "released_at = excluded.released_at, "
+        "expires_at = excluded.expires_at",
+        (target, holder, node, generation, lease_stamp, now_iso, now + ttl),
+    )
 
 
 def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None = None) -> tuple[int, dict[str, Any]]:
@@ -775,6 +924,14 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
     without it): the delete is fenced to that exact row, so a claim
     re-acquired between the caller's inspect and its release is never
     deleted (409 with the current row). Only ``force`` deletes unfenced.
+
+    Release also writes a tombstone for the released (target, holder, node)
+    carrying that row's generation and lease stamp (issue #1189). A later
+    acquire or renew whose generation is not newer, whose holder matches the
+    tombstone, or whose lock ``acquired_at`` predates the tombstone stamp is
+    refused with ``reason: "stale-generation"``. A holder-scoped release
+    that finds no row still plants a tombstone so an in-flight acquire for
+    that holder cannot land after the release.
     """
     request = _validate_claim_request(raw)
     if caller_node is not None and request["node_id"] != caller_node:
@@ -796,24 +953,37 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             return 200, {"inspected": True, "claim": None, "owned": False}
         inspected: dict[str, Any] = {"inspected": True, "claim": _claim_payload(row), "owned": row[1] == node}
         if row[1] == node:
-            inspected["lock_run_dir"] = row[14]
+            inspected["lock_run_dir"] = row[15]
         return 200, inspected
     if request["action"] == "acquire":
-        # One write transaction: the prune, the prior-row read that the
-        # ``superseded`` receipt describes, and the upsert see one state.
+        # One write transaction: the prune, the tombstone check, the
+        # prior-row read that the ``superseded`` receipt describes, and the
+        # upsert see one state.
         conn.execute("BEGIN IMMEDIATE")
         conn.execute("DELETE FROM claims WHERE expires_at <= ?", (now,))
-        # Only a same-node supersede needs the prior row (to report what it
-        # replaced); expired rows are already gone, so this is a live claim.
-        prior = _fetch_claim(conn, target) if scope == "node" else None
+        conn.execute("DELETE FROM claim_tombstones WHERE expires_at <= ?", (now,))
+        prior = _fetch_claim(conn, target)
+        tombstones = _fetch_tombstones(conn, target)
+        if _is_stale_against_tombstones(
+            node=node,
+            holder=holder,
+            generation=request["generation"],
+            lease_stamp=_request_lease_stamp(request),
+            prior=prior,
+            tombstones=tombstones,
+            now=now,
+        ):
+            conn.commit()
+            return 409, _stale_generation_payload("acquire", target)
         lock = request["lock"] or {"token": None, "acquired_at": None, "run_dir": None}
         supersede = request["supersede"] or {"token": None, "acquired_at": None}
+        next_generation = _next_claim_generation(prior, tombstones, now)
         cursor = conn.execute(
             "INSERT INTO claims "
             "(target, owner_node, owner_conductor, harness, role, job, session, holder_token, "
             "lock_token, lock_acquired_at, lock_run_dir, "
-            "acquired_at, renewed_at, ttl_seconds, expires_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "acquired_at, renewed_at, ttl_seconds, expires_at, generation) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(target) DO UPDATE SET "
             "owner_node = excluded.owner_node, "
             "owner_conductor = excluded.owner_conductor, "
@@ -828,6 +998,9 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             "acquired_at = CASE WHEN claims.holder_token = excluded.holder_token "
             "AND claims.owner_node = excluded.owner_node "
             "AND claims.expires_at > ? THEN claims.acquired_at ELSE excluded.acquired_at END, "
+            "generation = CASE WHEN claims.holder_token = excluded.holder_token "
+            "AND claims.owner_node = excluded.owner_node "
+            "AND claims.expires_at > ? THEN claims.generation ELSE excluded.generation END, "
             "renewed_at = excluded.renewed_at, "
             "ttl_seconds = excluded.ttl_seconds, "
             "expires_at = excluded.expires_at "
@@ -853,6 +1026,8 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
                 now_iso,
                 ttl,
                 now + ttl,
+                next_generation,
+                now,
                 now,
                 now,
                 supersede["token"],
@@ -876,9 +1051,10 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
                 now_iso,
                 ttl,
                 now + ttl,
+                next_generation,
             )
             granted: dict[str, Any] = {"granted": True, "claim": _claim_payload(row if row is not None else written)}
-            if prior is not None and prior[11] != holder:
+            if scope == "node" and prior is not None and prior[12] != holder:
                 granted["superseded"] = _claim_payload(prior)
             return 200, granted
         row = _fetch_claim(conn, target)
@@ -889,6 +1065,17 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             error += " under another lease than the reconciled dead run's (not superseded)"
         return 409, {"granted": False, "error": error, "owner": owner}
     if request["action"] == "renew":
+        prior = _fetch_claim(conn, target)
+        if _is_stale_against_tombstones(
+            node=node,
+            holder=holder,
+            generation=request["generation"],
+            lease_stamp=_request_lease_stamp(request),
+            prior=prior,
+            tombstones=_fetch_tombstones(conn, target),
+            now=now,
+        ):
+            return 409, _stale_generation_payload("renew", target)
         cursor = conn.execute(
             "UPDATE claims SET renewed_at = ?, ttl_seconds = ?, expires_at = ? "
             "WHERE target = ? AND holder_token = ? AND owner_node = ? AND expires_at > ?",
@@ -897,10 +1084,23 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         conn.commit()
         if cursor.rowcount == 1:
             row = _fetch_claim(conn, target)
-            written = (target, node, conductor, None, None, None, None, now_iso, now_iso, ttl, now + ttl)
+            written = (
+                target,
+                node,
+                conductor,
+                None,
+                None,
+                None,
+                None,
+                now_iso,
+                now_iso,
+                ttl,
+                now + ttl,
+                request["generation"] or 1,
+            )
             return 200, {"renewed": True, "claim": _claim_payload(row if row is not None else written)}
         row = _fetch_claim(conn, target)
-        if row is not None and row[10] > now and (row[11] != holder or row[1] != node):
+        if row is not None and row[10] > now and (row[12] != holder or row[1] != node):
             return 409, {
                 "renewed": False,
                 "error": f"target {target!r} is held by {row[1]}",
@@ -908,20 +1108,45 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
             }
         return 409, {"renewed": False, "error": f"claim on {target!r} is expired or missing", "owner": None}
     if scope == "holder":
+        conn.execute("BEGIN IMMEDIATE")
+        prior = _fetch_claim(conn, target)
         cursor = conn.execute(
             "DELETE FROM claims WHERE target = ? AND holder_token = ? AND owner_node = ?",
             (target, holder, node),
         )
-        conn.commit()
         if cursor.rowcount == 1:
+            _write_claim_tombstone(
+                conn,
+                target=target,
+                generation=_as_generation(prior[11]) if prior is not None else 1,
+                holder=str(holder),
+                node=node,
+                lease_stamp=_row_lease_stamp(prior) if prior is not None else None,
+                ttl=int(prior[9]) if prior is not None else ttl,
+                now=now,
+                now_iso=now_iso,
+            )
+            conn.commit()
             return 200, {"released": True}
-        row = _fetch_claim(conn, target)
-        if row is not None:
+        if prior is not None:
+            conn.commit()
             return 409, {
                 "released": False,
-                "error": f"target {target!r} is held by {row[1]}",
-                "owner": _claim_payload(row),
+                "error": f"target {target!r} is held by {prior[1]}",
+                "owner": _claim_payload(prior),
             }
+        _write_claim_tombstone(
+            conn,
+            target=target,
+            generation=1,
+            holder=str(holder),
+            node=node,
+            lease_stamp=_request_lease_stamp(request),
+            ttl=ttl,
+            now=now,
+            now_iso=now_iso,
+        )
+        conn.commit()
         return 200, {"released": False}
     # Token-less release (issue #1141): the caller's own node's row, or with
     # "force" whoever holds the target. The read and the delete share one
@@ -936,6 +1161,18 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         "DELETE FROM claims WHERE target = ? AND (? = 1 OR owner_node = ?) AND (? IS NULL OR acquired_at = ?)",
         (target, int(scope == "force"), node, expected_acquired_at, expected_acquired_at),
     )
+    if cursor.rowcount == 1 and prior is not None:
+        _write_claim_tombstone(
+            conn,
+            target=target,
+            generation=_as_generation(prior[11]),
+            holder=str(prior[12]),
+            node=str(prior[1]),
+            lease_stamp=_row_lease_stamp(prior),
+            ttl=int(prior[9]),
+            now=now,
+            now_iso=now_iso,
+        )
     conn.commit()
     if cursor.rowcount == 1:
         released: dict[str, Any] = {"released": True}

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -144,6 +144,7 @@ class GrokbotAdapter:
     def __init__(self, config: ListenerConfig):
         config.validate()
         self.config = config
+        self._fleet_generations: dict[str, int] = {}
 
     def tool_inventory(self) -> list[dict[str, str]]:
         return [{"name": name, "description": _TOOL_DESCRIPTIONS[name]} for name in sorted(self._tools())]
@@ -257,23 +258,44 @@ class GrokbotAdapter:
     def _fleet_target(self) -> str:
         return fleet_client.resolve_claim_target(self.config.target)
 
+    def _remember_fleet_generation(self, holder: str, decision: fleet_client.ClaimDecision) -> None:
+        claim = decision.claim
+        if decision.granted and isinstance(claim, dict):
+            value = claim.get("generation")
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 1:
+                self._fleet_generations[holder] = value
+                return
+        if decision.reason == "stale-generation":
+            self._fleet_generations.pop(holder, None)
+
     def _fleet_acquire(self, job_id: str, holder: str, session: str) -> fleet_client.ClaimDecision:
         try:
-            return fleet_client.acquire_claim(
-                self._fleet_target(),
-                holder=holder,
-                ttl_seconds=LEASE_SECONDS,
-                harness="grokbot",
-                role=self.config.instance,
-                job=job_id,
-                session=session,
-            )
+            kwargs: dict[str, Any] = {
+                "holder": holder,
+                "ttl_seconds": LEASE_SECONDS,
+                "harness": "grokbot",
+                "role": self.config.instance,
+                "job": job_id,
+                "session": session,
+            }
+            generation = self._fleet_generations.get(holder)
+            if generation is not None:
+                kwargs["generation"] = generation
+            decision = fleet_client.acquire_claim(self._fleet_target(), **kwargs)
+            self._remember_fleet_generation(holder, decision)
+            return decision
         except Exception:
             return fleet_client.ClaimDecision(granted=False, reason="hub-unavailable", holder=holder)
 
     def _fleet_renew(self, holder: str) -> fleet_client.ClaimDecision:
         try:
-            return fleet_client.renew_claim(self._fleet_target(), holder=holder, ttl_seconds=LEASE_SECONDS)
+            kwargs: dict[str, Any] = {"holder": holder, "ttl_seconds": LEASE_SECONDS}
+            generation = self._fleet_generations.get(holder)
+            if generation is not None:
+                kwargs["generation"] = generation
+            decision = fleet_client.renew_claim(self._fleet_target(), **kwargs)
+            self._remember_fleet_generation(holder, decision)
+            return decision
         except Exception:
             return fleet_client.ClaimDecision(granted=False, reason="hub-unavailable", holder=holder)
 
@@ -282,6 +304,7 @@ class GrokbotAdapter:
             fleet_client.release_claim(self._fleet_target(), holder=holder)
         except Exception:
             return
+        self._fleet_generations.pop(holder, None)
 
     def _fleet_event(self, job_id: str, session: str, state: str) -> None:
         try:

--- a/tests/test_fleet_claim_release.py
+++ b/tests/test_fleet_claim_release.py
@@ -355,7 +355,9 @@ class TestHubScopes:
         try:
             columns = [row[1] for row in conn.execute("PRAGMA table_info(claims)").fetchall()]
             assert columns.count("lock_token") == 1 and "lock_acquired_at" in columns and "lock_run_dir" in columns
+            assert "generation" in columns
             assert [c["target"] for c in fleet_hub.list_claims(conn)] == ["repo-a"]
+            assert fleet_hub.list_claims(conn)[0]["generation"] == 1
         finally:
             conn.close()
 

--- a/tests/test_fleet_claim_release.py
+++ b/tests/test_fleet_claim_release.py
@@ -308,14 +308,14 @@ class TestHubScopes:
         conn.close()
         conn = fleet_hub.init_db(db)
         try:
-            assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION == 4
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION == 5
             assert [c["target"] for c in fleet_hub.list_claims(conn)] == ["repo-a"]
             # No lease recorded: never supersedable, only released or expired.
             status, _payload = fleet_hub.handle_claim(conn, _claim(holder="h2", scope="node", supersede=_lease("L1")))
             assert status == 409
             assert fleet_hub.handle_claim(conn, _claim("renew", holder="h1"))[1]["renewed"] is True
             # Re-opening is idempotent.
-            assert fleet_hub.init_db(db).execute("PRAGMA user_version").fetchone()[0] == 4
+            assert fleet_hub.init_db(db).execute("PRAGMA user_version").fetchone()[0] == 5
         finally:
             conn.close()
 

--- a/tests/test_fleet_claim_release.py
+++ b/tests/test_fleet_claim_release.py
@@ -502,7 +502,14 @@ class TestReleaseCli:
         out = capsys.readouterr().out
         assert "released claim on 'repo-a'" in out and NODE_A in out and "chef" in out
         assert fleet_client.fetch_claims() == []
-        _post(url, token, _claim(holder="dead2", lock=_lease(run_dir=str(run_dir))))
+        _post(
+            url,
+            token,
+            _claim(
+                holder="dead2",
+                lock=_lease(token="dead-owner-2", acquired_at="2026-08-26T12:00:00+00:00", run_dir=str(run_dir)),
+            ),
+        )
         assert cli.main(["fleet", "claims", "--release", "repo-a", "--json"]) == 0
         payload = json.loads(capsys.readouterr().out)
         assert payload["released"] is True and payload["forced"] is False
@@ -607,7 +614,19 @@ class TestReleaseCli:
         assert [c["target"] for c in fleet_client.fetch_claims()] == ["api"]
         # A run directory that is not on this machine: same refusal.
         _post(url, token, _claim("release", target="api", holder="bare"))
-        _post(url, token, _claim(target="api", holder="elsewhere", lock=_lease(run_dir="/nonexistent/.brigade/runs/x")))
+        _post(
+            url,
+            token,
+            _claim(
+                target="api",
+                holder="elsewhere",
+                lock=_lease(
+                    token="elsewhere-owner",
+                    acquired_at="2026-08-26T12:00:00+00:00",
+                    run_dir="/nonexistent/.brigade/runs/x",
+                ),
+            ),
+        )
         assert cli.main(["fleet", "claims", "--release", "api"]) == 1
         assert "does not exist on this machine" in capsys.readouterr().err
         assert cli.main(["fleet", "claims", "--release", "api", "--force", "--json"]) == 0
@@ -656,7 +675,15 @@ class TestReleaseCli:
         assert payload["released"] is True and payload["forced"] is False and payload["target"] == "api"
         assert fleet_client.fetch_claims() == []
         # --force skips the proof (and says so in the receipt).
-        _post(url, token, _claim(target="api", holder="live2", lock=_lease(run_dir=str(run_dir))))
+        _post(
+            url,
+            token,
+            _claim(
+                target="api",
+                holder="live2",
+                lock=_lease(token="live-owner-2", acquired_at="2026-08-26T12:00:00+00:00", run_dir=str(run_dir)),
+            ),
+        )
         lock.mkdir()
         (lock / "pid").write_text(f"{os.getpid()}\n")
         assert cli.main(["fleet", "claims", "--release", str(ws_b), "--path", "--force", "--json"]) == 0

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -503,7 +503,7 @@ class TestHubClaims:
         conn.close()
         conn = fleet_hub.init_db(db)
         try:
-            assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION == 4
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION == 5
             assert conn.execute("SELECT COUNT(*) FROM claims").fetchone()[0] == 0
         finally:
             conn.close()
@@ -552,6 +552,24 @@ class TestHubClaims:
         assert status == 409 and payload["reason"] == "stale-generation"
         assert _post(url, token, _claim(holder="h-fresh"))[1]["granted"] is True
 
+    def test_released_holder_stays_stale_after_claim_ttl(self, hub, clock):
+        """Generation floor survives claim TTL: a released holder cannot
+        re-acquire as generation 1 after the tombstone's former expiry."""
+        url, token, _db = hub
+        first = _post(url, token, _claim(ttl_seconds=60))[1]["claim"]
+        assert first["generation"] == 1
+        assert _post(url, token, _claim("release"))[1]["released"] is True
+        clock["now"] += 61
+        status, payload = _post(url, token, _claim(ttl_seconds=60))
+        assert status == 409 and payload["reason"] == "stale-generation"
+        assert payload["granted"] is False
+        status, payload = _post(url, token, _claim(ttl_seconds=60, generation=1))
+        assert status == 409 and payload["reason"] == "stale-generation"
+        assert _get(url, "/claims", token)[1]["claims"] == []
+        status, payload = _post(url, token, _claim(holder="h2", ttl_seconds=60))
+        assert status == 200 and payload["granted"] is True
+        assert payload["claim"]["generation"] == 2
+
     def test_generation_is_only_valid_on_acquire_or_renew(self, hub):
         url, token, _db = hub
         assert _post(url, token, _claim("release", generation=1))[0] == 400
@@ -578,18 +596,56 @@ class TestHubClaims:
         conn.close()
         conn = fleet_hub.init_db(db)
         try:
-            assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION == 5
             columns = {row[1] for row in conn.execute("PRAGMA table_info(claims)").fetchall()}
             assert "generation" in columns
             tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
             assert "claim_tombstones" in tables
+            assert "claim_generation_floors" in tables
             listed = fleet_hub.list_claims(conn)
             assert listed[0]["target"] == "repo-a"
             assert listed[0]["generation"] == 1
+            assert conn.execute(
+                "SELECT generation FROM claim_generation_floors WHERE target = 'repo-a'"
+            ).fetchone() == (1,)
             status, payload = fleet_hub.handle_claim(conn, _claim("renew", holder="h1"))
             assert status == 200 and payload["claim"]["generation"] == 1
         finally:
             conn.close()
+
+    def test_newer_schema_is_refused_by_init_and_open(self, tmp_path):
+        db = tmp_path / "future.db"
+        conn = fleet_hub.init_db(db)
+        conn.execute(f"PRAGMA user_version={fleet_hub.SCHEMA_VERSION + 1}")
+        conn.commit()
+        conn.close()
+        with pytest.raises(fleet_hub.FleetHubError, match="schema version"):
+            fleet_hub.init_db(db)
+        with pytest.raises(fleet_hub.FleetHubError, match="schema version"):
+            fleet_hub.open_db(db)
+
+    def test_tombstones_are_bounded_per_target_node(self, hub):
+        """No-row release spam cannot grow tombstones without limit; the
+        newest in-flight holder fence is kept."""
+        url, token, db = hub
+        limit = fleet_hub.CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE
+        for i in range(limit + 8):
+            holder = f"h{i:02d}"
+            assert _post(url, token, _claim("release", holder=holder, target="repo-a"))[1]["released"] is False
+        conn = fleet_hub.init_db(db)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM claim_tombstones WHERE target = 'repo-a' AND owner_node = ?",
+                (NODE_A,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == limit
+        last = f"h{limit + 7:02d}"
+        status, payload = _post(url, token, _claim(holder=last, target="repo-a"))
+        assert status == 409 and payload["reason"] == "stale-generation"
+        status, payload = _post(url, token, _claim(holder="h-fresh", target="repo-a"))
+        assert status == 200 and payload["granted"] is True
 
     def test_pre_holder_token_claims_table_is_recreated(self, tmp_path):
         db = tmp_path / "early-v2.db"
@@ -655,6 +711,18 @@ class TestClientClaims:
         assert fleet_client.fetch_claims(include_all=True) == []
         fresh = fleet_client.acquire_claim("repo-a", node_id=NODE_A)
         assert fresh.granted is True and (fresh.claim or {}).get("generation") == 2
+
+    def test_client_released_holder_stays_stale_after_claim_ttl(self, hub, clock, monkeypatch):
+        url, token, _db = hub
+        self._env(monkeypatch, url, token)
+        won = fleet_client.acquire_claim("repo-a", node_id=NODE_A, ttl_seconds=60)
+        holder = won.holder
+        assert won.granted is True and (won.claim or {}).get("generation") == 1
+        assert fleet_client.release_claim("repo-a", node_id=NODE_A, holder=holder).granted is True
+        clock["now"] += 61
+        late = fleet_client.acquire_claim("repo-a", node_id=NODE_A, holder=holder, ttl_seconds=60, generation=1)
+        assert late.granted is False and late.reason == "stale-generation"
+        assert fleet_client.fetch_claims(include_all=True) == []
 
     def test_no_hub_and_unreachable_hub_reasons(self, monkeypatch):
         decision = fleet_client.acquire_claim("repo-a", node_id=NODE_A)

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -420,6 +420,7 @@ class TestHubClaims:
             {**_claim(), "action": "steal"},
             {**_claim(), "action": None},
             {**_claim(), "target": " "},
+            {**_claim(), "target": "a" * (fleet_hub.CLAIM_TARGET_MAX_CHARS + 1)},
             {"action": "acquire", "target": "repo-a", "holder": "h1"},
             {"action": "acquire", "target": "repo-a", "node_id": NODE_A},
             {**_claim(), "ttl_seconds": 0},
@@ -631,14 +632,31 @@ class TestHubClaims:
         with pytest.raises(fleet_hub.FleetHubError, match="schema version"):
             fleet_hub.open_db(db)
 
+    def test_delayed_initial_acquire_stays_fenced_after_newer_no_row_releases(self, hub):
+        """Generation-less delayed acquire must not land after 16 newer
+        no-row fences on the same target and node would have evicted
+        holder ``stalled``."""
+        url, token, _db = hub
+        assert _post(url, token, _claim("release", holder="stalled"))[1]["released"] is False
+        for i in range(fleet_hub.CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE):
+            _post(url, token, _claim("release", holder=f"newer{i:02d}"))
+        status, payload = _post(url, token, _claim(holder="stalled"))
+        assert status == 409 and payload["reason"] == "stale-generation"
+        assert payload["granted"] is False
+        assert _get(url, "/claims", token)[1]["claims"] == []
+        status, payload = _post(url, token, _claim(holder="h-fresh"))
+        assert status == 200 and payload["granted"] is True
+
     def test_tombstones_are_bounded_per_target_node(self, hub):
-        """No-row release spam cannot grow tombstones without limit; the
-        newest in-flight holder fence is kept."""
+        """No-row release spam cannot grow tombstones without limit; existing
+        fences are kept (fail closed) instead of evicted."""
         url, token, db = hub
         limit = fleet_hub.CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE
+        statuses: list[tuple[int, dict, str]] = []
         for i in range(limit + 8):
             holder = f"h{i:02d}"
-            assert _post(url, token, _claim("release", holder=holder, target="repo-a"))[1]["released"] is False
+            status, payload = _post(url, token, _claim("release", holder=holder, target="repo-a"))
+            statuses.append((status, payload, holder))
         conn = fleet_hub.init_db(db)
         try:
             count = conn.execute(
@@ -648,11 +666,42 @@ class TestHubClaims:
         finally:
             conn.close()
         assert count == limit
-        last = f"h{limit + 7:02d}"
-        status, payload = _post(url, token, _claim(holder=last, target="repo-a"))
+        assert statuses[0][0] == 200 and statuses[0][1]["released"] is False
+        assert statuses[limit][0] == 409 and statuses[limit][1]["reason"] == "storage-full"
+        status, payload = _post(url, token, _claim(holder="h00", target="repo-a"))
         assert status == 409 and payload["reason"] == "stale-generation"
         status, payload = _post(url, token, _claim(holder="h-fresh", target="repo-a"))
         assert status == 200 and payload["granted"] is True
+
+    def test_no_row_releases_cannot_grow_durable_state_across_targets(self, tmp_path):
+        """Holder-scoped no-row releases over distinct targets fail closed
+        at the durable fence budget instead of writing unbounded floors."""
+        db = tmp_path / "hub.db"
+        conn = fleet_hub.init_db(db)
+        try:
+            limit = fleet_hub.CLAIM_DURABLE_FENCE_LIMIT
+            planted = 0
+            overflow = 0
+            for i in range(limit + 8):
+                status, payload = fleet_hub.handle_claim(conn, _claim("release", target=f"t{i:04d}", holder="h1"))
+                if status == 200 and payload.get("released") is False:
+                    planted += 1
+                elif status == 409 and payload.get("reason") == "storage-full":
+                    overflow += 1
+                else:
+                    raise AssertionError((status, payload))
+            tombs = conn.execute("SELECT COUNT(*) FROM claim_tombstones").fetchone()[0]
+            floors = conn.execute("SELECT COUNT(*) FROM claim_generation_floors").fetchone()[0]
+            assert tombs == limit
+            assert floors == limit
+            assert planted == limit
+            assert overflow == 8
+            status, payload = fleet_hub.handle_claim(conn, _claim(target="t0000", holder="h1"))
+            assert status == 409 and payload["reason"] == "stale-generation"
+            status, payload = fleet_hub.handle_claim(conn, _claim(target="fresh-target", holder="h-fresh"))
+            assert status == 409 and payload["reason"] == "storage-full"
+        finally:
+            conn.close()
 
     def test_pre_holder_token_claims_table_is_recreated(self, tmp_path):
         db = tmp_path / "early-v2.db"
@@ -730,6 +779,25 @@ class TestClientClaims:
         late = fleet_client.acquire_claim("repo-a", node_id=NODE_A, holder=holder, ttl_seconds=60, generation=1)
         assert late.granted is False and late.reason == "stale-generation"
         assert fleet_client.fetch_claims(include_all=True) == []
+
+    def test_client_delayed_acquire_after_tombstone_cap_is_stale(self, hub, monkeypatch):
+        url, token, _db = hub
+        self._env(monkeypatch, url, token)
+        assert fleet_client.release_claim("repo-a", node_id=NODE_A, holder="stalled").reason == "missing"
+        for i in range(fleet_hub.CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE):
+            fleet_client.release_claim("repo-a", node_id=NODE_A, holder=f"newer{i:02d}")
+        late = fleet_client.acquire_claim("repo-a", node_id=NODE_A, holder="stalled")
+        assert late.granted is False and late.reason == "stale-generation"
+        assert fleet_client.fetch_claims(include_all=True) == []
+
+    def test_client_storage_full_is_not_missing(self, hub, monkeypatch):
+        url, token, _db = hub
+        self._env(monkeypatch, url, token)
+        limit = fleet_hub.CLAIM_TOMBSTONE_LIMIT_PER_TARGET_NODE
+        for i in range(limit):
+            assert fleet_client.release_claim("repo-a", node_id=NODE_A, holder=f"h{i:02d}").reason == "missing"
+        overflow = fleet_client.release_claim("repo-a", node_id=NODE_A, holder="h-overflow")
+        assert overflow.granted is False and overflow.reason == "storage-full"
 
     def test_no_hub_and_unreachable_hub_reasons(self, monkeypatch):
         decision = fleet_client.acquire_claim("repo-a", node_id=NODE_A)

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -508,6 +508,89 @@ class TestHubClaims:
         finally:
             conn.close()
 
+    def test_acquire_after_release_is_refused_as_stale_generation(self, hub):
+        """A late-committing acquire for the released holder cannot resurrect the row."""
+        url, token, _db = hub
+        first = _post(url, token, _claim())[1]["claim"]
+        assert first["generation"] == 1
+        assert _post(url, token, _claim("release")) == (200, {"released": True})
+        status, payload = _post(url, token, _claim())
+        assert status == 409
+        assert payload["granted"] is False
+        assert payload["reason"] == "stale-generation"
+        assert payload["owner"] is None
+        assert _get(url, "/claims", token)[1]["claims"] == []
+        # A new holder on the same node, or the same holder on another node, may take the target.
+        status, payload = _post(url, token, _claim(holder="h2"))
+        assert status == 200 and payload["granted"] is True
+        assert payload["claim"]["generation"] == 2
+        assert _post(url, token, _claim("release", holder="h2"))[1]["released"] is True
+        status, payload = _post(url, token, _claim(node=NODE_B))
+        assert status == 200 and payload["granted"] is True
+        assert payload["claim"]["generation"] == 3
+
+    def test_late_acquire_with_stale_generation_or_lease_stamp_is_refused(self, hub):
+        url, token, _db = hub
+        lock = {"token": "run-lock-1", "acquired_at": "2026-08-26T00:00:00+00:00"}
+        granted = _post(url, token, _claim(lock=lock))[1]["claim"]
+        assert granted["generation"] == 1
+        assert _post(url, token, _claim("release"))[1]["released"] is True
+        status, payload = _post(url, token, _claim(generation=1))
+        assert status == 409 and payload["reason"] == "stale-generation"
+        status, payload = _post(url, token, _claim(holder="h-late", lock=lock))
+        assert status == 409 and payload["reason"] == "stale-generation"
+        status, payload = _post(url, token, _claim("renew", generation=1))
+        assert status == 409 and payload["reason"] == "stale-generation"
+        assert payload["renewed"] is False
+        assert _get(url, "/claims", token)[1]["claims"] == []
+
+    def test_no_row_release_still_tombs_an_in_flight_acquire(self, hub):
+        """Release before the first acquire lands still fences that holder."""
+        url, token, _db = hub
+        assert _post(url, token, _claim("release"))[1]["released"] is False
+        status, payload = _post(url, token, _claim())
+        assert status == 409 and payload["reason"] == "stale-generation"
+        assert _post(url, token, _claim(holder="h-fresh"))[1]["granted"] is True
+
+    def test_generation_is_only_valid_on_acquire_or_renew(self, hub):
+        url, token, _db = hub
+        assert _post(url, token, _claim("release", generation=1))[0] == 400
+        assert _post(url, token, _claim(generation=0))[0] == 400
+        assert _post(url, token, _claim(generation=True))[0] == 400
+
+    def test_schema_v4_rows_gain_generation_without_dropping_live_claims(self, tmp_path):
+        db = tmp_path / "v4.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "CREATE TABLE claims (target TEXT NOT NULL PRIMARY KEY, owner_node TEXT NOT NULL, "
+            "owner_conductor TEXT, harness TEXT, role TEXT, job TEXT, session TEXT, "
+            "holder_token TEXT NOT NULL, acquired_at TEXT NOT NULL, renewed_at TEXT NOT NULL, "
+            "ttl_seconds INTEGER NOT NULL, expires_at REAL NOT NULL, lock_token TEXT, "
+            "lock_acquired_at TEXT, lock_run_dir TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO claims VALUES ('repo-a', ?, 'chef', NULL, NULL, NULL, NULL, 'h1', "
+            "'then', 'then', 900, ?, NULL, NULL, NULL)",
+            (NODE_A, time.time() + 900),
+        )
+        conn.execute("PRAGMA user_version=4")
+        conn.commit()
+        conn.close()
+        conn = fleet_hub.init_db(db)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(claims)").fetchall()}
+            assert "generation" in columns
+            tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+            assert "claim_tombstones" in tables
+            listed = fleet_hub.list_claims(conn)
+            assert listed[0]["target"] == "repo-a"
+            assert listed[0]["generation"] == 1
+            status, payload = fleet_hub.handle_claim(conn, _claim("renew", holder="h1"))
+            assert status == 200 and payload["claim"]["generation"] == 1
+        finally:
+            conn.close()
+
     def test_pre_holder_token_claims_table_is_recreated(self, tmp_path):
         db = tmp_path / "early-v2.db"
         conn = sqlite3.connect(str(db))
@@ -556,8 +639,22 @@ class TestClientClaims:
         assert fleet_client.renew_claim("repo-a", node_id=NODE_A, holder=holder).granted is True
         assert fleet_client.renew_claim("repo-a", node_id=NODE_B, holder="h-other").reason == "held"
         assert fleet_client.release_claim("repo-a", node_id=NODE_A, holder=holder).granted is True
-        assert fleet_client.renew_claim("repo-a", node_id=NODE_A, holder=holder).reason == "missing"
+        assert fleet_client.renew_claim("repo-a", node_id=NODE_A, holder=holder).reason == "stale-generation"
         assert fleet_client.fetch_claims() == []
+
+    def test_late_acquire_after_release_is_terminal_stale_generation(self, hub, monkeypatch):
+        url, token, _db = hub
+        self._env(monkeypatch, url, token)
+        won = fleet_client.acquire_claim("repo-a", node_id=NODE_A)
+        holder = won.holder
+        generation = (won.claim or {}).get("generation")
+        assert won.granted is True and holder and generation == 1
+        assert fleet_client.release_claim("repo-a", node_id=NODE_A, holder=holder).granted is True
+        late = fleet_client.acquire_claim("repo-a", node_id=NODE_A, holder=holder, generation=generation)
+        assert late.granted is False and late.reason == "stale-generation"
+        assert fleet_client.fetch_claims(include_all=True) == []
+        fresh = fleet_client.acquire_claim("repo-a", node_id=NODE_A)
+        assert fresh.granted is True and (fresh.claim or {}).get("generation") == 2
 
     def test_no_hub_and_unreachable_hub_reasons(self, monkeypatch):
         decision = fleet_client.acquire_claim("repo-a", node_id=NODE_A)
@@ -959,10 +1056,13 @@ class TestFleetClaimsCli:
         assert cli.main(["fleet", "claims", "--json"]) == 0
         payload = json.loads(capsys.readouterr().out)
         assert [c["target"] for c in payload["claims"]] == ["repo-a"]
+        assert payload["claims"][0]["generation"] == 1
         assert cli.main(["fleet", "claims"]) == 0
         out = capsys.readouterr().out
         assert "repo-a" in out and NODE_A[:12] in out and "cond-1" in out
-        assert out.splitlines()[0].split()[0] == "target"
+        header = out.splitlines()[0].split()
+        assert header[0] == "target" and "gen" in header
+        assert out.splitlines()[1].split()[header.index("gen")] == "1"
 
     def test_claims_table_renders_legacy_nonprintables_inert(self, hub, monkeypatch, capsys):
         from brigade import cli

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -605,11 +605,18 @@ class TestHubClaims:
             listed = fleet_hub.list_claims(conn)
             assert listed[0]["target"] == "repo-a"
             assert listed[0]["generation"] == 1
+            # A live migrated claim is not a released floor; lost-row
+            # re-acquire of this generation must still be possible.
+            assert (
+                conn.execute("SELECT generation FROM claim_generation_floors WHERE target = 'repo-a'").fetchone()
+                is None
+            )
+            status, payload = fleet_hub.handle_claim(conn, _claim("renew", holder="h1"))
+            assert status == 200 and payload["claim"]["generation"] == 1
+            assert fleet_hub.handle_claim(conn, _claim("release", holder="h1"))[1]["released"] is True
             assert conn.execute(
                 "SELECT generation FROM claim_generation_floors WHERE target = 'repo-a'"
             ).fetchone() == (1,)
-            status, payload = fleet_hub.handle_claim(conn, _claim("renew", holder="h1"))
-            assert status == 200 and payload["claim"]["generation"] == 1
         finally:
             conn.close()
 

--- a/tests/test_grokbot_mcp.py
+++ b/tests/test_grokbot_mcp.py
@@ -303,7 +303,7 @@ def test_same_lease_id_on_different_jobs_cannot_share_or_release_fleet_claims(tm
 def test_known_fleet_refusal_does_not_claim_or_emit(tmp_path: Path, monkeypatch):
     job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
     adapter = _adapter(tmp_path)
-    for reason in ("held", "auth-failed", "invalid", "missing"):
+    for reason in ("held", "auth-failed", "invalid", "missing", "stale-generation", "storage-full"):
         calls: list[tuple[str, dict[str, object]]] = []
 
         def refuse(target, *, _reason=reason, **kwargs):
@@ -504,7 +504,7 @@ def test_fleet_outage_then_missing_renew_allows_best_effort_acquire(tmp_path: Pa
 
 
 def test_fleet_outage_then_missing_renew_refuses_known_acquire_refusal(tmp_path: Path, monkeypatch):
-    for reason in ("held", "auth-failed", "invalid", "missing"):
+    for reason in ("held", "auth-failed", "invalid", "missing", "stale-generation", "storage-full"):
         job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), f"{reason}-refuse")["job_id"]
         adapter = _adapter(tmp_path)
         events: list[dict[str, object]] = []

--- a/tests/test_grokbot_mcp.py
+++ b/tests/test_grokbot_mcp.py
@@ -334,6 +334,39 @@ def test_best_effort_fleet_gaps_still_claim_the_queue(tmp_path: Path, monkeypatc
         assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
 
 
+def test_stale_generation_renew_is_terminal_and_does_not_reacquire(tmp_path: Path, monkeypatch):
+    job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def granted(target, **kwargs):
+        calls.append(("acquire", {"target": target, **kwargs}))
+        return fleet_client.ClaimDecision(
+            granted=True,
+            reason="ok",
+            holder=str(kwargs["holder"]),
+            claim={"generation": 1, "target": target},
+        )
+
+    def stale_renew(target, **kwargs):
+        calls.append(("renew", {"target": target, **kwargs}))
+        return fleet_client.ClaimDecision(granted=False, reason="stale-generation", holder=str(kwargs["holder"]))
+
+    monkeypatch.setattr(fleet_client, "acquire_claim", granted)
+    monkeypatch.setattr(fleet_client, "renew_claim", stale_renew)
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(fleet_client, "report_external_event", lambda **kwargs: events.append(kwargs), raising=False)
+    adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-stale"})
+    events.clear()
+    before = grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"]
+    with pytest.raises(grokbot_mcp.AdapterError):
+        adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": "lease-stale"})
+    assert grokbot_jobs.get_job(tmp_path, job_id)["lease_expires_at"] == before
+    assert events == []
+    assert [kind for kind, _payload in calls] == ["acquire", "renew"]
+    assert calls[1][1]["generation"] == 1
+
+
 def test_known_fleet_renew_refusal_does_not_heartbeat_or_extend_the_lease(tmp_path: Path, monkeypatch):
     job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
     adapter = _adapter(tmp_path)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

A late-committing fleet claim acquire or re-acquire could land after a later release and resurrect the row until TTL expiry. Release correctness is now a protocol property: the hub records a per-claim generation, a per-holder tombstone, and a durable per-target generation floor, then refuses stale acquire/renew requests instead of depending on client timing.

A follow-up review reproduced two remaining defects on that fencing: (1) a generation-less delayed initial acquire for holder `stalled` landed as generation 2 after 16 newer no-row fences evicted its tombstone; (2) holder-scoped no-row releases over arbitrary distinct targets grew tombstone and generation-floor rows without limit. Overflow now fails closed. Existing fences are not evicted.

Fixes #1189

## Type of change

- [x] Bug fix

## Behavior

- Hub schema remains **v5**. Forward migration from v4 adds `generation` (live claims kept), `claim_tombstones`, and `claim_generation_floors`. `init_db` / `open_db` refuse a newer `user_version`.
- Each release writes a `(target, holder, node)` tombstone and raises a durable per-target generation floor. The floor does **not** expire with claim TTL, so a released holder cannot re-acquire as generation 1 after 61s on a 60s TTL.
- The floor is raised only on release (and backfilled from tombstones). A live grant does not retire its own generation, so a lost-row heartbeat can still re-acquire.
- No-row tombstones are capped at 16 per `(target, node)` and at 1024 durable rows (`tombstones + claims`) globally. A new fence that would exceed either cap answers `409` with `reason: "storage-full"` instead of evicting a fence a delayed generation-less acquire can still match. Real releases may exceed the per-node no-row cap; they still consume the global budget reserved at acquire.
- Target strings are bounded at 256 characters.
- Acquire and renew whose generation is at or below the floor, whose holder+node matches a tombstone, or whose lock `acquired_at` exactly matches a released lease answer `409` with `reason: "stale-generation"`.
- Target, node, holder-token, and lock-lease fencing is unchanged. A new holder, or the same holder on another node, can still take a free target at the next generation when durable budget remains.
- The client sends generation and lease stamp on acquire/renew and treats `stale-generation` and `storage-full` as terminal (no retry, no heartbeat re-acquire). `brigade fleet claims` prints both refusals.
- Grok Bot session reporting treats `storage-full` as a known refusal (not best-effort). Authentication, bounded field validation, and existing JSON contracts are preserved; `generation` and `reason: "storage-full"` are additive.

## Verification

All four required commands passed at `5916013e4a5550a66b5522d69819cc69f2328fc2`.

```
$ python -m pytest -q tests/test_fleet_claims.py tests/test_fleet_claim_release.py tests/test_grokbot_mcp.py
........................................................................ [ 51%]
.............................................................s..ss.      [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/test_grokbot_mcp.py:689: requires the grokbot extra
SKIPPED [1] tests/test_grokbot_mcp.py:805: requires the grokbot extra
SKIPPED [1] tests/test_grokbot_mcp.py:852: requires the grokbot extra
136 passed, 3 skipped in 58.75s
```

```
$ ruff check src/brigade/fleet_hub.py src/brigade/fleet_client.py src/brigade/cli/fleet.py src/brigade/grokbot_mcp.py tests/test_fleet_claims.py tests/test_fleet_claim_release.py tests/test_grokbot_mcp.py
All checks passed!
```

```
$ ruff format --check src/brigade/fleet_hub.py src/brigade/fleet_client.py src/brigade/cli/fleet.py src/brigade/grokbot_mcp.py tests/test_fleet_claims.py tests/test_fleet_claim_release.py tests/test_grokbot_mcp.py
7 files already formatted
```

```
$ git diff --check
(no output; exit 0)
```

## Checklist

- [x] Required verification commands pass
- [x] Added or updated tests covering the change
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit message

Does not merge, close, or otherwise touch draft PR #1181. Kept draft.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86f71907-612c-48c9-aa37-6b173720c081?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86f71907-612c-48c9-aa37-6b173720c081&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

