### PR TITLE
fix(hooks): serialize timeout-latch state writes per session

### DIFF
--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import multiprocessing as mp
 import os
@@ -18,6 +19,7 @@ from typing import Any, BinaryIO, Callable, Iterator
 
 from .. import localio
 from ..component_paths import cache_root
+from ..work_cmd import inbox_lock
 from ..work_cmd.verification import _tree_fingerprint
 from ..wiring import resolve_wired_target
 from . import compaction_marker, envelope
@@ -28,6 +30,8 @@ BRIEF_TIMEOUT_SECONDS = 10
 HOOK_TIMEOUT_LATCH_AFTER = 2
 _TIMEOUT_FOLLOWUP_SECONDS = 0.5
 _HOOK_OUTCOME_KINDS = frozenset({"ok", "latched", "latched_silent"})
+_SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
+_SESSION_STATE_PROCESS_LOCKS: dict[str, threading.Lock] = {}
 MAX_RECENT_SESSION_STATES = 512
 MAX_HOOK_STDIN_BYTES = 1_048_576
 MAX_HOOK_STDIN_STRING_CHARS = 262_144
@@ -3149,41 +3153,77 @@ def _read_hook_latch(target: Path, session_id: str) -> tuple[bool, bool]:
     return True, state.get("hook_latch_announced") is not True
 
 
+def _session_state_process_lock(state_path: Path) -> threading.Lock:
+    """Return this process's serializer for one session-state lock path."""
+    key = str(state_path)
+    with _SESSION_STATE_PROCESS_LOCKS_GUARD:
+        lock = _SESSION_STATE_PROCESS_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _SESSION_STATE_PROCESS_LOCKS[key] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
+    """Serialize one session state's read-modify-write window.
+
+    ``held_file_lock`` creates the state directory as needed, matching the
+    parent creation performed by ``write_session_state`` through ``localio``.
+    """
+    state_path = _state_path(target.expanduser().resolve(), session_id)
+    process_lock = _session_state_process_lock(state_path)
+    with process_lock:
+        with inbox_lock.held_file_lock(
+            Path(f"{state_path}.lock"),
+            deadline_seconds=_TIMEOUT_FOLLOWUP_SECONDS,
+        ):
+            yield
+
+
 def _mark_hook_latch_announced(target: Path, session_id: str) -> None:
-    state = read_session_state(target, session_id)
-    if not isinstance(state, dict):
+    try:
+        with _session_state_lock(target, session_id):
+            state = read_session_state(target, session_id)
+            if not isinstance(state, dict) or state.get("hook_latch_announced") is True:
+                return
+            updated = dict(state)
+            updated["hook_latched"] = True
+            updated["hook_latch_announced"] = True
+            write_session_state(target, session_id, updated)
+    except inbox_lock.InboxLockTimeout:
         return
-    if state.get("hook_latch_announced") is True:
-        return
-    updated = dict(state)
-    updated["hook_latched"] = True
-    updated["hook_latch_announced"] = True
-    write_session_state(target, session_id, updated)
 
 
 def _record_hook_timeout(target: Path, session_id: str) -> dict[str, Any]:
     state = read_session_state(target, session_id)
-    updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
-    count = updated.get("hook_timeout_count")
-    next_count = count + 1 if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 1
-    updated["hook_timeout_count"] = next_count
-    if next_count >= HOOK_TIMEOUT_LATCH_AFTER:
-        updated["hook_latched"] = True
-    write_session_state(target, session_id, updated)
-    return updated
+    fallback: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
+    try:
+        with _session_state_lock(target, session_id):
+            state = read_session_state(target, session_id)
+            updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
+            count = updated.get("hook_timeout_count")
+            next_count = count + 1 if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 1
+            updated["hook_timeout_count"] = next_count
+            if updated.get("hook_latched") is True or next_count >= HOOK_TIMEOUT_LATCH_AFTER:
+                updated["hook_latched"] = True
+            write_session_state(target, session_id, updated)
+            return updated
+    except inbox_lock.InboxLockTimeout:
+        return fallback
 
 
 def _clear_hook_timeouts(target: Path, session_id: str) -> None:
-    state = read_session_state(target, session_id)
-    if not isinstance(state, dict):
+    try:
+        with _session_state_lock(target, session_id):
+            state = read_session_state(target, session_id)
+            if not isinstance(state, dict) or state.get("hook_latched") is True or not state.get("hook_timeout_count"):
+                return
+            updated = dict(state)
+            updated["hook_timeout_count"] = 0
+            write_session_state(target, session_id, updated)
+    except inbox_lock.InboxLockTimeout:
         return
