### PR TITLE
types(center_cmd): replace the namespace copy with explicit imports (#1228 phase 2, 3/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-    "brigade.center_cmd",
-    "brigade.center_cmd.*",
     "brigade.cli.run",
     "brigade.daily_cmd",
     "brigade.daily_cmd.*",

--- a/src/brigade/center_cmd/actions.py
+++ b/src/brigade/center_cmd/actions.py
@@ -43,9 +43,19 @@ from ..localio import (
 )
 from ..render import emit
 
-from . import schema_ops as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import core as _core_mod
+from . import report_review_ops as _report_review_ops_mod
+from . import reports as _reports_mod
+from .schema_ops import (
+    ACTION_ACTIVE_STALE_HOURS,
+    ACTION_DEFERRED_STALE_HOURS,
+    ACTION_DONE_ARCHIVE_HOURS,
+    ACTION_PENDING_STALE_HOURS,
+    ACTION_STATUSES,
+    SCHEMA_VERSION,
+    _action_schema,
+    _parse_time,
+)
 
 
 def _action_priority_rank(action: dict[str, Any]) -> tuple[int, int]:
@@ -59,13 +69,13 @@ def _action_priority_rank(action: dict[str, Any]) -> tuple[int, int]:
 
 
 def _planned_actions(report: dict[str, Any]) -> list[dict[str, Any]]:
-    plan = _action_plan(report)
+    plan = _reports_mod._action_plan(report)
     report_id = str(report.get("report_id") or "planned")
     report_fingerprint = str(
         report.get("report_fingerprint")
-        or _fingerprint_payload({"reviews": report.get("reviews"), "activity": report.get("activity")})
+        or _reports_mod._fingerprint_payload({"reviews": report.get("reviews"), "activity": report.get("activity")})
     )
-    reviewed_at = _report_reviewed_at(report)
+    reviewed_at = _report_review_ops_mod._report_reviewed_at(report)
     created = _now().isoformat()
     actions: list[dict[str, Any]] = []
     seen_source_items: set[str] = set()
@@ -79,7 +89,7 @@ def _planned_actions(report: dict[str, Any]) -> list[dict[str, Any]]:
             if source_item_id in seen_source_items:
                 continue
             seen_source_items.add(source_item_id)
-            source_fingerprint = _fingerprint_payload(
+            source_fingerprint = _reports_mod._fingerprint_payload(
                 {
                     "report_fingerprint": report_fingerprint,
                     "source_item_id": source_item_id,
@@ -97,8 +107,8 @@ def _planned_actions(report: dict[str, Any]) -> list[dict[str, Any]]:
                     "source_subsystem": source_subsystem,
                     "source_local_id": source_local_id,
                     "status": "pending",
-                    "priority": item.get("priority") if isinstance(item.get("priority"), str) else None,
-                    "severity": item.get("severity") if isinstance(item.get("severity"), str) else None,
+                    "priority": _priority if isinstance(_priority := item.get("priority"), str) else None,
+                    "severity": _severity if isinstance(_severity := item.get("severity"), str) else None,
                     "safe_summary": str(item.get("safe_summary") or "operator action"),
                     "suggested_command": str(item.get("suggested_next_command") or ""),
                     "created_at": created,
@@ -118,7 +128,7 @@ def _planned_actions(report: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _find_action(target: Path, action_id: str) -> tuple[list[dict[str, Any]], dict[str, Any] | None, str | None]:
-    actions = _read_actions(target)
+    actions = _core_mod._read_actions(target)
     action, error = actionqueue.find_action(actions, action_id, id_field="action_id", label="action")
     return actions, action, error
 
@@ -199,7 +209,7 @@ def _action_policy_issues(actions: list[dict[str, Any]]) -> list[dict[str, Any]]
 
 def actions_health(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    actions = _read_actions(target)
+    actions = _core_mod._read_actions(target)
     open_actions = [action for action in actions if action.get("status") in {"pending", "active", "deferred"}]
     open_actions.sort(key=_action_priority_rank)
     checks: list[dict[str, Any]] = []
@@ -216,7 +226,7 @@ def actions_health(target: Path) -> dict[str, Any]:
         )
     checks.extend(policy_issues)
     return {
-        "actions_path": str(_actions_path(target)),
+        "actions_path": str(_core_mod._actions_path(target)),
         "action_count": len(actions),
         "open_count": len(open_actions),
         "counts": _action_counts(actions),
@@ -237,15 +247,15 @@ def actions_health(target: Path) -> dict[str, Any]:
 
 def actions_doctor(*, target: Path, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
+    health = actions_health(target)
     payload = {
         "schema_version": SCHEMA_VERSION,
         "schema": _action_schema("center-actions-doctor"),
         "target": str(target),
-        "health": actions_health(target),
+        "health": health,
     }
     if json_output:
         return emit(payload, json_output, [], 0)
-    health = payload["health"]
     text_lines = [
         f"center actions doctor: {target}",
         f"actions: {health['action_count']}",
@@ -261,7 +271,7 @@ def _action_policy_import_record(issue: dict[str, Any], actions_by_id: dict[str,
     action_id = str(issue.get("action_id") or "")
     action = actions_by_id.get(action_id, {})
     source_key = f"center-action-policy:{issue.get('name')}:{action_id}"
-    fingerprint = _fingerprint_payload(
+    fingerprint = _reports_mod._fingerprint_payload(
         {
             "source_key": source_key,
             "source_fingerprint": action.get("source_fingerprint"),
@@ -298,7 +308,7 @@ def _action_policy_import_record(issue: dict[str, Any], actions_by_id: dict[str,
 
 def actions_import_issues(*, target: Path, dry_run: bool = False, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    actions = _read_actions(target)
+    actions = _core_mod._read_actions(target)
     actions_by_id = {str(action.get("action_id") or ""): action for action in actions}
     issues = _action_policy_issues(actions)
     records = [_action_policy_import_record(issue, actions_by_id) for issue in issues]
@@ -332,7 +342,7 @@ def actions_import_issues(*, target: Path, dry_run: bool = False, json_output: b
 
 def actions_plan(*, target: Path, report_id: str = "latest", json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    report, error = _resolve_report(target, report_id)
+    report, error = _reports_mod._resolve_report(target, report_id)
     if report is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -343,8 +353,8 @@ def actions_plan(*, target: Path, report_id: str = "latest", json_output: bool =
         "target": str(target),
         "report_id": report.get("report_id"),
         "report_path": report.get("path"),
-        "report_review_status": _report_review_status(report),
-        "actions_root": str(_actions_root(target)),
+        "report_review_status": _report_review_ops_mod._report_review_status(report),
+        "actions_root": str(_core_mod._actions_root(target)),
         "actions": actions,
         "action_count": len(actions),
         "write_required": False,
@@ -369,11 +379,11 @@ def actions_build(
     *, target: Path, report_id: str = "latest", allow_unreviewed: bool = False, json_output: bool = False
 ) -> int:
     target = target.expanduser().resolve()
-    report, error = _resolve_report(target, report_id)
+    report, error = _reports_mod._resolve_report(target, report_id)
     if report is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
-    review_status = _report_review_status(report)
+    review_status = _report_review_ops_mod._report_review_status(report)
     if review_status not in {"reviewed", "deferred"} and not allow_unreviewed:
         print(
             "error: source report must be closed out as reviewed or deferred before building actions",
@@ -381,9 +391,9 @@ def actions_build(
         )
         return 2
     planned = _planned_actions(report)
-    existing = _read_actions(target)
-    created, skipped = actionqueue.merge_planned(existing, _read_action_archive(target), planned)
-    _write_actions(target, existing)
+    existing = _core_mod._read_actions(target)
+    created, skipped = actionqueue.merge_planned(existing, _core_mod._read_action_archive(target), planned)
+    _core_mod._write_actions(target, existing)
     payload = {
         "schema_version": SCHEMA_VERSION,
         "schema": _action_schema("center-actions-build"),
@@ -391,7 +401,7 @@ def actions_build(
         "report_id": report.get("report_id"),
         "report_path": report.get("path"),
         "report_review_status": review_status,
-        "actions_path": str(_actions_path(target)),
+        "actions_path": str(_core_mod._actions_path(target)),
         "created_count": len(created),
         "skipped_count": len(skipped),
         "created_actions": created,
@@ -403,7 +413,7 @@ def actions_build(
     print(f"center actions build: {report.get('report_id')}")
     print(f"created: {len(created)}")
     print(f"skipped: {len(skipped)}")
-    print(f"path: {_actions_path(target)}")
+    print(f"path: {_core_mod._actions_path(target)}")
     return 0
 
 
@@ -412,13 +422,13 @@ def actions_list(*, target: Path, json_output: bool = False, limit: int = 50) ->
         print("error: --limit must be a positive integer", file=sys.stderr)
         return 2
     target = target.expanduser().resolve()
-    actions = _read_actions(target)
+    actions = _core_mod._read_actions(target)
     actions.sort(key=lambda action: (_action_priority_rank(action), str(action.get("updated_at") or "")))
     payload = {
         "schema_version": SCHEMA_VERSION,
         "schema": _action_schema("center-actions-list"),
         "target": str(target),
-        "actions_path": str(_actions_path(target)),
+        "actions_path": str(_core_mod._actions_path(target)),
         "actions": actions[:limit],
         "action_count": len(actions),
         "counts": _action_counts(actions),
@@ -427,7 +437,7 @@ def actions_list(*, target: Path, json_output: bool = False, limit: int = 50) ->
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
     print(f"center actions: {target}")
-    print(f"actions_path: {_actions_path(target)}")
+    print(f"actions_path: {_core_mod._actions_path(target)}")
     for action in actions[:limit]:
         print(
             f"- {action.get('action_id')} [{action.get('status')}] {action.get('source_group')} {action.get('source_local_id')}: {action.get('safe_summary')}"
@@ -478,7 +488,7 @@ def _set_action_status(
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
     actionqueue.stamp_status(action, status, now=_now().isoformat(), reason=reason)
-    _write_actions(target, actions)
+    _core_mod._write_actions(target, actions)
     payload = {
         "schema_version": SCHEMA_VERSION,
         "schema": _action_schema(f"center-actions-{status}"),
@@ -512,17 +522,17 @@ def actions_defer(*, target: Path, action_id: str, reason: str, json_output: boo
 
 def actions_archive_completed(*, target: Path, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    actions = _read_actions(target)
+    actions = _core_mod._read_actions(target)
     archived, remaining = actionqueue.split_archived_completed(actions, now=_now().isoformat())
-    _write_actions(target, remaining)
-    _append_action_archive(target, archived)
+    _core_mod._write_actions(target, remaining)
+    _core_mod._append_action_archive(target, archived)
     payload = {
         "schema_version": SCHEMA_VERSION,
         "schema": _action_schema("center-actions-archive"),
         "target": str(target),
         "archived_count": len(archived),
-        "archive_path": str(_actions_archive_path(target)),
-        "actions_path": str(_actions_path(target)),
+        "archive_path": str(_core_mod._actions_archive_path(target)),
+        "actions_path": str(_core_mod._actions_path(target)),
         "archived_actions": archived,
     }
     if json_output:
@@ -530,5 +540,5 @@ def actions_archive_completed(*, target: Path, json_output: bool = False) -> int
         return 0
     print("center actions archive: completed")
     print(f"archived: {len(archived)}")
-    print(f"path: {_actions_archive_path(target)}")
+    print(f"path: {_core_mod._actions_archive_path(target)}")
     return 0

--- a/src/brigade/center_cmd/agent_activity.py
+++ b/src/brigade/center_cmd/agent_activity.py
@@ -251,7 +251,7 @@ def _session_task_hints(path: Path, provider: str) -> tuple[str, str | None]:
                 cwd_folder = parts[index + 1]
     for item in _head_json_objects(path):
         item_type = item.get("type")
-        payload = item.get("payload") if isinstance(item.get("payload"), dict) else {}
+        payload = _payload if isinstance(_payload := item.get("payload"), dict) else {}
         if item_type == "session_meta" and not cwd_folder:
             cwd = payload.get("cwd")
             if isinstance(cwd, str) and cwd:
@@ -395,7 +395,7 @@ def _worker_records(
     lock_state: str,
 ) -> list[dict[str, Any]]:
     plan = _read_json(run_dir / "plan.json") or {}
-    assignments = plan.get("assignments") if isinstance(plan.get("assignments"), list) else []
+    assignments = _assignments if isinstance(_assignments := plan.get("assignments"), list) else []
     results = _read_json(run_dir / "worker-results.json") or {}
     result_by_worker = {
         str(item.get("worker")): item
@@ -443,7 +443,7 @@ def _worker_records(
 
 def _configured_sources(target: Path, now: datetime) -> list[dict[str, Any]]:
     config = _read_json(target / ".brigade" / "center" / "agent-activity-sources.json") or {}
-    sources = config.get("sources") if isinstance(config.get("sources"), list) else []
+    sources = _sources if isinstance(_sources := config.get("sources"), list) else []
     records: list[dict[str, Any]] = []
     for index, source_config in enumerate(sources[:50]):
         if not isinstance(source_config, dict):

--- a/src/brigade/center_cmd/core.py
+++ b/src/brigade/center_cmd/core.py
@@ -43,11 +43,16 @@ from ..localio import (
 )
 from ..render import emit
 
+from . import actions as _actions_mod
 from . import agent_activity
-
-from . import schema_ops as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import readiness as _readiness_mod
+from . import reports as _reports_mod
+from .schema_ops import (
+    SCHEMA_VERSION,
+    _action_schema,
+    _center_schema_manifest,
+    _schema,
+)
 
 
 def _git_value(target: Path, *args: str) -> str | None:
@@ -165,7 +170,7 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(payload.get("status") or "unknown"),
                 str(payload.get("title") or "work session"),
                 f"brigade work show {path.name}",
-                created_at=payload.get("started_at") if isinstance(payload.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := payload.get("started_at"), str) else None,
                 updated_at=payload.get("ended_at") or payload.get("started_at"),
                 receipt_path=str(path / "session.json"),
                 path=str(path),
@@ -180,12 +185,12 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(receipt.get("status") or "unknown"),
                 "work verification",
                 f"brigade work verify show {run_id}",
-                created_at=receipt.get("started_at") if isinstance(receipt.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := receipt.get("started_at"), str) else None,
                 updated_at=receipt.get("completed_at") or receipt.get("started_at"),
                 receipt_path=str(Path(str(receipt.get("path") or "")) / "receipt.json")
                 if receipt.get("path")
                 else None,
-                path=receipt.get("path") if isinstance(receipt.get("path"), str) else None,
+                path=_path if isinstance(_path := receipt.get("path"), str) else None,
             )
         )
     for receipt in work_cmd._scanner_receipts(target)[:20]:
@@ -197,17 +202,17 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(receipt.get("status") or "unknown"),
                 str(receipt.get("scanner_id") or "scanner run"),
                 f"brigade work scanners run-show {run_id}",
-                created_at=receipt.get("started_at") if isinstance(receipt.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := receipt.get("started_at"), str) else None,
                 updated_at=receipt.get("completed_at") or receipt.get("started_at"),
                 receipt_path=str(Path(str(receipt.get("path") or "")) / "receipt.json")
                 if receipt.get("path")
                 else None,
-                path=receipt.get("path") if isinstance(receipt.get("path"), str) else None,
+                path=_path if isinstance(_path := receipt.get("path"), str) else None,
             )
         )
     for sweep in work_cmd._scanner_sweeps(target)[:20]:
         sweep_id = str(sweep.get("sweep_id") or "")
-        path = str(Path(str(sweep.get("path") or "")) / "sweep.json") if sweep.get("path") else None
+        receipt_path = str(Path(str(sweep.get("path") or "")) / "sweep.json") if sweep.get("path") else None
         items.append(
             _item(
                 "scanner-sweep",
@@ -215,10 +220,10 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(sweep.get("status") or "unknown"),
                 "scanner sweep",
                 f"brigade work sweep-show {sweep_id}",
-                created_at=sweep.get("started_at") if isinstance(sweep.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := sweep.get("started_at"), str) else None,
                 updated_at=sweep.get("completed_at") or sweep.get("started_at"),
-                receipt_path=path,
-                path=sweep.get("path") if isinstance(sweep.get("path"), str) else None,
+                receipt_path=receipt_path,
+                path=_path if isinstance(_path := sweep.get("path"), str) else None,
             )
         )
     for receipt in work_cmd._review_receipts(target)[:20]:
@@ -230,12 +235,12 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(receipt.get("status") or "unknown"),
                 str(receipt.get("reviewer_id") or "review run"),
                 f"brigade work review show {run_id}",
-                created_at=receipt.get("started_at") if isinstance(receipt.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := receipt.get("started_at"), str) else None,
                 updated_at=receipt.get("completed_at") or receipt.get("started_at"),
                 receipt_path=str(Path(str(receipt.get("path") or "")) / "receipt.json")
                 if receipt.get("path")
                 else None,
-                path=receipt.get("path") if isinstance(receipt.get("path"), str) else None,
+                path=_path if isinstance(_path := receipt.get("path"), str) else None,
             )
         )
     for draft in handoff_cmd.draft_queue_payload(target).get("drafts", [])[:20]:
@@ -249,9 +254,9 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(draft.get("status") or "pending"),
                 str(draft.get("title") or draft.get("target_document") or "handoff draft"),
                 f"brigade handoff show {draft_id}",
-                severity=draft.get("severity") if isinstance(draft.get("severity"), str) else None,
-                updated_at=draft.get("modified_at") if isinstance(draft.get("modified_at"), str) else None,
-                path=draft.get("path") if isinstance(draft.get("path"), str) else None,
+                severity=_severity if isinstance(_severity := draft.get("severity"), str) else None,
+                updated_at=_modified_at if isinstance(_modified_at := draft.get("modified_at"), str) else None,
+                path=_path if isinstance(_path := draft.get("path"), str) else None,
             )
         )
     for receipt in _iter_json_files(target / ".brigade" / "handoffs" / "ingest-runs", "*.json")[:20]:
@@ -263,24 +268,26 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(receipt.get("status") or "completed"),
                 "handoff ingest receipt",
                 f"brigade handoff run-show {run_id}",
-                created_at=receipt.get("started_at") if isinstance(receipt.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := receipt.get("started_at"), str) else None,
                 updated_at=receipt.get("completed_at") or receipt.get("started_at"),
-                receipt_path=receipt.get("path") if isinstance(receipt.get("path"), str) else None,
+                receipt_path=_path if isinstance(_path := receipt.get("path"), str) else None,
             )
         )
-    for diff in _report_diffs(target)[:20]:
+    for diff in _reports_mod._report_diffs(target)[:20]:
         diff_id = str(diff.get("diff_id") or Path(str(diff.get("path") or "diff")).parent.name)
-        summary = diff.get("summary") if isinstance(diff.get("summary"), dict) else {}
+        summary = _summary if isinstance(_summary := diff.get("summary"), dict) else {}
+        new_count = summary.get("new_item_count", 0) if isinstance(summary, dict) else 0
+        resolved_count = summary.get("resolved_item_count", 0) if isinstance(summary, dict) else 0
         items.append(
             _item(
                 "center-report-diff",
                 diff_id,
                 str(diff.get("status") or "unknown"),
-                f"{summary.get('new_item_count', 0)} new, {summary.get('resolved_item_count', 0)} resolved",
+                f"{new_count} new, {resolved_count} resolved",
                 f"brigade center report diff {diff.get('base_report_id')} {diff.get('compare_report_id')}",
-                created_at=diff.get("created_at") if isinstance(diff.get("created_at"), str) else None,
-                updated_at=diff.get("created_at") if isinstance(diff.get("created_at"), str) else None,
-                receipt_path=diff.get("path") if isinstance(diff.get("path"), str) else None,
+                created_at=_created_at if isinstance(_created_at := diff.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := diff.get("created_at"), str) else None,
+                receipt_path=_path if isinstance(_path := diff.get("path"), str) else None,
             )
         )
     for call in _read_jsonl(tools_cmd.calls_path(target))[:20]:
@@ -292,8 +299,8 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(call.get("status") or "unknown"),
                 str(call.get("tool_id") or "tool call"),
                 f"brigade tools call show {call_id}",
-                severity=call.get("severity") if isinstance(call.get("severity"), str) else None,
-                created_at=call.get("created_at") if isinstance(call.get("created_at"), str) else None,
+                severity=_severity if isinstance(_severity := call.get("severity"), str) else None,
+                created_at=_created_at if isinstance(_created_at := call.get("created_at"), str) else None,
                 updated_at=call.get("reviewed_at") or call.get("created_at"),
                 receipt_path=str(tools_cmd.calls_path(target)),
             )
@@ -307,9 +314,9 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(receipt.get("status") or "unknown"),
                 str(receipt.get("tool_id") or "tool run"),
                 f"brigade tools run show {run_id}",
-                created_at=receipt.get("started_at") if isinstance(receipt.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := receipt.get("started_at"), str) else None,
                 updated_at=receipt.get("completed_at") or receipt.get("started_at"),
-                receipt_path=receipt.get("path") if isinstance(receipt.get("path"), str) else None,
+                receipt_path=_path if isinstance(_path := receipt.get("path"), str) else None,
             )
         )
     for checkpoint in _iter_json_files(tools_cmd.checkpoints_path(target), "*.json")[:20]:
@@ -321,10 +328,10 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(checkpoint.get("status") or "waiting"),
                 str(checkpoint.get("reason") or "tool checkpoint"),
                 f"brigade tools checkpoint show {checkpoint_id}",
-                severity=checkpoint.get("severity") if isinstance(checkpoint.get("severity"), str) else None,
-                created_at=checkpoint.get("created_at") if isinstance(checkpoint.get("created_at"), str) else None,
+                severity=_severity if isinstance(_severity := checkpoint.get("severity"), str) else None,
+                created_at=_created_at if isinstance(_created_at := checkpoint.get("created_at"), str) else None,
                 updated_at=checkpoint.get("reviewed_at") or checkpoint.get("created_at"),
-                receipt_path=checkpoint.get("path") if isinstance(checkpoint.get("path"), str) else None,
+                receipt_path=_path if isinstance(_path := checkpoint.get("path"), str) else None,
             )
         )
     for pack in tools_cmd._tool_packs(target)[:20]:
@@ -336,10 +343,10 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(pack.get("status") or "built"),
                 "portable tool pack",
                 f"brigade tools pack show {pack_id}",
-                created_at=pack.get("created_at") if isinstance(pack.get("created_at"), str) else None,
-                updated_at=pack.get("created_at") if isinstance(pack.get("created_at"), str) else None,
+                created_at=_created_at if isinstance(_created_at := pack.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := pack.get("created_at"), str) else None,
                 receipt_path=str(Path(str(pack.get("path") or "")) / "tool-pack.json") if pack.get("path") else None,
-                path=pack.get("path") if isinstance(pack.get("path"), str) else None,
+                path=_path if isinstance(_path := pack.get("path"), str) else None,
             )
         )
     for pack in context_cmd._packs(target)[:20]:
@@ -351,10 +358,10 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(pack.get("status") or "built"),
                 str(pack.get("kind") or "context"),
                 f"brigade context show {pack_id}",
-                created_at=pack.get("created_at") if isinstance(pack.get("created_at"), str) else None,
-                updated_at=pack.get("created_at") if isinstance(pack.get("created_at"), str) else None,
+                created_at=_created_at if isinstance(_created_at := pack.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := pack.get("created_at"), str) else None,
                 receipt_path=str(Path(str(pack.get("path") or "")) / "context.json") if pack.get("path") else None,
-                path=pack.get("path") if isinstance(pack.get("path"), str) else None,
+                path=_path if isinstance(_path := pack.get("path"), str) else None,
             )
         )
     for receipt in _iter_json_files(target / ".brigade" / "context" / "sync-plans", "*/sync-plan.json")[:20]:
@@ -366,9 +373,9 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(receipt.get("status") or "planned"),
                 f"{receipt.get('destination_count', 0)} destination(s)",
                 f"brigade context sync plan {receipt.get('pack_id') or 'latest'}",
-                created_at=receipt.get("created_at") if isinstance(receipt.get("created_at"), str) else None,
-                updated_at=receipt.get("created_at") if isinstance(receipt.get("created_at"), str) else None,
-                receipt_path=receipt.get("path") if isinstance(receipt.get("path"), str) else None,
+                created_at=_created_at if isinstance(_created_at := receipt.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := receipt.get("created_at"), str) else None,
+                receipt_path=_path if isinstance(_path := receipt.get("path"), str) else None,
             )
         )
     for replay in _iter_json_files(target / ".brigade" / "learn" / "replays", "*/replay.json")[:20]:
@@ -380,16 +387,14 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(replay.get("status") or "recorded"),
                 str(replay.get("scenario_id") or "learning replay"),
                 "brigade learn plan",
-                updated_at=replay.get("created_at") if isinstance(replay.get("created_at"), str) else None,
-                receipt_path=replay.get("path") if isinstance(replay.get("path"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := replay.get("created_at"), str) else None,
+                receipt_path=_path if isinstance(_path := replay.get("path"), str) else None,
             )
         )
     security_latest = target / ".brigade" / "security" / "latest" / "security-report.json"
     security_report = _read_json(security_latest)
     if security_report is not None:
-        generated = (
-            security_report.get("generated_at") if isinstance(security_report.get("generated_at"), str) else None
-        )
+        generated = _generated_at if isinstance(_generated_at := security_report.get("generated_at"), str) else None
         items.append(
             _item(
                 "security-report",
@@ -412,9 +417,9 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(closeout.get("status") or "reviewed"),
                 "security closeout",
                 "brigade security closeout",
-                created_at=closeout.get("created_at") if isinstance(closeout.get("created_at"), str) else None,
-                updated_at=closeout.get("created_at") if isinstance(closeout.get("created_at"), str) else None,
-                receipt_path=closeout.get("path") if isinstance(closeout.get("path"), str) else None,
+                created_at=_created_at if isinstance(_created_at := closeout.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := closeout.get("created_at"), str) else None,
+                receipt_path=_path if isinstance(_path := closeout.get("path"), str) else None,
             )
         )
     for closeout in _iter_json_files(target / ".brigade" / "backups" / "closeouts", "*/closeout.json")[:20]:
@@ -426,9 +431,9 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(closeout.get("status") or "reviewed"),
                 "backup closeout",
                 "brigade work backup closeout",
-                created_at=closeout.get("created_at") if isinstance(closeout.get("created_at"), str) else None,
-                updated_at=closeout.get("created_at") if isinstance(closeout.get("created_at"), str) else None,
-                receipt_path=closeout.get("path") if isinstance(closeout.get("path"), str) else None,
+                created_at=_created_at if isinstance(_created_at := closeout.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := closeout.get("created_at"), str) else None,
+                receipt_path=_path if isinstance(_path := closeout.get("path"), str) else None,
             )
         )
     for closeout in _iter_json_files(target / ".brigade" / "memory-care" / "closeouts", "*/closeout.json")[:20]:
@@ -440,9 +445,9 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(closeout.get("status") or "reviewed"),
                 "memory-care closeout",
                 "brigade memory care closeout",
-                created_at=closeout.get("created_at") if isinstance(closeout.get("created_at"), str) else None,
-                updated_at=closeout.get("created_at") if isinstance(closeout.get("created_at"), str) else None,
-                receipt_path=closeout.get("path") if isinstance(closeout.get("path"), str) else None,
+                created_at=_created_at if isinstance(_created_at := closeout.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := closeout.get("created_at"), str) else None,
+                receipt_path=_path if isinstance(_path := closeout.get("path"), str) else None,
             )
         )
     release = release_cmd._latest_release_receipt(target)
@@ -455,12 +460,12 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(release.get("status") or "unknown"),
                 "release readiness",
                 f"brigade release show {run_id}",
-                created_at=release.get("started_at") if isinstance(release.get("started_at"), str) else None,
+                created_at=_started_at if isinstance(_started_at := release.get("started_at"), str) else None,
                 updated_at=release.get("completed_at") or release.get("created_at") or release.get("started_at"),
                 receipt_path=str(Path(str(release.get("path") or "")) / "receipt.json")
                 if release.get("path")
                 else None,
-                path=release.get("path") if isinstance(release.get("path"), str) else None,
+                path=_path if isinstance(_path := release.get("path"), str) else None,
             )
         )
     candidate = release_cmd._latest_candidate(target)
@@ -473,12 +478,12 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(candidate.get("status") or "draft"),
                 "release candidate",
                 f"brigade release candidate show {candidate_id}",
-                created_at=candidate.get("created_at") if isinstance(candidate.get("created_at"), str) else None,
-                updated_at=candidate.get("created_at") if isinstance(candidate.get("created_at"), str) else None,
+                created_at=_created_at if isinstance(_created_at := candidate.get("created_at"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := candidate.get("created_at"), str) else None,
                 receipt_path=str(Path(str(candidate.get("path") or "")) / "EVIDENCE.json")
                 if candidate.get("path")
                 else None,
-                path=candidate.get("path") if isinstance(candidate.get("path"), str) else None,
+                path=_path if isinstance(_path := candidate.get("path"), str) else None,
             )
         )
     for receipt in release_cmd._read_install_smoke_receipts(target)[:20]:
@@ -490,7 +495,7 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(receipt.get("status") or "unknown"),
                 str(receipt.get("matrix_id") or "install smoke"),
                 f"brigade release smoke show {receipt_id}",
-                created_at=receipt.get("created_at") if isinstance(receipt.get("created_at"), str) else None,
+                created_at=_created_at if isinstance(_created_at := receipt.get("created_at"), str) else None,
                 updated_at=receipt.get("completed_at") or receipt.get("created_at"),
                 receipt_path=str(release_cmd._install_smoke_receipts_path(target)),
             )
@@ -504,14 +509,14 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(action.get("status") or "pending"),
                 str(action.get("safe_summary") or "operator action"),
                 f"brigade center actions show {action_id}",
-                priority=action.get("priority") if isinstance(action.get("priority"), str) else None,
-                severity=action.get("severity") if isinstance(action.get("severity"), str) else None,
-                created_at=action.get("created_at") if isinstance(action.get("created_at"), str) else None,
-                updated_at=action.get("updated_at") if isinstance(action.get("updated_at"), str) else None,
+                priority=_priority if isinstance(_priority := action.get("priority"), str) else None,
+                severity=_severity if isinstance(_severity := action.get("severity"), str) else None,
+                created_at=_created_at if isinstance(_created_at := action.get("created_at"), str) else None,
+                updated_at=_updated_at if isinstance(_updated_at := action.get("updated_at"), str) else None,
                 receipt_path=str(_actions_path(target)),
             )
         )
