### PR TITLE
types(cli/work): replace the namespace copy with explicit imports (#1228 phase 2, 1/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ module = [
     "brigade.center_cmd",
     "brigade.center_cmd.*",
     "brigade.cli.run",
-    "brigade.cli.work.*",
     "brigade.daily_cmd",
     "brigade.daily_cmd.*",
     "brigade.doctor",

--- a/src/brigade/cli/work/dispatching.py
+++ b/src/brigade/cli/work/dispatching.py
@@ -12,10 +12,6 @@ from ...dogfood_cmd import DEFAULT_TIMEOUT_SECONDS
 from ...work_cmd import TASK_PRIORITIES, TASK_TYPES
 from .. import extras as _extras_cli
 
-from . import registration as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
-
 
 def dispatch(args) -> int:
     from ...work_cmd.ledger import guard_task_ledger_dispatch

--- a/src/brigade/cli/work/phases.py
+++ b/src/brigade/cli/work/phases.py
@@ -12,10 +12,6 @@ from ...dogfood_cmd import DEFAULT_TIMEOUT_SECONDS
 from ...work_cmd import TASK_PRIORITIES, TASK_TYPES
 from .. import extras as _extras_cli
 
-from . import registration as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
-
 
 def _register_phases(work_sub: argparse._SubParsersAction) -> None:
     p_work_phases = work_sub.add_parser("phases", help="Plan and inspect auditable phase execution records.")

--- a/src/brigade/cli/work/registration.py
+++ b/src/brigade/cli/work/registration.py
@@ -12,6 +12,8 @@ from ...claude_hooks.package import MANAGED_EVENTS as _CLAUDE_HOOK_EVENTS
 from ...dogfood_cmd import DEFAULT_TIMEOUT_SECONDS
 from ...work_cmd import TASK_PRIORITIES, TASK_SEAT_CLASSES, TASK_TYPES
 from .. import extras as _extras_cli
+from .dispatching import dispatch
+from .phases import _register_phases
 
 
 def register(sub: argparse._SubParsersAction) -> None:

--- a/tests/fixtures/mypy_override_baseline.txt
+++ b/tests/fixtures/mypy_override_baseline.txt
@@ -1,7 +1,6 @@
 brigade.center_cmd
 brigade.center_cmd.*
 brigade.cli.run
-brigade.cli.work.*
 brigade.daily_cmd
 brigade.daily_cmd.*
 brigade.doctor


### PR DESCRIPTION
## What

Family 1 of 7 for #1228 phase 2. `cli/work/dispatching.py` and `cli/work/phases.py` copied `registration`'s globals at import time (`globals().update(vars(_family_base))`); both already import everything they use, so the copy is removed. `registration.py` now imports `dispatch` and `_register_phases` from its siblings explicitly. `brigade.cli.work.*` leaves the mypy override and `tests/fixtures/mypy_override_baseline.txt`.

The facade `cli/work/__init__.py` (`_sync_module_globals`, `_CommandFamilyFacade.__setattr__`) is unchanged, so monkeypatches through `brigade.cli.work` still reach every submodule.

## Verify

mypy exit 0 (446 files), ruff check and format clean, size-ratchet baseline ok; the work-CLI and facade suites (test_run_cli, test_work_cmd_facade, test_phase257_facades, test_mypy_override_ratchet, test_module_size_ratchet, test_work_cmd_verification, test_work_cmd_services, test_phase_ledger_session_cmd, test_runs_cmd, test_work_cmd_imports): 648 passed, receipt `20260827-130307-work-verify-fb758c`.

Worker: agy_flash (Gemini 3.7 Flash via Antigravity). No Daybreak pass: the diff is two imports and two deletions.

Refs #1228