-    if state.get("hook_latched") is True:
-        return
-    if not state.get("hook_timeout_count"):
-        return
-    updated = dict(state)
-    updated["hook_timeout_count"] = 0
-    write_session_state(target, session_id, updated)
 
 
 def _run_best_effort_bounded(

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import json
 import multiprocessing as mp
 import os
@@ -19,19 +18,25 @@ from typing import Any, BinaryIO, Callable, Iterator
 
 from .. import localio
 from ..component_paths import cache_root
-from ..work_cmd import inbox_lock
 from ..work_cmd.verification import _tree_fingerprint
 from ..wiring import resolve_wired_target
 from . import compaction_marker, envelope
 from .package import PACKAGE_REF
 from .paths import is_operator_home, resolved_path
+from .session_state import (
+    _clear_hook_timeouts,
+    _mark_hook_latch_announced,
+    _read_hook_latch,
+    _record_hook_timeout,
+    _session_state_lock,  # noqa: F401 - runtime compatibility alias
+    _write_session_state_preserving_latch,
+)
 
 BRIEF_TIMEOUT_SECONDS = 10
 HOOK_TIMEOUT_LATCH_AFTER = 2
 _TIMEOUT_FOLLOWUP_SECONDS = 0.5
 _HOOK_OUTCOME_KINDS = frozenset({"ok", "latched", "latched_silent"})
-_SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
-_SESSION_STATE_PROCESS_LOCKS: dict[str, threading.Lock] = {}
+
 MAX_RECENT_SESSION_STATES = 512
 MAX_HOOK_STDIN_BYTES = 1_048_576
 MAX_HOOK_STDIN_STRING_CHARS = 262_144
@@ -676,7 +681,7 @@ def _link_session_targets(session_id: str, *targets: Path, task_epoch: str | Non
             continue
         updated = dict(state)
         updated["session_repos"] = sorted_repos
-        write_session_state(target, session_id, updated)
+        _write_session_state_preserving_latch(target, session_id, updated)
 
 
 def _touch_session_targets(
@@ -2360,7 +2365,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
     persisted_state = read_session_state(target, session_id)
     state = _normalize_state(target, session_id, persisted_state, task_epoch=task_epoch)
     if persisted_state != state:
-        write_session_state(target, session_id, state)
+        _write_session_state_preserving_latch(target, session_id, state, log_target=target)
     if event != "Stop":
         _touch_session_targets(session_id, target, payload, task_epoch=task_epoch)
     if event == "SessionStart":
@@ -2377,7 +2382,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
             brief_text = _run_brief(target)
             recall_text = _run_recall(target, payload)
             state["briefed"] = True
-            write_session_state(target, session_id, state)
+            _write_session_state_preserving_latch(target, session_id, state, log_target=target)
             records = _restore_brief_records(brief_text)
             if recall_text.strip():
                 records.extend(_brief_records(recall_text))
@@ -2394,7 +2399,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
         brief_text = _run_brief(target)
         recall_text = _run_recall(target, payload)
         state["briefed"] = True
-        write_session_state(target, session_id, state)
+        _write_session_state_preserving_latch(target, session_id, state, log_target=target)
         records = _brief_records(brief_text)
         if recall_text.strip():
             records.extend(_brief_records(recall_text))
@@ -2412,7 +2417,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
             # Heartbeat so a concurrent session can attribute the coming write
             # to this session instead of a shared worktree delta (#959).
             state["pending_write_at"] = localio.utc_now_iso()
-            write_session_state(target, session_id, state)
+            _write_session_state_preserving_latch(target, session_id, state, log_target=target)
             return None
         if tool_name != "Bash":
             return None
@@ -2422,11 +2427,11 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
         baseline = repo_worktree_fingerprint(target)
         state["pending_bash_fingerprint"] = baseline or _UNAVAILABLE_FINGERPRINT
         state["pending_bash_started_at"] = localio.utc_now_iso()
-        write_session_state(target, session_id, state)
+        _write_session_state_preserving_latch(target, session_id, state, log_target=target)
         if not is_raw_verification(command):
             return None
         state["verify_denied_count"] = int(state.get("verify_denied_count") or 0) + 1
-        write_session_state(target, session_id, state)
+        _write_session_state_preserving_latch(target, session_id, state, log_target=target)
         capture_artifact_id = state.get("exercised_artifact_id")
         if not isinstance(capture_artifact_id, str):
             capture_artifact_id = None
@@ -2466,14 +2471,14 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
         if tool_name == "Read":
             skill_id = _skill_id_from_skill_path(target, post_tool_input.get("file_path"))
             if _record_exercised_artifact(state, skill_id):
-                write_session_state(target, session_id, state)
+                _write_session_state_preserving_latch(target, session_id, state, log_target=target)
             return None
         if tool_name == "Bash" and (_is_routed_verify(command) or _is_brigade_run(command)):
             if _is_routed_verify(command):
                 _record_exercised_artifact(state, _parse_capture_flag(command))
             state.pop("pending_bash_fingerprint", None)
             state.pop("pending_bash_started_at", None)
-            write_session_state(target, session_id, state)
+            _write_session_state_preserving_latch(target, session_id, state, log_target=target)
             return None
         wrote = tool_name in _WRITE_TOOLS or (
             tool_name == "Bash"
@@ -2503,11 +2508,11 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
             state.pop("pending_bash_fingerprint", None)
             state.pop("pending_bash_started_at", None)
             state.pop("pending_write_at", None)
-            write_session_state(target, session_id, state)
+            _write_session_state_preserving_latch(target, session_id, state, log_target=target)
         elif state.get("pending_bash_fingerprint") is not None:
             state.pop("pending_bash_fingerprint", None)
             state.pop("pending_bash_started_at", None)
-            write_session_state(target, session_id, state)
+            _write_session_state_preserving_latch(target, session_id, state, log_target=target)
         return None
 
     if event == "PostToolUseFailure":
@@ -3144,86 +3149,6 @@ def _resolve_log_target(payload: dict[str, Any] | None, *, pin: Path | None = No
 
 def _is_timeout_degraded(exc: BaseException) -> bool:
     return "timed out" in str(exc)
-
-
-def _read_hook_latch(target: Path, session_id: str) -> tuple[bool, bool]:
-    state = read_session_state(target, session_id)
-    if not isinstance(state, dict) or state.get("hook_latched") is not True:
-        return False, False
-    return True, state.get("hook_latch_announced") is not True
-
-
-def _session_state_process_lock(state_path: Path) -> threading.Lock:
-    """Return this process's serializer for one session-state lock path."""
-    key = str(state_path)
-    with _SESSION_STATE_PROCESS_LOCKS_GUARD:
-        lock = _SESSION_STATE_PROCESS_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _SESSION_STATE_PROCESS_LOCKS[key] = lock
-        return lock
-
-
-@contextlib.contextmanager
-def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
-    """Serialize one session state's read-modify-write window.
-
-    ``held_file_lock`` creates the state directory as needed, matching the
-    parent creation performed by ``write_session_state`` through ``localio``.
-    """
-    state_path = _state_path(target.expanduser().resolve(), session_id)
-    process_lock = _session_state_process_lock(state_path)
-    with process_lock:
-        with inbox_lock.held_file_lock(
-            Path(f"{state_path}.lock"),
-            deadline_seconds=_TIMEOUT_FOLLOWUP_SECONDS,
-        ):
-            yield
-
-
-def _mark_hook_latch_announced(target: Path, session_id: str) -> None:
-    try:
-        with _session_state_lock(target, session_id):
-            state = read_session_state(target, session_id)
-            if not isinstance(state, dict) or state.get("hook_latch_announced") is True:
-                return
-            updated = dict(state)
-            updated["hook_latched"] = True
-            updated["hook_latch_announced"] = True
-            write_session_state(target, session_id, updated)
-    except inbox_lock.InboxLockTimeout:
-        return
-
-
-def _record_hook_timeout(target: Path, session_id: str) -> dict[str, Any]:
-    state = read_session_state(target, session_id)
-    fallback: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
-    try:
-        with _session_state_lock(target, session_id):
-            state = read_session_state(target, session_id)
-            updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
-            count = updated.get("hook_timeout_count")
-            next_count = count + 1 if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 1
-            updated["hook_timeout_count"] = next_count
-            if updated.get("hook_latched") is True or next_count >= HOOK_TIMEOUT_LATCH_AFTER:
-                updated["hook_latched"] = True
-            write_session_state(target, session_id, updated)
-            return updated
-    except inbox_lock.InboxLockTimeout:
-        return fallback
-
-
-def _clear_hook_timeouts(target: Path, session_id: str) -> None:
-    try:
-        with _session_state_lock(target, session_id):
-            state = read_session_state(target, session_id)
-            if not isinstance(state, dict) or state.get("hook_latched") is True or not state.get("hook_timeout_count"):
-                return
-            updated = dict(state)
-            updated["hook_timeout_count"] = 0
-            write_session_state(target, session_id, updated)
-    except inbox_lock.InboxLockTimeout:
-        return
 
 
 def _run_best_effort_bounded(

--- a/src/brigade/claude_hooks/session_state.py
+++ b/src/brigade/claude_hooks/session_state.py
@@ -1,0 +1,147 @@
+"""Session-state synchronization and timeout-latch helpers for Claude hooks."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..work_cmd import inbox_lock
+from . import envelope
+
+_SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
+_SESSION_STATE_PROCESS_LOCKS: dict[str, threading.Lock] = {}
+
+
+def _rt() -> Any:
+    """Resolve runtime lazily so its state primitives remain monkeypatchable."""
+    from . import runtime
+
+    return runtime
+
+
+def _reset_session_state_locks() -> None:
+    """Discard inherited thread locks after a POSIX fork."""
+    global _SESSION_STATE_PROCESS_LOCKS_GUARD, _SESSION_STATE_PROCESS_LOCKS
+    _SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
+    _SESSION_STATE_PROCESS_LOCKS = {}
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_session_state_locks)
+
+
+def _session_state_process_lock(state_path: Path) -> threading.Lock:
+    """Return this process's serializer for one session-state lock path."""
+    key = str(state_path)
+    with _SESSION_STATE_PROCESS_LOCKS_GUARD:
+        lock = _SESSION_STATE_PROCESS_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _SESSION_STATE_PROCESS_LOCKS[key] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
+    """Serialize one session state's read-modify-write window.
+
+    ``held_file_lock`` creates the state directory as needed, matching the
+    parent creation performed by ``write_session_state`` through ``localio``.
+    """
+    state_path = _rt()._state_path(target.expanduser().resolve(), session_id)
+    process_lock = _session_state_process_lock(state_path)
+    with process_lock:
+        with inbox_lock.held_file_lock(
+            Path(f"{state_path}.lock"),
+            deadline_seconds=_rt()._TIMEOUT_FOLLOWUP_SECONDS,
+        ):
+            yield
+
+
+def _read_hook_latch(target: Path, session_id: str) -> tuple[bool, bool]:
+    state = _rt().read_session_state(target, session_id)
+    if not isinstance(state, dict) or state.get("hook_latched") is not True:
+        return False, False
+    return True, state.get("hook_latch_announced") is not True
+
+
+def _write_session_state_preserving_latch(
+    target: Path,
+    session_id: str,
+    state: dict[str, Any],
+    *,
+    log_target: Path | None = None,
+) -> bool:
+    """Write state without allowing an older payload to clear the timeout latch."""
+    try:
+        with _rt()._session_state_lock(target, session_id):
+            current = _rt().read_session_state(target, session_id)
+            current_state = current if isinstance(current, dict) else {}
+            updated = dict(state)
+            current_count = current_state.get("hook_timeout_count")
+            next_count = updated.get("hook_timeout_count")
+            counts = [
+                count for count in (current_count, next_count) if isinstance(count, int) and not isinstance(count, bool)
+            ]
+            if counts:
+                updated["hook_timeout_count"] = max(counts)
+            else:
+                updated.pop("hook_timeout_count", None)
+            updated["hook_latched"] = current_state.get("hook_latched") is True or updated.get("hook_latched") is True
+            updated["hook_latch_announced"] = (
+                current_state.get("hook_latch_announced") is True or updated.get("hook_latch_announced") is True
+            )
+            _rt().write_session_state(target, session_id, updated)
+            return True
+    except inbox_lock.InboxLockTimeout:
+        if log_target is not None:
+            envelope.append_log(log_target, f"session state write skipped after lock timeout: {session_id}")
+        return False
+
+
+def _mark_hook_latch_announced(target: Path, session_id: str) -> None:
+    try:
+        with _rt()._session_state_lock(target, session_id):
+            state = _rt().read_session_state(target, session_id)
+            if not isinstance(state, dict) or state.get("hook_latch_announced") is True:
+                return
+            updated = dict(state)
+            updated["hook_latched"] = True
+            updated["hook_latch_announced"] = True
+            _rt().write_session_state(target, session_id, updated)
+    except inbox_lock.InboxLockTimeout:
+        return
+
+
+def _record_hook_timeout(target: Path, session_id: str) -> dict[str, Any]:
+    state = _rt().read_session_state(target, session_id)
+    fallback: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
+    try:
+        with _rt()._session_state_lock(target, session_id):
+            state = _rt().read_session_state(target, session_id)
+            updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
+            count = updated.get("hook_timeout_count")
+            next_count = count + 1 if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 1
+            updated["hook_timeout_count"] = next_count
+            if updated.get("hook_latched") is True or next_count >= _rt().HOOK_TIMEOUT_LATCH_AFTER:
+                updated["hook_latched"] = True
+            _rt().write_session_state(target, session_id, updated)
+            return updated
+    except inbox_lock.InboxLockTimeout:
+        return fallback
+
+
+def _clear_hook_timeouts(target: Path, session_id: str) -> None:
+    try:
+        with _rt()._session_state_lock(target, session_id):
+            state = _rt().read_session_state(target, session_id)
+            if not isinstance(state, dict) or state.get("hook_latched") is True or not state.get("hook_timeout_count"):
+                return
+            updated = dict(state)
+            updated["hook_timeout_count"] = 0
+            _rt().write_session_state(target, session_id, updated)
+    except inbox_lock.InboxLockTimeout:
+        return

--- a/src/brigade/claude_hooks/session_state.py
+++ b/src/brigade/claude_hooks/session_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import stat
 import threading
 import time
 from pathlib import Path
@@ -15,6 +16,7 @@ from . import envelope
 
 _SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
 _SESSION_STATE_PROCESS_LOCKS: dict[str, threading.Lock] = {}
+_TIMEOUT_JOURNAL_MAX_LINES = 16
 
 
 def _rt() -> Any:
@@ -56,12 +58,35 @@ def _journal_path(target: Path, session_id: str) -> Path:
     return _timeouts_path(state_path)
 
 
+def _journal_path_is_safe_without_nofollow(path: Path) -> bool:
+    """Reject links before opening when the platform lacks ``O_NOFOLLOW``."""
+    if getattr(os, "O_NOFOLLOW", 0):
+        return True
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return not stat.S_ISLNK(info.st_mode) and not getattr(info, "st_reparse_tag", 0)
+
+
+def _journal_fd_is_safe(fd: int) -> bool:
+    """Accept only a single-link regular file for the timeout journal."""
+    info = os.fstat(fd)
+    return stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+
+
 def _journal_timeout_count(target: Path, session_id: str) -> int:
     """Return the number of non-empty timeout markers, or zero on read failure."""
     path = _journal_path(target, session_id)
     try:
-        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        if not _journal_path_is_safe_without_nofollow(path):
+            return 0
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
         try:
+            if not _journal_fd_is_safe(fd):
+                return 0
             chunks = []
             while chunk := os.read(fd, 65_536):
                 chunks.append(chunk)
@@ -75,11 +100,18 @@ def _journal_timeout_count(target: Path, session_id: str) -> int:
 def _append_timeout_marker(target: Path, session_id: str) -> int:
     """Append one timeout marker without taking the session-state lock."""
     path = _journal_path(target, session_id)
+    journal_lines = _journal_timeout_count(target, session_id)
+    if journal_lines >= _TIMEOUT_JOURNAL_MAX_LINES:
+        return journal_lines
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_NOFOLLOW", 0)
+        if not _journal_path_is_safe_without_nofollow(path):
+            return 0
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
         fd = os.open(path, flags, 0o600)
         try:
+            if not _journal_fd_is_safe(fd):
+                return 0
             os.write(fd, f"{localio.utc_now_iso()}\n".encode())
         finally:
             os.close(fd)
@@ -88,14 +120,19 @@ def _append_timeout_marker(target: Path, session_id: str) -> int:
     return _journal_timeout_count(target, session_id)
 
 
-def _truncate_timeout_journal(target: Path, session_id: str) -> None:
-    """Discard recorded markers after their count has been folded into state."""
-    path = _journal_path(target, session_id)
-    try:
-        fd = os.open(path, os.O_WRONLY | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0))
-        os.close(fd)
-    except OSError:
-        return
+def _timeout_state_count(state: dict[str, Any]) -> int:
+    count = state.get("hook_timeout_count")
+    return count if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 0
+
+
+def _timeout_journal_folded(state: dict[str, Any]) -> int:
+    folded = state.get("hook_timeout_journal_folded")
+    return folded if isinstance(folded, int) and not isinstance(folded, bool) and folded >= 0 else 0
+
+
+def _effective_timeout_count(state: dict[str, Any], journal_lines: int) -> int:
+    """Return state count plus journal markers not yet folded into it."""
+    return _timeout_state_count(state) + max(journal_lines - _timeout_journal_folded(state), 0)
 
 
 @contextlib.contextmanager
@@ -128,10 +165,14 @@ def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
 
 
 def _read_hook_latch(target: Path, session_id: str) -> tuple[bool, bool]:
+    journal_lines = _journal_timeout_count(target, session_id)
     state = _rt().read_session_state(target, session_id)
-    state_latched = isinstance(state, dict) and state.get("hook_latched") is True
-    journal_latched = _journal_timeout_count(target, session_id) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
-    if not state_latched and not journal_latched:
+    current_state = state if isinstance(state, dict) else {}
+    latched = (
+        current_state.get("hook_latched") is True
+        or _effective_timeout_count(current_state, journal_lines) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
+    )
+    if not latched:
         return False, False
     return True, not isinstance(state, dict) or state.get("hook_latch_announced") is not True
 
@@ -158,6 +199,17 @@ def _write_session_state_preserving_latch(
                 updated["hook_timeout_count"] = max(counts)
             else:
                 updated.pop("hook_timeout_count", None)
+            current_folded = current_state.get("hook_timeout_journal_folded")
+            next_folded = updated.get("hook_timeout_journal_folded")
+            folded_counts = [
+                folded
+                for folded in (current_folded, next_folded)
+                if isinstance(folded, int) and not isinstance(folded, bool)
+            ]
+            if folded_counts:
+                updated["hook_timeout_journal_folded"] = max(folded_counts)
+            else:
+                updated.pop("hook_timeout_journal_folded", None)
             updated["hook_latched"] = current_state.get("hook_latched") is True or updated.get("hook_latched") is True
             updated["hook_latch_announced"] = (
                 current_state.get("hook_latch_announced") is True or updated.get("hook_latch_announced") is True
@@ -189,22 +241,21 @@ def _record_hook_timeout(target: Path, session_id: str) -> dict[str, Any]:
     fallback: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
     try:
         with _rt()._session_state_lock(target, session_id):
+            journal_lines = _journal_timeout_count(target, session_id)
             state = _rt().read_session_state(target, session_id)
             updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
-            count = updated.get("hook_timeout_count")
-            current_count = count if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 0
-            next_count = current_count + 1 + _journal_timeout_count(target, session_id)
+            next_count = _effective_timeout_count(updated, journal_lines) + 1
             updated["hook_timeout_count"] = next_count
+            updated["hook_timeout_journal_folded"] = journal_lines
             if updated.get("hook_latched") is True or next_count >= _rt().HOOK_TIMEOUT_LATCH_AFTER:
                 updated["hook_latched"] = True
             _rt().write_session_state(target, session_id, updated)
-            _truncate_timeout_journal(target, session_id)
             return updated
     except inbox_lock.InboxLockTimeout:
         journal_count = _append_timeout_marker(target, session_id)
-        count = fallback.get("hook_timeout_count")
-        fallback_count = count if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 0
-        next_count = max(fallback_count, journal_count)
+        next_count = (
+            _effective_timeout_count(fallback, journal_count) if journal_count else _timeout_state_count(fallback) + 1
+        )
         fallback["hook_timeout_count"] = next_count
         if fallback.get("hook_latched") is True or next_count >= _rt().HOOK_TIMEOUT_LATCH_AFTER:
             fallback["hook_latched"] = True
@@ -214,17 +265,17 @@ def _record_hook_timeout(target: Path, session_id: str) -> dict[str, Any]:
 def _clear_hook_timeouts(target: Path, session_id: str) -> None:
     try:
         with _rt()._session_state_lock(target, session_id):
+            journal_lines = _journal_timeout_count(target, session_id)
             state = _rt().read_session_state(target, session_id)
+            current_state = state if isinstance(state, dict) else {}
             if (
-                isinstance(state, dict)
-                and state.get("hook_latched") is True
-                or _journal_timeout_count(target, session_id) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
+                current_state.get("hook_latched") is True
+                or _effective_timeout_count(current_state, journal_lines) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
             ):
                 return
-            if isinstance(state, dict) and state.get("hook_timeout_count"):
-                updated = dict(state)
-                updated["hook_timeout_count"] = 0
-                _rt().write_session_state(target, session_id, updated)
-            _truncate_timeout_journal(target, session_id)
+            updated = dict(current_state) if current_state else {"session_id": session_id}
+            updated["hook_timeout_count"] = 0
+            updated["hook_timeout_journal_folded"] = journal_lines
+            _rt().write_session_state(target, session_id, updated)
     except inbox_lock.InboxLockTimeout:
         return

--- a/src/brigade/claude_hooks/session_state.py
+++ b/src/brigade/claude_hooks/session_state.py
@@ -17,6 +17,7 @@ from . import envelope
 _SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
 _SESSION_STATE_PROCESS_LOCKS: dict[str, threading.Lock] = {}
 _TIMEOUT_JOURNAL_MAX_LINES = 16
+_TIMEOUT_JOURNAL_MAX_BYTES = 4096
 
 
 def _rt() -> Any:
@@ -71,10 +72,20 @@ def _journal_path_is_safe_without_nofollow(path: Path) -> bool:
     return not stat.S_ISLNK(info.st_mode) and not getattr(info, "st_reparse_tag", 0)
 
 
-def _journal_fd_is_safe(fd: int) -> bool:
-    """Accept only a single-link regular file for the timeout journal."""
-    info = os.fstat(fd)
-    return stat.S_ISREG(info.st_mode) and info.st_nlink == 1
+def _journal_fd_is_safe(fd: int, path: Path) -> bool:
+    """Accept only the single-link regular file currently named by ``path``."""
+    try:
+        path_info = os.lstat(path)
+        fd_info = os.fstat(fd)
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(fd_info.st_mode)
+        and fd_info.st_nlink == 1
+        and not stat.S_ISLNK(path_info.st_mode)
+        and not getattr(path_info, "st_reparse_tag", 0)
+        and (path_info.st_ino, path_info.st_dev) == (fd_info.st_ino, fd_info.st_dev)
+    )
 
 
 def _journal_timeout_count(target: Path, session_id: str) -> int:
@@ -85,16 +96,14 @@ def _journal_timeout_count(target: Path, session_id: str) -> int:
             return 0
         fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
         try:
-            if not _journal_fd_is_safe(fd):
+            if not _journal_fd_is_safe(fd, path):
                 return 0
-            chunks = []
-            while chunk := os.read(fd, 65_536):
-                chunks.append(chunk)
+            data = os.read(fd, _TIMEOUT_JOURNAL_MAX_BYTES)
         finally:
             os.close(fd)
     except OSError:
         return 0
-    return sum(1 for line in b"".join(chunks).splitlines() if line.strip())
+    return sum(1 for line in data.splitlines() if line.strip())
 
 
 def _append_timeout_marker(target: Path, session_id: str) -> int:
@@ -110,8 +119,10 @@ def _append_timeout_marker(target: Path, session_id: str) -> int:
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
         fd = os.open(path, flags, 0o600)
         try:
-            if not _journal_fd_is_safe(fd):
+            if not _journal_fd_is_safe(fd, path):
                 return 0
+            if os.fstat(fd).st_size >= _TIMEOUT_JOURNAL_MAX_BYTES:
+                return journal_lines
             os.write(fd, f"{localio.utc_now_iso()}\n".encode())
         finally:
             os.close(fd)

--- a/src/brigade/claude_hooks/session_state.py
+++ b/src/brigade/claude_hooks/session_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import os
 import threading
+import time
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -50,15 +51,24 @@ def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
 
     ``held_file_lock`` creates the state directory as needed, matching the
     parent creation performed by ``write_session_state`` through ``localio``.
+    Both the process-local lock and the file lock share one budget
+    (``_TIMEOUT_FOLLOWUP_SECONDS``); running out raises ``InboxLockTimeout``
+    and the caller writes nothing.
     """
     state_path = _rt()._state_path(target.expanduser().resolve(), session_id)
     process_lock = _session_state_process_lock(state_path)
-    with process_lock:
-        with inbox_lock.held_file_lock(
-            Path(f"{state_path}.lock"),
-            deadline_seconds=_rt()._TIMEOUT_FOLLOWUP_SECONDS,
-        ):
+    budget = float(_rt()._TIMEOUT_FOLLOWUP_SECONDS)
+    deadline = time.monotonic() + budget
+    # One monotonic budget covers both stages so a stalled follow-up holding
+    # the process lock cannot park later follow-ups past the file-lock deadline.
+    if not process_lock.acquire(timeout=max(budget, 0.0)):
+        raise inbox_lock.InboxLockTimeout(f"session state lock busy past {budget:.3f}s: {state_path}")
+    try:
+        remaining = max(deadline - time.monotonic(), 0.0)
+        with inbox_lock.held_file_lock(Path(f"{state_path}.lock"), deadline_seconds=remaining):
             yield
+    finally:
+        process_lock.release()
 
 
 def _read_hook_latch(target: Path, session_id: str) -> tuple[bool, bool]:

--- a/src/brigade/claude_hooks/session_state.py
+++ b/src/brigade/claude_hooks/session_state.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from typing import Any, Iterator
 
+from .. import localio
 from ..work_cmd import inbox_lock
 from . import envelope
 
@@ -45,6 +46,58 @@ def _session_state_process_lock(state_path: Path) -> threading.Lock:
         return lock
 
 
+def _timeouts_path(state_path: Path) -> Path:
+    """Return the append-only timeout journal beside one session state file."""
+    return Path(f"{state_path}.timeouts")
+
+
+def _journal_path(target: Path, session_id: str) -> Path:
+    state_path = _rt()._state_path(target.expanduser().resolve(), session_id)
+    return _timeouts_path(state_path)
+
+
+def _journal_timeout_count(target: Path, session_id: str) -> int:
+    """Return the number of non-empty timeout markers, or zero on read failure."""
+    path = _journal_path(target, session_id)
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            chunks = []
+            while chunk := os.read(fd, 65_536):
+                chunks.append(chunk)
+        finally:
+            os.close(fd)
+    except OSError:
+        return 0
+    return sum(1 for line in b"".join(chunks).splitlines() if line.strip())
+
+
+def _append_timeout_marker(target: Path, session_id: str) -> int:
+    """Append one timeout marker without taking the session-state lock."""
+    path = _journal_path(target, session_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags, 0o600)
+        try:
+            os.write(fd, f"{localio.utc_now_iso()}\n".encode())
+        finally:
+            os.close(fd)
+    except OSError:
+        return 0
+    return _journal_timeout_count(target, session_id)
+
+
+def _truncate_timeout_journal(target: Path, session_id: str) -> None:
+    """Discard recorded markers after their count has been folded into state."""
+    path = _journal_path(target, session_id)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0))
+        os.close(fd)
+    except OSError:
+        return
+
+
 @contextlib.contextmanager
 def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
     """Serialize one session state's read-modify-write window.
@@ -61,21 +114,26 @@ def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
     deadline = time.monotonic() + budget
     # One monotonic budget covers both stages so a stalled follow-up holding
     # the process lock cannot park later follow-ups past the file-lock deadline.
-    if not process_lock.acquire(timeout=max(budget, 0.0)):
-        raise inbox_lock.InboxLockTimeout(f"session state lock busy past {budget:.3f}s: {state_path}")
+    acquired = False
     try:
+        acquired = process_lock.acquire(timeout=max(budget, 0.0))
+        if not acquired:
+            raise inbox_lock.InboxLockTimeout(f"session state lock busy past {budget:.3f}s: {state_path}")
         remaining = max(deadline - time.monotonic(), 0.0)
         with inbox_lock.held_file_lock(Path(f"{state_path}.lock"), deadline_seconds=remaining):
             yield
     finally:
-        process_lock.release()
+        if acquired:
+            process_lock.release()
 
 
 def _read_hook_latch(target: Path, session_id: str) -> tuple[bool, bool]:
     state = _rt().read_session_state(target, session_id)
-    if not isinstance(state, dict) or state.get("hook_latched") is not True:
+    state_latched = isinstance(state, dict) and state.get("hook_latched") is True
+    journal_latched = _journal_timeout_count(target, session_id) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
+    if not state_latched and not journal_latched:
         return False, False
-    return True, state.get("hook_latch_announced") is not True
+    return True, not isinstance(state, dict) or state.get("hook_latch_announced") is not True
 
 
 def _write_session_state_preserving_latch(
@@ -134,13 +192,22 @@ def _record_hook_timeout(target: Path, session_id: str) -> dict[str, Any]:
             state = _rt().read_session_state(target, session_id)
             updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
             count = updated.get("hook_timeout_count")
-            next_count = count + 1 if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 1
+            current_count = count if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 0
+            next_count = current_count + 1 + _journal_timeout_count(target, session_id)
             updated["hook_timeout_count"] = next_count
             if updated.get("hook_latched") is True or next_count >= _rt().HOOK_TIMEOUT_LATCH_AFTER:
                 updated["hook_latched"] = True
             _rt().write_session_state(target, session_id, updated)
+            _truncate_timeout_journal(target, session_id)
             return updated
     except inbox_lock.InboxLockTimeout:
+        journal_count = _append_timeout_marker(target, session_id)
+        count = fallback.get("hook_timeout_count")
+        fallback_count = count if isinstance(count, int) and not isinstance(count, bool) and count >= 0 else 0
+        next_count = max(fallback_count, journal_count)
+        fallback["hook_timeout_count"] = next_count
+        if fallback.get("hook_latched") is True or next_count >= _rt().HOOK_TIMEOUT_LATCH_AFTER:
+            fallback["hook_latched"] = True
         return fallback
 
 
@@ -148,10 +215,16 @@ def _clear_hook_timeouts(target: Path, session_id: str) -> None:
     try:
         with _rt()._session_state_lock(target, session_id):
             state = _rt().read_session_state(target, session_id)
-            if not isinstance(state, dict) or state.get("hook_latched") is True or not state.get("hook_timeout_count"):
+            if (
+                isinstance(state, dict)
+                and state.get("hook_latched") is True
+                or _journal_timeout_count(target, session_id) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
+            ):
                 return
-            updated = dict(state)
-            updated["hook_timeout_count"] = 0
-            _rt().write_session_state(target, session_id, updated)
+            if isinstance(state, dict) and state.get("hook_timeout_count"):
+                updated = dict(state)
+                updated["hook_timeout_count"] = 0
+                _rt().write_session_state(target, session_id, updated)
+            _truncate_timeout_journal(target, session_id)
     except inbox_lock.InboxLockTimeout:
         return

--- a/src/brigade/work_cmd/inbox_lock.py
+++ b/src/brigade/work_cmd/inbox_lock.py
@@ -123,6 +123,22 @@ class InboxLockTimeout(TimeoutError):
     """Typed failure when an inbox lock stayed busy past its acquisition deadline."""
 
 
+@contextlib.contextmanager
+def held_file_lock(path: Path, *, deadline_seconds: float) -> Iterator[None]:
+    """Hold one cross-platform advisory lock file for the block.
+
+    This public primitive uses the same hardened open and deadline-bounded
+    ``flock`` / ``msvcrt`` acquisition as the inbox locks, without joining
+    their process-wide reentrancy registry.  It is suitable for adjacent
+    state-file locks that need independent cross-process exclusion.
+    """
+    held = _acquire_cross_process(str(path), deadline_seconds=deadline_seconds)
+    try:
+        yield
+    finally:
+        held.release()
+
+
 def _resolve_deadline(deadline_seconds: float | None) -> tuple[float, float]:
     """Return ``(requested_seconds, absolute_monotonic_deadline)``."""
     requested = DEFAULT_LOCK_DEADLINE_SECONDS if deadline_seconds is None else deadline_seconds
@@ -385,7 +401,12 @@ def _open_lock_parent_posix(lock_path: Path) -> tuple[int, str]:
             try:
                 child = os.open(component, directory_flags, dir_fd=parent)
             except FileNotFoundError:
-                os.mkdir(component, 0o700, dir_fd=parent)
+                try:
+                    os.mkdir(component, 0o700, dir_fd=parent)
+                except FileExistsError:
+                    # A concurrent lock opener created the same component.
+                    # Re-open it below with the normal no-follow validation.
+                    pass
                 child = os.open(component, directory_flags, dir_fd=parent)
             os.close(parent)
             parent = child

--- a/src/brigade/work_cmd/inbox_lock.py
+++ b/src/brigade/work_cmd/inbox_lock.py
@@ -84,6 +84,24 @@ except ImportError:  # pragma: no cover - POSIX does not provide msvcrt.
 
 _PROCESS_LOCK = threading.Lock()
 _ACTIVE_LOCKS: dict[str, "_ActiveInboxLock"] = {}
+_HELD_FILE_LOCK_FDS_GUARD = threading.Lock()
+_HELD_FILE_LOCK_FDS: set[int] = set()
+
+
+def _close_held_file_locks_after_fork() -> None:
+    """Close child copies of adjacent state-file locks after a fork."""
+    global _HELD_FILE_LOCK_FDS_GUARD, _HELD_FILE_LOCK_FDS
+    for fd in _HELD_FILE_LOCK_FDS:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    _HELD_FILE_LOCK_FDS_GUARD = threading.Lock()
+    _HELD_FILE_LOCK_FDS = set()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_close_held_file_locks_after_fork)
 
 
 class _ActiveInboxLock:
@@ -133,9 +151,13 @@ def held_file_lock(path: Path, *, deadline_seconds: float) -> Iterator[None]:
     state-file locks that need independent cross-process exclusion.
     """
     held = _acquire_cross_process(str(path), deadline_seconds=deadline_seconds)
+    with _HELD_FILE_LOCK_FDS_GUARD:
+        _HELD_FILE_LOCK_FDS.add(held.fd)
     try:
         yield
     finally:
+        with _HELD_FILE_LOCK_FDS_GUARD:
+            _HELD_FILE_LOCK_FDS.discard(held.fd)
         held.release()
 
 

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -48,6 +48,61 @@ def test_session_state_helpers_resolve_runtime_primitives_at_call_time(tmp_path:
     assert calls == [(tmp_path, "s")]
 
 
+def test_lock_gap_does_not_leak_process_lock(tmp_path: Path, monkeypatch) -> None:
+    from brigade.claude_hooks import session_state
+
+    @contextlib.contextmanager
+    def failing_file_lock(*_args, **_kwargs):
+        raise RuntimeError("file lock entry failed")
+        yield
+
+    monkeypatch.setattr(inbox_lock, "held_file_lock", failing_file_lock)
+
+    with pytest.raises(RuntimeError, match="file lock entry failed"):
+        with session_state._session_state_lock(tmp_path, "s"):
+            pass
+
+    state_path = runtime._state_path(tmp_path.expanduser().resolve(), "s")
+    assert session_state._session_state_process_lock(state_path).locked() is False
+
+
+def test_persistent_lock_timeout_still_latches(tmp_path: Path, monkeypatch) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+
+    @contextlib.contextmanager
+    def timeout_lock(_target: Path, _session_id: str):
+        raise inbox_lock.InboxLockTimeout("busy")
+        yield
+
+    with monkeypatch.context() as patch:
+        patch.setattr(runtime, "_session_state_lock", timeout_lock)
+        runtime._record_hook_timeout(target, "s")
+        second = runtime._record_hook_timeout(target, "s")
+
+        assert second["hook_latched"] is True
+        assert runtime._read_hook_latch(target, "s")[0] is True
+
+    recovered = runtime._record_hook_timeout(target, "s")
+    assert recovered["hook_timeout_count"] == 3
+    assert recovered["hook_latched"] is True
+    assert session_state._journal_timeout_count(target, "s") == 0
+
+
+def test_clear_after_journal_latch_keeps_latch(tmp_path: Path) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    session_state._append_timeout_marker(target, "s")
+    session_state._append_timeout_marker(target, "s")
+
+    runtime._clear_hook_timeouts(target, "s")
+
+    assert runtime.read_session_state(target, "s") is None
+    assert session_state._journal_timeout_count(target, "s") == 2
+
+
 def test_slow_timeout_writes_eventually_latch_and_hold(tmp_path: Path, monkeypatch, capsys) -> None:
     """Slow state writes still converge on a held latch (consistency check; passes on main too)."""
     target = _wired_claude(tmp_path)

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -183,6 +183,41 @@ def test_journal_refuses_hardlink_and_caps_growth(tmp_path: Path) -> None:
     assert session_state._journal_timeout_count(target, "capped") == session_state._TIMEOUT_JOURNAL_MAX_LINES
 
 
+def test_journal_read_is_bounded_and_append_stops_at_byte_cap(tmp_path: Path) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    journal = session_state._journal_path(target, "byte-capped")
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    journal.write_bytes((b"x" * 19_999 + b"\n") * 10)
+
+    count = session_state._journal_timeout_count(target, "byte-capped")
+    assert count <= session_state._TIMEOUT_JOURNAL_MAX_BYTES
+
+    before = journal.stat().st_size
+    assert session_state._append_timeout_marker(target, "byte-capped") == count
+    assert journal.stat().st_size == before
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics required")
+def test_journal_refuses_symlink_after_open_identity_check(tmp_path: Path, monkeypatch) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    journal = session_state._journal_path(target, "symlink")
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside-timeouts"
+    outside.write_bytes(b"outside\n")
+    journal.symlink_to(outside)
+    monkeypatch.setattr(os, "O_NOFOLLOW", 0, raising=False)
+    # Simulate the path swap after the pre-open refusal check.
+    monkeypatch.setattr(session_state, "_journal_path_is_safe_without_nofollow", lambda _path: True)
+
+    assert session_state._journal_timeout_count(target, "symlink") == 0
+    assert session_state._append_timeout_marker(target, "symlink") == 0
+    assert outside.read_bytes() == b"outside\n"
+
+
 def test_clear_after_journal_latch_keeps_latch(tmp_path: Path) -> None:
     from brigade.claude_hooks import session_state
 

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -8,10 +8,15 @@ read-modify-write sequence is serialized per session.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import multiprocessing as mp
+import os
 import threading
 import time
 from pathlib import Path
+
+import pytest
 
 from brigade.claude_hooks import envelope, runtime
 from brigade.work_cmd import inbox_lock
@@ -23,6 +28,24 @@ def _wait_for_timeout_followups() -> None:
     while any(thread.name == "brigade-hook-best-effort" for thread in threading.enumerate()):
         assert time.monotonic() < deadline, "timeout follow-up thread did not finish"
         time.sleep(0.02)
+
+
+def _record_hook_timeout_in_fork(target: Path, session_id: str) -> None:
+    runtime._record_hook_timeout(target, session_id)
+
+
+def test_session_state_helpers_resolve_runtime_primitives_at_call_time(tmp_path: Path, monkeypatch) -> None:
+    from brigade.claude_hooks import session_state
+
+    calls: list[tuple[Path, str]] = []
+    monkeypatch.setattr(
+        runtime,
+        "read_session_state",
+        lambda target, session_id: calls.append((target, session_id)) or {"hook_latched": True},
+    )
+
+    assert session_state._read_hook_latch(tmp_path, "s") == (True, True)
+    assert calls == [(tmp_path, "s")]
 
 
 def test_slow_timeout_writes_eventually_latch_and_hold(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -82,6 +105,80 @@ def test_concurrent_timeout_increments_are_not_lost(tmp_path: Path) -> None:
     assert state is not None
     assert state["hook_timeout_count"] == 200
     assert state["hook_latched"] is True
+
+
+def test_preserving_writer_keeps_latch_from_a_stale_state(tmp_path: Path) -> None:
+    target = _wired_claude(tmp_path)
+    stale = {"session_id": "s", "hook_timeout_count": 0, "hook_latched": False, "stale_field": "written"}
+    runtime.write_session_state(target, "s", stale)
+    stale = runtime.read_session_state(target, "s")
+    assert stale is not None
+    runtime._record_hook_timeout(target, "s")
+    runtime._record_hook_timeout(target, "s")
+    assert runtime._write_session_state_preserving_latch(target, "s", stale)
+
+    preserved = runtime.read_session_state(target, "s")
+    assert preserved is not None
+    assert preserved["hook_timeout_count"] == 2
+    assert preserved["hook_latched"] is True
+    assert preserved["stale_field"] == "written"
+
+    # The raw primitive documents the race: a stale writer erases the latch.
+    raw_stale = {"session_id": "raw", "hook_timeout_count": 0, "hook_latched": False}
+    runtime.write_session_state(target, "raw", raw_stale)
+    raw_stale = runtime.read_session_state(target, "raw")
+    assert raw_stale is not None
+    runtime._record_hook_timeout(target, "raw")
+    runtime._record_hook_timeout(target, "raw")
+    runtime.write_session_state(target, "raw", raw_stale)
+    clobbered = runtime.read_session_state(target, "raw")
+    assert clobbered is not None
+    assert clobbered["hook_timeout_count"] == 0
+    assert clobbered["hook_latched"] is False
+
+
+def test_preserving_writer_logs_when_the_session_lock_times_out(tmp_path: Path, monkeypatch) -> None:
+    target = _wired_claude(tmp_path)
+    logged: list[tuple[Path, str]] = []
+
+    @contextlib.contextmanager
+    def timeout_lock(_target: Path, _session_id: str):
+        raise inbox_lock.InboxLockTimeout("busy")
+        yield
+
+    monkeypatch.setattr(runtime, "_session_state_lock", timeout_lock)
+    monkeypatch.setattr(envelope, "append_log", lambda path, message: logged.append((path, message)))
+
+    assert runtime._write_session_state_preserving_latch(target, "s", {"session_id": "s"}, log_target=target) is False
+    assert logged == [(target, "session state write skipped after lock timeout: s")]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="fork is only available on POSIX")
+def test_forked_timeout_writer_does_not_inherit_held_session_lock(tmp_path: Path) -> None:
+    target = _wired_claude(tmp_path)
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_session_lock() -> None:
+        with runtime._session_state_lock(target, "s"):
+            acquired.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_session_lock)
+    holder.start()
+    assert acquired.wait(timeout=2)
+    process = mp.get_context("fork").Process(target=_record_hook_timeout_in_fork, args=(target, "s"))
+    try:
+        process.start()
+        process.join(timeout=3)
+        assert not process.is_alive(), "forked timeout writer inherited a permanently-held lock"
+        assert process.exitcode == 0
+    finally:
+        release.set()
+        holder.join(timeout=2)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=2)
 
 
 def test_session_lock_timeout_preserves_latched_state(tmp_path: Path) -> None:

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -1,0 +1,142 @@
+"""Timeout-latch state remains monotonic when best-effort writers overlap.
+
+``test_stale_clear_cannot_clobber_latch`` reproduces the CI failure from #1236
+deterministically and fails on main: a ``_clear_hook_timeouts`` that read the
+pre-latch state writes it back after the latch landed. It passes once the whole
+read-modify-write sequence is serialized per session.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+from brigade.claude_hooks import envelope, runtime
+from brigade.work_cmd import inbox_lock
+from tests.test_claude_hooks_user_target import PACKAGE_REF, _payload, _wired_claude
+
+
+def _wait_for_timeout_followups() -> None:
+    deadline = time.monotonic() + 10
+    while any(thread.name == "brigade-hook-best-effort" for thread in threading.enumerate()):
+        assert time.monotonic() < deadline, "timeout follow-up thread did not finish"
+        time.sleep(0.02)
+
+
+def test_slow_timeout_writes_eventually_latch_and_hold(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Slow state writes still converge on a held latch (consistency check; passes on main too)."""
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(envelope, "HOOK_TIMEOUT_SECONDS", 0.01)
+    calls = 0
+
+    def hang(_event: str, _payload: dict, *, pin=None) -> dict | None:
+        nonlocal calls
+        calls += 1
+        time.sleep(1)
+        return None
+
+    original_write = runtime.write_session_state
+
+    def slow_write(target: Path, session_id: str, state: dict) -> None:
+        time.sleep(0.6)
+        original_write(target, session_id, state)
+
+    monkeypatch.setattr(runtime, "handle_payload", hang)
+    monkeypatch.setattr(runtime, "write_session_state", slow_write)
+    payload = json.dumps(_payload(target, "PreToolUse"))
+    capsys.readouterr()
+
+    for _ in range(3):
+        assert runtime.hook_run(event="PreToolUse", package=PACKAGE_REF, stdin_text=payload) == 0
+        capsys.readouterr()
+
+    _wait_for_timeout_followups()
+    state = runtime.read_session_state(target, "session-1")
+    assert state is not None
+    assert state["hook_latched"] is True
+    assert state["hook_timeout_count"] >= 2
+
+    calls = 0
+    assert runtime.hook_run(event="PreToolUse", package=PACKAGE_REF, stdin_text=payload) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert calls == 0
+    assert output in (envelope.empty_envelope("PreToolUse"), envelope.latched_envelope("PreToolUse"))
+
+
+def test_concurrent_timeout_increments_are_not_lost(tmp_path: Path) -> None:
+    target = _wired_claude(tmp_path)
+
+    def record() -> None:
+        for _ in range(25):
+            runtime._record_hook_timeout(target, "s")
+
+    threads = [threading.Thread(target=record) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    state = runtime.read_session_state(target, "s")
+    assert state is not None
+    assert state["hook_timeout_count"] == 200
+    assert state["hook_latched"] is True
+
+
+def test_session_lock_timeout_preserves_latched_state(tmp_path: Path) -> None:
+    target = _wired_claude(tmp_path)
+    initial = {"session_id": "s", "hook_timeout_count": 2, "hook_latched": True, "hook_latch_announced": True}
+    runtime.write_session_state(target, "s", initial)
+    results: list[object] = []
+
+    def mutate_while_locked() -> None:
+        runtime._clear_hook_timeouts(target, "s")
+        results.append(runtime._record_hook_timeout(target, "s"))
+
+    lock_path = Path(f"{runtime._state_path(target, 's')}.lock")
+    with inbox_lock.held_file_lock(lock_path, deadline_seconds=1):
+        thread = threading.Thread(target=mutate_while_locked)
+        thread.start()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+    assert results == [initial]
+    assert runtime.read_session_state(target, "s") == initial
+
+
+def test_stale_clear_cannot_clobber_latch(tmp_path: Path, monkeypatch) -> None:
+    """A clear that read pre-latch state must not overwrite a latch that landed later.
+
+    On main the clear thread's write is held until both timeout records have
+    landed, so its stale state (count 0, no latch) is written last and the
+    latch is lost. With the per-session lock the clear holds the lock through
+    its read-modify-write, the gate times out, and the records that follow
+    re-derive the latch.
+    """
+    target = _wired_claude(tmp_path)
+    runtime.write_session_state(target, "s", {"session_id": "s", "hook_timeout_count": 1})
+    records_done = threading.Event()
+    clear_started = threading.Event()
+    original_write = runtime.write_session_state
+
+    def gated_write(target_: Path, session_id: str, state: dict) -> None:
+        if state.get("hook_timeout_count") == 0 and state.get("hook_latched") is not True:
+            clear_started.set()
+            records_done.wait(timeout=2)
+        original_write(target_, session_id, state)
+
+    monkeypatch.setattr(runtime, "write_session_state", gated_write)
+    clear = threading.Thread(target=runtime._clear_hook_timeouts, args=(target, "s"))
+    clear.start()
+    assert clear_started.wait(timeout=2), "clear never reached its write"
+    runtime._record_hook_timeout(target, "s")
+    runtime._record_hook_timeout(target, "s")
+    records_done.set()
+    clear.join(timeout=10)
+    assert not clear.is_alive()
+
+    state = runtime.read_session_state(target, "s")
+    assert state is not None
+    assert state.get("hook_latched") is True, state
+    assert state["hook_timeout_count"] >= 2

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -208,8 +208,9 @@ def test_stale_clear_cannot_clobber_latch(tmp_path: Path, monkeypatch) -> None:
     On main the clear thread's write is held until both timeout records have
     landed, so its stale state (count 0, no latch) is written last and the
     latch is lost. With the per-session lock the clear holds the lock through
-    its read-modify-write, the gate times out, and the records that follow
-    re-derive the latch.
+    its read-modify-write, the 0.3 s gate (inside the 0.5 s lock budget) times
+    out, and the records that were waiting on the lock then re-derive the
+    latch.
     """
     target = _wired_claude(tmp_path)
     runtime.write_session_state(target, "s", {"session_id": "s", "hook_timeout_count": 1})
@@ -220,7 +221,7 @@ def test_stale_clear_cannot_clobber_latch(tmp_path: Path, monkeypatch) -> None:
     def gated_write(target_: Path, session_id: str, state: dict) -> None:
         if state.get("hook_timeout_count") == 0 and state.get("hook_latched") is not True:
             clear_started.set()
-            records_done.wait(timeout=2)
+            records_done.wait(timeout=0.3)
         original_write(target_, session_id, state)
 
     monkeypatch.setattr(runtime, "write_session_state", gated_write)

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -86,8 +86,101 @@ def test_persistent_lock_timeout_still_latches(tmp_path: Path, monkeypatch) -> N
 
     recovered = runtime._record_hook_timeout(target, "s")
     assert recovered["hook_timeout_count"] == 3
+    assert recovered["hook_timeout_journal_folded"] == 2
     assert recovered["hook_latched"] is True
-    assert session_state._journal_timeout_count(target, "s") == 0
+    assert session_state._journal_timeout_count(target, "s") == 2
+
+
+def test_effective_count_sums_state_and_journal(tmp_path: Path) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    session_state._append_timeout_marker(target, "s")
+    runtime.write_session_state(target, "s", {"session_id": "s", "hook_timeout_count": 1})
+
+    assert runtime._read_hook_latch(target, "s")[0] is True
+
+    runtime.write_session_state(
+        target,
+        "s",
+        {"session_id": "s", "hook_timeout_count": 1, "hook_timeout_journal_folded": 1},
+    )
+    assert runtime._read_hook_latch(target, "s")[0] is False
+
+
+def test_marker_appended_during_fold_is_not_lost(tmp_path: Path) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_session_lock() -> None:
+        with runtime._session_state_lock(target, "s"):
+            acquired.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_session_lock)
+    holder.start()
+    assert acquired.wait(timeout=2)
+    try:
+        assert session_state._append_timeout_marker(target, "s") == 1
+        assert session_state._append_timeout_marker(target, "s") == 2
+    finally:
+        release.set()
+        holder.join(timeout=2)
+    assert not holder.is_alive()
+
+    first = runtime._record_hook_timeout(target, "s")
+    assert first["hook_timeout_count"] == 3
+    assert first["hook_timeout_journal_folded"] == 2
+
+    assert session_state._append_timeout_marker(target, "s") == 3
+    second = runtime._record_hook_timeout(target, "s")
+    assert second["hook_timeout_count"] == 5
+    assert second["hook_timeout_journal_folded"] == 3
+    assert session_state._journal_timeout_count(target, "s") == 3
+
+
+def test_clear_consumes_journal_without_truncating(tmp_path: Path) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    runtime.write_session_state(target, "s", {"session_id": "s", "hook_timeout_count": 0})
+    assert session_state._append_timeout_marker(target, "s") == 1
+
+    runtime._clear_hook_timeouts(target, "s")
+
+    cleared = runtime.read_session_state(target, "s")
+    assert cleared is not None
+    assert cleared["hook_timeout_count"] == 0
+    assert cleared["hook_timeout_journal_folded"] == 1
+    assert session_state._journal_timeout_count(target, "s") == 1
+
+    recorded = runtime._record_hook_timeout(target, "s")
+    assert recorded["hook_timeout_count"] == 1
+    assert recorded["hook_timeout_journal_folded"] == 1
+
+
+def test_journal_refuses_hardlink_and_caps_growth(tmp_path: Path) -> None:
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    assert session_state._append_timeout_marker(target, "hardlink") == 1
+    journal = session_state._journal_path(target, "hardlink")
+    hardlink = journal.with_name("hardlink-copy")
+    try:
+        os.link(journal, hardlink)
+    except OSError:
+        if os.name != "nt":
+            raise
+    else:
+        assert session_state._journal_timeout_count(target, "hardlink") == 0
+        assert session_state._append_timeout_marker(target, "hardlink") == 0
+
+    for _ in range(session_state._TIMEOUT_JOURNAL_MAX_LINES + 5):
+        session_state._append_timeout_marker(target, "capped")
+    assert session_state._journal_timeout_count(target, "capped") == session_state._TIMEOUT_JOURNAL_MAX_LINES
 
 
 def test_clear_after_journal_latch_keeps_latch(tmp_path: Path) -> None:
@@ -253,7 +346,7 @@ def test_session_lock_timeout_preserves_latched_state(tmp_path: Path) -> None:
         thread.join(timeout=2)
         assert not thread.is_alive()
 
-    assert results == [initial]
+    assert results == [{**initial, "hook_timeout_count": 3}]
     assert runtime.read_session_state(target, "s") == initial
 
 

--- a/tests/test_module_size_ratchet.py
+++ b/tests/test_module_size_ratchet.py
@@ -14,7 +14,7 @@ LEGACY_OVERSIZED: dict[str, int] = {
     "src/brigade/aboyeur.py": 5362,
     "src/brigade/skills_cmd.py": 5305,
     "src/brigade/runs_cmd.py": 3584,
-    "src/brigade/claude_hooks/runtime.py": 3389,
+    "src/brigade/claude_hooks/runtime.py": 3354,
     "src/brigade/work_cmd/scanners.py": 3332,
     "src/brigade/research_cmd.py": 3088,
     "src/brigade/outcome_cmd.py": 2903,


### PR DESCRIPTION
## What

`_record_hook_timeout`, `_mark_hook_latch_announced`, and `_clear_hook_timeouts` in `claude_hooks/runtime.py` now run their read-modify-write under a per-session lock: a process-local `threading.Lock` keyed by state path plus a `<state>.lock` file taken through a new public `inbox_lock.held_file_lock(path, deadline_seconds=...)`, built on the flock/msvcrt primitives the inbox locks already use. Each helper re-reads state under the lock, `hook_latched` is monotonic, and a lock timeout means no write (fail closed toward "degraded", never toward clearing a latch). `_TIMEOUT_FOLLOWUP_SECONDS` stays 0.5. `_open_lock_parent_posix` tolerates a concurrent `mkdir` of the same component.

## Why

#1236. `_bounded_timeout_followup` abandons its daemon thread after 0.5 s, and the call-1 worker's late `_clear_hook_timeouts` can read pre-latch state and write it back after the latch landed. That is the recurring `test shard (3.10, 3)` failure of `test_hook_run_latches_after_repeated_timeouts` (five of the last six 3.10 runs across #1232 and #1234 heads), and it can lose a real session's latch the same way.

## Tests

`tests/test_claude_hooks_latch_race.py`:
- `test_stale_clear_cannot_clobber_latch`: deterministic interleaving of the CI failure (clear's write gated until two timeout records landed). Fails on main, passes here.
- `test_concurrent_timeout_increments_are_not_lost`: 8 threads x 25 records -> count 200, latched. Fails on main.
- `test_session_lock_timeout_preserves_latched_state`: lock held elsewhere -> no write, latch intact.
- `test_slow_timeout_writes_eventually_latch_and_hold`: 0.6 s writes still converge (consistency check; passes on main too).

## Verify

```
.venv/bin/python -m mypy                                   # exit 0
.venv/bin/ruff check . && .venv/bin/ruff format --check .  # clean
.venv/bin/python -m pytest tests/test_claude_hooks_latch_race.py tests/test_claude_hooks_user_target.py tests/test_claude_hooks_runtime.py tests/test_claude_hooks_envelope.py tests/test_claude_hooks_stdin_bounds.py tests/test_claude_hooks_doctor.py tests/test_work_cmd_scanners.py tests/test_work_cmd_imports.py -q
```

Brigade receipts: suites `20260827-023605-work-verify-c717b7` (460 passed), race tests `20260827-024105-work-verify-e9ecb5` (4 passed) and 5x repeat `20260827-023656-work-verify-50a7c5`, negative control against a detached `origin/main` worktree `20260827-024117-work-verify-e52826` (3 of 4 fail on main, as intended).

## Look hardest at

- The process-level lock has no deadline (only the file lock does). A follow-up thread blocked behind a slow writer keeps waiting after the parent has returned "degraded"; it is a daemon thread and its eventual write is now consistent, so this is intended, but it is the one place a stall can pile up threads.
- `_record_hook_timeout` on lock timeout returns the pre-lock read (`fallback`) without incrementing; callers treat that as a plain timeout.

Refs #1212 for the other CI timing failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Claude hook timeout tracking during concurrent activity.
  * Prevented timeout records from being lost or accidentally clearing an established latched state.
  * Preserved session state when lock contention occurs.
* **Tests**
  * Added coverage for concurrent timeout updates, delayed writes, lock contention, and stale state clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->