-    readiness = _latest_readiness(target)
+    readiness = _readiness_mod._latest_readiness(target)
     if readiness:
         readiness_id = str(readiness.get("readiness_id") or "latest")
         items.append(
@@ -521,12 +526,12 @@ def _activity(target: Path) -> list[dict[str, Any]]:
                 str(readiness.get("status") or "unknown"),
                 "operator readiness closeout",
                 f"brigade center readiness show {readiness_id}",
-                created_at=readiness.get("created_at") if isinstance(readiness.get("created_at"), str) else None,
+                created_at=_created_at if isinstance(_created_at := readiness.get("created_at"), str) else None,
                 updated_at=readiness.get("completed_at") or readiness.get("created_at"),
                 receipt_path=str(Path(str(readiness.get("path") or "")) / "readiness.json")
                 if readiness.get("path")
                 else None,
-                path=readiness.get("path") if isinstance(readiness.get("path"), str) else None,
+                path=_path if isinstance(_path := readiness.get("path"), str) else None,
             )
         )
     items.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
@@ -546,15 +551,15 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                 "pending",
                 str(item.get("text") or ""),
                 f"brigade work import plan {import_id}",
-                priority=item.get("priority") if isinstance(item.get("priority"), str) else None,
-                severity=item.get("severity") if isinstance(item.get("severity"), str) else None,
+                priority=_priority if isinstance(_priority := item.get("priority"), str) else None,
+                severity=_severity if isinstance(_severity := item.get("severity"), str) else None,
                 receipt_path=str(work_cmd._imports_path(target)),
                 updated_at=item.get("updated_at") or item.get("created_at"),
             )
         )
     review_health = work_cmd._review_health(target)
     for finding_key in ("top_pending_finding", "top_unresolved_finding"):
