### PR TITLE
types(release_cmd): replace the namespace copy with explicit imports (#1228 phase 2, 2/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,6 @@ module = [
     "brigade.phases_cmd.constants",
     "brigade.phases_cmd.session_lifecycle",
     "brigade.phases_cmd.session_ops",
-    "brigade.release_cmd",
-    "brigade.release_cmd.*",
     "brigade.security_cmd",
     "brigade.security_cmd.*",
     "brigade.work_cmd.backup",

--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -10,8 +10,8 @@ from .. import reportstore, roadmap_cmd, work_cmd
 from ..guard.engine import scan_text
 from ..guard.policy import Policy, default_policy, load_policy
 from ..localio import utc_now as _now
-from . import evidence as _evidence
-from . import schema_ops as _schema_ops
+from . import evidence as _evidence_mod
+from . import schema_ops as _schema_ops_mod
 from .paths import (
     RELEASE_CANDIDATE_STALE_HOURS,
     RELEASE_PRIVATE_PATH_RE,
@@ -40,7 +40,7 @@ def _commit_subjects(target: Path, base_ref: str | None) -> list[str]:
     result = _git(target, *args)
     if result.returncode != 0:
         return []
-    return [_evidence._release_safe_text(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+    return [_evidence_mod._release_safe_text(line.strip()) for line in result.stdout.splitlines() if line.strip()]
 
 
 def _commit_messages(target: Path, base_ref: str | None, *, guard_policy: Policy) -> list[str]:
@@ -61,7 +61,7 @@ def _commit_messages(target: Path, base_ref: str | None, *, guard_policy: Policy
 
 
 def _release_safe_commit_text(message: str, *, guard_policy: Policy) -> str:
-    cleaned = _evidence._release_safe_text(message.strip())
+    cleaned = _evidence_mod._release_safe_text(message.strip())
     return scan_text(cleaned, policy=guard_policy).redacted_text.strip()
 
 
@@ -149,10 +149,10 @@ def _release_receipt_matches_head(receipt: dict[str, Any], target: Path, *, base
 
 
 def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:
-    latest = _evidence._latest_release_receipt(target)
+    latest = _evidence_mod._latest_release_receipt(target)
     if latest is not None and _release_receipt_matches_head(latest, target, base_ref=base_ref):
         return latest
-    payload = _evidence._payload(target, base_ref=base_ref, run_checks=True)
+    payload = _evidence_mod._payload(target, base_ref=base_ref, run_checks=True)
     return {
         **payload,
         "run_id": "inline-readiness",
@@ -232,7 +232,7 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
         "phase_ledger": evidence.get("phase_ledger"),
         "git": git,
         "changed_files": changed_files,
-        "docs_touch_status": _evidence._candidate_docs_touch([str(item) for item in changed_files]),
+        "docs_touch_status": _evidence_mod._candidate_docs_touch([str(item) for item in changed_files]),
         "content_guard": {
             str(check.get("name")): check
             for check in readiness.get("checks", [])
@@ -274,7 +274,7 @@ def _command_contract_snapshot(target: Path) -> dict[str, Any]:
 
 def _candidate_health(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    latest = _evidence._latest_candidate(target)
+    latest = _evidence_mod._latest_candidate(target)
     checks: list[dict[str, Any]] = []
     if latest is None:
         checks.append(
@@ -348,8 +348,8 @@ def _release_dogfood_health(target: Path) -> dict[str, Any]:
         }
 
     checks: list[dict[str, Any]] = []
-    latest_readiness = _evidence._latest_release_receipt(target)
-    latest_candidate = _evidence._latest_candidate(target)
+    latest_readiness = _evidence_mod._latest_release_receipt(target)
+    latest_candidate = _evidence_mod._latest_candidate(target)
     latest_daily_run = daily_run_loop._latest_run(target)
     if latest_readiness is None:
         checks.append(
@@ -433,7 +433,7 @@ def _release_dogfood_health(target: Path) -> dict[str, Any]:
                     "suggested_next_command": "brigade daily closeout --json",
                 }
             )
-    schema_ids = {schema["id"] for schema in _schema_ops._schema_manifest_schemas()}
+    schema_ids = {schema["id"] for schema in _schema_ops_mod._schema_manifest_schemas()}
     if "release-dogfood-health" not in schema_ids:
         checks.append(
             {
@@ -558,7 +558,7 @@ def plan(*, target: Path, base_ref: str | None = "origin/main", json_output: boo
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    payload = _evidence._payload(target, base_ref=base_ref, run_checks=False)
+    payload = _evidence_mod._payload(target, base_ref=base_ref, run_checks=False)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -579,8 +579,8 @@ def doctor(*, target: Path, base_ref: str | None = "origin/main", json_output: b
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    payload = _evidence._payload_with_candidate_health(
-        _evidence._payload(target, base_ref=base_ref, run_checks=True), target
+    payload = _evidence_mod._payload_with_candidate_health(
+        _evidence_mod._payload(target, base_ref=base_ref, run_checks=True), target
     )
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -601,7 +601,7 @@ def schema(*, target: Path, json_output: bool = False) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    payload = _schema_ops._schema_manifest(target)
+    payload = _schema_ops_mod._schema_manifest(target)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -697,7 +697,7 @@ def candidate_list(*, target: Path, limit: int = 20, json_output: bool = False) 
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidates = _evidence._release_candidates(target)[:limit]
+    candidates = _evidence_mod._release_candidates(target)[:limit]
     payload = {"target": str(target), "candidate_root": str(_release_candidates_root(target)), "candidates": candidates}
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -719,7 +719,7 @@ def candidate_show(*, target: Path, candidate_id: str, json_output: bool = False
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _evidence._resolve_candidate(target, candidate_id)
+    candidate, error = _evidence_mod._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -742,7 +742,7 @@ def candidate_archive(*, target: Path, candidate_id: str, json_output: bool = Fa
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _evidence._resolve_candidate(target, candidate_id)
+    candidate, error = _evidence_mod._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2

--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -1,47 +1,34 @@
-"""Local release readiness receipts."""
-# ruff: noqa: E402,F401,F403,F811,F821
-
 from __future__ import annotations
 
 import json
-import os
-import re
-import subprocess
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from .. import (
-    context_cmd,
-    handoff_cmd,
-    learn_cmd,
-    memory_cmd,
-    phases_cmd,
-    projects_cmd,
-    repos_cmd,
-    reportstore,
-    research_cmd,
-    roadmap_cmd,
-    scrub,
-    security_cmd,
-    tools_cmd,
-    work_cmd,
-)
+from .. import reportstore, roadmap_cmd, work_cmd
 from ..guard.engine import scan_text
 from ..guard.policy import Policy, default_policy, load_policy
-from ..selection import KNOWN_HARNESSES
-from ..localio import (
-    read_json_dict as _read_json,
-    read_jsonl_dicts as _read_jsonl,
-    utc_now as _now,
-    write_json as _write_json,
+from ..localio import utc_now as _now
+from . import evidence as _evidence
+from . import schema_ops as _schema_ops
+from .paths import (
+    RELEASE_CANDIDATE_STALE_HOURS,
+    RELEASE_PRIVATE_PATH_RE,
+    RELEASE_PRIVATE_VALUE_RE,
+    RELEASE_REPORT_CONTROL_RE,
+    RELEASE_REPORT_TOKEN_RE,
+    RELEASE_REPORT_URL_RE,
+    SCHEMA_MANIFEST_VERSION,
+    WARN,
+    _changed_files,
+    _git,
+    _git_state,
+    _git_value,
+    _release_candidates_archive_root,
+    _release_candidates_root,
+    _release_report_safe_text,
 )
-
-from . import paths as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
 
 
 def _commit_subjects(target: Path, base_ref: str | None) -> list[str]:
@@ -53,7 +40,7 @@ def _commit_subjects(target: Path, base_ref: str | None) -> list[str]:
     result = _git(target, *args)
     if result.returncode != 0:
         return []
-    return [_release_safe_text(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+    return [_evidence._release_safe_text(line.strip()) for line in result.stdout.splitlines() if line.strip()]
 
 
 def _commit_messages(target: Path, base_ref: str | None, *, guard_policy: Policy) -> list[str]:
@@ -74,7 +61,7 @@ def _commit_messages(target: Path, base_ref: str | None, *, guard_policy: Policy
 
 
 def _release_safe_commit_text(message: str, *, guard_policy: Policy) -> str:
-    cleaned = _release_safe_text(message.strip())
+    cleaned = _evidence._release_safe_text(message.strip())
     return scan_text(cleaned, policy=guard_policy).redacted_text.strip()
 
 
@@ -139,8 +126,8 @@ def _changelog_unreleased(path: Path) -> list[str]:
 
 
 def _release_receipt_matches_head(receipt: dict[str, Any], target: Path, *, base_ref: str | None) -> bool:
-    evidence = receipt.get("evidence") if isinstance(receipt.get("evidence"), dict) else {}
-    git = evidence.get("git") if isinstance(evidence.get("git"), dict) else {}
+    evidence = raw_ev if isinstance((raw_ev := receipt.get("evidence")), dict) else {}
+    git = raw_git if isinstance((raw_git := evidence.get("git")), dict) else {}
     receipt_head = git.get("head")
     current_head = _git_value(target, "rev-parse", "HEAD")
     # Require an explicit top-level base_ref; legacy receipts omit it and must refresh.
@@ -162,10 +149,10 @@ def _release_receipt_matches_head(receipt: dict[str, Any], target: Path, *, base
 
 
 def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:
-    latest = _latest_release_receipt(target)
+    latest = _evidence._latest_release_receipt(target)
     if latest is not None and _release_receipt_matches_head(latest, target, base_ref=base_ref):
         return latest
-    payload = _payload(target, base_ref=base_ref, run_checks=True)
+    payload = _evidence._payload(target, base_ref=base_ref, run_checks=True)
     return {
         **payload,
         "run_id": "inline-readiness",
@@ -175,11 +162,28 @@ def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[st
     }
 
 
+def _candidate_metadata(target: Path, candidate_id: str, candidate_dir: Path) -> dict[str, Any]:
+    return {
+        "candidate_id": candidate_id,
+        "target": str(target),
+        "path": str(candidate_dir),
+        "manifest_path": str(candidate_dir / "CANDIDATE.json"),
+        "archive_path": str(candidate_dir / "CANDIDATE.tar.gz"),
+        "evidence_path": str(candidate_dir / "EVIDENCE.json"),
+        "release_notes_path": str(candidate_dir / "RELEASE_NOTES_DRAFT.md"),
+        "publish_plan_path": str(candidate_dir / "PUBLISH_PLAN.md"),
+        "summary_path": str(candidate_dir / "RELEASE_CANDIDATE.md"),
+        "schema_manifest_path": str(candidate_dir / "SCHEMA_MANIFEST.json"),
+        "created_at": _now().isoformat(),
+        "completed_at": _now().isoformat(),
+    }
+
+
 def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str | Path | None = None) -> dict[str, Any]:
     readiness = _latest_release_or_payload(target, base_ref=base_ref)
-    evidence = readiness.get("evidence") if isinstance(readiness.get("evidence"), dict) else {}
-    git = evidence.get("git") if isinstance(evidence.get("git"), dict) else _git_state(target)
-    changed_files = evidence.get("docs", {}).get("changed_files") if isinstance(evidence.get("docs"), dict) else None
+    evidence = raw_ev if isinstance((raw_ev := readiness.get("evidence")), dict) else {}
+    git = raw_git if isinstance((raw_git := evidence.get("git")), dict) else _git_state(target)
+    changed_files = raw_docs.get("changed_files") if isinstance((raw_docs := evidence.get("docs")), dict) else None
     if not isinstance(changed_files, list):
         changed_files = _changed_files(target, base_ref)
     active_guard_policy = _load_guard_policy(guard_policy)
@@ -228,7 +232,7 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
         "phase_ledger": evidence.get("phase_ledger"),
         "git": git,
         "changed_files": changed_files,
-        "docs_touch_status": _candidate_docs_touch([str(item) for item in changed_files]),
+        "docs_touch_status": _evidence._candidate_docs_touch([str(item) for item in changed_files]),
         "content_guard": {
             str(check.get("name")): check
             for check in readiness.get("checks", [])
@@ -256,13 +260,11 @@ def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str 
 
 def _command_contract_snapshot(target: Path) -> dict[str, Any]:
     payload = roadmap_cmd.command_contract_payload(target)
+    cli_cmds = raw_cli if isinstance((raw_cli := payload.get("cli_commands")), list) else []
+    doc_cmds = raw_doc if isinstance((raw_doc := payload.get("normalized_documented_commands")), list) else []
     snapshot = {
-        "cli_command_count": len(payload.get("cli_commands") if isinstance(payload.get("cli_commands"), list) else []),
-        "documented_command_count": len(
-            payload.get("normalized_documented_commands")
-            if isinstance(payload.get("normalized_documented_commands"), list)
-            else []
-        ),
+        "cli_command_count": len(cli_cmds),
+        "documented_command_count": len(doc_cmds),
         "issue_count": payload.get("issue_count"),
         "top_issue": payload.get("top_issue"),
     }
@@ -271,10 +273,20 @@ def _command_contract_snapshot(target: Path) -> dict[str, Any]:
 
 
 def _candidate_health(target: Path) -> dict[str, Any]:
+    target = target.expanduser().resolve()
+    latest = _evidence._latest_candidate(target)
     checks: list[dict[str, Any]] = []
-    latest = _latest_candidate(target)
     if latest is None:
-        return {"latest": None, "checks": checks, "issue_count": 0, "top_issue": None}
+        checks.append(
+            {
+                "status": WARN,
+                "name": "release_candidate_missing",
+                "detail": "no release candidate found",
+                "phase": 155,
+                "suggested_next_command": "brigade release candidate build",
+            }
+        )
+        return {"latest": None, "checks": checks, "issue_count": len(checks), "top_issue": checks[0]}
     created = work_cmd._parse_iso_datetime(latest.get("created_at"))
     if created is not None:
         age_hours = (_now() - created).total_seconds() / 3600
@@ -286,7 +298,7 @@ def _candidate_health(target: Path) -> dict[str, Any]:
                     "detail": f"{latest.get('candidate_id')}={age_hours:.1f}h",
                 }
             )
-    git = latest.get("git") if isinstance(latest.get("git"), dict) else {}
+    git = raw_git if isinstance((raw_git := latest.get("git")), dict) else {}
     current_head = _git_value(target, "rev-parse", "HEAD")
     if git.get("head") and current_head and git.get("head") != current_head:
         checks.append(
@@ -296,7 +308,7 @@ def _candidate_health(target: Path) -> dict[str, Any]:
                 "detail": f"{latest.get('candidate_id')} head changed",
             }
         )
-    readiness = latest.get("release_readiness") if isinstance(latest.get("release_readiness"), dict) else {}
+    readiness = raw_rd if isinstance((raw_rd := latest.get("release_readiness")), dict) else {}
     if readiness.get("ready") is False:
         checks.append(
             {
@@ -322,7 +334,7 @@ def _candidate_health(target: Path) -> dict[str, Any]:
 
 
 def _release_dogfood_health(target: Path) -> dict[str, Any]:
-    from .. import daily_cmd
+    from ..daily_cmd import run_loop as daily_run_loop
 
     target = target.expanduser().resolve()
 
@@ -336,9 +348,9 @@ def _release_dogfood_health(target: Path) -> dict[str, Any]:
         }
 
     checks: list[dict[str, Any]] = []
-    latest_readiness = _latest_release_receipt(target)
-    latest_candidate = _latest_candidate(target)
-    latest_daily_run = daily_cmd._latest_run(target)
+    latest_readiness = _evidence._latest_release_receipt(target)
+    latest_candidate = _evidence._latest_candidate(target)
+    latest_daily_run = daily_run_loop._latest_run(target)
     if latest_readiness is None:
         checks.append(
             {
@@ -421,7 +433,7 @@ def _release_dogfood_health(target: Path) -> dict[str, Any]:
                     "suggested_next_command": "brigade daily closeout --json",
                 }
             )
-    schema_ids = {schema["id"] for schema in _schema_manifest_schemas()}
+    schema_ids = {schema["id"] for schema in _schema_ops._schema_manifest_schemas()}
     if "release-dogfood-health" not in schema_ids:
         checks.append(
             {
@@ -456,11 +468,11 @@ def _receipt_ref(payload: dict[str, Any] | None, id_field: str) -> dict[str, Any
 
 
 def _candidate_release_notes(candidate: dict[str, Any]) -> str:
-    inputs = candidate.get("release_notes_inputs") if isinstance(candidate.get("release_notes_inputs"), dict) else {}
+    inputs = raw_inp if isinstance((raw_inp := candidate.get("release_notes_inputs")), dict) else {}
     changelog = inputs.get("changelog_unreleased") if isinstance(inputs.get("changelog_unreleased"), list) else []
     commits = inputs.get("commit_subjects") if isinstance(inputs.get("commit_subjects"), list) else []
     docs = inputs.get("touched_docs") if isinstance(inputs.get("touched_docs"), list) else []
-    redactions = inputs.get("changelog_redactions") if isinstance(inputs.get("changelog_redactions"), dict) else {}
+    redactions = raw_red if isinstance((raw_red := inputs.get("changelog_redactions")), dict) else {}
     lines = ["# Release Notes Draft", "", "## Highlights", ""]
     if changelog:
         lines.extend(f"- {item}" for item in changelog[:10])
@@ -468,7 +480,7 @@ def _candidate_release_notes(candidate: dict[str, Any]) -> str:
         lines.append("- review-needed: summarize user-visible changes.")
     redaction_count = int(redactions.get("count") or 0)
     if redaction_count:
-        reasons = redactions.get("reasons") if isinstance(redactions.get("reasons"), dict) else {}
+        reasons = raw_reas if isinstance((raw_reas := redactions.get("reasons")), dict) else {}
         reason_summary = ", ".join(f"{name}={count}" for name, count in sorted(reasons.items()))
         detail = f" ({reason_summary})" if reason_summary else ""
         lines.append(f"- {redaction_count} Unreleased changelog entries redacted{detail}.")
@@ -484,8 +496,9 @@ def _candidate_release_notes(candidate: dict[str, Any]) -> str:
 
 
 def _candidate_publish_plan(candidate: dict[str, Any]) -> str:
-    head = candidate.get("git", {}).get("short_head") if isinstance(candidate.get("git"), dict) else None
-    branch = candidate.get("git", {}).get("branch") if isinstance(candidate.get("git"), dict) else None
+    git = raw_git if isinstance((raw_git := candidate.get("git")), dict) else {}
+    head = git.get("short_head")
+    branch = git.get("branch")
     lines = [
         "# Publish Plan",
         "",
@@ -503,7 +516,7 @@ def _candidate_publish_plan(candidate: dict[str, Any]) -> str:
 
 
 def _candidate_summary(candidate: dict[str, Any]) -> str:
-    readiness = candidate.get("release_readiness") if isinstance(candidate.get("release_readiness"), dict) else {}
+    readiness = raw_rd if isinstance((raw_rd := candidate.get("release_readiness")), dict) else {}
     lines = [
         "# Release Candidate",
         "",
@@ -545,7 +558,7 @@ def plan(*, target: Path, base_ref: str | None = "origin/main", json_output: boo
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    payload = _payload(target, base_ref=base_ref, run_checks=False)
+    payload = _evidence._payload(target, base_ref=base_ref, run_checks=False)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -566,7 +579,9 @@ def doctor(*, target: Path, base_ref: str | None = "origin/main", json_output: b
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    payload = _payload_with_candidate_health(_payload(target, base_ref=base_ref, run_checks=True), target)
+    payload = _evidence._payload_with_candidate_health(
+        _evidence._payload(target, base_ref=base_ref, run_checks=True), target
+    )
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0 if payload["ready"] else 1
@@ -586,7 +601,7 @@ def schema(*, target: Path, json_output: bool = False) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    payload = _schema_manifest(target)
+    payload = _schema_ops._schema_manifest(target)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -682,7 +697,7 @@ def candidate_list(*, target: Path, limit: int = 20, json_output: bool = False) 
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidates = _release_candidates(target)[:limit]
+    candidates = _evidence._release_candidates(target)[:limit]
     payload = {"target": str(target), "candidate_root": str(_release_candidates_root(target)), "candidates": candidates}
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -704,7 +719,7 @@ def candidate_show(*, target: Path, candidate_id: str, json_output: bool = False
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _resolve_candidate(target, candidate_id)
+    candidate, error = _evidence._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -727,7 +742,7 @@ def candidate_archive(*, target: Path, candidate_id: str, json_output: bool = Fa
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _resolve_candidate(target, candidate_id)
+    candidate, error = _evidence._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2

--- a/src/brigade/release_cmd/candidate_audit_ops.py
+++ b/src/brigade/release_cmd/candidate_audit_ops.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from .. import phases_cmd, reportstore, security_cmd, work_cmd
 from ..localio import utc_now as _now
-from . import candidate as _candidate
-from . import evidence as _evidence
+from . import candidate as _candidate_mod
+from . import evidence as _evidence_mod
 from .paths import (
     RELEASE_CANDIDATE_STALE_HOURS,
     RELEASE_PRIVATE_PATH_RE,
@@ -108,7 +108,7 @@ def _candidate_audit_payload(target: Path, candidate: dict[str, Any]) -> dict[st
     docs_changed = _candidate_docs_changed_after_build(candidate)
     if docs_changed:
         issues.append({"status": WARN, "name": "candidate_docs_changed", "detail": ", ".join(docs_changed)})
-    current_contract = _candidate._command_contract_snapshot(target)
+    current_contract = _candidate_mod._command_contract_snapshot(target)
     candidate_contract = raw_contract if isinstance((raw_contract := candidate.get("command_contract")), dict) else {}
     if not candidate_contract.get("fingerprint"):
         issues.append(
@@ -151,7 +151,7 @@ def candidate_audit(*, target: Path, candidate_id: str = "latest", json_output: 
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _evidence._resolve_candidate(target, candidate_id)
+    candidate, error = _evidence_mod._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -174,7 +174,7 @@ def candidate_import_issues(
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _evidence._resolve_candidate(target, candidate_id)
+    candidate, error = _evidence_mod._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -239,14 +239,14 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _evidence._resolve_candidate(target, candidate_id)
+    candidate, error = _evidence_mod._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
     candidate_created = work_cmd._parse_iso_datetime(candidate.get("created_at"))
     current_git = _git_state(target)
     candidate_git = raw_git if isinstance((raw_git := candidate.get("git")), dict) else {}
-    latest_release = _evidence._latest_release_receipt(target)
+    latest_release = _evidence_mod._latest_release_receipt(target)
     latest_verify = work_cmd._latest_verify_receipt(target)
     review_health = work_cmd._review_health(target)
     latest_review = raw_review if isinstance((raw_review := review_health.get("latest_run")), dict) else None
@@ -530,7 +530,7 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
                     "detail": f"{candidate_gate_key} -> {current_gate_key}",
                 }
             )
-    phase_checks = _evidence._phase_release_checks(target)
+    phase_checks = _evidence_mod._phase_release_checks(target)
     issues.extend(
         {"status": check.get("status", WARN), "name": f"release_{check.get('name')}", "detail": check.get("detail")}
         for check in phase_checks
@@ -577,7 +577,7 @@ def candidate_closeout(
     if status not in {"draft", "reviewed", "superseded", "archived"}:
         print("error: --status must be one of draft, reviewed, superseded, archived", file=sys.stderr)
         return 2
-    candidate, error = _evidence._resolve_candidate(target, candidate_id)
+    candidate, error = _evidence_mod._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2

--- a/src/brigade/release_cmd/candidate_audit_ops.py
+++ b/src/brigade/release_cmd/candidate_audit_ops.py
@@ -1,45 +1,23 @@
-"""Local release readiness receipts."""
-# ruff: noqa: E402,F401,F403,F811,F821
-
 from __future__ import annotations
 
 import json
-import os
-import re
-import subprocess
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
-from .. import (
-    context_cmd,
-    handoff_cmd,
-    learn_cmd,
-    memory_cmd,
-    phases_cmd,
-    projects_cmd,
-    repos_cmd,
-    reportstore,
-    research_cmd,
-    roadmap_cmd,
-    scrub,
-    security_cmd,
-    tools_cmd,
-    work_cmd,
+from .. import phases_cmd, reportstore, security_cmd, work_cmd
+from ..localio import utc_now as _now
+from . import candidate as _candidate
+from . import evidence as _evidence
+from .paths import (
+    RELEASE_CANDIDATE_STALE_HOURS,
+    RELEASE_PRIVATE_PATH_RE,
+    RELEASE_PRIVATE_VALUE_RE,
+    WARN,
+    _git_state,
+    _git_value,
 )
-from ..selection import KNOWN_HARNESSES
-from ..localio import (
-    read_json_dict as _read_json,
-    read_jsonl_dicts as _read_jsonl,
-    utc_now as _now,
-    write_json as _write_json,
-)
-
-from . import paths as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
 
 
 def _candidate_bundle_files(candidate: dict[str, Any]) -> list[Path]:
@@ -47,7 +25,8 @@ def _candidate_bundle_files(candidate: dict[str, Any]) -> list[Path]:
     if not isinstance(path, str) or not path:
         return []
     root = Path(path)
-    names = candidate.get("bundle_files") if isinstance(candidate.get("bundle_files"), list) else []
+    bundle_files = candidate.get("bundle_files")
+    names = bundle_files if isinstance(bundle_files, list) else []
     return [root / str(name) for name in names if str(name)]
 
 
@@ -119,7 +98,7 @@ def _candidate_audit_payload(target: Path, candidate: dict[str, Any]) -> dict[st
         age_hours = (_now() - created).total_seconds() / 3600
         if age_hours > RELEASE_CANDIDATE_STALE_HOURS:
             issues.append({"status": WARN, "name": "candidate_stale", "detail": f"{age_hours:.1f}h"})
-    git = candidate.get("git") if isinstance(candidate.get("git"), dict) else {}
+    git = raw_git if isinstance((raw_git := candidate.get("git")), dict) else {}
     current_head = _git_value(target, "rev-parse", "HEAD")
     if git.get("head") and current_head and git.get("head") != current_head:
         issues.append(
@@ -129,10 +108,8 @@ def _candidate_audit_payload(target: Path, candidate: dict[str, Any]) -> dict[st
     docs_changed = _candidate_docs_changed_after_build(candidate)
     if docs_changed:
         issues.append({"status": WARN, "name": "candidate_docs_changed", "detail": ", ".join(docs_changed)})
-    current_contract = _command_contract_snapshot(target)
-    candidate_contract = (
-        candidate.get("command_contract") if isinstance(candidate.get("command_contract"), dict) else {}
-    )
+    current_contract = _candidate._command_contract_snapshot(target)
+    candidate_contract = raw_contract if isinstance((raw_contract := candidate.get("command_contract")), dict) else {}
     if not candidate_contract.get("fingerprint"):
         issues.append(
             {
@@ -174,7 +151,7 @@ def candidate_audit(*, target: Path, candidate_id: str = "latest", json_output: 
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _resolve_candidate(target, candidate_id)
+    candidate, error = _evidence._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -197,7 +174,7 @@ def candidate_import_issues(
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _resolve_candidate(target, candidate_id)
+    candidate, error = _evidence._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -262,17 +239,17 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate, error = _resolve_candidate(target, candidate_id)
+    candidate, error = _evidence._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
     candidate_created = work_cmd._parse_iso_datetime(candidate.get("created_at"))
     current_git = _git_state(target)
-    candidate_git = candidate.get("git") if isinstance(candidate.get("git"), dict) else {}
-    latest_release = _latest_release_receipt(target)
+    candidate_git = raw_git if isinstance((raw_git := candidate.get("git")), dict) else {}
+    latest_release = _evidence._latest_release_receipt(target)
     latest_verify = work_cmd._latest_verify_receipt(target)
     review_health = work_cmd._review_health(target)
-    latest_review = review_health.get("latest_run") if isinstance(review_health.get("latest_run"), dict) else None
+    latest_review = raw_review if isinstance((raw_review := review_health.get("latest_run")), dict) else None
     latest_sweep = work_cmd._scanner_sweep_health(target).get("latest")
     latest_security = security_cmd.health(target).get("evidence")
     changed_docs_after_candidate = []
@@ -283,17 +260,19 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
         if evidence_mtime is not None and repo_file.exists() and repo_file.stat().st_mtime > evidence_mtime:
             changed_docs_after_candidate.append(path)
     issues: list[dict[str, Any]] = []
-    if candidate_git.get("head") and current_git.get("head") and candidate_git.get("head") != current_git.get("head"):
+    current_head = current_git.get("head")
+    candidate_head = candidate_git.get("head")
+    if candidate_head and current_head and candidate_head != current_head:
         issues.append(
             {"status": WARN, "name": "candidate_head_changed", "detail": "current HEAD differs from candidate HEAD"}
         )
-    if _receipt_newer_than_candidate(latest_release, candidate_created):
+    if latest_release and _receipt_newer_than_candidate(latest_release, candidate_created):
         issues.append({"status": WARN, "name": "newer_release_readiness", "detail": str(latest_release.get("run_id"))})
-    if _receipt_newer_than_candidate(latest_verify, candidate_created):
+    if latest_verify and _receipt_newer_than_candidate(latest_verify, candidate_created):
         issues.append({"status": WARN, "name": "newer_verification", "detail": str(latest_verify.get("run_id"))})
-    if _receipt_newer_than_candidate(latest_review, candidate_created):
+    if latest_review and _receipt_newer_than_candidate(latest_review, candidate_created):
         issues.append({"status": WARN, "name": "newer_review_run", "detail": str(latest_review.get("run_id"))})
-    if _receipt_newer_than_candidate(latest_sweep, candidate_created):
+    if isinstance(latest_sweep, dict) and _receipt_newer_than_candidate(latest_sweep, candidate_created):
         issues.append({"status": WARN, "name": "newer_scanner_sweep", "detail": str(latest_sweep.get("sweep_id"))})
     security_generated = work_cmd._parse_iso_datetime(
         (latest_security or {}).get("generated_at") if isinstance(latest_security, dict) else None
@@ -328,8 +307,8 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
         issues.append(
             {"status": WARN, "name": "docs_changed_after_candidate", "detail": ", ".join(changed_docs_after_candidate)}
         )
-    operator_report = candidate.get("operator_report") if isinstance(candidate.get("operator_report"), dict) else {}
-    candidate_report = operator_report.get("latest") if isinstance(operator_report.get("latest"), dict) else None
+    operator_report = raw_op if isinstance((raw_op := candidate.get("operator_report")), dict) else {}
+    candidate_report = raw_lat if isinstance((raw_lat := operator_report.get("latest")), dict) else None
     current_report = center_cmd.latest_report(target)
     if isinstance(candidate_report, dict) and isinstance(current_report, dict):
         if candidate_report.get("report_id") != current_report.get("report_id"):
@@ -352,19 +331,25 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
         issues.append({"status": WARN, "name": "operator_report_health", "detail": str(top_report_issue.get("detail"))})
     candidate_phase = candidate.get("phase_ledger") if isinstance(candidate.get("phase_ledger"), dict) else {}
     current_phase = phases_cmd.health(target)
-    if int(current_phase.get("issue_count") or 0) != int(candidate_phase.get("issue_count") or 0):
+    candidate_phase_issue_count = candidate_phase.get("issue_count") if isinstance(candidate_phase, dict) else None
+    current_phase_issue_count = current_phase.get("issue_count") if isinstance(current_phase, dict) else None
+    if int(current_phase_issue_count or 0) != int(candidate_phase_issue_count or 0):
         issues.append(
             {
                 "status": WARN,
                 "name": "phase_ledger_issue_count_changed",
-                "detail": f"{candidate_phase.get('issue_count')} -> {current_phase.get('issue_count')}",
+                "detail": f"{candidate_phase_issue_count} -> {current_phase_issue_count}",
             }
         )
     candidate_closeout = (
-        candidate_phase.get("latest_closeout") if isinstance(candidate_phase.get("latest_closeout"), dict) else None
+        candidate_phase.get("latest_closeout")
+        if isinstance(candidate_phase, dict) and isinstance(candidate_phase.get("latest_closeout"), dict)
+        else None
     )
     current_closeout = (
-        current_phase.get("latest_closeout") if isinstance(current_phase.get("latest_closeout"), dict) else None
+        current_phase.get("latest_closeout")
+        if isinstance(current_phase, dict) and isinstance(current_phase.get("latest_closeout"), dict)
+        else None
     )
     if isinstance(current_closeout, dict) and (
         not isinstance(candidate_closeout, dict)
@@ -374,10 +359,14 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
             {"status": WARN, "name": "newer_phase_closeout", "detail": str(current_closeout.get("closeout_id"))}
         )
     candidate_report = (
-        candidate_phase.get("latest_report") if isinstance(candidate_phase.get("latest_report"), dict) else None
+        candidate_phase.get("latest_report")
+        if isinstance(candidate_phase, dict) and isinstance(candidate_phase.get("latest_report"), dict)
+        else None
     )
     current_phase_report = (
-        current_phase.get("latest_report") if isinstance(current_phase.get("latest_report"), dict) else None
+        current_phase.get("latest_report")
+        if isinstance(current_phase, dict) and isinstance(current_phase.get("latest_report"), dict)
+        else None
     )
     if isinstance(current_phase_report, dict) and (
         not isinstance(candidate_report, dict)
@@ -387,10 +376,14 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
             {"status": WARN, "name": "newer_phase_report", "detail": str(current_phase_report.get("report_id"))}
         )
     candidate_session = (
-        candidate_phase.get("latest_session") if isinstance(candidate_phase.get("latest_session"), dict) else None
+        candidate_phase.get("latest_session")
+        if isinstance(candidate_phase, dict) and isinstance(candidate_phase.get("latest_session"), dict)
+        else None
     )
     current_session = (
-        current_phase.get("latest_session") if isinstance(current_phase.get("latest_session"), dict) else None
+        current_phase.get("latest_session")
+        if isinstance(current_phase, dict) and isinstance(current_phase.get("latest_session"), dict)
+        else None
     )
     if isinstance(current_session, dict) and (
         not isinstance(candidate_session, dict)
@@ -400,12 +393,12 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
         issues.append({"status": WARN, "name": "newer_phase_session", "detail": str(current_session.get("session_id"))})
     candidate_session_report = (
         candidate_phase.get("latest_session_report")
-        if isinstance(candidate_phase.get("latest_session_report"), dict)
+        if isinstance(candidate_phase, dict) and isinstance(candidate_phase.get("latest_session_report"), dict)
         else None
     )
     current_session_report = (
         current_phase.get("latest_session_report")
-        if isinstance(current_phase.get("latest_session_report"), dict)
+        if isinstance(current_phase, dict) and isinstance(current_phase.get("latest_session_report"), dict)
         else None
     )
     if isinstance(current_session_report, dict) and (
@@ -421,12 +414,12 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
         )
     candidate_session_checkpoint = (
         candidate_phase.get("latest_session_checkpoint")
-        if isinstance(candidate_phase.get("latest_session_checkpoint"), dict)
+        if isinstance(candidate_phase, dict) and isinstance(candidate_phase.get("latest_session_checkpoint"), dict)
         else None
     )
     current_session_checkpoint = (
         current_phase.get("latest_session_checkpoint")
-        if isinstance(current_phase.get("latest_session_checkpoint"), dict)
+        if isinstance(current_phase, dict) and isinstance(current_phase.get("latest_session_checkpoint"), dict)
         else None
     )
     if isinstance(candidate_session_checkpoint, dict) or isinstance(current_session_checkpoint, dict):
@@ -455,12 +448,13 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
             issues.append({"status": WARN, "name": "phase_session_checkpoint_changed", "detail": detail})
     candidate_checkpoint_compare = (
         candidate_phase.get("latest_session_checkpoint_compare")
-        if isinstance(candidate_phase.get("latest_session_checkpoint_compare"), dict)
+        if isinstance(candidate_phase, dict)
+        and isinstance(candidate_phase.get("latest_session_checkpoint_compare"), dict)
         else None
     )
     current_checkpoint_compare = (
         current_phase.get("latest_session_checkpoint_compare")
-        if isinstance(current_phase.get("latest_session_checkpoint_compare"), dict)
+        if isinstance(current_phase, dict) and isinstance(current_phase.get("latest_session_checkpoint_compare"), dict)
         else None
     )
     if isinstance(candidate_checkpoint_compare, dict) or isinstance(current_checkpoint_compare, dict):
@@ -496,11 +490,13 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
             )
     candidate_session_gate = (
         candidate_phase.get("latest_session_gate")
-        if isinstance(candidate_phase.get("latest_session_gate"), dict)
+        if isinstance(candidate_phase, dict) and isinstance(candidate_phase.get("latest_session_gate"), dict)
         else None
     )
     current_session_gate = (
-        current_phase.get("latest_session_gate") if isinstance(current_phase.get("latest_session_gate"), dict) else None
+        current_phase.get("latest_session_gate")
+        if isinstance(current_phase, dict) and isinstance(current_phase.get("latest_session_gate"), dict)
+        else None
     )
     if isinstance(candidate_session_gate, dict) or isinstance(current_session_gate, dict):
         candidate_gate_key = (
@@ -534,7 +530,7 @@ def candidate_compare(*, target: Path, candidate_id: str = "latest", json_output
                     "detail": f"{candidate_gate_key} -> {current_gate_key}",
                 }
             )
-    phase_checks = _phase_release_checks(target)
+    phase_checks = _evidence._phase_release_checks(target)
     issues.extend(
         {"status": check.get("status", WARN), "name": f"release_{check.get('name')}", "detail": check.get("detail")}
         for check in phase_checks
@@ -581,7 +577,7 @@ def candidate_closeout(
     if status not in {"draft", "reviewed", "superseded", "archived"}:
         print("error: --status must be one of draft, reviewed, superseded, archived", file=sys.stderr)
         return 2
-    candidate, error = _resolve_candidate(target, candidate_id)
+    candidate, error = _evidence._resolve_candidate(target, candidate_id)
     if candidate is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2

--- a/src/brigade/release_cmd/ci.py
+++ b/src/brigade/release_cmd/ci.py
@@ -1,6 +1,3 @@
-"""Local release readiness receipts."""
-# ruff: noqa: E402,F401,F403,F811,F821
-
 from __future__ import annotations
 
 import json
@@ -8,40 +5,21 @@ import os
 import re
 import subprocess
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
-from .. import (
-    context_cmd,
-    handoff_cmd,
-    learn_cmd,
-    memory_cmd,
-    phases_cmd,
-    projects_cmd,
-    repos_cmd,
-    reportstore,
-    research_cmd,
-    roadmap_cmd,
-    scrub,
-    security_cmd,
-    tools_cmd,
-    work_cmd,
-)
-from ..selection import KNOWN_HARNESSES
+from .. import scrub, security_cmd, work_cmd
 from ..guard.audit import run_audit
 from ..guard.policy import load_policy
-from ..localio import (
-    read_json_dict as _read_json,
-    read_jsonl_dicts as _read_jsonl,
-    utc_now as _now,
-    write_json as _write_json,
+from . import evidence as _evidence
+from .paths import (
+    CI_ACTION_REF_RE,
+    CI_DEPRECATED_ACTION_MAJORS,
+    CI_DEPRECATION_PATTERNS,
+    FAIL,
+    OK,
+    WARN,
 )
-
-from . import paths as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
 
 
 def _safe_path_label(target: Path, path: Path) -> str:
@@ -52,7 +30,7 @@ def _safe_path_label(target: Path, path: Path) -> str:
 
 
 def _ci_safe_excerpt(text: str) -> str:
-    excerpt = _release_safe_text(text.strip())
+    excerpt = _evidence._release_safe_text(text.strip())
     excerpt = security_cmd._redact_secret_evidence(excerpt)
     if len(excerpt) > 220:
         return excerpt[:217].rstrip() + "..."
@@ -213,7 +191,8 @@ def ci_doctor(*, target: Path, summary_path: Path | None = None, json_output: bo
 
 def _ci_import_records(payload: dict[str, Any]) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
-    for finding in payload.get("findings") if isinstance(payload.get("findings"), list) else []:
+    findings = payload.get("findings")
+    for finding in findings if isinstance(findings, list) else []:
         if not isinstance(finding, dict):
             continue
         records.append(

--- a/src/brigade/release_cmd/ci.py
+++ b/src/brigade/release_cmd/ci.py
@@ -11,7 +11,7 @@ from typing import Any
 from .. import scrub, security_cmd, work_cmd
 from ..guard.audit import run_audit
 from ..guard.policy import load_policy
-from . import evidence as _evidence
+from . import evidence as _evidence_mod
 from .paths import (
     CI_ACTION_REF_RE,
     CI_DEPRECATED_ACTION_MAJORS,
@@ -30,7 +30,7 @@ def _safe_path_label(target: Path, path: Path) -> str:
 
 
 def _ci_safe_excerpt(text: str) -> str:
-    excerpt = _evidence._release_safe_text(text.strip())
+    excerpt = _evidence_mod._release_safe_text(text.strip())
     excerpt = security_cmd._redact_secret_evidence(excerpt)
     if len(excerpt) > 220:
         return excerpt[:217].rstrip() + "..."

--- a/src/brigade/release_cmd/commands.py
+++ b/src/brigade/release_cmd/commands.py
@@ -1,45 +1,16 @@
-"""Local release readiness receipts."""
-# ruff: noqa: E402,F401,F403,F811,F821
-
 from __future__ import annotations
 
 import json
-import os
-import re
-import subprocess
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
 from uuid import uuid4
 
-from .. import (
-    context_cmd,
-    handoff_cmd,
-    learn_cmd,
-    memory_cmd,
-    phases_cmd,
-    projects_cmd,
-    repos_cmd,
-    reportstore,
-    research_cmd,
-    roadmap_cmd,
-    scrub,
-    security_cmd,
-    tools_cmd,
-    work_cmd,
-)
-from ..selection import KNOWN_HARNESSES
 from ..localio import (
-    read_json_dict as _read_json,
-    read_jsonl_dicts as _read_jsonl,
     utc_now as _now,
     write_json as _write_json,
 )
-
-from . import paths as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import evidence as _evidence
+from .paths import _release_runs_root
 
 
 def run(*, target: Path, base_ref: str | None = "origin/main", json_output: bool = False) -> int:
@@ -49,7 +20,7 @@ def run(*, target: Path, base_ref: str | None = "origin/main", json_output: bool
         return 2
     started = _now()
     run_id = f"{started.strftime('%Y%m%d-%H%M%S')}-release-{uuid4().hex[:6]}"
-    payload = _payload(target, base_ref=base_ref, run_checks=True)
+    payload = _evidence._payload(target, base_ref=base_ref, run_checks=True)
     completed = _now()
     receipt = {
         **payload,
@@ -61,7 +32,7 @@ def run(*, target: Path, base_ref: str | None = "origin/main", json_output: bool
     }
     receipt_path = _release_runs_root(target) / run_id / "receipt.json"
     _write_json(receipt_path, receipt)
-    _write_release_markdown(receipt_path, receipt)
+    _evidence._write_release_markdown(receipt_path, receipt)
     if json_output:
         print(json.dumps(receipt, indent=2, sort_keys=True))
         return 0 if receipt["ready"] else 1
@@ -82,7 +53,7 @@ def runs(*, target: Path, limit: int = 20, json_output: bool = False) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    items = _release_receipts(target)[:limit]
+    items = _evidence._release_receipts(target)[:limit]
     payload = {"target": str(target), "release_runs_root": str(_release_runs_root(target)), "runs": items}
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -104,7 +75,7 @@ def show(*, target: Path, run_id: str, json_output: bool = False) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    receipt, error = _resolve_release_receipt(target, run_id)
+    receipt, error = _evidence._resolve_release_receipt(target, run_id)
     if receipt is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2

--- a/src/brigade/release_cmd/commands.py
+++ b/src/brigade/release_cmd/commands.py
@@ -9,7 +9,7 @@ from ..localio import (
     utc_now as _now,
     write_json as _write_json,
 )
-from . import evidence as _evidence
+from . import evidence as _evidence_mod
 from .paths import _release_runs_root
 
 
@@ -20,7 +20,7 @@ def run(*, target: Path, base_ref: str | None = "origin/main", json_output: bool
         return 2
     started = _now()
     run_id = f"{started.strftime('%Y%m%d-%H%M%S')}-release-{uuid4().hex[:6]}"
-    payload = _evidence._payload(target, base_ref=base_ref, run_checks=True)
+    payload = _evidence_mod._payload(target, base_ref=base_ref, run_checks=True)
     completed = _now()
     receipt = {
         **payload,
@@ -32,7 +32,7 @@ def run(*, target: Path, base_ref: str | None = "origin/main", json_output: bool
     }
     receipt_path = _release_runs_root(target) / run_id / "receipt.json"
     _write_json(receipt_path, receipt)
-    _evidence._write_release_markdown(receipt_path, receipt)
+    _evidence_mod._write_release_markdown(receipt_path, receipt)
     if json_output:
         print(json.dumps(receipt, indent=2, sort_keys=True))
         return 0 if receipt["ready"] else 1
@@ -53,7 +53,7 @@ def runs(*, target: Path, limit: int = 20, json_output: bool = False) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    items = _evidence._release_receipts(target)[:limit]
+    items = _evidence_mod._release_receipts(target)[:limit]
     payload = {"target": str(target), "release_runs_root": str(_release_runs_root(target)), "runs": items}
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -75,7 +75,7 @@ def show(*, target: Path, run_id: str, json_output: bool = False) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    receipt, error = _evidence._resolve_release_receipt(target, run_id)
+    receipt, error = _evidence_mod._resolve_release_receipt(target, run_id)
     if receipt is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2

--- a/src/brigade/release_cmd/evidence.py
+++ b/src/brigade/release_cmd/evidence.py
@@ -22,10 +22,10 @@ from ..localio import (
     read_json_dict as _read_json,
     utc_now as _now,
 )
-from . import candidate as _candidate
-from . import candidate_audit_ops as _candidate_audit_ops
-from . import ci as _ci
-from . import install_smoke as _install_smoke
+from . import candidate as _candidate_mod
+from . import candidate_audit_ops as _candidate_audit_ops_mod
+from . import ci as _ci_mod
+from . import install_smoke as _install_smoke_mod
 from .paths import (
     FAIL,
     OK,
@@ -269,7 +269,7 @@ def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
     repo_health = repos_cmd.health(target)
     repo_daily_use = repos_cmd.daily_use_health(target)
     roadmap_health = roadmap_cmd.health(target)
-    dogfood_health = _candidate._release_dogfood_health(target)
+    dogfood_health = _candidate_mod._release_dogfood_health(target)
     tool_health = tools_cmd.health(target)
     memory_health = memory_cmd.health(target)
     backup_health = work_cmd._backup_health(target)
@@ -278,8 +278,8 @@ def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
     phase_ledger = phases_cmd.health(target)
     operator_report_health = center_cmd.report_health(target)
     operator_actions_health = center_cmd.actions_health(target)
-    ci_platform = _ci.ci_platform_payload(target)
-    install_smoke = _install_smoke.install_smoke_health(target)
+    ci_platform = _ci_mod.ci_platform_payload(target)
+    install_smoke = _install_smoke_mod.install_smoke_health(target)
     return {
         "git": _git_state(target),
         "latest_work_closeout": _latest_work_closeout(target),
@@ -663,11 +663,11 @@ def _payload(target: Path, *, base_ref: str | None, run_checks: bool, policy: st
     evidence = _evidence(target, base_ref=base_ref)
     checks: list[dict[str, Any]] = []
     if run_checks:
-        checks.append(_ci._run_content_guard_check(target, name="tip", policy=policy, base_ref=base_ref))
+        checks.append(_ci_mod._run_content_guard_check(target, name="tip", policy=policy, base_ref=base_ref))
         if base_ref:
-            checks.append(_ci._run_content_guard_check(target, name="introduced", policy=policy, base_ref=base_ref))
+            checks.append(_ci_mod._run_content_guard_check(target, name="introduced", policy=policy, base_ref=base_ref))
         checks.append(version_tag_check(target))
-    elif not _ci._content_guard_available(target):
+    elif not _ci_mod._content_guard_available(target):
         checks.append(
             {"name": "content_guard", "status": WARN, "detail": "content-guard not available", "available": False}
         )
@@ -687,13 +687,13 @@ def _payload(target: Path, *, base_ref: str | None, run_checks: bool, policy: st
 
 
 def _payload_with_candidate_health(payload: dict[str, Any], target: Path) -> dict[str, Any]:
-    candidate_health = _candidate._candidate_health(target)
+    candidate_health = _candidate_mod._candidate_health(target)
     checks: list[dict[str, Any]] = list(raw_chk if isinstance((raw_chk := payload.get("checks")), list) else [])
     checks.extend(raw_c_chk if isinstance((raw_c_chk := candidate_health.get("checks")), list) else [])
     checks.extend(_phase_release_checks(target))
     latest_candidate = candidate_health.get("latest") if isinstance(candidate_health.get("latest"), dict) else None
     if latest_candidate is not None:
-        audit = _candidate_audit_ops._candidate_audit_payload(target, latest_candidate)
+        audit = _candidate_audit_ops_mod._candidate_audit_payload(target, latest_candidate)
         raw_issues = audit.get("issues")
         issues = raw_issues if isinstance(raw_issues, list) else []
         checks.extend(

--- a/src/brigade/release_cmd/evidence.py
+++ b/src/brigade/release_cmd/evidence.py
@@ -1,17 +1,8 @@
-"""Local release readiness receipts."""
-# ruff: noqa: E402,F401,F403,F811,F821
-
 from __future__ import annotations
 
-import json
-import os
-import re
-import subprocess
-import sys
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
 from .. import (
     context_cmd,
@@ -20,27 +11,43 @@ from .. import (
     memory_cmd,
     phases_cmd,
     projects_cmd,
-    repos_cmd,
     reportstore,
+    repos_cmd,
     research_cmd,
     roadmap_cmd,
-    scrub,
-    security_cmd,
     tools_cmd,
     work_cmd,
 )
-from ..selection import KNOWN_HARNESSES
 from ..localio import (
     read_json_dict as _read_json,
-    read_jsonl_dicts as _read_jsonl,
     utc_now as _now,
-    write_json as _write_json,
 )
-
-from . import paths as _family_base
+from . import candidate as _candidate
+from . import candidate_audit_ops as _candidate_audit_ops
+from . import ci as _ci
+from . import install_smoke as _install_smoke
+from .paths import (
+    FAIL,
+    OK,
+    PHASE_REPORT_STALE_HOURS,
+    RELEASE_PRIVATE_PATH_RE,
+    RELEASE_PRIVATE_VALUE_RE,
+    WARN,
+    _changed_files,
+    _check_remediation_text,
+    _docs_warnings,
+    _format_readiness_check,
+    _git_state,
+    _latest_closeout_json,
+    _latest_review_closeout,
+    _latest_work_closeout,
+    _release_candidates_archive_root,
+    _release_candidates_root,
+    _release_report_safe_text,
+    _release_runs_root,
+    _security_summary,
+)
 from .version_guard import version_tag_check
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
 
 
 def _read_release_receipt(path: Path) -> dict[str, Any] | None:
@@ -249,6 +256,8 @@ def _resolve_candidate(target: Path, candidate_id: str) -> tuple[dict[str, Any] 
 
 def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
     from .. import center_cmd, daily_cmd
+    from ..center_cmd import schema_ops as center_schema_ops
+    from ..daily_cmd import hardening as daily_hardening_ops, run_loop as daily_run_loop
 
     sweep = work_cmd._scanner_sweep_health(target)
     review = work_cmd._review_health(target)
@@ -260,7 +269,7 @@ def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
     repo_health = repos_cmd.health(target)
     repo_daily_use = repos_cmd.daily_use_health(target)
     roadmap_health = roadmap_cmd.health(target)
-    dogfood_health = _release_dogfood_health(target)
+    dogfood_health = _candidate._release_dogfood_health(target)
     tool_health = tools_cmd.health(target)
     memory_health = memory_cmd.health(target)
     backup_health = work_cmd._backup_health(target)
@@ -269,8 +278,8 @@ def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
     phase_ledger = phases_cmd.health(target)
     operator_report_health = center_cmd.report_health(target)
     operator_actions_health = center_cmd.actions_health(target)
-    ci_platform = ci_platform_payload(target)
-    install_smoke = install_smoke_health(target)
+    ci_platform = _ci.ci_platform_payload(target)
+    install_smoke = _install_smoke.install_smoke_health(target)
     return {
         "git": _git_state(target),
         "latest_work_closeout": _latest_work_closeout(target),
@@ -439,7 +448,7 @@ def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
         },
         "operator_center_contract": {
             key: value
-            for key, value in center_cmd._center_contract_health(target).items()
+            for key, value in center_schema_ops._center_contract_health(target).items()
             if key
             in {
                 "schema_version",
@@ -464,8 +473,8 @@ def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
         },
         "daily_driver": {
             "health": daily_cmd.health(target),
-            "latest_run": daily_cmd._latest_run(target),
-            "latest_plan": daily_cmd._latest_plan(target),
+            "latest_run": daily_run_loop._latest_run(target),
+            "latest_plan": daily_run_loop._latest_plan(target),
             "telemetry": daily_cmd.telemetry_payload(target).get("metrics"),
         },
         "daily_hardening": {
@@ -484,7 +493,7 @@ def _evidence(target: Path, *, base_ref: str | None) -> dict[str, Any]:
                     "workstreams",
                 }
             },
-            "latest_closeout": daily_cmd._latest_hardening_closeout(target),
+            "latest_closeout": daily_hardening_ops._latest_hardening_closeout(target),
         },
         "release_dogfood": {
             "issue_count": dogfood_health.get("issue_count"),
@@ -506,37 +515,37 @@ def _assess(
 ) -> tuple[list[str], list[str]]:
     blockers: list[str] = []
     warnings = list(docs_warnings)
-    git = evidence.get("git") if isinstance(evidence.get("git"), dict) else {}
+    git = raw_git if isinstance((raw_git := evidence.get("git")), dict) else {}
     if git.get("tracked_dirty_count"):
         blockers.append(f"tracked files are dirty: {git.get('tracked_dirty_count')}")
-    closeout = evidence.get("latest_work_closeout") if isinstance(evidence.get("latest_work_closeout"), dict) else None
+    closeout = raw_closeout if isinstance((raw_closeout := evidence.get("latest_work_closeout")), dict) else None
     if closeout is None:
         blockers.append("missing work closeout")
     elif not closeout.get("ready"):
         blockers.append(f"latest work closeout is not ready: {closeout.get('closeout_id')}")
-    verify = evidence.get("latest_verification") if isinstance(evidence.get("latest_verification"), dict) else None
+    verify = raw_verify if isinstance((raw_verify := evidence.get("latest_verification")), dict) else None
     if verify is None:
         blockers.append("missing verification receipt")
     elif verify.get("status") != "completed":
         blockers.append(f"latest verification did not complete: {verify.get('run_id')}")
-    review = evidence.get("code_review") if isinstance(evidence.get("code_review"), dict) else {}
+    review = raw_rev if isinstance((raw_rev := evidence.get("code_review")), dict) else {}
     if review.get("latest_unclosed_run"):
         run = review["latest_unclosed_run"]
         blockers.append(f"review run is not closed out: {run.get('run_id') if isinstance(run, dict) else run}")
     if int(review.get("unresolved_finding_count") or 0) > 0:
         blockers.append(f"code review has unresolved finding(s): {review.get('unresolved_finding_count')}")
-    task_acceptance = evidence.get("task_acceptance") if isinstance(evidence.get("task_acceptance"), dict) else {}
+    task_acceptance = raw_acc if isinstance((raw_acc := evidence.get("task_acceptance")), dict) else {}
     if int(task_acceptance.get("issue_count") or 0) > 0:
-        top_acceptance = task_acceptance.get("top_issue") if isinstance(task_acceptance.get("top_issue"), dict) else {}
+        top_acceptance = raw_top_acc if isinstance((raw_top_acc := task_acceptance.get("top_issue")), dict) else {}
         blockers.append(
             f"task acceptance has issue(s): {top_acceptance.get('detail') or task_acceptance.get('issue_count')}"
         )
-    sweep = evidence.get("scanner_sweep") if isinstance(evidence.get("scanner_sweep"), dict) else {}
-    sweep_review = sweep.get("review") if isinstance(sweep.get("review"), dict) else {}
+    sweep = raw_sw if isinstance((raw_sw := evidence.get("scanner_sweep")), dict) else {}
+    sweep_review = raw_sw_rev if isinstance((raw_sw_rev := sweep.get("review")), dict) else {}
     if int(sweep_review.get("issue_count") or 0) > 0:
         blockers.append(f"scanner sweep has unresolved issue(s): {sweep_review.get('issue_count')}")
-    security = evidence.get("security") if isinstance(evidence.get("security"), dict) else {}
-    security_evidence = security.get("evidence") if isinstance(security.get("evidence"), dict) else {}
+    security = raw_sec if isinstance((raw_sec := evidence.get("security")), dict) else {}
+    security_evidence = raw_sec_ev if isinstance((raw_sec_ev := security.get("evidence")), dict) else {}
     candidate_commit = git.get("head")
     evidence_commit = security_evidence.get("candidate_commit")
     if not candidate_commit or evidence_commit != candidate_commit:
@@ -551,7 +560,7 @@ def _assess(
     security_health_checks = [
         item for item in security_checks if item.get("name") != "security_open_findings" and item.get("status") != OK
     ]
-    top_finding = security.get("top_finding") if isinstance(security.get("top_finding"), dict) else None
+    top_finding = raw_top_find if isinstance((raw_top_find := security.get("top_finding")), dict) else None
     reported_open_finding_count = security.get("open_finding_count")
     open_finding_count = (
         reported_open_finding_count
@@ -594,53 +603,51 @@ def _assess(
             blockers.append(message)
         else:
             warnings.append(message)
-    ci_platform = evidence.get("ci_platform") if isinstance(evidence.get("ci_platform"), dict) else {}
+    ci_platform = raw_ci if isinstance((raw_ci := evidence.get("ci_platform")), dict) else {}
     if int(ci_platform.get("issue_count") or 0) > 0:
-        top_ci = ci_platform.get("top_issue") if isinstance(ci_platform.get("top_issue"), dict) else {}
+        top_ci = raw_top_ci if isinstance((raw_top_ci := ci_platform.get("top_issue")), dict) else {}
         warnings.append(
             f"ci platform deprecation warning(s): {top_ci.get('safe_excerpt') or ci_platform.get('issue_count')}"
         )
-    install_smoke = evidence.get("install_smoke") if isinstance(evidence.get("install_smoke"), dict) else {}
+    install_smoke = raw_smk if isinstance((raw_smk := evidence.get("install_smoke")), dict) else {}
     if int(install_smoke.get("issue_count") or 0) > 0:
-        top_smoke = install_smoke.get("top_issue") if isinstance(install_smoke.get("top_issue"), dict) else {}
+        top_smoke = raw_top_smk if isinstance((raw_top_smk := install_smoke.get("top_issue")), dict) else {}
         warnings.append(f"install smoke matrix issue(s): {top_smoke.get('detail') or install_smoke.get('issue_count')}")
-    handoffs = evidence.get("handoff_drafts") if isinstance(evidence.get("handoff_drafts"), dict) else {}
+    handoffs = raw_ho if isinstance((raw_ho := evidence.get("handoff_drafts")), dict) else {}
     if int(handoffs.get("issue_count") or 0) > 0:
         blockers.append(f"handoff draft queue has issue(s): {handoffs.get('issue_count')}")
-    research_handoffs = evidence.get("research_handoffs") if isinstance(evidence.get("research_handoffs"), dict) else {}
+    research_handoffs = raw_rho if isinstance((raw_rho := evidence.get("research_handoffs")), dict) else {}
     if int(research_handoffs.get("issue_count") or 0) > 0:
-        top_research = (
-            research_handoffs.get("top_issue") if isinstance(research_handoffs.get("top_issue"), dict) else {}
-        )
+        top_research = raw_top_res if isinstance((raw_top_res := research_handoffs.get("top_issue")), dict) else {}
         warnings.append(
             f"research handoff export issue(s): {top_research.get('run_id') or research_handoffs.get('issue_count')}"
         )
-    operator_report = evidence.get("operator_report") if isinstance(evidence.get("operator_report"), dict) else {}
+    operator_report = raw_or if isinstance((raw_or := evidence.get("operator_report")), dict) else {}
     if int(operator_report.get("issue_count") or 0) > 0:
-        top_report = operator_report.get("top_issue") if isinstance(operator_report.get("top_issue"), dict) else {}
+        top_report = raw_top_rep if isinstance((raw_top_rep := operator_report.get("top_issue")), dict) else {}
         warnings.append(
             f"operator report has issue(s): {top_report.get('detail') or operator_report.get('issue_count')}"
         )
-    operator_actions = evidence.get("operator_actions") if isinstance(evidence.get("operator_actions"), dict) else {}
+    operator_actions = raw_oa if isinstance((raw_oa := evidence.get("operator_actions")), dict) else {}
     if int(operator_actions.get("open_count") or 0) > 0:
-        top_action = operator_actions.get("top_action") if isinstance(operator_actions.get("top_action"), dict) else {}
+        top_action = raw_top_act if isinstance((raw_top_act := operator_actions.get("top_action")), dict) else {}
         warnings.append(
             f"operator action queue has open action(s): {top_action.get('action_id') or operator_actions.get('open_count')}"
         )
-    repo_fleet = evidence.get("repo_fleet") if isinstance(evidence.get("repo_fleet"), dict) else {}
-    repo_actions = repo_fleet.get("actions") if isinstance(repo_fleet.get("actions"), dict) else {}
+    repo_fleet = raw_rf if isinstance((raw_rf := evidence.get("repo_fleet")), dict) else {}
+    repo_actions = raw_ra if isinstance((raw_ra := repo_fleet.get("actions")), dict) else {}
     if int(repo_actions.get("open_count") or 0) > 0:
-        top_action = repo_actions.get("top_action") if isinstance(repo_actions.get("top_action"), dict) else {}
+        top_action = raw_top_ract if isinstance((raw_top_ract := repo_actions.get("top_action")), dict) else {}
         warnings.append(
             f"repo fleet action queue has open action(s): {top_action.get('fleet_action_id') or repo_actions.get('open_count')}"
         )
-    repo_sweep = repo_fleet.get("sweep") if isinstance(repo_fleet.get("sweep"), dict) else {}
+    repo_sweep = raw_rsw if isinstance((raw_rsw := repo_fleet.get("sweep")), dict) else {}
     if int(repo_sweep.get("issue_count") or 0) > 0:
-        top_sweep = repo_sweep.get("top_issue") if isinstance(repo_sweep.get("top_issue"), dict) else {}
+        top_sweep = raw_top_rsw if isinstance((raw_top_rsw := repo_sweep.get("top_issue")), dict) else {}
         warnings.append(f"repo fleet sweep has issue(s): {top_sweep.get('detail') or repo_sweep.get('issue_count')}")
-    repo_release = repo_fleet.get("release_train") if isinstance(repo_fleet.get("release_train"), dict) else {}
+    repo_release = raw_rrel if isinstance((raw_rrel := repo_fleet.get("release_train")), dict) else {}
     if int(repo_release.get("issue_count") or 0) > 0:
-        top_release = repo_release.get("top_issue") if isinstance(repo_release.get("top_issue"), dict) else {}
+        top_release = raw_top_rrel if isinstance((raw_top_rrel := repo_release.get("top_issue")), dict) else {}
         warnings.append(
             f"repo fleet release train has issue(s): {top_release.get('detail') or repo_release.get('issue_count')}"
         )
@@ -656,11 +663,11 @@ def _payload(target: Path, *, base_ref: str | None, run_checks: bool, policy: st
     evidence = _evidence(target, base_ref=base_ref)
     checks: list[dict[str, Any]] = []
     if run_checks:
-        checks.append(_run_content_guard_check(target, name="tip", policy=policy, base_ref=base_ref))
+        checks.append(_ci._run_content_guard_check(target, name="tip", policy=policy, base_ref=base_ref))
         if base_ref:
-            checks.append(_run_content_guard_check(target, name="introduced", policy=policy, base_ref=base_ref))
+            checks.append(_ci._run_content_guard_check(target, name="introduced", policy=policy, base_ref=base_ref))
         checks.append(version_tag_check(target))
-    elif not _content_guard_available(target):
+    elif not _ci._content_guard_available(target):
         checks.append(
             {"name": "content_guard", "status": WARN, "detail": "content-guard not available", "available": False}
         )
@@ -680,23 +687,27 @@ def _payload(target: Path, *, base_ref: str | None, run_checks: bool, policy: st
 
 
 def _payload_with_candidate_health(payload: dict[str, Any], target: Path) -> dict[str, Any]:
-    candidate_health = _candidate_health(target)
-    checks = list(payload.get("checks") if isinstance(payload.get("checks"), list) else [])
-    checks.extend(candidate_health.get("checks") if isinstance(candidate_health.get("checks"), list) else [])
+    candidate_health = _candidate._candidate_health(target)
+    checks: list[dict[str, Any]] = list(raw_chk if isinstance((raw_chk := payload.get("checks")), list) else [])
+    checks.extend(raw_c_chk if isinstance((raw_c_chk := candidate_health.get("checks")), list) else [])
     checks.extend(_phase_release_checks(target))
     latest_candidate = candidate_health.get("latest") if isinstance(candidate_health.get("latest"), dict) else None
     if latest_candidate is not None:
-        audit = _candidate_audit_payload(target, latest_candidate)
+        audit = _candidate_audit_ops._candidate_audit_payload(target, latest_candidate)
+        raw_issues = audit.get("issues")
+        issues = raw_issues if isinstance(raw_issues, list) else []
         checks.extend(
             {
                 "status": issue.get("status", WARN),
                 "name": f"release_candidate_audit_{issue.get('name')}",
                 "detail": issue.get("detail"),
             }
-            for issue in audit.get("issues", [])
+            for issue in issues
+            if isinstance(issue, dict)
         )
+    evidence = raw_ev if isinstance((raw_ev := payload.get("evidence")), dict) else {}
     blockers, warnings = _assess(
-        payload.get("evidence") if isinstance(payload.get("evidence"), dict) else {},
+        evidence,
         checks,
         _docs_warnings(target, payload.get("base_ref") if isinstance(payload.get("base_ref"), str) else None),
     )

--- a/src/brigade/release_cmd/install_smoke.py
+++ b/src/brigade/release_cmd/install_smoke.py
@@ -1,45 +1,25 @@
-"""Local release readiness receipts."""
-# ruff: noqa: E402,F401,F403,F811,F821
-
 from __future__ import annotations
 
 import json
-import os
-import re
-import subprocess
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
-from .. import (
-    context_cmd,
-    handoff_cmd,
-    learn_cmd,
-    memory_cmd,
-    phases_cmd,
-    projects_cmd,
-    repos_cmd,
-    reportstore,
-    research_cmd,
-    roadmap_cmd,
-    scrub,
-    security_cmd,
-    tools_cmd,
-    work_cmd,
-)
-from ..selection import KNOWN_HARNESSES
+from .. import work_cmd
 from ..localio import (
     read_json_dict as _read_json,
     read_jsonl_dicts as _read_jsonl,
     utc_now as _now,
-    write_json as _write_json,
 )
-
-from . import paths as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from ..selection import KNOWN_HARNESSES
+from . import evidence as _evidence
+from .paths import (
+    INSTALL_SMOKE_MATRIX,
+    INSTALL_SMOKE_STALE_HOURS,
+    INSTALL_SMOKE_STATUSES,
+    WARN,
+    _release_root,
+)
 
 
 def _install_smoke_root(target: Path) -> Path:
@@ -105,17 +85,17 @@ def _install_smoke_record_from_payload(payload: dict[str, Any]) -> dict[str, Any
         "depth": depth,
         "harnesses": harnesses,
         "status": status,
-        "command_label": _release_safe_text(
+        "command_label": _evidence._release_safe_text(
             str(
                 payload.get("command_label")
                 or f"brigade init --depth {depth} --harnesses {','.join(harnesses) or 'none'}"
             )
         ),
-        "safe_summary": _release_safe_text(
+        "safe_summary": _evidence._release_safe_text(
             str(payload.get("safe_summary") or payload.get("summary") or f"install smoke {status}")
         ),
-        "stdout_summary": _release_safe_text(str(payload.get("stdout_summary") or "")),
-        "stderr_summary": _release_safe_text(str(payload.get("stderr_summary") or "")),
+        "stdout_summary": _evidence._release_safe_text(str(payload.get("stdout_summary") or "")),
+        "stderr_summary": _evidence._release_safe_text(str(payload.get("stderr_summary") or "")),
         "duration_seconds": payload.get("duration_seconds"),
         "created_at": completed_at,
         "completed_at": completed_at,

--- a/src/brigade/release_cmd/install_smoke.py
+++ b/src/brigade/release_cmd/install_smoke.py
@@ -12,7 +12,7 @@ from ..localio import (
     utc_now as _now,
 )
 from ..selection import KNOWN_HARNESSES
-from . import evidence as _evidence
+from . import evidence as _evidence_mod
 from .paths import (
     INSTALL_SMOKE_MATRIX,
     INSTALL_SMOKE_STALE_HOURS,
@@ -85,17 +85,17 @@ def _install_smoke_record_from_payload(payload: dict[str, Any]) -> dict[str, Any
         "depth": depth,
         "harnesses": harnesses,
         "status": status,
-        "command_label": _evidence._release_safe_text(
+        "command_label": _evidence_mod._release_safe_text(
             str(
                 payload.get("command_label")
                 or f"brigade init --depth {depth} --harnesses {','.join(harnesses) or 'none'}"
             )
         ),
-        "safe_summary": _evidence._release_safe_text(
+        "safe_summary": _evidence_mod._release_safe_text(
             str(payload.get("safe_summary") or payload.get("summary") or f"install smoke {status}")
         ),
-        "stdout_summary": _evidence._release_safe_text(str(payload.get("stdout_summary") or "")),
-        "stderr_summary": _evidence._release_safe_text(str(payload.get("stderr_summary") or "")),
+        "stdout_summary": _evidence_mod._release_safe_text(str(payload.get("stdout_summary") or "")),
+        "stderr_summary": _evidence_mod._release_safe_text(str(payload.get("stderr_summary") or "")),
         "duration_seconds": payload.get("duration_seconds"),
         "created_at": completed_at,
         "completed_at": completed_at,

--- a/src/brigade/release_cmd/schema_ops.py
+++ b/src/brigade/release_cmd/schema_ops.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from .. import repos_cmd
 from ..localio import utc_now as _now
-from . import candidate as _candidate
-from . import evidence as _evidence
+from . import candidate as _candidate_mod
+from . import evidence as _evidence_mod
 from .paths import (
     OK,
     SCHEMA_MANIFEST_VERSION,
@@ -135,8 +135,8 @@ def _latest_fleet_release_train(target: Path) -> dict[str, Any] | None:
 
 
 def _schema_manifest(target: Path) -> dict[str, Any]:
-    latest_readiness = _evidence._latest_release_receipt(target)
-    latest_candidate = _evidence._latest_candidate(target)
+    latest_readiness = _evidence_mod._latest_release_receipt(target)
+    latest_candidate = _evidence_mod._latest_candidate(target)
     latest_train = _latest_fleet_release_train(target)
     waivers_path = target / ".brigade" / "repos" / "releases" / "waivers.jsonl"
     manual_evidence_path = target / ".brigade" / "repos" / "releases" / "evidence.jsonl"
@@ -155,7 +155,7 @@ def _schema_manifest(target: Path) -> dict[str, Any]:
             "detail": str(latest_candidate.get("path")) if latest_candidate else "no release candidate evidence found",
         }
     )
-    candidate_health = _candidate._candidate_health(target)
+    candidate_health = _candidate_mod._candidate_health(target)
     checks.extend(
         candidate_health_checks if isinstance((candidate_health_checks := candidate_health.get("checks")), list) else []
     )
@@ -189,9 +189,9 @@ def _schema_manifest(target: Path) -> dict[str, Any]:
         "schema_count": len(_schema_manifest_schemas()),
         "schemas": _schema_manifest_schemas(),
         "latest": {
-            "release_readiness": _candidate._receipt_ref(latest_readiness, "run_id"),
-            "release_candidate": _candidate._receipt_ref(latest_candidate, "candidate_id"),
-            "fleet_release_train": _candidate._receipt_ref(latest_train, "train_id"),
+            "release_readiness": _candidate_mod._receipt_ref(latest_readiness, "run_id"),
+            "release_candidate": _candidate_mod._receipt_ref(latest_candidate, "candidate_id"),
+            "fleet_release_train": _candidate_mod._receipt_ref(latest_train, "train_id"),
         },
         "checks": checks,
         "issue_count": len([check for check in checks if check.get("status") != OK]),

--- a/src/brigade/release_cmd/schema_ops.py
+++ b/src/brigade/release_cmd/schema_ops.py
@@ -1,45 +1,18 @@
-"""Local release readiness receipts."""
-# ruff: noqa: E402,F401,F403,F811,F821
-
 from __future__ import annotations
 
-import json
-import os
-import re
-import subprocess
-import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
-from .. import (
-    context_cmd,
-    handoff_cmd,
-    learn_cmd,
-    memory_cmd,
-    phases_cmd,
-    projects_cmd,
-    repos_cmd,
-    reportstore,
-    research_cmd,
-    roadmap_cmd,
-    scrub,
-    security_cmd,
-    tools_cmd,
-    work_cmd,
+from .. import repos_cmd
+from ..localio import utc_now as _now
+from . import candidate as _candidate
+from . import evidence as _evidence
+from .paths import (
+    OK,
+    SCHEMA_MANIFEST_VERSION,
+    WARN,
+    _field,
 )
-from ..selection import KNOWN_HARNESSES
-from ..localio import (
-    read_json_dict as _read_json,
-    read_jsonl_dicts as _read_jsonl,
-    utc_now as _now,
-    write_json as _write_json,
-)
-
-from . import paths as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
 
 
 def _schema_manifest_schemas() -> list[dict[str, Any]]:
@@ -162,8 +135,8 @@ def _latest_fleet_release_train(target: Path) -> dict[str, Any] | None:
 
 
 def _schema_manifest(target: Path) -> dict[str, Any]:
-    latest_readiness = _latest_release_receipt(target)
-    latest_candidate = _latest_candidate(target)
+    latest_readiness = _evidence._latest_release_receipt(target)
+    latest_candidate = _evidence._latest_candidate(target)
     latest_train = _latest_fleet_release_train(target)
     waivers_path = target / ".brigade" / "repos" / "releases" / "waivers.jsonl"
     manual_evidence_path = target / ".brigade" / "repos" / "releases" / "evidence.jsonl"
@@ -182,8 +155,10 @@ def _schema_manifest(target: Path) -> dict[str, Any]:
             "detail": str(latest_candidate.get("path")) if latest_candidate else "no release candidate evidence found",
         }
     )
-    candidate_health = _candidate_health(target)
-    checks.extend(candidate_health.get("checks") if isinstance(candidate_health.get("checks"), list) else [])
+    candidate_health = _candidate._candidate_health(target)
+    checks.extend(
+        candidate_health_checks if isinstance((candidate_health_checks := candidate_health.get("checks")), list) else []
+    )
     checks.append(
         {
             "name": "fleet_release_train_latest",
@@ -214,9 +189,9 @@ def _schema_manifest(target: Path) -> dict[str, Any]:
         "schema_count": len(_schema_manifest_schemas()),
         "schemas": _schema_manifest_schemas(),
         "latest": {
-            "release_readiness": _receipt_ref(latest_readiness, "run_id"),
-            "release_candidate": _receipt_ref(latest_candidate, "candidate_id"),
-            "fleet_release_train": _receipt_ref(latest_train, "train_id"),
+            "release_readiness": _candidate._receipt_ref(latest_readiness, "run_id"),
+            "release_candidate": _candidate._receipt_ref(latest_candidate, "candidate_id"),
+            "fleet_release_train": _candidate._receipt_ref(latest_train, "train_id"),
         },
         "checks": checks,
         "issue_count": len([check for check in checks if check.get("status") != OK]),

--- a/tests/fixtures/mypy_override_baseline.txt
+++ b/tests/fixtures/mypy_override_baseline.txt
@@ -20,8 +20,6 @@ brigade.phases_cmd.checks_actions
 brigade.phases_cmd.constants
 brigade.phases_cmd.session_lifecycle
 brigade.phases_cmd.session_ops
-brigade.release_cmd
-brigade.release_cmd.*
 brigade.security_cmd
 brigade.security_cmd.*
 brigade.work_cmd.backup


### PR DESCRIPTION
## What

Family 2 of 7 for #1228 phase 2. Every `release_cmd` submodule that copied `paths`'s globals at import time (`globals().update(vars(_family_base))`) now imports what it uses explicitly. Leaf modules (`paths`, `version_guard`) are imported by name; the cyclic group around the `evidence` hub (`candidate`, `candidate_audit_ops`, `ci`, `install_smoke`, `schema_ops`, `commands`, and `evidence` itself) uses module aliases (`from . import evidence as _evidence`, and the reverse in `evidence.py`) so partially initialized modules resolve at call time instead of raising `ImportError` during the facade's import sequence. The facade `__init__.py` is unchanged, so `_sync_module_globals` and `_CommandFamilyFacade.__setattr__` still propagate monkeypatches to every submodule.

`brigade.release_cmd` and `brigade.release_cmd.*` leave the mypy override and `tests/fixtures/mypy_override_baseline.txt`. The errors that surfaced (106, almost all `union-attr` on Optional `.get()` chains in `candidate.py`, `evidence.py`, `candidate_audit_ops.py`) are fixed with bind-once narrowing; no `type: ignore` added.

## Verify

mypy exit 0 (446 files), ruff check and format clean, size-ratchet baseline ok; release, facade, ratchet, and adjacent suites: 172 passed (receipt `20260827-132734-work-verify-d64db4`; release, version-sync, phase-257 facades, override and size ratchets, ci-workflow, component-manifest-provenance, cli-setup).

Workers: agy_flash (Gemini 3.7 Flash via Antigravity) for the conversion and narrowing, cursor_grok for the import-cycle fix.

## Look hardest at

The module-alias call sites in `evidence.py` and `candidate.py`: a name that was previously a direct import is now `_module.name`, which is the behavior the old namespace copy had for monkeypatching but not for import order. `tests/test_phase257_facades.py` covers dotted-path reachability and facade patching.

Refs #1228
