### PR TITLE
test: add repo-wide module size ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,10 @@ jobs:
         run: python -m ruff format --check .
       - name: Mypy
         run: python -m mypy
+      - name: Size ratchet baseline
+        run: |
+          git fetch --no-tags --depth=1 origin ${{ github.base_ref || 'main' }}
+          python scripts/check_size_ratchet_baseline.py --base-ref origin/${{ github.base_ref || 'main' }}
       - name: Version sync
         run: python scripts/version_sync.py --check
       - name: Managed snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Thumbs.db
 !/scripts/verify-fast
 !/scripts/ci_pytest_shard.py
 !/scripts/verify_lock.py
+!/scripts/check_size_ratchet_baseline.py
 /skills/
 
 # Local plan/spec scratch dirs only. Reviewed planning artifacts ARE

--- a/scripts/check_size_ratchet_baseline.py
+++ b/scripts/check_size_ratchet_baseline.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Refuse new or raised LEGACY_OVERSIZED entries versus a git merge base.
+
+The on-disk mapping in tests/test_module_size_ratchet.py is not a baseline by
+itself: a PR can add a key or raise a cap in the same change and the in-repo
+tests still pass. This script compares the current mapping to the file at
+``--base-ref`` (default ``origin/main``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CURRENT_FILE = REPO_ROOT / "tests" / "test_module_size_ratchet.py"
+BASELINE_RELATIVE_PATH = "tests/test_module_size_ratchet.py"
+
+
+def _is_legacy_target(node: ast.expr) -> bool:
+    return isinstance(node, ast.Name) and node.id == "LEGACY_OVERSIZED"
+
+
+def parse_legacy_oversized(source: str) -> dict[str, int]:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(_is_legacy_target(target) for target in node.targets):
+            mapping = ast.literal_eval(node.value)
+            return {str(key): int(value) for key, value in mapping.items()}
+        if isinstance(node, ast.AnnAssign) and _is_legacy_target(node.target) and node.value is not None:
+            mapping = ast.literal_eval(node.value)
+            return {str(key): int(value) for key, value in mapping.items()}
+    raise ValueError("LEGACY_OVERSIZED assignment not found")
+
+
+def _git_toplevel(start: Path) -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=start,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return REPO_ROOT
+    return Path(result.stdout.strip())
+
+
+def _missing_at_ref(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return "does not exist" in lowered or "exists on disk, but not in" in lowered
+
+
+def read_baseline(base_ref: str, repo_root: Path) -> tuple[dict[str, int], bool]:
+    result = subprocess.run(
+        ["git", "show", f"{base_ref}:{BASELINE_RELATIVE_PATH}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        if _missing_at_ref(result.stderr):
+            return {}, True
+        sys.stderr.write(result.stderr)
+        raise SystemExit(1)
+    return parse_legacy_oversized(result.stdout), False
+
+
+def compare(current: dict[str, int], baseline: dict[str, int]) -> list[str]:
+    violations: list[str] = []
+    for key in sorted(current):
+        if key not in baseline:
+            violations.append(f"{key}: added allowlist entry")
+            continue
+        if current[key] > baseline[key]:
+            violations.append(f"{key}: cap raised from {baseline[key]} to {current[key]}")
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare LEGACY_OVERSIZED against the merge-base mapping.")
+    parser.add_argument("--base-ref", default="origin/main")
+    parser.add_argument("--current-file", default=str(DEFAULT_CURRENT_FILE))
+    args = parser.parse_args(argv)
+
+    current_path = Path(args.current_file)
+    current = parse_legacy_oversized(current_path.read_text(encoding="utf-8"))
+    repo_root = _git_toplevel(current_path.resolve().parent)
+    baseline, missing = read_baseline(args.base_ref, repo_root)
+    if missing:
+        print(f"size ratchet baseline: {BASELINE_RELATIVE_PATH} missing at {args.base_ref}; treating baseline as empty")
+        print(f"size ratchet baseline: ok ({len(current)} entries)")
+        return 0
+
+    violations = compare(current, baseline)
+    if violations:
+        for line in violations:
+            print(line)
+        return 1
+    print(f"size ratchet baseline: ok ({len(current)} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_module_size_ratchet.py
+++ b/tests/test_module_size_ratchet.py
@@ -1,4 +1,7 @@
-"""Entries may be lowered or removed, never added or raised. A new module over 2000 lines must be split before merge."""
+"""Entries may be lowered or removed, never added or raised. A new module over 2000 lines must be split before merge.
+
+CI enforces the shrink-only rule against the merge base with scripts/check_size_ratchet_baseline.py.
+"""
 
 from __future__ import annotations
 
@@ -33,8 +36,6 @@ def _production_module_sizes() -> dict[str, int]:
     sizes: dict[str, int] = {}
     for path in (REPO_ROOT / "src" / "brigade").rglob("*.py"):
         relative = path.relative_to(REPO_ROOT)
-        if "engines" in relative.parts:
-            continue
         sizes[relative.as_posix()] = _line_count(path)
     return sizes
 
@@ -65,13 +66,13 @@ def test_allowlisted_modules_never_grow() -> None:
 
 
 def test_allowlist_only_shrinks() -> None:
+    sizes = _production_module_sizes()
     stale = []
     for rel, cap in LEGACY_OVERSIZED.items():
-        path = REPO_ROOT / rel
-        if not path.is_file():
-            stale.append(f"{rel} is missing; delete its LEGACY_OVERSIZED entry (cap {cap})")
+        count = sizes.get(rel)
+        if count is None:
+            stale.append(f"{rel} is not a scanned src/brigade module; delete its LEGACY_OVERSIZED entry (cap {cap})")
             continue
-        count = _line_count(path)
         if count <= CEILING:
             stale.append(f"{rel} is {count} lines (<= {CEILING}); delete its LEGACY_OVERSIZED entry")
     assert not stale, "allowlist entries that no longer belong: " + "; ".join(stale)

--- a/tests/test_module_size_ratchet.py
+++ b/tests/test_module_size_ratchet.py
@@ -1,0 +1,77 @@
+"""Entries may be lowered or removed, never added or raised. A new module over 2000 lines must be split before merge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CEILING = 2000
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+LEGACY_OVERSIZED: dict[str, int] = {
+    "src/brigade/work_cmd/ledger.py": 6850,
+    "src/brigade/aboyeur.py": 5362,
+    "src/brigade/skills_cmd.py": 5305,
+    "src/brigade/runs_cmd.py": 3584,
+    "src/brigade/claude_hooks/runtime.py": 3389,
+    "src/brigade/work_cmd/scanners.py": 3332,
+    "src/brigade/research_cmd.py": 3088,
+    "src/brigade/outcome_cmd.py": 2903,
+    "src/brigade/run_redaction.py": 2802,
+    "src/brigade/harness_profile_cmd.py": 2570,
+    "src/brigade/work_cmd/verification.py": 2380,
+    "src/brigade/memory_cmd.py": 2189,
+    "src/brigade/care_cmd.py": 2084,
+    "src/brigade/receipts_cmd.py": 2055,
+}
+
+
+def _line_count(path: Path) -> int:
+    return len(path.read_text(encoding="utf-8").splitlines())
+
+
+def _production_module_sizes() -> dict[str, int]:
+    sizes: dict[str, int] = {}
+    for path in (REPO_ROOT / "src" / "brigade").rglob("*.py"):
+        relative = path.relative_to(REPO_ROOT)
+        if "engines" in relative.parts:
+            continue
+        sizes[relative.as_posix()] = _line_count(path)
+    return sizes
+
+
+def test_modules_outside_allowlist_stay_under_ceiling() -> None:
+    oversized = {
+        rel: count
+        for rel, count in _production_module_sizes().items()
+        if rel not in LEGACY_OVERSIZED and count > CEILING
+    }
+    assert not oversized, (
+        "modules over the 2000-line ceiling that are not in LEGACY_OVERSIZED: "
+        + ", ".join(f"{rel} ({count})" for rel, count in sorted(oversized.items()))
+        + "; split them before merge instead of adding allowlist entries"
+    )
+
+
+def test_allowlisted_modules_never_grow() -> None:
+    grown = []
+    for rel, cap in LEGACY_OVERSIZED.items():
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            continue
+        count = _line_count(path)
+        if count > cap:
+            grown.append(f"{rel} grew from {cap} to {count}")
+    assert not grown, "allowlisted modules must not grow: " + "; ".join(grown)
+
+
+def test_allowlist_only_shrinks() -> None:
+    stale = []
+    for rel, cap in LEGACY_OVERSIZED.items():
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            stale.append(f"{rel} is missing; delete its LEGACY_OVERSIZED entry (cap {cap})")
+            continue
+        count = _line_count(path)
+        if count <= CEILING:
+            stale.append(f"{rel} is {count} lines (<= {CEILING}); delete its LEGACY_OVERSIZED entry")
+    assert not stale, "allowlist entries that no longer belong: " + "; ".join(stale)

--- a/tests/test_size_ratchet_baseline.py
+++ b/tests/test_size_ratchet_baseline.py
@@ -1,0 +1,94 @@
+"""Merge-base comparison for LEGACY_OVERSIZED (scripts/check_size_ratchet_baseline.py)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_size_ratchet_baseline.py"
+
+GIT_IDENTITY = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "Size Ratchet Test",
+    "GIT_AUTHOR_EMAIL": "size-ratchet@example.invalid",
+    "GIT_COMMITTER_NAME": "Size Ratchet Test",
+    "GIT_COMMITTER_EMAIL": "size-ratchet@example.invalid",
+}
+
+BASELINE = {
+    "src/a.py": 3000,
+    "src/b.py": 2500,
+}
+
+
+def _mapping_source(mapping: dict[str, int]) -> str:
+    body = ",\n".join(f'    "{key}": {cap}' for key, cap in mapping.items())
+    return f"LEGACY_OVERSIZED: dict[str, int] = {{\n{body},\n}}\n"
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    test_dir = repo / "tests"
+    test_dir.mkdir()
+    baseline_file = test_dir / "test_module_size_ratchet.py"
+    baseline_file.write_text(_mapping_source(BASELINE), encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "tests/test_module_size_ratchet.py"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "baseline"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=GIT_IDENTITY,
+    )
+    return repo
+
+
+def _run_check(repo: Path, current: dict[str, int]) -> subprocess.CompletedProcess[str]:
+    current_file = repo / "current.py"
+    current_file.write_text(_mapping_source(current), encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--base-ref",
+            "HEAD",
+            "--current-file",
+            str(current_file),
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_lowered_cap_and_removed_key_pass(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    result = _run_check(repo, {"src/a.py": 2800})
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "size ratchet baseline: ok (1 entries)" in result.stdout
+
+
+def test_added_key_fails_with_added_allowlist_entry(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    result = _run_check(
+        repo,
+        {"src/a.py": 3000, "src/b.py": 2500, "src/c.py": 2100},
+    )
+    assert result.returncode == 1
+    assert "added allowlist entry" in result.stdout
+
+
+def test_raised_cap_fails_with_cap_raised(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    result = _run_check(repo, {"src/a.py": 3100, "src/b.py": 2500})
+    assert result.returncode == 1
+    assert "cap raised" in result.stdout


### PR DESCRIPTION
## What

Adds `tests/test_module_size_ratchet.py`: a repo-wide 2,000-line ceiling for every module under `src/brigade` (engines excluded), with a `LEGACY_OVERSIZED` allowlist that caps the 14 current offenders at today's line counts.

Three assertions:

- a module outside the allowlist is at or under 2,000 lines
- an allowlisted module never exceeds its cap
- every allowlist entry still exists and is still over the ceiling, otherwise the test tells you to delete the entry

Entries may be lowered or removed, never added or raised.

## Why

The ceiling from #203 (`tests/test_phase257_facades.py::test_phase257_production_family_files_stay_under_2000_lines`) only scans the seven roots that PR split. `work_cmd/ledger.py` went from 2,036 lines at v0.26.1 to 6,850 in the 17 days after, across #948, #949, #950, #1047, #1057, #1058, #1060, #1070, #1185, and #1207, and that test stayed green the whole time. `aboyeur.py` (5,362) and `skills_cmd.py` (5,305) are in the same state. Details and the ranked follow-ups are in #1226 through #1230.

The phase-257 test is left in place; it is a stricter check (no allowlist) for the roots it covers.

## Verify

```
.venv/bin/python -m pytest tests/test_module_size_ratchet.py tests/test_phase257_facades.py -q
.venv/bin/ruff check tests/test_module_size_ratchet.py
.venv/bin/ruff format --check tests/test_module_size_ratchet.py
```

Brigade receipts: `20260826-224115-work-verify-8dc93e` (pytest, both files), `20260826-224213-work-verify-a04e4b` (pytest after formatting), format check exit 0.

To see the ratchet bite, append 20 blank lines to `src/brigade/care_cmd.py` and run the test: `test_allowlisted_modules_never_grow` names the file and both numbers.

## Look hardest at

The allowlist numbers. Each is `len(read_text().splitlines())` at `2b55678a`; if anything lands on main that touches one of those 14 files before this merges, the cap for that file needs to be re-read from main.

Refs #1226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added safeguards to prevent oversized modules in the `src/brigade` package.
  * Established a 2,000-line limit for new or previously untracked modules.
  * Added checks to ensure existing exceptions do not grow and are removed as modules are reduced below the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->