-        finding = review_health.get(finding_key) if isinstance(review_health.get(finding_key), dict) else None
+        finding = _finding_key if isinstance(_finding_key := review_health.get(finding_key), dict) else None
         if finding:
             finding_id = str(finding.get("id") or finding.get("import_id") or finding_key)
             items.append(
@@ -564,8 +569,8 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                     "pending",
                     str(finding.get("text") or finding.get("safe_detail") or "review finding"),
                     f"brigade work review finding-show {finding_id}",
-                    severity=finding.get("severity") if isinstance(finding.get("severity"), str) else None,
-                    updated_at=finding.get("created_at") if isinstance(finding.get("created_at"), str) else None,
+                    severity=_severity if isinstance(_severity := finding.get("severity"), str) else None,
+                    updated_at=_created_at if isinstance(_created_at := finding.get("created_at"), str) else None,
                 )
             )
     handoffs = handoff_cmd.draft_queue_payload(target)
@@ -579,9 +584,9 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                     str(draft.get("status") or "pending"),
                     str(draft.get("title") or draft.get("target_document") or "handoff draft"),
                     f"brigade handoff show {draft_id}",
-                    severity=draft.get("severity") if isinstance(draft.get("severity"), str) else None,
-                    updated_at=draft.get("modified_at") if isinstance(draft.get("modified_at"), str) else None,
-                    path=draft.get("path") if isinstance(draft.get("path"), str) else None,
+                    severity=_severity if isinstance(_severity := draft.get("severity"), str) else None,
+                    updated_at=_modified_at if isinstance(_modified_at := draft.get("modified_at"), str) else None,
+                    path=_path if isinstance(_path := draft.get("path"), str) else None,
                 )
             )
     research_handoffs = research_cmd.health(target)
@@ -604,8 +609,9 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
         ("run_history", "brigade tools run list"),
         ("checkpoints", "brigade tools checkpoint list"),
     ):
-        value = tool_health.get(bucket) if isinstance(tool_health.get(bucket), dict) else {}
-        top = value.get("top_issue") if isinstance(value.get("top_issue"), dict) else None
+        bucket_val = tool_health.get(bucket) if isinstance(tool_health, dict) else None
+        value = bucket_val if isinstance(bucket_val, dict) else {}
+        top = _top_issue if isinstance(_top_issue := value.get("top_issue"), dict) else None
         if top:
             items.append(
                 _item(
@@ -614,7 +620,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                     str(top.get("status") or "warn"),
                     str(top.get("detail") or top.get("issue_type") or bucket),
                     command,
-                    severity=top.get("severity") if isinstance(top.get("severity"), str) else None,
+                    severity=_severity if isinstance(_severity := top.get("severity"), str) else None,
                 )
             )
     for name, health, command in (
@@ -622,7 +628,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
         ("memory-care", memory_cmd.health(target), "brigade memory care status"),
         ("security", security_cmd.health(target), "brigade security findings"),
     ):
-        top = health.get("top_issue") or health.get("top_finding")
+        top = health.get("top_issue") or health.get("top_finding") if isinstance(health, dict) else None
         if isinstance(top, dict):
             items.append(
                 _item(
@@ -631,7 +637,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                     str(top.get("status") or "warn"),
                     str(top.get("detail") or top.get("title") or top.get("safe_summary") or name),
                     command,
-                    severity=top.get("severity") if isinstance(top.get("severity"), str) else None,
+                    severity=_severity if isinstance(_severity := top.get("severity"), str) else None,
                 )
             )
     for candidate in learn_cmd.candidates(target):
@@ -642,12 +648,12 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                 str(candidate.get("status") or "pending"),
                 str(candidate.get("safe_summary") or ""),
                 str(candidate.get("suggested_next_command") or "brigade learn plan"),
-                severity=candidate.get("severity") if isinstance(candidate.get("severity"), str) else None,
+                severity=_severity if isinstance(_severity := candidate.get("severity"), str) else None,
             )
         )
-    learning_health = learn_cmd.health(target)
-    replay = learning_health.get("replay") if isinstance(learning_health.get("replay"), dict) else {}
-    replay_issue = replay.get("top_issue") if isinstance(replay.get("top_issue"), dict) else None
+    learning_health = _health if isinstance(_health := learn_cmd.health(target), dict) else {}
+    replay = _replay if isinstance(_replay := learning_health.get("replay"), dict) else {}
+    replay_issue = _top_issue if isinstance(_top_issue := replay.get("top_issue"), dict) else None
     if replay_issue:
         items.append(
             _item(
@@ -670,18 +676,21 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                     "brigade projects audit",
                 )
             )
-    repo_health = repos_cmd.health(target)
-    repo_report = repo_health.get("report") if isinstance(repo_health.get("report"), dict) else {}
-    repo_actions = repo_health.get("actions") if isinstance(repo_health.get("actions"), dict) else {}
-    repo_sweep = repo_health.get("sweep") if isinstance(repo_health.get("sweep"), dict) else {}
-    repo_release = repo_health.get("release_train") if isinstance(repo_health.get("release_train"), dict) else {}
-    for bucket, command in (
+    repo_health: dict[str, Any] = _health if isinstance(_health := repos_cmd.health(target), dict) else {}
+    repo_report: dict[str, Any] = _report if isinstance(_report := repo_health.get("report"), dict) else {}
+    repo_actions: dict[str, Any] = _actions if isinstance(_actions := repo_health.get("actions"), dict) else {}
+    repo_sweep: dict[str, Any] = _sweep if isinstance(_sweep := repo_health.get("sweep"), dict) else {}
+    repo_release: dict[str, Any] = (
+        _release_train if isinstance(_release_train := repo_health.get("release_train"), dict) else {}
+    )
+    buckets: list[tuple[dict[str, Any], str]] = [
         (repo_report, "brigade repos report build"),
         (repo_actions, "brigade repos actions list"),
         (repo_sweep, "brigade repos sweep run"),
         (repo_release, "brigade repos release build"),
-    ):
-        top = bucket.get("top_issue") if isinstance(bucket.get("top_issue"), dict) else None
+    ]
+    for bucket_data, default_cmd in buckets:
+        top = _top_issue if isinstance(_top_issue := bucket_data.get("top_issue"), dict) else None
         if top:
             items.append(
                 _item(
@@ -689,7 +698,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                     str(top.get("name") or "repo-fleet"),
                     str(top.get("status") or "warn"),
                     str(top.get("detail") or "repo fleet issue"),
-                    str(top.get("suggested_next_command") or command),
+                    str(top.get("suggested_next_command") or default_cmd),
                 )
             )
     context_health = context_cmd.health(target)
@@ -713,8 +722,8 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                 str(candidate.get("status") or "draft"),
                 "release candidate awaits review",
                 f"brigade release candidate compare {candidate_id}",
-                updated_at=candidate.get("created_at") if isinstance(candidate.get("created_at"), str) else None,
-                path=candidate.get("path") if isinstance(candidate.get("path"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := candidate.get("created_at"), str) else None,
+                path=_path if isinstance(_path := candidate.get("path"), str) else None,
             )
         )
     for action in _read_actions(target):
@@ -728,14 +737,14 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                 str(action.get("status") or "pending"),
                 str(action.get("safe_summary") or "operator action"),
                 f"brigade center actions show {action_id}",
-                priority=action.get("priority") if isinstance(action.get("priority"), str) else None,
-                severity=action.get("severity") if isinstance(action.get("severity"), str) else None,
-                updated_at=action.get("updated_at") if isinstance(action.get("updated_at"), str) else None,
+                priority=_priority if isinstance(_priority := action.get("priority"), str) else None,
+                severity=_severity if isinstance(_severity := action.get("severity"), str) else None,
+                updated_at=_updated_at if isinstance(_updated_at := action.get("updated_at"), str) else None,
                 receipt_path=str(_actions_path(target)),
             )
         )
-    readiness = readiness_health(target)
-    top_readiness = readiness.get("top_issue") if isinstance(readiness.get("top_issue"), dict) else None
+    readiness = _readiness_mod.readiness_health(target)
+    top_readiness = _top_issue if isinstance(_top_issue := readiness.get("top_issue"), dict) else None
     if top_readiness:
         items.append(
             _item(
@@ -746,9 +755,9 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                 "brigade center readiness plan",
             )
         )
-    daily_health = daily_cmd.health(target)
-    approvals = daily_health.get("approvals") if isinstance(daily_health.get("approvals"), dict) else {}
-    top_approval = approvals.get("top_pending") if isinstance(approvals.get("top_pending"), dict) else None
+    daily_health = _health if isinstance(_health := daily_cmd.health(target), dict) else {}
+    approvals = _approvals if isinstance(_approvals := daily_health.get("approvals"), dict) else {}
+    top_approval = _top_pending if isinstance(_top_pending := approvals.get("top_pending"), dict) else None
     if top_approval:
         approval_id = str(top_approval.get("approval_id") or "approval")
         items.append(
@@ -760,7 +769,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                 f"brigade daily approvals show {approval_id}",
             )
         )
-    top_daily = daily_health.get("top_issue") if isinstance(daily_health.get("top_issue"), dict) else None
+    top_daily = _top_issue if isinstance(_top_issue := daily_health.get("top_issue"), dict) else None
     if top_daily:
         items.append(
             _item(
@@ -772,7 +781,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
             )
         )
     phase_health = phases_cmd.health(target)
-    top_phase = phase_health.get("top_issue") if isinstance(phase_health.get("top_issue"), dict) else None
+    top_phase = _top_issue if isinstance(_top_issue := phase_health.get("top_issue"), dict) else None
     if top_phase:
         items.append(
             _item(
@@ -784,7 +793,7 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
             )
         )
     latest_phase_session = (
-        phase_health.get("latest_session") if isinstance(phase_health.get("latest_session"), dict) else None
+        _latest_session if isinstance(_latest_session := phase_health.get("latest_session"), dict) else None
     )
     if latest_phase_session and latest_phase_session.get("status") not in {"closed", "archived"}:
         items.append(
@@ -797,13 +806,13 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
             )
         )
     latest_checkpoint = (
-        phase_health.get("latest_session_checkpoint")
-        if isinstance(phase_health.get("latest_session_checkpoint"), dict)
+        _latest_session_checkpoint
+        if isinstance(_latest_session_checkpoint := phase_health.get("latest_session_checkpoint"), dict)
         else None
     )
     latest_checkpoint_compare = (
-        phase_health.get("latest_session_checkpoint_compare")
-        if isinstance(phase_health.get("latest_session_checkpoint_compare"), dict)
+        _latest_session_checkpoint_compare
+        if isinstance(_latest_session_checkpoint_compare := phase_health.get("latest_session_checkpoint_compare"), dict)
         else None
     )
     if latest_checkpoint and latest_checkpoint.get("status") == "blocked":
@@ -816,18 +825,14 @@ def _reviews(target: Path) -> list[dict[str, Any]]:
                 str(latest_checkpoint.get("summary") or "phase session checkpoint is blocked"),
                 f"brigade work phases session checkpoints show {checkpoint_id}",
                 severity="high",
-                updated_at=latest_checkpoint.get("created_at")
-                if isinstance(latest_checkpoint.get("created_at"), str)
-                else None,
-                receipt_path=latest_checkpoint.get("path") if isinstance(latest_checkpoint.get("path"), str) else None,
+                updated_at=_created_at if isinstance(_created_at := latest_checkpoint.get("created_at"), str) else None,
+                receipt_path=_path if isinstance(_path := latest_checkpoint.get("path"), str) else None,
             )
         )
     if latest_checkpoint_compare and int(latest_checkpoint_compare.get("issue_count") or 0) > 0:
         checkpoint_id = str(latest_checkpoint_compare.get("checkpoint_id") or "latest")
         top_checkpoint = (
-            latest_checkpoint_compare.get("top_issue")
-            if isinstance(latest_checkpoint_compare.get("top_issue"), dict)
-            else {}
+            _top_issue if isinstance(_top_issue := latest_checkpoint_compare.get("top_issue"), dict) else {}
         )
         items.append(
             _item(
@@ -878,9 +883,9 @@ def status_payload(target: Path) -> dict[str, Any]:
         "roadmap": roadmap_cmd.health(target),
         "projects": projects_cmd.health(target),
         "security": security_cmd.health(target),
-        "operator_readiness": readiness_health(target),
-        "operator_report": report_health(target),
-        "action_queue": actions_health(target),
+        "operator_readiness": _readiness_mod.readiness_health(target),
+        "operator_report": _reports_mod.report_health(target),
+        "action_queue": _actions_mod.actions_health(target),
         "daily_driver": daily_cmd.health(target),
         "cloud_tracker": cloud_tracker.health(target),
         "phase_ledger": phases_cmd.health(target),
@@ -900,19 +905,19 @@ def status(*, target: Path, json_output: bool = False) -> int:
         f"actions: {payload['action_queue']['open_count']}",
         f"context_packs: {payload['context']['pack_count']}",
     ]
-    pantry = payload.get("pantry") if isinstance(payload.get("pantry"), dict) else {}
+    pantry = _pantry if isinstance(_pantry := payload.get("pantry"), dict) else {}
     if pantry:
         text_lines.append(f"pantry: {pantry.get('summary')}")
-    notifications = payload.get("notifications") if isinstance(payload.get("notifications"), dict) else {}
+    notifications = _notifications if isinstance(_notifications := payload.get("notifications"), dict) else {}
     if notifications:
         text_lines.append(f"notifications: {notifications.get('status')} configured={notifications.get('configured')}")
-    phase_ledger = payload.get("phase_ledger") if isinstance(payload.get("phase_ledger"), dict) else {}
+    phase_ledger = _phase_ledger if isinstance(_phase_ledger := payload.get("phase_ledger"), dict) else {}
     if phase_ledger:
         text_lines.append(f"phase_records: {phase_ledger.get('record_count', 0)}")
         text_lines.append(f"phase_issues: {phase_ledger.get('issue_count', 0)}")
         text_lines.append(f"phase_actions: {phase_ledger.get('open_action_count', 0)}")
         latest_phase_session = (
-            phase_ledger.get("latest_session") if isinstance(phase_ledger.get("latest_session"), dict) else None
+            _latest_session if isinstance(_latest_session := phase_ledger.get("latest_session"), dict) else None
         )
         if latest_phase_session:
             text_lines.append(

--- a/src/brigade/center_cmd/dashboard/views/code_graph.py
+++ b/src/brigade/center_cmd/dashboard/views/code_graph.py
@@ -92,7 +92,7 @@ def _query_flag(query: dict[str, str], key: str, truthy: str) -> bool:
 
 
 def render(payload: dict, nonce: str) -> str:
-    export = payload.get("export") if isinstance(payload.get("export"), dict) else {}
+    export = _export if isinstance(_export := payload.get("export"), dict) else {}
     symbol = payload.get("symbol")
     show_full_map = payload.get("show_full_map") is True
     show_worktrees = payload.get("show_worktrees") is True
@@ -151,7 +151,7 @@ def _changed_module_ids(export: dict) -> list[str]:
     overlay = export.get("change_overlay")
     if not isinstance(overlay, dict):
         return []
-    raw = overlay.get("changed_modules") if isinstance(overlay.get("changed_modules"), list) else []
+    raw = _changed_modules if isinstance(_changed_modules := overlay.get("changed_modules"), list) else []
     ids: list[str] = []
     seen: set[str] = set()
     for item in raw:
@@ -248,15 +248,15 @@ def _summary_strip(
     overlay_active: bool,
     changed_ids: list[str],
 ) -> str:
-    stats = export.get("stats") if isinstance(export.get("stats"), dict) else {}
-    module_map = export.get("module_map") if isinstance(export.get("module_map"), dict) else {}
-    insights = module_map.get("insights") if isinstance(module_map.get("insights"), dict) else {}
+    stats = _stats if isinstance(_stats := export.get("stats"), dict) else {}
+    module_map = _module_map if isinstance(_module_map := export.get("module_map"), dict) else {}
+    insights = _insights if isinstance(_insights := module_map.get("insights"), dict) else {}
     modules = shown if shown else [row for row in module_map.get("modules", []) if isinstance(row, dict)]
 
-    core = insights.get("core") if isinstance(insights.get("core"), dict) else {}
-    hub = insights.get("most_connected") if isinstance(insights.get("most_connected"), dict) else {}
-    change = insights.get("biggest_change") if isinstance(insights.get("biggest_change"), dict) else {}
-    largest = insights.get("largest") if isinstance(insights.get("largest"), dict) else {}
+    core = _core if isinstance(_core := insights.get("core"), dict) else {}
+    hub = _most_connected if isinstance(_most_connected := insights.get("most_connected"), dict) else {}
+    change = _biggest_change if isinstance(_biggest_change := insights.get("biggest_change"), dict) else {}
+    largest = _largest if isinstance(_largest := insights.get("largest"), dict) else {}
     isolated = insights.get("isolated_count")
 
     if overlay_active:
@@ -388,10 +388,10 @@ def _map_toggles(
 
 
 def _render_module_map(export: dict, *, show_full_map: bool, show_worktrees: bool) -> str:
-    module_map = export.get("module_map") if isinstance(export.get("module_map"), dict) else {}
+    module_map = _module_map if isinstance(_module_map := export.get("module_map"), dict) else {}
     modules = [row for row in module_map.get("modules", []) if isinstance(row, dict)]
     edges = [row for row in module_map.get("edges", []) if isinstance(row, dict)]
-    trunc = module_map.get("truncation") if isinstance(module_map.get("truncation"), dict) else {}
+    trunc = _truncation if isinstance(_truncation := module_map.get("truncation"), dict) else {}
     changed_ids = _changed_module_ids(export)
     has_overlay_data = isinstance(export.get("change_overlay"), dict)
     has_noncanonical = any(_is_noncanonical_module(row) for row in modules)
@@ -442,8 +442,8 @@ def _render_module_map(export: dict, *, show_full_map: bool, show_worktrees: boo
         trunc_note = f'<p class="cg-muted" data-cg-overlay="1" id="cg-isolated">{html.esc(overlay_note)}</p>'
 
     hub_id = ""
-    insights = module_map.get("insights") if isinstance(module_map.get("insights"), dict) else {}
-    hub = insights.get("most_connected") if isinstance(insights.get("most_connected"), dict) else {}
+    insights = _insights if isinstance(_insights := module_map.get("insights"), dict) else {}
+    hub = _most_connected if isinstance(_most_connected := insights.get("most_connected"), dict) else {}
     if isinstance(hub.get("id"), str) and any(str(row.get("id") or "") == hub["id"] for row in shown):
         hub_id = hub["id"]
 
@@ -659,7 +659,7 @@ def _blast_payload(export: dict) -> dict[str, Any]:
 
 
 def _picker_module_choices(export: dict) -> list[tuple[str, str]]:
-    module_map = export.get("module_map") if isinstance(export.get("module_map"), dict) else {}
+    module_map = _module_map if isinstance(_module_map := export.get("module_map"), dict) else {}
     choices: list[tuple[str, str]] = []
     seen: set[str] = set()
     for module_id in _changed_module_ids(export):
@@ -674,7 +674,7 @@ def _picker_module_choices(export: dict) -> list[tuple[str, str]]:
         seen.add(module_id)
         choices.append((module_id, str(row.get("label") or module_id)))
     blast = _blast_payload(export)
-    focus = blast.get("focus") if isinstance(blast.get("focus"), dict) else {}
+    focus = _focus if isinstance(_focus := blast.get("focus"), dict) else {}
     focus_id = str(focus.get("id") or "").strip()
     if focus_id and focus_id not in seen:
         choices.insert(0, (focus_id, str(focus.get("label") or focus_id)))
@@ -685,7 +685,7 @@ def _seed_focus_id(export: dict, requested: str | None) -> str:
     if requested and requested.strip():
         return requested.strip()
     blast = _blast_payload(export)
-    focus = blast.get("focus") if isinstance(blast.get("focus"), dict) else {}
+    focus = _focus if isinstance(_focus := blast.get("focus"), dict) else {}
     focus_id = str(focus.get("id") or "").strip()
     if focus_id and blast.get("resolved") is not False:
         return focus_id
@@ -938,7 +938,7 @@ def _render_blast_radius(
     if isinstance(blast.get("downstream_depth"), int):
         down_hops = code_export.parse_blast_hops(blast["downstream_depth"], down_hops)
     focus_id = _seed_focus_id(export, requested)
-    focus_meta = blast.get("focus") if isinstance(blast.get("focus"), dict) else {}
+    focus_meta = _focus if isinstance(_focus := blast.get("focus"), dict) else {}
     focus_label = str(focus_meta.get("label") or focus_id or "this module")
     picker = _blast_picker(
         export,
@@ -1065,7 +1065,7 @@ def _changed_module_shortcut(
     changed_ids = _changed_module_ids(export)
     if not changed_ids:
         return ""
-    module_map = export.get("module_map") if isinstance(export.get("module_map"), dict) else {}
+    module_map = _module_map if isinstance(_module_map := export.get("module_map"), dict) else {}
     labels = {
         str(row.get("id") or ""): str(row.get("label") or row.get("id") or "")
         for row in module_map.get("modules", [])
@@ -1106,7 +1106,7 @@ def _render_impact(
     )
     shortcut = _changed_module_shortcut(export, show_worktrees=show_worktrees, show_full_map=show_full_map)
 
-    impact = export.get("impact") if isinstance(export.get("impact"), dict) else None
+    impact = _impact if isinstance(_impact := export.get("impact"), dict) else None
     if not symbol:
         return html.panel(
             html.esc("Impact"),
@@ -1120,16 +1120,16 @@ def _render_impact(
             search_form + shortcut + f"<p>{html.esc('No impact data for that symbol.')}</p>",
         )
 
-    resolved = impact.get("resolved_symbol") if isinstance(impact.get("resolved_symbol"), dict) else {}
+    resolved = _resolved_symbol if isinstance(_resolved_symbol := impact.get("resolved_symbol"), dict) else {}
     plain_name = str(resolved.get("name") or resolved.get("qualified_name") or symbol)
     file_path = str(resolved.get("file_path") or "")
     intro = f"Blast radius for {plain_name}."
     if file_path:
         intro += f" Defined in {file_path}."
 
-    callers = impact.get("callers") if isinstance(impact.get("callers"), list) else []
-    edges = impact.get("edges") if isinstance(impact.get("edges"), list) else []
-    affected = impact.get("affected_tests") if isinstance(impact.get("affected_tests"), dict) else {}
+    callers = _callers if isinstance(_callers := impact.get("callers"), list) else []
+    edges = _edges if isinstance(_edges := impact.get("edges"), list) else []
+    affected = _affected_tests if isinstance(_affected_tests := impact.get("affected_tests"), dict) else {}
 
     sections = [
         search_form,
@@ -1225,7 +1225,7 @@ def _impact_table(title: str, rows: list, *, limit: int) -> str:
 
 
 def _affected_tests_table(affected: dict) -> str:
-    tests = affected.get("affected_tests") if isinstance(affected.get("affected_tests"), list) else []
+    tests = _affected_tests if isinstance(_affected_tests := affected.get("affected_tests"), list) else []
     if not tests:
         return f"<h3>{html.esc('Attributed tests')}</h3><p>{html.esc('No attributed tests.')}</p>"
     attr = affected.get("attribution")
@@ -1236,7 +1236,7 @@ def _affected_tests_table(affected: dict) -> str:
             continue
         path = str(row.get("file_path") or "-")
         hops = str(row.get("min_hops") if row.get("min_hops") is not None else "-")
-        via = row.get("via") if isinstance(row.get("via"), list) else []
+        via = _via if isinstance(_via := row.get("via"), list) else []
         via_text = ", ".join(str(item) for item in via[:5])
         rows.append([html.esc(path), html.esc(hops), html.esc(via_text or "-")])
     table = html.table([html.esc("Test file"), html.esc("Hops"), html.esc("Via")], rows)
@@ -1244,7 +1244,7 @@ def _affected_tests_table(affected: dict) -> str:
 
 
 def _impact_debug(impact: dict) -> str:
-    hits = impact.get("search_hits") if isinstance(impact.get("search_hits"), list) else []
+    hits = _search_hits if isinstance(_search_hits := impact.get("search_hits"), list) else []
     if not hits:
         return ""
     lines = []
@@ -1263,7 +1263,7 @@ def _impact_debug(impact: dict) -> str:
 
 
 def _debug_details(export: dict) -> str:
-    stats = export.get("stats") if isinstance(export.get("stats"), dict) else {}
+    stats = _stats if isinstance(_stats := export.get("stats"), dict) else {}
     if not stats:
         return ""
     bits = ", ".join(f"{key}={value}" for key, value in sorted(stats.items()))

--- a/src/brigade/center_cmd/dashboard/views/memory_operations.py
+++ b/src/brigade/center_cmd/dashboard/views/memory_operations.py
@@ -78,9 +78,9 @@ def fetch(target: Path) -> dict:
 
 
 def render(payload: dict, nonce: str) -> str:
-    topology = payload.get("topology") if isinstance(payload.get("topology"), dict) else {}
-    inventory = payload.get("inventory") if isinstance(payload.get("inventory"), dict) else {}
-    handoffs = payload.get("handoffs") if isinstance(payload.get("handoffs"), dict) else {}
+    topology = _topology if isinstance(_topology := payload.get("topology"), dict) else {}
+    inventory = _inventory if isinstance(_inventory := payload.get("inventory"), dict) else {}
+    handoffs = _handoffs if isinstance(_handoffs := payload.get("handoffs"), dict) else {}
 
     parts = [
         _stylesheet(nonce),
@@ -150,7 +150,7 @@ def _fetch_inventory(target: Path) -> dict:
         if master_index is None and isinstance(page.get("master_index"), dict):
             master_index = page["master_index"]
 
-        pagination = page.get("pagination") if isinstance(page.get("pagination"), dict) else {}
+        pagination = _pagination if isinstance(_pagination := page.get("pagination"), dict) else {}
         total_val = pagination.get("total")
         if isinstance(total_val, int):
             contract_total = total_val
@@ -220,11 +220,11 @@ def _render_topology(topology: dict, inventory: dict) -> str:
     if topology.get("error"):
         return html.error_panel("Topology", str(topology["error"]))
 
-    health = topology.get("health") if isinstance(topology.get("health"), dict) else {}
-    flags = topology.get("flags") if isinstance(topology.get("flags"), list) else []
-    paths = topology.get("paths") if isinstance(topology.get("paths"), list) else []
-    nodes = topology.get("nodes") if isinstance(topology.get("nodes"), list) else []
-    edges = topology.get("edges") if isinstance(topology.get("edges"), list) else []
+    health = _health if isinstance(_health := topology.get("health"), dict) else {}
+    flags = _flags if isinstance(_flags := topology.get("flags"), list) else []
+    paths = _paths if isinstance(_paths := topology.get("paths"), list) else []
+    nodes = _nodes if isinstance(_nodes := topology.get("nodes"), list) else []
+    edges = _edges if isinstance(_edges := topology.get("edges"), list) else []
 
     if not health and not flags and not paths and not nodes and not edges:
         return html.panel(html.esc("Topology"), f"<p>{html.esc('Nothing here.')}</p>")
@@ -242,7 +242,7 @@ def _render_topology(topology: dict, inventory: dict) -> str:
 
 def _destination_counts(inventory: dict) -> dict[str, int]:
     counts: dict[str, int] = {}
-    items = inventory.get("items") if isinstance(inventory.get("items"), list) else []
+    items = _items if isinstance(_items := inventory.get("items"), list) else []
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -308,11 +308,13 @@ def _health_word(raw: object) -> str:
 
 def _summary_strip(health: dict, nodes: list, flags: list) -> str:
     sentences: list[str] = []
-    care = health.get("care_scan") if isinstance(health.get("care_scan"), dict) else {}
-    refresh = health.get("refresh_queue") if isinstance(health.get("refresh_queue"), dict) else {}
-    backlog = health.get("handoff_backlog") if isinstance(health.get("handoff_backlog"), dict) else {}
-    evidence = health.get("evidence_projection") if isinstance(health.get("evidence_projection"), dict) else {}
-    closeout = health.get("closeout") if isinstance(health.get("closeout"), dict) else {}
+    care = _care_scan if isinstance(_care_scan := health.get("care_scan"), dict) else {}
+    refresh = _refresh_queue if isinstance(_refresh_queue := health.get("refresh_queue"), dict) else {}
+    backlog = _handoff_backlog if isinstance(_handoff_backlog := health.get("handoff_backlog"), dict) else {}
+    evidence = (
+        _evidence_projection if isinstance(_evidence_projection := health.get("evidence_projection"), dict) else {}
+    )
+    closeout = _closeout if isinstance(_closeout := health.get("closeout"), dict) else {}
 
     issue_count = care.get("issue_count")
     queued = refresh.get("count")
@@ -333,7 +335,7 @@ def _summary_strip(health: dict, nodes: list, flags: list) -> str:
             inbox = by_id.get(f"inbox:{harness}")
             if not isinstance(inbox, dict):
                 continue
-            counts = inbox.get("counts") if isinstance(inbox.get("counts"), dict) else {}
+            counts = _counts if isinstance(_counts := inbox.get("counts"), dict) else {}
             value = counts.get("pending")
             if isinstance(value, int):
                 pending += value
@@ -411,7 +413,7 @@ def _health_meaning(key: str, block: dict) -> str:
 def _health_tiles(health: dict) -> str:
     tiles: list[str] = []
     for key, label in _HEALTH_KEYS:
-        block = health.get(key) if isinstance(health.get(key), dict) else {}
+        block = _key if isinstance(_key := health.get(key), dict) else {}
         status = block.get("status", "unknown")
         role, _word, icon, _ = _status_role(status)
         meaning = _health_meaning(key, block)
@@ -464,7 +466,7 @@ def _count_label(node: dict | None, dest_counts: dict[str, int], node_id: str) -
             return str(dest_counts[key])
     if not isinstance(node, dict):
         return ""
-    counts = node.get("counts") if isinstance(node.get("counts"), dict) else {}
+    counts = _counts if isinstance(_counts := node.get("counts"), dict) else {}
     for key in ("pending", "issue_count", "queued", "record_count", "processed"):
         if isinstance(counts.get(key), int):
             if key == "processed":
@@ -578,7 +580,7 @@ def _pipeline_svg(nodes: list, edges: list, paths: list, dest_counts: dict[str, 
     pending_total = 0
     for name in harnesses:
         inbox = by_id.get(f"inbox:{name}")
-        counts = (inbox or {}).get("counts") if isinstance((inbox or {}).get("counts"), dict) else {}
+        counts = _counts if isinstance(_counts := (inbox or {}).get("counts"), dict) else {}
         if isinstance(counts.get("pending"), int):
             pending_total += counts["pending"]
 
@@ -643,11 +645,11 @@ def _pipeline_svg(nodes: list, edges: list, paths: list, dest_counts: dict[str, 
     care_count = ""
     care_source = care_node or refresh_node
     if isinstance(care_node, dict):
-        c = care_node.get("counts") if isinstance(care_node.get("counts"), dict) else {}
+        c = _counts if isinstance(_counts := care_node.get("counts"), dict) else {}
         if isinstance(c.get("issue_count"), int):
             care_count = str(c["issue_count"])
     if not care_count and isinstance(refresh_node, dict):
-        c = refresh_node.get("counts") if isinstance(refresh_node.get("counts"), dict) else {}
+        c = _counts if isinstance(_counts := refresh_node.get("counts"), dict) else {}
         if isinstance(c.get("queued"), int):
             care_count = str(c["queued"])
     care_box, care_x, care_cy = place(5, care_source, care_label, "stage:care_scan", care_count)
@@ -759,8 +761,8 @@ def _debug_details(nodes: list, edges: list) -> str:
     for node in nodes:
         if not isinstance(node, dict):
             continue
-        latest = node.get("latest_run") if isinstance(node.get("latest_run"), dict) else {}
-        counts = node.get("counts") if isinstance(node.get("counts"), dict) else {}
+        latest = _latest_run if isinstance(_latest_run := node.get("latest_run"), dict) else {}
+        counts = _counts if isinstance(_counts := node.get("counts"), dict) else {}
         schedule = node.get("schedule")
         if isinstance(schedule, dict):
             schedule_text = f"{schedule.get('source') or '-'} / {schedule.get('cadence') or '-'}"
@@ -789,7 +791,7 @@ def _debug_details(nodes: list, edges: list) -> str:
     for edge in edges:
         if not isinstance(edge, dict):
             continue
-        receipt = edge.get("latest_receipt") if isinstance(edge.get("latest_receipt"), dict) else {}
+        receipt = _latest_receipt if isinstance(_latest_receipt := edge.get("latest_receipt"), dict) else {}
         enabled = "yes" if edge.get("enabled") else "no"
         edge_rows.append(
             "<tr>"
@@ -877,80 +879,6 @@ def _display(value: Any) -> str:
     if value is None or value == "":
         return "-"
     return str(value)
-
-
-def _render_inventory(inventory: dict) -> str:
-    if inventory.get("error"):
-        return html.error_panel("Inventory", str(inventory["error"]))
-
-    items = inventory.get("items") if isinstance(inventory.get("items"), list) else []
-    warning = inventory.get("warning")
-    partial = bool(inventory.get("partial"))
-    loaded = len(items)
-    contract_total = inventory.get("contract_total")
-    if not isinstance(contract_total, int):
-        raw_total = inventory.get("total")
-        contract_total = raw_total if isinstance(raw_total, int) and not partial else None
-
-    if not items:
-        inner = f"<p>{html.esc('Nothing here.')}</p>"
-        if warning:
-            inner = f'<p class="error">{html.esc(warning)}</p>' + inner
-        return html.panel(html.esc("Inventory"), inner)
-
-    columns = _inventory_columns(items)
-    filter_bar = _inventory_filters(items)
-    rows: list[list[str]] = []
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        rows.append(_inventory_row(item, columns))
-
-    headers = [html.esc(col["label"]) for col in columns]
-    table = html.table(headers, rows)
-    parts = table.split("<tbody>", 1)
-    if len(parts) == 2:
-        head, rest = parts
-        body, tail = rest.split("</tbody>", 1)
-        body = body.replace("<tr>", '<tr data-mo-row="1">')
-        table = head + "<tbody>" + body + "</tbody>" + tail
-
-    if partial and isinstance(contract_total, int):
-        total_attr = str(contract_total)
-    elif not partial:
-        pager_total = inventory.get("total") if isinstance(inventory.get("total"), int) else loaded
-        total_attr = str(pager_total)
-    else:
-        total_attr = str(loaded)
-
-    pager = (
-        f'<div class="mo-pager" data-mo-page-size="{_CLIENT_PAGE_SIZE}" '
-        f'data-mo-total="{html.esc(total_attr)}">'
-        f'<button type="button" data-mo-page="prev" disabled>{html.esc("Prior")}</button>'
-        f"<span data-mo-page-status>{html.esc('Page 1')}</span>"
-        f'<button type="button" data-mo-page="next">{html.esc("Next")}</button>'
-        "</div>"
-    )
-    warn_bits: list[str] = []
-    if warning:
-        warn_bits.append(str(warning))
-    elif partial:
-        if isinstance(contract_total, int):
-            warn_bits.append(f"Inventory is partial: loaded {loaded} of {contract_total}.")
-        else:
-            warn_bits.append(f"Inventory is partial: loaded {loaded} item(s).")
-    warn_html = "".join(f'<p class="error">{html.esc(bit)}</p>' for bit in warn_bits)
-    meta = ""
-    if partial and isinstance(contract_total, int):
-        meta = f'<p class="mo-muted">{html.esc(f"Loaded {loaded} of {contract_total} (partial).")}</p>'
-    hidden_notes = _hidden_column_notes(items)
-    hidden_note = ""
-    if hidden_notes:
-        hidden_note = f'<p class="mo-muted">{html.esc("; ".join(hidden_notes))}</p>'
-    return html.panel(
-        html.esc("Inventory"),
-        warn_html + meta + hidden_note + filter_bar + pager + f'<div class="mo-scroll">{table}</div>',
-    )
 
 
 def _hidden_column_notes(items: list) -> list[str]:
@@ -1066,10 +994,10 @@ def _inventory_filters(items: list) -> str:
 
 
 def _mutation_text(item: dict) -> str:
-    mutation = item.get("last_mutation") if isinstance(item.get("last_mutation"), dict) else None
+    mutation = _last_mutation if isinstance(_last_mutation := item.get("last_mutation"), dict) else None
     if not mutation:
         return "-"
-    receipt = mutation.get("receipt") if isinstance(mutation.get("receipt"), dict) else {}
+    receipt = _receipt if isinstance(_receipt := mutation.get("receipt"), dict) else {}
     workflow = _display(mutation.get("workflow"))
     return (
         f"{workflow} / "
@@ -1099,8 +1027,8 @@ def _inventory_row(item: dict, columns: list[dict[str, Any]]) -> list[str]:
     else:
         tag_list = [] if tags in (None, "") else [str(tags)]
     mutation_text = _mutation_text(item)
-    care = item.get("care") if isinstance(item.get("care"), dict) else {}
-    issues = care.get("issues") if isinstance(care.get("issues"), list) else []
+    care = _care if isinstance(_care := item.get("care"), dict) else {}
+    issues = _issues if isinstance(_issues := care.get("issues"), list) else []
     issue_text = ", ".join(str(i) for i in issues) if issues else "-"
     queued = care.get("queued_action")
     care_text = f"{issue_text}; queued={queued or '-'}"

--- a/src/brigade/center_cmd/dashboard/views/research.py
+++ b/src/brigade/center_cmd/dashboard/views/research.py
@@ -106,9 +106,9 @@ def fetch(target: Path, query: dict[str, str] | None = None) -> dict:
 
 
 def render(payload: dict, nonce: str) -> str:
-    status = payload.get("status") if isinstance(payload.get("status"), dict) else {}
-    doctor = payload.get("doctor") if isinstance(payload.get("doctor"), dict) else {}
-    show = payload.get("show") if isinstance(payload.get("show"), dict) else None
+    status = _status if isinstance(_status := payload.get("status"), dict) else {}
+    doctor = _doctor if isinstance(_doctor := payload.get("doctor"), dict) else {}
+    show = _show if isinstance(_show := payload.get("show"), dict) else None
     selected = str(payload.get("selected_run") or "")
     now = datetime.now(timezone.utc)
     runs = _runs_from_status(status)
@@ -512,7 +512,7 @@ def _inspector_section(show: dict[str, Any] | None, selected: str, now: datetime
     problem = _schema_problem(show, SHOW_SCHEMAS)
     if problem is not None:
         return html.error_panel("Run inspector", problem)
-    rec = show.get("run") if isinstance(show.get("run"), Mapping) else {}
+    rec = _run if isinstance(_run := show.get("run"), Mapping) else {}
     state = run_tile_state(rec)
     if show.get("schema") == SHOW_V1_SCHEMA:
         parts = [
@@ -653,8 +653,8 @@ def _inspector_citations(show: Mapping[str, Any], state: str) -> str:
         )
         return _sub("Citations", f'<p class="rs-muted">{html.esc(message)}</p>')
     accepted = bool(audit.get("accepted"))
-    citations = audit.get("citations") if isinstance(audit.get("citations"), list) else []
-    unresolved = audit.get("unresolved") if isinstance(audit.get("unresolved"), list) else []
+    citations = _citations if isinstance(_citations := audit.get("citations"), list) else []
+    unresolved = _unresolved if isinstance(_unresolved := audit.get("unresolved"), list) else []
     chip = _state_chip("accepted" if accepted else "rejected", "good" if accepted else "serious")
     body = [
         f"<p>Citation audit {chip}: {html.esc(str(len(citations)))} citation(s), "
@@ -684,7 +684,7 @@ def _inspector_fallbacks(rec: Mapping[str, Any]) -> str:
 
 
 def _inspector_report(show: Mapping[str, Any]) -> str:
-    report = show.get("report") if isinstance(show.get("report"), Mapping) else {}
+    report = _report if isinstance(_report := show.get("report"), Mapping) else {}
     verification = str(report.get("verification") or "unknown")
     css = "good" if verification == "verified" else "warning"
     label = f'<p>Final report is <span class="rs-state rs-state-{html.esc(css)}">{html.esc(verification)}</span>.</p>'

--- a/src/brigade/center_cmd/dashboard/views/run_timeline.py
+++ b/src/brigade/center_cmd/dashboard/views/run_timeline.py
@@ -35,8 +35,8 @@ def fetch(target: Path) -> dict:
 
 
 def render(payload: dict, nonce: str) -> str:
-    brigade_payload = payload.get("brigade") if isinstance(payload.get("brigade"), dict) else {}
-    verify_payload = payload.get("verify") if isinstance(payload.get("verify"), dict) else {}
+    brigade_payload = _brigade if isinstance(_brigade := payload.get("brigade"), dict) else {}
+    verify_payload = _verify if isinstance(_verify := payload.get("verify"), dict) else {}
     strip = _summary_strip(brigade_payload, verify_payload)
     return strip + _render_brigade_panel(brigade_payload) + _render_verify_panel(verify_payload, nonce)
 
@@ -112,8 +112,10 @@ def _summary_strip(brigade_payload: dict, verify_payload: dict) -> str:
         if status:
             failed += 1
         parsed = _parse_ts(run.get("started_at"))
+        if parsed is None:
+            continue
         stamps.append((parsed, status))
-        if parsed is not None and parsed >= week_start:
+        if parsed >= week_start:
             this_week += 1
     last_run = "unknown age"
     known = [parsed for (parsed, _) in stamps if parsed is not None]

--- a/src/brigade/center_cmd/dashboard/views/status_grid.py
+++ b/src/brigade/center_cmd/dashboard/views/status_grid.py
@@ -125,13 +125,13 @@ def _plural(n: int, one: str, many: str) -> str:
 
 
 def _top_issue_detail(section: dict) -> str:
-    top = section.get("top_issue") if isinstance(section.get("top_issue"), dict) else {}
+    top = _top_issue if isinstance(_top_issue := section.get("top_issue"), dict) else {}
     detail = str(top.get("detail") or "").strip()
     return detail
 
 
 def _scheduled_care_names(section: dict) -> str:
-    entries = section.get("entries") if isinstance(section.get("entries"), list) else []
+    entries = _entries if isinstance(_entries := section.get("entries"), list) else []
     names = [str(item.get("id")) for item in entries if isinstance(item, dict) and item.get("id")]
     return ", ".join(names[:5])
 

--- a/src/brigade/center_cmd/dashboard/views/work.py
+++ b/src/brigade/center_cmd/dashboard/views/work.py
@@ -43,9 +43,9 @@ def fetch(target: Path) -> dict:
 
 
 def render(payload: dict, nonce: str) -> str:
-    ready = payload.get("ready") if isinstance(payload.get("ready"), dict) else {}
-    tasks = payload.get("tasks") if isinstance(payload.get("tasks"), dict) else {}
-    runs = payload.get("runs") if isinstance(payload.get("runs"), dict) else {}
+    ready = _ready if isinstance(_ready := payload.get("ready"), dict) else {}
+    tasks = _tasks if isinstance(_tasks := payload.get("tasks"), dict) else {}
+    runs = _runs if isinstance(_runs := payload.get("runs"), dict) else {}
     now = datetime.now(timezone.utc)
     return "".join(
         [
@@ -145,7 +145,7 @@ def _wave_tasks(wave: dict) -> list[dict[str, Any]]:
     tasks = wave.get("tasks")
     if isinstance(tasks, list) and tasks:
         return [item for item in tasks if isinstance(item, dict)]
-    ids = wave.get("task_ids") if isinstance(wave.get("task_ids"), list) else []
+    ids = _task_ids if isinstance(_task_ids := wave.get("task_ids"), list) else []
     return [{"id": task_id} for task_id in ids if isinstance(task_id, str)]
 
 

--- a/src/brigade/center_cmd/dashboard/work_graph.py
+++ b/src/brigade/center_cmd/dashboard/work_graph.py
@@ -73,7 +73,7 @@ def footprint_of(task: dict[str, Any] | None) -> dict[str, Any] | None:
     if raw is None:
         return None
     # Preserve degrade markers from the stored object (normalize drops them).
-    metadata = task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
+    metadata = _metadata if isinstance(_metadata := task.get("metadata"), dict) else {}
     stored = metadata.get("footprint") if isinstance(metadata, dict) else None
     if isinstance(stored, dict) and stored.get("degraded") is True:
         raw = dict(raw)

--- a/src/brigade/center_cmd/readiness.py
+++ b/src/brigade/center_cmd/readiness.py
@@ -43,9 +43,13 @@ from ..localio import (
 )
 from ..render import emit
 
-from . import schema_ops as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import core as _core_mod
+from . import reports as _reports_mod
+from .schema_ops import (
+    READINESS_STATUSES,
+    SCHEMA_VERSION,
+    _schema,
+)
 
 
 def _readiness_root(target: Path) -> Path:
@@ -82,7 +86,9 @@ def _active_readiness_waivers(target: Path) -> dict[str, dict[str, Any]]:
 def _readiness_finding(
     subsystem: str, name: str, severity: str, summary: str, command: str, *, status: str = "warn"
 ) -> dict[str, Any]:
-    fingerprint = _fingerprint_payload({"subsystem": subsystem, "name": name, "severity": severity, "summary": summary})
+    fingerprint = _reports_mod._fingerprint_payload(
+        {"subsystem": subsystem, "name": name, "severity": severity, "summary": summary}
+    )
     return {
         "finding_id": f"readiness-{fingerprint[:16]}",
         "subsystem": subsystem,
@@ -133,9 +139,9 @@ def _readiness_findings(target: Path, status_data: dict[str, Any]) -> list[dict[
                 "brigade center reviews",
             )
         )
-    cloud = status_data.get("cloud_tracker") if isinstance(status_data.get("cloud_tracker"), dict) else {}
+    cloud = _cloud_tracker if isinstance(_cloud_tracker := status_data.get("cloud_tracker"), dict) else {}
     if int(cloud.get("issue_count") or 0) > 0:
-        top = cloud.get("top_issue") if isinstance(cloud.get("top_issue"), dict) else {}
+        top = _top_issue if isinstance(_top_issue := cloud.get("top_issue"), dict) else {}
         findings.append(
             _readiness_finding(
                 "cloud_tracker",
@@ -145,7 +151,9 @@ def _readiness_findings(target: Path, status_data: dict[str, Any]) -> list[dict[
                 "brigade run cloud status --json",
             )
         )
-    release = status_data.get("release_readiness") if isinstance(status_data.get("release_readiness"), dict) else None
+    release = (
+        _release_readiness if isinstance(_release_readiness := status_data.get("release_readiness"), dict) else None
+    )
     if not release:
         findings.append(
             _readiness_finding(
@@ -185,19 +193,19 @@ def _readiness_findings(target: Path, status_data: dict[str, Any]) -> list[dict[
         if not isinstance(health, dict):
             continue
         issue_count = int(health.get("issue_count") or health.get("open_count") or 0)
-        top = health.get("top_issue") if isinstance(health.get("top_issue"), dict) else None
-        if issue_count <= 0 and not top:
+        top_issue = _top_issue if isinstance(_top_issue := health.get("top_issue"), dict) else None
+        if issue_count <= 0 and not top_issue:
             continue
         detail = _readiness_safe_text(
             target,
             str(
-                (top or {}).get("detail")
-                or (top or {}).get("safe_summary")
+                (top_issue or {}).get("detail")
+                or (top_issue or {}).get("safe_summary")
                 or f"{subsystem} has unresolved health issue(s)"
             ),
         )
         findings.append(
-            _readiness_finding(subsystem, str((top or {}).get("name") or "health"), "warning", detail, command)
+            _readiness_finding(subsystem, str((top_issue or {}).get("name") or "health"), "warning", detail, command)
         )
     command_health = roadmap_cmd.command_contract_payload(target)
     if not command_health.get("inventory_current"):
@@ -216,9 +224,9 @@ def _readiness_findings(target: Path, status_data: dict[str, Any]) -> list[dict[
 
 def _readiness_payload(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    status_data = status_payload(target)
+    status_data = _core_mod.status_payload(target)
     status_data["review_queue_count"] = len(
-        [item for item in _reviews(target) if item.get("subsystem") != "center-readiness"]
+        [item for item in _core_mod._reviews(target) if item.get("subsystem") != "center-readiness"]
     )
     findings = _readiness_findings(target, status_data)
     waivers = _active_readiness_waivers(target)
@@ -273,7 +281,7 @@ def _readiness_payload(target: Path) -> dict[str, Any]:
         "warnings": warnings,
         "waivers": list(waivers.values()),
         "manual_publish_checklist": manual_checklist,
-        "source_fingerprint": _fingerprint_payload({"findings": findings, "checklist": manual_checklist}),
+        "source_fingerprint": _reports_mod._fingerprint_payload({"findings": findings, "checklist": manual_checklist}),
     }
     return payload
 
@@ -369,7 +377,7 @@ def readiness_closeout(
         if finding is None:
             print(f"error: readiness finding not found: {finding_id}", file=sys.stderr)
             return 1
-        waiver_id = f"readiness-waiver-{_fingerprint_payload({'finding_id': finding_id, 'source': finding.get('source_fingerprint')})[:16]}"
+        waiver_id = f"readiness-waiver-{_reports_mod._fingerprint_payload({'finding_id': finding_id, 'source': finding.get('source_fingerprint')})[:16]}"
         waivers = [waiver for waiver in waivers if waiver.get("waiver_id") != waiver_id]
         waivers.append(
             {

--- a/src/brigade/center_cmd/report_review_ops.py
+++ b/src/brigade/center_cmd/report_review_ops.py
@@ -43,18 +43,24 @@ from ..localio import (
 )
 from ..render import emit
 
-from . import schema_ops as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import core as _core_mod
+from . import reports as _reports_mod
+from .schema_ops import (
+    SCHEMA_VERSION,
+    _parse_time,
+    _path_label,
+    _receipt_reference_exists,
+    _schema,
+)
 
 
 def report_review(*, target: Path, report_id: str = "latest", json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    report, error = _resolve_report(target, report_id)
+    report, error = _reports_mod._resolve_report(target, report_id)
     if report is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
-    plan = _action_plan(report)
+    plan = _reports_mod._action_plan(report)
     payload = {
         "schema_version": SCHEMA_VERSION,
         "schema": _schema("center-report-review"),
@@ -93,14 +99,14 @@ def _receipt_newer_than_report(receipt: dict[str, Any] | None, report_created: d
 
 
 def _report_queue_changed(report: dict[str, Any], current_reviews: list[dict[str, Any]]) -> bool:
-    old = sorted(_item_key(item) for item in report.get("reviews", []) if isinstance(item, dict))
-    new = sorted(_item_key(item) for item in current_reviews if isinstance(item, dict))
+    old = sorted(_reports_mod._item_key(item) for item in report.get("reviews", []) if isinstance(item, dict))
+    new = sorted(_reports_mod._item_key(item) for item in current_reviews if isinstance(item, dict))
     return old != new
 
 
 def _report_review_map(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    reviews_data = report.get("reviews") if isinstance(report.get("reviews"), list) else []
-    return {_item_key(item): item for item in reviews_data if isinstance(item, dict)}
+    reviews_data = _reviews if isinstance(_reviews := report.get("reviews"), list) else []
+    return {_reports_mod._item_key(item): item for item in reviews_data if isinstance(item, dict)}
 
 
 def _is_blocker_item(item: dict[str, Any]) -> bool:
@@ -111,7 +117,7 @@ def _missing_receipt_refs(report: dict[str, Any]) -> list[dict[str, Any]]:
     report_id = str(report.get("report_id") or "unknown")
     stale: list[dict[str, Any]] = []
     target = Path(str(report.get("target") or ".")).expanduser().resolve()
-    for ref in report.get("receipt_references") if isinstance(report.get("receipt_references"), list) else []:
+    for ref in _receipt_references if isinstance(_receipt_references := report.get("receipt_references"), list) else []:
         if isinstance(ref, str) and ref and not _receipt_reference_exists(target, ref):
             stale.append({"report_id": report_id, "path": _path_label(target, ref)})
     return stale
@@ -138,7 +144,7 @@ def _report_diff_payload(
             "item_key": key,
         }
         for key in sorted(base_keys & compare_keys)
-        if _fingerprint_payload(base_map[key]) != _fingerprint_payload(compare_map[key])
+        if _reports_mod._fingerprint_payload(base_map[key]) != _reports_mod._fingerprint_payload(compare_map[key])
     ]
     new_blockers: list[dict[str, Any]] = []
     for key in sorted(compare_keys):
@@ -190,7 +196,7 @@ def _report_diff_payload(
         "new_blockers": new_blockers,
         "stale_references": stale_references,
         "issue_count": len(new_blockers) + len(stale_references),
-        "diff_fingerprint": _fingerprint_payload(fingerprint_payload),
+        "diff_fingerprint": _reports_mod._fingerprint_payload(fingerprint_payload),
         "path": str(path / "diff.json") if path is not None else None,
         "write_required": path is None,
     }
@@ -206,8 +212,8 @@ def report_diff(
     json_output: bool = False,
 ) -> int:
     target = target.expanduser().resolve()
-    base_report, base_error = _resolve_report(target, base_report_id)
-    compare_report, compare_error = _resolve_report(target, compare_report_id)
+    base_report, base_error = _reports_mod._resolve_report(target, base_report_id)
+    compare_report, compare_error = _reports_mod._resolve_report(target, compare_report_id)
     if base_report is None:
         print(f"error: {base_error}", file=sys.stderr)
         return 1 if base_error and "not found" in base_error else 2
@@ -222,7 +228,7 @@ def report_diff(
     if record:
         created = _now()
         diff_id = f"{created.strftime('%Y%m%d-%H%M%S')}-report-diff-{uuid4().hex[:6]}"
-        diff_dir = _report_diffs_root(target) / diff_id
+        diff_dir = _reports_mod._report_diffs_root(target) / diff_id
     payload = _report_diff_payload(
         target=target, base_report=base_report, compare_report=compare_report, diff_id=diff_id, path=diff_dir
     )
@@ -247,14 +253,14 @@ def report_diff(
 
 def report_compare(*, target: Path, report_id: str = "latest", json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    report, error = _resolve_report(target, report_id)
+    report, error = _reports_mod._resolve_report(target, report_id)
     if report is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
     report_created = _parse_time(report.get("created_at") or report.get("generated_at"))
     issues: list[dict[str, Any]] = []
-    current_head = _git_value(target, "rev-parse", "HEAD")
-    report_git = report.get("git") if isinstance(report.get("git"), dict) else {}
+    current_head = _core_mod._git_value(target, "rev-parse", "HEAD")
+    report_git = _git if isinstance(_git := report.get("git"), dict) else {}
     if report_git.get("head") and current_head and report_git.get("head") != current_head:
         issues.append(
             {
@@ -263,7 +269,7 @@ def report_compare(*, target: Path, report_id: str = "latest", json_output: bool
                 "detail": "current HEAD differs from report HEAD",
             }
         )
-    for ref in report.get("receipt_references") if isinstance(report.get("receipt_references"), list) else []:
+    for ref in _receipt_references if isinstance(_receipt_references := report.get("receipt_references"), list) else []:
         if isinstance(ref, str) and ref and not _receipt_reference_exists(target, ref):
             issues.append(
                 {
@@ -273,8 +279,8 @@ def report_compare(*, target: Path, report_id: str = "latest", json_output: bool
                 }
             )
             break
-    current_activity = _activity(target)
-    report_activity = report.get("activity") if isinstance(report.get("activity"), list) else []
+    current_activity = _core_mod._activity(target)
+    report_activity = _activity if isinstance(_activity := report.get("activity"), list) else []
     current_activity_time = _parse_time(current_activity[0].get("updated_at")) if current_activity else None
     report_activity_time = _parse_time(report_activity[0].get("updated_at")) if report_activity else report_created
     if (
@@ -289,7 +295,7 @@ def report_compare(*, target: Path, report_id: str = "latest", json_output: bool
     latest_candidate = release_cmd._latest_candidate(target)
     latest_verify = work_cmd._latest_verify_receipt(target)
     review_health = work_cmd._review_health(target)
-    latest_review = review_health.get("latest_run") if isinstance(review_health.get("latest_run"), dict) else None
+    latest_review = _latest_run if isinstance(_latest_run := review_health.get("latest_run"), dict) else None
     latest_sweep = work_cmd._scanner_sweep_health(target).get("latest")
     latest_security = security_cmd.health(target).get("evidence")
     for name, receipt, key in (
@@ -308,7 +314,7 @@ def report_compare(*, target: Path, report_id: str = "latest", json_output: bool
         issues.append(
             {"status": "warn", "name": "newer_security_report", "detail": str((latest_security or {}).get("path"))}
         )
-    current_reviews = _reviews(target)
+    current_reviews = _core_mod._reviews(target)
     if _report_queue_changed(report, current_reviews):
         issues.append(
             {
@@ -357,7 +363,7 @@ def report_closeout(
     if status not in reportstore.CLOSEOUT_STATUSES:
         print("error: --status must be one of reviewed, deferred, superseded, archived", file=sys.stderr)
         return 2
-    report, error = _resolve_report(target, report_id)
+    report, error = _reports_mod._resolve_report(target, report_id)
     if report is None:
         print(f"error: {error}", file=sys.stderr)
         return 1 if error and "not found" in error else 2
@@ -365,7 +371,7 @@ def report_closeout(
     if not report_path.is_dir():
         print(f"error: operator report path is missing: {report.get('path')}", file=sys.stderr)
         return 2
-    plan = _action_plan(report)
+    plan = _reports_mod._action_plan(report)
     deferred = list(deferred_item_ids or [])
     payload = {
         "schema_version": SCHEMA_VERSION,
@@ -378,7 +384,7 @@ def report_closeout(
         "unresolved_item_count": plan["unresolved_item_count"],
         "deferred_item_ids": deferred,
         "report_fingerprint": report.get("report_fingerprint")
-        or _fingerprint_payload({"reviews": report.get("reviews"), "activity": report.get("activity")}),
+        or _reports_mod._fingerprint_payload({"reviews": report.get("reviews"), "activity": report.get("activity")}),
     }
     closeout_path = reportstore.write_closeout(report_path, payload)
     report["closeout"] = payload
@@ -394,12 +400,12 @@ def report_closeout(
 
 
 def _report_review_status(report: dict[str, Any]) -> str | None:
-    closeout = report.get("closeout") if isinstance(report.get("closeout"), dict) else None
+    closeout = _closeout if isinstance(_closeout := report.get("closeout"), dict) else None
     status = closeout.get("status") if isinstance(closeout, dict) else None
     return status if isinstance(status, str) else None
 
 
 def _report_reviewed_at(report: dict[str, Any]) -> str | None:
-    closeout = report.get("closeout") if isinstance(report.get("closeout"), dict) else None
+    closeout = _closeout if isinstance(_closeout := report.get("closeout"), dict) else None
     reviewed_at = closeout.get("reviewed_at") if isinstance(closeout, dict) else None
     return reviewed_at if isinstance(reviewed_at, str) else None

--- a/src/brigade/center_cmd/reports.py
+++ b/src/brigade/center_cmd/reports.py
@@ -43,9 +43,15 @@ from ..localio import (
 )
 from ..render import emit
 
-from . import schema_ops as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import core as _core_mod
+from .schema_ops import (
+    REPORT_STALE_HOURS,
+    SCHEMA_VERSION,
+    _parse_time,
+    _path_label,
+    _receipt_reference_exists,
+    _schema,
+)
 
 
 def _reports_root(target: Path) -> Path:
@@ -101,7 +107,7 @@ def latest_report(target: Path) -> dict[str, Any] | None:
 
 
 def _report_diffs(target: Path) -> list[dict[str, Any]]:
-    return _iter_json_files(_report_diffs_root(target), "*/diff.json")
+    return _core_mod._iter_json_files(_report_diffs_root(target), "*/diff.json")
 
 
 def latest_report_diff(target: Path) -> dict[str, Any] | None:
@@ -141,8 +147,8 @@ def _bounded_report_ref(payload: dict[str, Any]) -> dict[str, Any]:
     Never embeds the prior report body, so consecutive builds cannot grow
     with history.
     """
-    reviews = payload.get("reviews") if isinstance(payload.get("reviews"), list) else []
-    activity = payload.get("activity") if isinstance(payload.get("activity"), list) else []
+    reviews = _reviews if isinstance(_reviews := payload.get("reviews"), list) else []
+    activity = _activity if isinstance(_activity := payload.get("activity"), list) else []
     return {
         "report_id": payload.get("report_id"),
         "created_at": payload.get("created_at"),
@@ -165,9 +171,9 @@ def _fingerprint_payload(value: Any) -> str:
 
 def _report_payload(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    status_data = status_payload(target)
-    activity_data = _activity(target)[:100]
-    review_data = _reviews(target)[:100]
+    status_data = _core_mod.status_payload(target)
+    activity_data = _core_mod._activity(target)[:100]
+    review_data = _core_mod._reviews(target)[:100]
     release_ready = release_cmd._latest_release_receipt(target)
     release_candidate = release_cmd._latest_candidate(target)
     payload = {
@@ -175,7 +181,7 @@ def _report_payload(target: Path) -> dict[str, Any]:
         "schema": _schema("center-report"),
         "target": str(target),
         "generated_at": _now().isoformat(),
-        "git": _git_snapshot(target),
+        "git": _core_mod._git_snapshot(target),
         "status": status_data,
         "activity": activity_data,
         "reviews": review_data,
@@ -230,9 +236,9 @@ def _suggested_report_commands(status_data: dict[str, Any], reviews_data: list[d
             else:
                 next_steps.append(command)
     report_health_data = (
-        status_data.get("operator_report") if isinstance(status_data.get("operator_report"), dict) else {}
+        _operator_report if isinstance(_operator_report := status_data.get("operator_report"), dict) else {}
     )
-    top = report_health_data.get("top_issue") if isinstance(report_health_data.get("top_issue"), dict) else None
+    top = _top_issue if isinstance(_top_issue := report_health_data.get("top_issue"), dict) else None
     if top:
         maintenance.insert(0, str(top.get("suggested_next_command") or "brigade center report build"))
     return {
@@ -243,9 +249,11 @@ def _suggested_report_commands(status_data: dict[str, Any], reviews_data: list[d
 
 
 def _report_markdown(payload: dict[str, Any]) -> str:
-    status_data = payload.get("status") if isinstance(payload.get("status"), dict) else {}
+    status_data = _status if isinstance(_status := payload.get("status"), dict) else {}
     commands = (
-        payload.get("suggested_next_commands") if isinstance(payload.get("suggested_next_commands"), dict) else {}
+        _suggested_next_commands
+        if isinstance(_suggested_next_commands := payload.get("suggested_next_commands"), dict)
+        else {}
     )
     lines = [
         "# Operator Report",
@@ -259,19 +267,19 @@ def _report_markdown(payload: dict[str, Any]) -> str:
         "",
         f"- Pending tasks: {status_data.get('pending_task_count')}",
         f"- Pending imports: {status_data.get('pending_import_count')}",
-        f"- Pending reviews: {len(payload.get('reviews') if isinstance(payload.get('reviews'), list) else [])}",
+        f"- Pending reviews: {len(_reviews if isinstance(_reviews := payload.get('reviews'), list) else [])}",
         "",
         "## Suggested Commands",
         "",
     ]
     for label in ("urgent", "next", "maintenance"):
-        values = commands.get(label) if isinstance(commands.get(label), list) else []
+        values = _label if isinstance(_label := commands.get(label), list) else []
         lines.append(f"### {label.title()}")
         lines.append("")
         lines.extend(f"- `{value}`" for value in values) if values else lines.append("- none")
         lines.append("")
     lines.extend(["## Review Queue", ""])
-    reviews_data = payload.get("reviews") if isinstance(payload.get("reviews"), list) else []
+    reviews_data = _reviews if isinstance(_reviews := payload.get("reviews"), list) else []
     for item in reviews_data[:25]:
         lines.append(
             f"- `{item.get('subsystem')}` `{item.get('id')}` [{item.get('status')}] {item.get('safe_summary')}"
@@ -281,7 +289,7 @@ def _report_markdown(payload: dict[str, Any]) -> str:
     if not reviews_data:
         lines.append("- none")
     lines.extend(["", "## Activity", ""])
-    activity_data = payload.get("activity") if isinstance(payload.get("activity"), list) else []
+    activity_data = _activity if isinstance(_activity := payload.get("activity"), list) else []
     for item in activity_data[:25]:
         lines.append(
             f"- `{item.get('subsystem')}` `{item.get('id')}` [{item.get('status')}] {item.get('safe_summary')}"
@@ -304,10 +312,10 @@ def _report_markdown(payload: dict[str, Any]) -> str:
 
 
 def _review_groups(report: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
-    reviews_data = report.get("reviews") if isinstance(report.get("reviews"), list) else []
-    status_data = report.get("status") if isinstance(report.get("status"), dict) else {}
-    summaries = report.get("summaries") if isinstance(report.get("summaries"), dict) else {}
-    release_data = report.get("release") if isinstance(report.get("release"), dict) else {}
+    reviews_data = _reviews if isinstance(_reviews := report.get("reviews"), list) else []
+    status_data = _status if isinstance(_status := report.get("status"), dict) else {}
+    summaries = _summaries if isinstance(_summaries := report.get("summaries"), dict) else {}
+    release_data = _release if isinstance(_release := report.get("release"), dict) else {}
     groups: dict[str, list[dict[str, Any]]] = {
         "urgent_blockers": [],
         "pending_work_imports": [],
@@ -349,12 +357,10 @@ def _review_groups(report: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
         else status_data.get("scanner_sweeps")
     )
     if isinstance(sweep_review, dict):
-        top = (sweep_review.get("review") if isinstance(sweep_review.get("review"), dict) else {}).get(
-            "top_pending_import"
-        )
+        top = (_review if isinstance(_review := sweep_review.get("review"), dict) else {}).get("top_pending_import")
         if isinstance(top, dict):
             groups["scanner_sweep_issues"].append(
-                _item(
+                _core_mod._item(
                     "scanner-sweep",
                     str(top.get("id") or "pending-import"),
                     "pending",
@@ -367,25 +373,25 @@ def _review_groups(report: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
         ("security", "brigade security findings"),
         ("memory_care", "brigade memory care status"),
     ):
-        value = summaries.get(name) if isinstance(summaries.get(name), dict) else None
+        value = _name if isinstance(_name := summaries.get(name), dict) else None
         top = value.get("top_issue") or value.get("top_finding") if isinstance(value, dict) else None
         if isinstance(top, dict):
             groups["backup_security_memory_care_issues"].append(
-                _item(
+                _core_mod._item(
                     name.replace("_", "-"),
                     str(top.get("id") or top.get("name") or top.get("issue_type") or name),
                     str(top.get("status") or "warn"),
                     str(top.get("detail") or top.get("title") or name),
                     command,
-                    severity=top.get("severity") if isinstance(top.get("severity"), str) else None,
+                    severity=_severity if isinstance(_severity := top.get("severity"), str) else None,
                 )
             )
-    readiness = release_data.get("readiness") if isinstance(release_data.get("readiness"), dict) else None
-    candidate = release_data.get("candidate") if isinstance(release_data.get("candidate"), dict) else None
+    readiness = _readiness if isinstance(_readiness := release_data.get("readiness"), dict) else None
+    candidate = _candidate if isinstance(_candidate := release_data.get("candidate"), dict) else None
     if isinstance(readiness, dict) and readiness.get("ready") is False:
         run_id = str(readiness.get("run_id") or "latest")
         groups["release_readiness_candidate_issues"].append(
-            _item(
+            _core_mod._item(
                 "release-readiness",
                 run_id,
                 str(readiness.get("status") or "blocked"),
@@ -396,7 +402,7 @@ def _review_groups(report: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     if isinstance(candidate, dict) and candidate.get("status") not in {None, "reviewed", "archived"}:
         candidate_id = str(candidate.get("candidate_id") or "latest")
         groups["release_readiness_candidate_issues"].append(
-            _item(
+            _core_mod._item(
                 "release-candidate",
                 candidate_id,
                 str(candidate.get("status") or "draft"),
@@ -465,7 +471,7 @@ def report_health(
             }
         )
         return {"latest": None, "checks": checks, "issue_count": len(checks), "top_issue": checks[0]}
-    closeout = latest.get("closeout") if isinstance(latest.get("closeout"), dict) else None
+    closeout = _closeout if isinstance(_closeout := latest.get("closeout"), dict) else None
     closeout_status = str(closeout.get("status") or "") if closeout else ""
     if closeout_status not in {"reviewed", "deferred", "superseded", "archived"}:
         checks.append(
@@ -488,8 +494,8 @@ def report_health(
                     "suggested_next_command": "brigade center report build",
                 }
             )
-    current_head = _git_value(target, "rev-parse", "HEAD")
-    git = latest.get("git") if isinstance(latest.get("git"), dict) else {}
+    current_head = _core_mod._git_value(target, "rev-parse", "HEAD")
+    git = _git if isinstance(_git := latest.get("git"), dict) else {}
     if git.get("head") and current_head and git.get("head") != current_head:
         checks.append(
             {
@@ -499,7 +505,7 @@ def report_health(
                 "suggested_next_command": "brigade center report build",
             }
         )
-    for ref in latest.get("receipt_references") if isinstance(latest.get("receipt_references"), list) else []:
+    for ref in _receipt_references if isinstance(_receipt_references := latest.get("receipt_references"), list) else []:
         if isinstance(ref, str) and ref and not _receipt_reference_exists(target, ref):
             checks.append(
                 {
@@ -510,8 +516,8 @@ def report_health(
                 }
             )
             break
-    latest_activity = [item for item in _activity(target) if item.get("subsystem") != "center-report-diff"]
-    report_activity = latest.get("activity") if isinstance(latest.get("activity"), list) else []
+    latest_activity = [item for item in _core_mod._activity(target) if item.get("subsystem") != "center-report-diff"]
+    report_activity = _activity if isinstance(_activity := latest.get("activity"), list) else []
     latest_time = _parse_time(latest_activity[0].get("updated_at")) if latest_activity else None
     report_time = _parse_time(report_activity[0].get("updated_at")) if report_activity else created
     if latest_time is not None and report_time is not None and latest_time > report_time:
@@ -641,7 +647,7 @@ def report_list(*, target: Path, limit: int = 20, json_output: bool = False) -> 
     print(f"reports_root: {payload['reports_root']}")
     for item in reports:
         print(
-            f"- {item.get('report_id')} reviews={len(item.get('reviews') if isinstance(item.get('reviews'), list) else [])} {item.get('created_at')}"
+            f"- {item.get('report_id')} reviews={len(_reviews if isinstance(_reviews := item.get('reviews'), list) else [])} {item.get('created_at')}"
         )
     return 0
 
@@ -669,8 +675,8 @@ def report_show(*, target: Path, report_id: str, json_output: bool = False) -> i
     print(f"operator report: {report.get('report_id')}")
     print(f"path: {report.get('path')}")
     print(f"created_at: {report.get('created_at')}")
-    print(f"reviews: {len(report.get('reviews') if isinstance(report.get('reviews'), list) else [])}")
-    print(f"activity: {len(report.get('activity') if isinstance(report.get('activity'), list) else [])}")
+    print(f"reviews: {len(_reviews if isinstance(_reviews := report.get('reviews'), list) else [])}")
+    print(f"activity: {len(_activity if isinstance(_activity := report.get('activity'), list) else [])}")
     return 0
 
 

--- a/src/brigade/center_cmd/schema_ops.py
+++ b/src/brigade/center_cmd/schema_ops.py
@@ -432,9 +432,11 @@ def _unsafe_reference(value: object) -> str | None:
 
 
 def _center_contract_health(target: Path) -> dict[str, Any]:
+    from . import core as _core_mod
+
     target = target.expanduser().resolve()
     manifest = _center_schema_manifest(target)
-    schemas = manifest.get("schemas") if isinstance(manifest.get("schemas"), list) else []
+    schemas = _schemas if isinstance(_schemas := manifest.get("schemas"), list) else []
     schema_ids = {str(item.get("id")) for item in schemas if isinstance(item, dict)}
     issues: list[dict[str, Any]] = []
     missing_schema_ids = sorted(CENTER_REQUIRED_SCHEMA_IDS - schema_ids)
@@ -450,31 +452,41 @@ def _center_contract_health(target: Path) -> dict[str, Any]:
         )
 
     outputs: dict[str, Any] = {
-        "activity": _activity(target)[:100],
-        "reviews": _reviews(target)[:100],
+        "activity": _core_mod._activity(target)[:100],
+        "reviews": _core_mod._reviews(target)[:100],
         "templates": [
-            _item("context", "task", "available", "Task context pack template", "brigade context plan --kind task"),
-            _item("context", "repo", "available", "Repo context pack template", "brigade context plan --kind repo"),
-            _item(
+            _core_mod._item(
+                "context", "task", "available", "Task context pack template", "brigade context plan --kind task"
+            ),
+            _core_mod._item(
+                "context", "repo", "available", "Repo context pack template", "brigade context plan --kind repo"
+            ),
+            _core_mod._item(
                 "context",
                 "release",
                 "available",
                 "Release context pack template",
                 "brigade context plan --kind release",
             ),
-            _item("tools", "tool-pack", "available", "Portable tool pack template", "brigade tools pack build"),
-            _item("projects", "audit-plan", "available", "Project audit plan template", "brigade projects audit"),
-            _item(
+            _core_mod._item(
+                "tools", "tool-pack", "available", "Portable tool pack template", "brigade tools pack build"
+            ),
+            _core_mod._item(
+                "projects", "audit-plan", "available", "Project audit plan template", "brigade projects audit"
+            ),
+            _core_mod._item(
                 "release",
                 "candidate",
                 "available",
                 "Release candidate checklist template",
                 "brigade release candidate plan",
             ),
-            _item("review", "closeout", "available", "Review closeout template", "brigade work review closeout latest"),
+            _core_mod._item(
+                "review", "closeout", "available", "Review closeout template", "brigade work review closeout latest"
+            ),
         ],
     }
-    status_data = status_payload(target)
+    status_data = _core_mod.status_payload(target)
     status_required = {
         "schema_version",
         "schema",

--- a/src/brigade/center_cmd/serve.py
+++ b/src/brigade/center_cmd/serve.py
@@ -10,7 +10,7 @@ import socket
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Sequence
+from typing import Sequence, cast
 from urllib.parse import parse_qs, urlparse
 
 from brigade.center_cmd.dashboard import render
@@ -61,7 +61,7 @@ def _is_loopback(host: str) -> bool:
         return False
     for family, _, _, _, sockaddr in infos:
         ip_str = sockaddr[0]
-        if family == socket.AF_INET6 and "%" in ip_str:
+        if isinstance(ip_str, str) and family == socket.AF_INET6 and "%" in ip_str:
             ip_str = ip_str.split("%", 1)[0]
         try:
             addr = ipaddress.ip_address(ip_str)
@@ -360,7 +360,8 @@ def serve(
         print(f"brigade center serve: cannot bind {host}:{port}: {exc}", file=sys.stderr)
         return 2
 
-    actual_host, actual_port = server.server_address[0], server.server_address[1]
+    actual_host = cast(str, server.server_address[0])
+    actual_port = server.server_address[1]
     print(f"http://{actual_host}:{actual_port}/", flush=True)
     print("Read-only dashboard. Press ctrl-c to stop.", flush=True)
     try:

--- a/tests/fixtures/mypy_override_baseline.txt
+++ b/tests/fixtures/mypy_override_baseline.txt
@@ -1,5 +1,3 @@
-brigade.center_cmd
-brigade.center_cmd.*
 brigade.cli.run
 brigade.daily_cmd
 brigade.daily_cmd.*


### PR DESCRIPTION
## What

Family 3 of 7 for #1228 phase 2. Every `center_cmd` submodule that copied `schema_ops`'s globals at import time (`globals().update(vars(_family_base))`) now imports what it uses explicitly. Siblings that import each other (`core`, `actions`, `readiness`, `reports`, `report_review_ops`) use `_<module>_mod` aliases so partially initialized modules resolve at call time and no alias can shadow a same-named function through the facade's `_sync_module_globals()` (the `_reports` alias would otherwise have hidden `reports._reports`, the same bug that hit #1243). The facade `__init__.py` is unchanged.

`brigade.center_cmd` and `brigade.center_cmd.*` leave the mypy override and `tests/fixtures/mypy_override_baseline.txt`; that also brings `center_cmd/dashboard/views/*` under mypy. The 190 errors that surfaced are fixed with bind-once narrowing; no `type: ignore` added. One dead duplicate definition of `_render_inventory` in `dashboard/views/memory_operations.py` (the module already bound the second one) is removed.

## Verify

mypy exit 0 (446 files), ruff check and format clean, size-ratchet baseline ok; center, facade, and ratchet suites: 184 passed (receipt `20260827-135518-work-verify-67981a`; center actions/agent-activity/dashboard/page-load/readiness/report, daily-driver, dashboard-runs, phase-257 facades, override and size ratchets).

Workers: agy_flash (Gemini 3.7 Flash via Antigravity) for the conversion, cursor_grok for the narrowing and alias rename.

Refs #1228
