### PR TITLE
types(handoff_cmd): replace the namespace copy with explicit imports (#1228 phase 2, 5/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,6 @@ module = [
     "brigade.daily_cmd",
     "brigade.daily_cmd.*",
     "brigade.doctor",
-    "brigade.handoff_cmd",
-    "brigade.handoff_cmd.*",
     "brigade.learn_cmd",
     "brigade.mcp_adapters",
     "brigade.mcp_cmd",

--- a/src/brigade/handoff_cmd/drafts.py
+++ b/src/brigade/handoff_cmd/drafts.py
@@ -19,9 +19,24 @@ from ..config import load_config as load_brigade_config
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import issue_ops as _issue_ops_mod
+from . import linting as _linting_mod
+from . import sources as _sources_mod
+from .models import (
+    CARD_ACTIONS,
+    DEFAULT_DRAFT_DOCUMENT,
+    DEFAULT_DRAFT_INBOX,
+    HANDOFF_ACTIONS,
+    HANDOFF_DRAFT_STALE_HOURS,
+    HandoffDraft,
+    IGNORED_HANDOFF_NAMES,
+    NO_CARD_ACTION,
+    OK,
+    SourceConfig,
+    WARN,
+    WRITER_INBOXES,
+    default_sources_path,
+)
 
 
 def _handoff_state_root(target: Path) -> Path:
@@ -51,7 +66,7 @@ def _load_source_config_for_drafts(
     sources_path = sources.expanduser().resolve() if sources is not None else default_sources_path(target)
     if sources_path.is_file():
         try:
-            return _load_sources(target, sources_path), sources_path, [], True
+            return _sources_mod._load_sources(target, sources_path), sources_path, [], True
         except ValueError as exc:
             return (
                 SourceConfig(watched=(), ingestor=None),
@@ -77,7 +92,7 @@ def _draft_inbox_specs(
     specs: dict[tuple[str, str], tuple[Path, str, bool]] = {}
     for rel in WRITER_INBOXES:
         path = (target / rel).resolve()
-        specs[(str(path), rel)] = (path, rel, _is_watched(target, rel, config.watched))
+        specs[(str(path), rel)] = (path, rel, _sources_mod._is_watched(target, rel, config.watched))
     for watched in config.watched:
         path = (watched.root / watched.inbox).resolve()
         label = watched.inbox if watched.root == target.resolve() else str(path)
@@ -325,13 +340,24 @@ def _latest_ingest_outcome_for_path(
 
 
 def _receipt_summary(receipt: dict[str, Any]) -> dict[str, Any]:
-    outcomes = receipt.get("outcomes") if isinstance(receipt.get("outcomes"), list) else []
+    raw_outcomes = receipt.get("outcomes")
+    outcomes: list[Any] = raw_outcomes if isinstance(raw_outcomes, list) else []
     counts: dict[str, int] = {}
     for outcome in outcomes:
         if not isinstance(outcome, dict):
             continue
         status = str(outcome.get("status") or "unknown")
         counts[status] = counts.get(status, 0) + 1
+    raw_malformed = receipt.get("malformed_handoff_paths")
+    malformed_len = len(raw_malformed) if isinstance(raw_malformed, list) else 0
+    raw_unreachable = receipt.get("unreachable_sources")
+    unreachable_len = len(raw_unreachable) if isinstance(raw_unreachable, list) else 0
+    raw_processed = receipt.get("processed_handoff_paths")
+    processed_len = len(raw_processed) if isinstance(raw_processed, list) else 0
+    raw_skipped = receipt.get("skipped_handoff_paths")
+    skipped_len = len(raw_skipped) if isinstance(raw_skipped, list) else 0
+    raw_failed = receipt.get("failed_handoff_paths")
+    failed_len = len(raw_failed) if isinstance(raw_failed, list) else 0
     return {
         "run_id": receipt.get("run_id"),
         "started_at": receipt.get("started_at"),
@@ -340,15 +366,15 @@ def _receipt_summary(receipt: dict[str, Any]) -> dict[str, Any]:
         "inbox_paths": receipt.get("inbox_paths") or [],
         "warning_count": receipt.get("warning_count") or 0,
         "warning_events": receipt.get("warning_events") or [],
-        "malformed": len(receipt.get("malformed_handoff_paths") or []),
-        "unreachable_sources": len(receipt.get("unreachable_sources") or []),
+        "malformed": malformed_len,
+        "unreachable_sources": unreachable_len,
         "no_reply": bool(receipt.get("no_reply")),
         "safe_summary": receipt.get("safe_summary") or "",
         "log_path": receipt.get("log_path") or "",
         "outcome_counts": counts,
-        "processed": len(receipt.get("processed_handoff_paths") or []),
-        "skipped": len(receipt.get("skipped_handoff_paths") or []),
-        "failed": len(receipt.get("failed_handoff_paths") or []),
+        "processed": processed_len,
+        "skipped": skipped_len,
+        "failed": failed_len,
     }
 
 
@@ -381,18 +407,18 @@ def _draft_summary(
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         text = ""
-    raw_sections = _parse_markdown_sections(text)
-    sections, _collision_errors, _ = _canonicalize_sections(raw_sections)
-    lint_result = lint_file(path)
+    raw_sections = _issue_ops_mod._parse_markdown_sections(text)
+    sections, _collision_errors, _ = _issue_ops_mod._canonicalize_sections(raw_sections)
+    lint_result = _linting_mod.lint_file(path)
     action = lint_result.action
     target_card = (
-        _section_value(sections, "Target card").splitlines()[0].strip()
-        if _section_value(sections, "Target card")
+        _issue_ops_mod._section_value(sections, "Target card").splitlines()[0].strip()
+        if _issue_ops_mod._section_value(sections, "Target card")
         else None
     )
     target_document = (
-        _section_value(sections, "Target document").splitlines()[0].strip()
-        if _section_value(sections, "Target document")
+        _issue_ops_mod._section_value(sections, "Target document").splitlines()[0].strip()
+        if _issue_ops_mod._section_value(sections, "Target document")
         else None
     )
     key_values = _extract_handoff_key_values(text)
@@ -814,8 +840,8 @@ def draft(
     )
     inbox_path.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
-    lint_result = lint_file(path)
-    guard_result = _guard_handoff_path(path, target=target, policy=guard_policy) if guard else None
+    lint_result = _linting_mod.lint_file(path)
+    guard_result = _linting_mod._guard_handoff_path(path, target=target, policy=guard_policy) if guard else None
     payload = {
         "target": str(target),
         "created_at": created_at,
@@ -985,18 +1011,18 @@ def archive_draft(
         if errors:
             print(f"error: {'; '.join(errors)}", file=sys.stderr)
             return 2
-        for draft in drafts:
-            if draft.lint.valid:
-                archived.append(_archive_one(target, draft, reason=reason))
+        for item in drafts:
+            if item.lint.valid:
+                archived.append(_archive_one(target, item, reason=reason))
     else:
         if not draft_id:
             print("error: handoff id/path is required unless --all-reviewed is passed", file=sys.stderr)
             return 2
-        draft, error = _find_draft(target, draft_id, sources=sources)
-        if draft is None:
+        single_draft, error = _find_draft(target, draft_id, sources=sources)
+        if single_draft is None:
             print(f"error: {error}", file=sys.stderr)
             return 1 if error and "not found" in error else 2
-        archived.append(_archive_one(target, draft, reason=reason))
+        archived.append(_archive_one(target, single_draft, reason=reason))
     payload = {
         "target": str(target),
         "archive_path": str(_handoff_archive_records_path(target)),
@@ -1077,6 +1103,7 @@ def closeout(
                 "closeout_fingerprint": _draft_closeout_fingerprint(draft),
             }
         )
+    out_path = _handoff_closeouts_root(target) / closeout_id / "closeout.json"
     payload = {
         "target": str(target),
         "closeout_id": closeout_id,
@@ -1086,9 +1113,9 @@ def closeout(
         "draft_count": len(records),
         "drafts": records,
         "source_fingerprints": [item["closeout_fingerprint"] for item in records],
-        "path": str(_handoff_closeouts_root(target) / closeout_id / "closeout.json"),
+        "path": str(out_path),
     }
-    _write_json(Path(payload["path"]), payload)
+    _write_json(out_path, payload)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0

--- a/src/brigade/handoff_cmd/inspect_ops.py
+++ b/src/brigade/handoff_cmd/inspect_ops.py
@@ -19,35 +19,46 @@ from ..config import load_config as load_brigade_config
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import drafts as _drafts_mod
+from . import issue_ops as _issue_ops_mod
+from . import linting as _linting_mod
+from . import sources as _sources_mod
+from .models import (
+    BACKLOG_STALE_SECONDS,
+    FAIL,
+    HandoffHealth,
+    HandoffIssue,
+    OK,
+    SourceConfig,
+    WARN,
+    default_sources_path,
+)
 
 
 def inspect(target: Path, sources: Path | None = None) -> HandoffHealth:
     target = target.expanduser().resolve()
-    sources_path = sources.expanduser().resolve() if sources is not None else default_sources_path(target)
+    configured_path = sources.expanduser().resolve() if sources is not None else default_sources_path(target)
+    sources_path: Path | None = configured_path
     source_config = SourceConfig(watched=(), ingestor=None)
     failures: list[str] = []
     sources_loaded = False
 
-    if sources_path.is_file():
+    if configured_path.is_file():
         try:
-            source_config = _load_sources(target, sources_path)
+            source_config = _sources_mod._load_sources(target, configured_path)
         except ValueError as exc:
-            failures.append(f"invalid handoff source config {sources_path}: {exc}")
+            failures.append(f"invalid handoff source config {configured_path}: {exc}")
         else:
             sources_loaded = True
     elif sources is not None:
         failures.append(f"handoff source config not found: {sources_path}")
-        sources_path = sources_path
     else:
         sources_path = None
 
     watched = source_config.watched
-    inboxes = _collect_inbox_health(target, watched)
-    ingestor = _inspect_ingestor(source_config.ingestor)
-    lint_results = lint_targets(target, sources=sources)
+    inboxes = _sources_mod._collect_inbox_health(target, watched)
+    ingestor = _sources_mod._inspect_ingestor(source_config.ingestor)
+    lint_results = _linting_mod.lint_targets(target, sources=sources)
     warnings: list[str] = []
     pending_total = sum(inbox.pending for inbox in inboxes)
     if pending_total and not sources_loaded and not failures:
@@ -144,7 +155,7 @@ def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, 
             )
         )
 
-    if source_config := _source_config_for_checks(health.target, health.sources_path):
+    if source_config := _sources_mod._source_config_for_checks(health.target, health.sources_path):
         for watched_inbox in source_config.watched:
             watched_path = watched_inbox.root / watched_inbox.inbox
             if not watched_path.exists():
@@ -158,15 +169,15 @@ def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, 
             level = WARN
             detail = (
                 f"{health.ingestor.log_path} "
-                f"(age={_format_seconds(health.ingestor.age_seconds)}, "
-                f"stale_after={_format_seconds(health.ingestor.stale_after_seconds)})"
+                f"(age={_sources_mod._format_seconds(health.ingestor.age_seconds)}, "
+                f"stale_after={_sources_mod._format_seconds(health.ingestor.stale_after_seconds)})"
             )
         elif health.ingestor.warnings:
             level = WARN
             detail = f"{health.ingestor.log_path} ({len(health.ingestor.warnings)} warning signal{'s' if len(health.ingestor.warnings) != 1 else ''})"
         else:
             level = OK
-            detail = f"{health.ingestor.log_path} (age={_format_seconds(health.ingestor.age_seconds)})"
+            detail = f"{health.ingestor.log_path} (age={_sources_mod._format_seconds(health.ingestor.age_seconds)})"
         checks.append((level, "handoff_ingestor", detail))
     else:
         checks.append((OK, "handoff_ingestor", "log not configured"))
@@ -188,7 +199,7 @@ def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, 
 
     for warning in health.warnings:
         checks.append((WARN, "handoff_warning", warning))
-    draft_payload = draft_queue_payload(target, sources=sources)
+    draft_payload = _drafts_mod.draft_queue_payload(target, sources=sources)
     for check in draft_payload["checks"]:
         checks.append((str(check.get("status")), str(check.get("name")), str(check.get("detail"))))
     return checks
@@ -204,7 +215,7 @@ def collect_issues(
     wanted_categories = {category for category in categories or [] if category}
     for failure in health.failures:
         issues.append(
-            _make_issue(
+            _issue_ops_mod._make_issue(
                 category="source-config-invalid",
                 kind="task",
                 text=f"Repair handoff source config: {failure}",
@@ -219,7 +230,7 @@ def collect_issues(
     pending_total = sum(inbox.pending for inbox in health.inboxes)
     if pending_total and not health.sources_loaded and not health.failures:
         issues.append(
-            _make_issue(
+            _issue_ops_mod._make_issue(
                 category="source-config-missing",
                 kind="task",
                 text="Configure handoff source coverage for pending writer inboxes",
@@ -231,14 +242,14 @@ def collect_issues(
                 },
             )
         )
-    source_config = _source_config_for_checks(health.target, health.sources_path)
+    source_config = _sources_mod._source_config_for_checks(health.target, health.sources_path)
     if source_config is not None and "source-inbox-missing" in wanted_categories:
         for watched_inbox in source_config.watched:
             watched_path = watched_inbox.root / watched_inbox.inbox
             if watched_path.exists():
                 continue
             issues.append(
-                _make_issue(
+                _issue_ops_mod._make_issue(
                     category="source-inbox-missing",
                     kind="task",
                     text=f"Repair missing configured handoff inbox {watched_inbox.inbox}",
@@ -254,7 +265,7 @@ def collect_issues(
     for inbox in health.inboxes:
         if inbox.pending and not inbox.watched:
             issues.append(
-                _make_issue(
+                _issue_ops_mod._make_issue(
                     category="untracked-inbox",
                     kind="task",
                     text=(
@@ -281,11 +292,11 @@ def collect_issues(
             continue
         first_error = result.errors[0] if result.errors else "invalid handoff"
         issues.append(
-            _make_issue(
+            _issue_ops_mod._make_issue(
                 category="lint",
                 kind="task",
                 text=f"Fix pending handoff lint error in {result.path.name}: {first_error}",
-                repair=_lint_repair_for_result(result),
+                repair=_issue_ops_mod._lint_repair_for_result(result),
                 evidence=str(result.path),
                 metadata={
                     "path": str(result.path),
@@ -299,7 +310,7 @@ def collect_issues(
     if ingestor.configured:
         if not ingestor.exists:
             issues.append(
-                _make_issue(
+                _issue_ops_mod._make_issue(
                     category="missing-log",
                     kind="incident",
                     text=f"Restore handoff ingestor latest-run log at {ingestor.log_path}",
@@ -313,12 +324,12 @@ def collect_issues(
             )
         elif ingestor.stale:
             issues.append(
-                _make_issue(
+                _issue_ops_mod._make_issue(
                     category="stale-log",
                     kind="incident",
                     text=f"Investigate stale handoff ingestor run log at {ingestor.log_path}",
                     repair="Run the handoff ingestor, then fix the scheduler or wrapper if the log does not refresh.",
-                    evidence=f"age={_format_seconds(ingestor.age_seconds)}, stale_after={_format_seconds(ingestor.stale_after_seconds)}",
+                    evidence=f"age={_sources_mod._format_seconds(ingestor.age_seconds)}, stale_after={_sources_mod._format_seconds(ingestor.stale_after_seconds)}",
                     metadata={
                         "log_path": str(ingestor.log_path),
                         "age_seconds": ingestor.age_seconds,
@@ -327,5 +338,5 @@ def collect_issues(
                 )
             )
         if ingestor.exists and ingestor.log_path is not None:
-            issues.extend(_parse_ingestor_log_issues(ingestor.log_path))
-    return _filter_issues_by_category(_dedupe_issues(issues), categories)
+            issues.extend(_sources_mod._parse_ingestor_log_issues(ingestor.log_path))
+    return _issue_ops_mod._filter_issues_by_category(_issue_ops_mod._dedupe_issues(issues), categories)

--- a/src/brigade/handoff_cmd/issue_ops.py
+++ b/src/brigade/handoff_cmd/issue_ops.py
@@ -20,9 +20,24 @@ from ..handoff_content import normalize_suggested_card_content
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import drafts as _drafts_mod
+from . import inspect_ops as _inspect_ops_mod
+from . import sources as _sources_mod
+from .models import (
+    CARD_ACTIONS,
+    CARD_TARGET_PATTERN,
+    DEFAULT_STALE_AFTER_MINUTES,
+    DEFAULT_WARNING_PATTERNS,
+    DOCUMENT_TARGETS,
+    DOCUMENT_TARGET_PREFIXES,
+    HandoffIssue,
+    HandoffLintResult,
+    IGNORED_HANDOFF_NAMES,
+    ISSUE_SOURCE,
+    NO_CARD_ACTION,
+    WRITER_INBOXES,
+    default_sources_path,
+)
 
 
 def issues(
@@ -40,7 +55,7 @@ def issues(
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    found = collect_issues(target, sources=sources, categories=categories)
+    found = _inspect_ops_mod.collect_issues(target, sources=sources, categories=categories)
     payload = _issues_payload(target, found)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -54,9 +69,9 @@ def issues(
         print(f"- {category}: {count}")
     print("items:")
     for issue in found[:limit]:
-        print(f"- {issue.id} [{issue.category}] {issue.kind}: {_short(issue.text)}")
-        print(f"  repair: {_short(issue.repair, 140)}")
-        print(f"  evidence: {_short(issue.evidence, 160)}")
+        print(f"- {issue.id} [{issue.category}] {issue.kind}: {_sources_mod._short(issue.text)}")
+        print(f"  repair: {_sources_mod._short(issue.repair, 140)}")
+        print(f"  evidence: {_sources_mod._short(issue.evidence, 160)}")
     if len(found) > limit:
         print(f"... {len(found) - limit} more")
     return 0
@@ -74,7 +89,7 @@ def import_issues(
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    found = collect_issues(target, sources=sources, categories=categories)
+    found = _inspect_ops_mod.collect_issues(target, sources=sources, categories=categories)
     records = [issue.as_import_record() for issue in found]
     from .. import work_cmd
 
@@ -100,7 +115,7 @@ def import_issues(
     print(f"imported: {len(imported)}")
     print(f"skipped_duplicates: {len(skipped)}")
     for item in imported:
-        print(f"- {item.get('id')} [{item.get('kind')}] {_short(str(item.get('text', '')))}")
+        print(f"- {item.get('id')} [{item.get('kind')}] {_sources_mod._short(str(item.get('text', '')))}")
     return 0
 
 
@@ -117,7 +132,7 @@ def sync_issues(
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    found = collect_issues(target, sources=sources, categories=categories)
+    found = _inspect_ops_mod.collect_issues(target, sources=sources, categories=categories)
     current_ids = {issue.id for issue in found}
     known_ids = _known_local_issue_ids(target)
     covered_summary_ids = _covered_warning_summary_ids(found, known_ids)
@@ -172,11 +187,11 @@ def sync_issues(
     print(f"stale_imports_closed: {len(stale['imports'])}")
     print(f"stale_tasks_closed: {len(stale['tasks'])}")
     for item in imported:
-        print(f"- imported {item.get('id')} [{item.get('kind')}] {_short(str(item.get('text', '')))}")
+        print(f"- imported {item.get('id')} [{item.get('kind')}] {_sources_mod._short(str(item.get('text', '')))}")
     for item in stale["imports"]:
-        print(f"- closed import {item.get('id')} {_short(str(item.get('text', '')))}")
+        print(f"- closed import {item.get('id')} {_sources_mod._short(str(item.get('text', '')))}")
     for task in stale["tasks"]:
-        print(f"- closed task {task.get('id')} {_short(str(task.get('text', '')))}")
+        print(f"- closed task {task.get('id')} {_sources_mod._short(str(task.get('text', '')))}")
     return 0
 
 
@@ -184,13 +199,13 @@ def doctor(*, target: Path, sources: Path | None = None, json_output: bool = Fal
     if not target.expanduser().exists():
         print(f"error: target does not exist: {target}", file=sys.stderr)
         return 2
-    health = inspect(target, sources=sources)
+    health = _inspect_ops_mod.inspect(target, sources=sources)
     if json_output:
         print(json.dumps(health.as_dict(), indent=2, sort_keys=True))
     else:
         print(f"handoff doctor: {health.target}")
         print(f"sources: {health.sources_path if health.sources_path else '(not configured)'}")
-        for status, name, detail in doctor_checks(health.target, sources=health.sources_path):
+        for status, name, detail in _inspect_ops_mod.doctor_checks(health.target, sources=health.sources_path):
             print(f"[{status}] {name}: {detail}")
     return 1 if health.failures else 0
 
@@ -306,7 +321,7 @@ def _resolve_lint_path(target: Path, path: Path) -> Path:
 def _pending_handoff_paths(target: Path, sources: Path | None = None) -> tuple[Path, ...]:
     paths: list[Path] = []
     seen: set[str] = set()
-    specs, _, _ = _draft_inbox_specs(target, sources=sources)
+    specs, _, _ = _drafts_mod._draft_inbox_specs(target, sources=sources)
     for inbox_path, _inbox, _watched in specs:
         if not inbox_path.is_dir():
             continue
@@ -652,13 +667,15 @@ def _close_stale_local_issue_work(
 
 
 def _handoff_issue_id(item: dict[str, Any]) -> str | None:
-    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    raw_metadata = item.get("metadata")
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
     issue_id = metadata.get("handoff_issue_id")
     return issue_id if isinstance(issue_id, str) and issue_id else None
 
 
 def _handoff_issue_category(item: dict[str, Any]) -> str | None:
-    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    raw_metadata = item.get("metadata")
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
     category = metadata.get("handoff_issue_category")
     return category if isinstance(category, str) and category else None
 

--- a/src/brigade/handoff_cmd/linting.py
+++ b/src/brigade/handoff_cmd/linting.py
@@ -19,10 +19,18 @@ from ..config import load_config as load_brigade_config
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
-from . import models as _family_base
+from . import issue_ops as _issue_ops_mod
+from . import sources as _sources_mod
+from .models import (
+    CARD_ACTIONS,
+    FAIL,
+    HANDOFF_ACTIONS,
+    HandoffLintResult,
+    NO_CARD_ACTION,
+    OK,
+    _LOOSE_FIELD_TEMPLATE,
+)
 from .readability import ReadabilityFinding, scan_standalone_readability
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
 
 
 def _readability_kind(category: str) -> str:
@@ -226,7 +234,8 @@ def lint(
     if content_guard:
         print(f"content_guard_policy: {guard_policy} (egress leak scan + injection heuristics)")
         for item in guard_results:
-            hits = item.get("injection_heuristics") or []
+            raw_hits = item.get("injection_heuristics")
+            hit_items: list[Any] = raw_hits if isinstance(raw_hits, list) else []
             egress_status = item.get("egress_verdict", OK)
             print(f"[{egress_status}] content_guard egress: {item.get('path')} {item.get('detail')}")
             injection_status = item.get("injection_verdict", OK)
@@ -236,18 +245,19 @@ def lint(
                 f"[{injection_status}] content_guard injection: {item.get('path')} "
                 f"{_injection_detail(warning_count=warning_count, unscanned=unscanned)}"
             )
-            for hit in hits:
-                if hit.get("severity") == "info":
-                    print(f"  line {hit['line']}: info: [{hit['rule']}] {hit['excerpt']}")
-                elif hit.get("severity") == "warning":
-                    print(f"  line {hit['line']}: warning: [{hit['rule']}] {hit['excerpt']}")
+            for hit in hit_items:
+                if isinstance(hit, dict):
+                    if hit.get("severity") == "info":
+                        print(f"  line {hit.get('line')}: info: [{hit.get('rule')}] {hit.get('excerpt')}")
+                    elif hit.get("severity") == "warning":
+                        print(f"  line {hit.get('line')}: warning: [{hit.get('rule')}] {hit.get('excerpt')}")
     return 0 if payload["valid"] else 1
 
 
 def _guard_handoff_path(path: Path, *, target: Path, policy: str) -> dict[str, Any]:
     result = scrub.run_scan(path, repo_target=target, policy=policy)
-    stdout_summary = _short(" ".join(str(result.get("stdout") or "").split()), 320)
-    stderr_summary = _short(" ".join(str(result.get("stderr") or "").split()), 320)
+    stdout_summary = _sources_mod._short(" ".join(str(result.get("stdout") or "").split()), 320)
+    stderr_summary = _sources_mod._short(" ".join(str(result.get("stderr") or "").split()), 320)
     return {
         "path": str(path),
         "policy": policy,
@@ -265,9 +275,9 @@ def lint_targets(
 ) -> tuple[HandoffLintResult, ...]:
     target = target.expanduser().resolve()
     candidates = (
-        tuple(_resolve_lint_path(target, path) for path in paths)
+        tuple(_issue_ops_mod._resolve_lint_path(target, path) for path in paths)
         if paths
-        else _pending_handoff_paths(target, sources=sources)
+        else _issue_ops_mod._pending_handoff_paths(target, sources=sources)
     )
     return tuple(lint_file(path) for path in candidates)
 
@@ -290,22 +300,22 @@ def lint_file(path: Path) -> HandoffLintResult:
             warnings=(),
         )
 
-    raw_sections = _parse_markdown_sections(text)
+    raw_sections = _issue_ops_mod._parse_markdown_sections(text)
     # Use the same structural boundary as ingest: a note with several populated
     # Markdown sections can be preserved for review, unlike unstructured text.
     from ..ingest import has_salvageable_structure
 
     salvageable = has_salvageable_structure(raw_sections)
-    sections, collision_errors, noncanonical_headings = _canonicalize_sections(raw_sections)
+    sections, collision_errors, noncanonical_headings = _issue_ops_mod._canonicalize_sections(raw_sections)
     errors.extend(collision_errors)
-    heading_warnings, heading_hints = _lint_noncanonical_heading_messages(noncanonical_headings)
+    heading_warnings, heading_hints = _issue_ops_mod._lint_noncanonical_heading_messages(noncanonical_headings)
     warnings.extend(heading_warnings)
     hints.extend(heading_hints)
-    order_warnings, order_hints = _lint_section_order_messages(raw_sections)
+    order_warnings, order_hints = _issue_ops_mod._lint_section_order_messages(raw_sections)
     warnings.extend(order_warnings)
     hints.extend(order_hints)
     for required in ("Type", "Title", "Summary", "Recommended memory action"):
-        if required not in sections or not _section_value(sections, required):
+        if required not in sections or not _issue_ops_mod._section_value(sections, required):
             errors.append(f"missing required section: {required}")
 
     if any(error.startswith("missing required section:") for error in errors):
@@ -319,19 +329,19 @@ def lint_file(path: Path) -> HandoffLintResult:
             from ..untrusted import scan_untrusted
 
             if not scan_untrusted(text).flagged:
-                expected = ", ".join(f"## {name}" for name in CANONICAL_HANDOFF_SECTION_HEADINGS)
+                expected = ", ".join(f"## {name}" for name in _issue_ops_mod.CANONICAL_HANDOFF_SECTION_HEADINGS)
                 hints.append(f"structured note detected; use Brigade handoff sections: {expected}")
 
-    action_value = _section_value(sections, "Recommended memory action")
+    action_value = _issue_ops_mod._section_value(sections, "Recommended memory action")
     if action_value:
         action = action_value.splitlines()[0].strip().casefold()
         if action not in HANDOFF_ACTIONS:
             errors.append("Recommended memory action must be one of: " + ", ".join(HANDOFF_ACTIONS))
 
     if action in CARD_ACTIONS:
-        _lint_card_action(sections, errors, warnings)
+        _issue_ops_mod._lint_card_action(sections, errors, warnings)
     elif action == NO_CARD_ACTION:
-        _lint_no_card_action(sections, errors)
+        _issue_ops_mod._lint_no_card_action(sections, errors)
 
     readability = scan_standalone_readability(text)
     warnings.extend(_readability_warning(finding) for finding in readability)
@@ -356,11 +366,11 @@ def _loose_field(text: str, name: str) -> str | None:
 
 def _migrate_extract(text: str) -> tuple[dict[str, str], list[str]]:
     """Merge proper `## Section` values with loose bullet metadata; report gaps."""
-    raw_sections = _parse_markdown_sections(text)
-    sections, _collision_errors, _ = _canonicalize_sections(raw_sections)
+    raw_sections = _issue_ops_mod._parse_markdown_sections(text)
+    sections, _collision_errors, _ = _issue_ops_mod._canonicalize_sections(raw_sections)
 
     def field(section_name: str) -> str:
-        return _section_value(sections, section_name) or _loose_field(text, section_name) or ""
+        return _issue_ops_mod._section_value(sections, section_name) or _loose_field(text, section_name) or ""
 
     action_raw = field("Recommended memory action")
     extracted = {
@@ -370,8 +380,8 @@ def _migrate_extract(text: str) -> tuple[dict[str, str], list[str]]:
         "action": (action_raw.splitlines() or [""])[0].strip().casefold(),
         "target_card": field("Target card"),
         "target_document": field("Target document"),
-        "card_content": _section_value(sections, "Suggested card content"),
-        "document_content": _section_value(sections, "Suggested document content"),
+        "card_content": _issue_ops_mod._section_value(sections, "Suggested card content"),
+        "document_content": _issue_ops_mod._section_value(sections, "Suggested document content"),
     }
     missing: list[str] = []
     for key in ("type", "title", "summary"):

--- a/src/brigade/handoff_cmd/migrate_ops.py
+++ b/src/brigade/handoff_cmd/migrate_ops.py
@@ -19,9 +19,9 @@ from ..config import load_config as load_brigade_config
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import drafts as _drafts_mod
+from . import linting as _linting_mod
+from .models import CARD_ACTIONS, WRITER_INBOXES
 
 
 def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json_output: bool = False) -> int:
@@ -40,7 +40,7 @@ def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     if inbox is not None:
-        inbox_paths = [_draft_inbox_path(target, inbox)[0]]
+        inbox_paths = [_drafts_mod._draft_inbox_path(target, inbox)[0]]
     else:
         inbox_paths = [target / rel for rel in WRITER_INBOXES if (target / rel).is_dir()]
     items: list[dict[str, Any]] = []
@@ -49,7 +49,7 @@ def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json
         for path in sorted(inbox_path.glob("*.md")):
             if path.name == "TEMPLATE.md":
                 continue
-            if lint_file(path).valid:
+            if _linting_mod.lint_file(path).valid:
                 continue
             rel = str(path.relative_to(target))
             text = path.read_text(encoding="utf-8", errors="replace")
@@ -59,14 +59,14 @@ def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json
                 item["detail"] = "carries prompt-injection signals; review manually before any conversion"
                 items.append(item)
                 continue
-            extracted, missing = _migrate_extract(text)
+            extracted, missing = _linting_mod._migrate_extract(text)
             if missing:
                 item["status"] = "unmigratable"
                 item["missing"] = missing
                 items.append(item)
                 continue
             action = extracted["action"]
-            rendered = _render_handoff_draft(
+            rendered = _drafts_mod._render_handoff_draft(
                 handoff_type=extracted["type"],
                 title=extracted["title"],
                 summary=extracted["summary"],
@@ -86,7 +86,7 @@ def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json
                 originals.mkdir(parents=True, exist_ok=True)
                 (originals / path.name).write_text(text, encoding="utf-8")
                 path.write_text(rendered, encoding="utf-8")
-                converted = lint_file(path)
+                converted = _linting_mod.lint_file(path)
                 if not converted.valid:
                     path.write_text(text, encoding="utf-8")
                     (originals / path.name).unlink()
@@ -100,7 +100,7 @@ def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json
     if apply and migrated:
         from ..localio import utc_now, write_json
 
-        migrations_dir = _handoff_state_root(target) / "migrations"
+        migrations_dir = _drafts_mod._handoff_state_root(target) / "migrations"
         migrations_dir.mkdir(parents=True, exist_ok=True)
         receipt_path = migrations_dir / f"{utc_now().strftime('%Y%m%dT%H%M%S')}.json"
         write_json(receipt_path, {"target": str(target), "migrated_count": migrated, "items": items})

--- a/src/brigade/handoff_cmd/models.py
+++ b/src/brigade/handoff_cmd/models.py
@@ -133,6 +133,27 @@ class IngestorHealth:
         }
 
 
+def _handoff_issue_source_key(issue: HandoffIssue) -> str:
+    value = issue.metadata.get("source_item_key")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return f"handoff-ingest:{issue.category}:{issue.id}"
+
+
+def _handoff_issue_fingerprint(issue: HandoffIssue, metadata: dict[str, Any]) -> str:
+    payload = {
+        "category": issue.category,
+        "kind": issue.kind,
+        "text": issue.text,
+        "repair": issue.repair,
+        "evidence": issue.evidence,
+        "metadata": {
+            key: value for key, value in metadata.items() if key not in {"source_fingerprint", "handoff_issue_id"}
+        },
+    }
+    return hashlib.sha1(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:16]
+
+
 @dataclass(frozen=True)
 class HandoffIssue:
     id: str

--- a/src/brigade/handoff_cmd/receipts.py
+++ b/src/brigade/handoff_cmd/receipts.py
@@ -19,9 +19,9 @@ from ..config import load_config as load_brigade_config
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import drafts as _drafts_mod
+from . import sources as _sources_mod
+from .models import HandoffDraft
 
 
 def runs(*, target: Path, json_output: bool = False, limit: int = 20) -> int:
@@ -32,12 +32,13 @@ def runs(*, target: Path, json_output: bool = False, limit: int = 20) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    receipts = _ingest_receipts(target)
-    payload = {
+    receipts = _drafts_mod._ingest_receipts(target)
+    runs_list = [_drafts_mod._receipt_summary(receipt) for receipt in receipts[:limit]]
+    payload: dict[str, Any] = {
         "target": str(target),
-        "runs_root": str(_handoff_ingest_runs_root(target)),
+        "runs_root": str(_drafts_mod._handoff_ingest_runs_root(target)),
         "count": len(receipts),
-        "runs": [_receipt_summary(receipt) for receipt in receipts[:limit]],
+        "runs": runs_list,
     }
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -45,7 +46,7 @@ def runs(*, target: Path, json_output: bool = False, limit: int = 20) -> int:
     print(f"handoff ingest runs: {target}")
     print(f"runs_root: {payload['runs_root']}")
     print(f"runs: {payload['count']}")
-    for item in payload["runs"]:
+    for item in runs_list:
         print(
             f"- {item.get('run_id')} completed={item.get('completed_at')} "
             f"processed={item.get('processed')} skipped={item.get('skipped')} "
@@ -61,7 +62,7 @@ def run_show(*, target: Path, run_id: str, json_output: bool = False) -> int:
         return 2
     matches = [
         receipt
-        for receipt in _ingest_receipts(target)
+        for receipt in _drafts_mod._ingest_receipts(target)
         if str(receipt.get("run_id")) == run_id or str(receipt.get("run_id", "")).startswith(run_id)
     ]
     if not matches:
@@ -113,14 +114,14 @@ def _select_receipt_drafts(
     if not all_reviewed and not draft_ids:
         return [], "pass at least one draft id/path or --all-reviewed"
     if all_reviewed:
-        drafts, errors, _ = _drafts(target, sources=sources)
+        drafts, errors, _ = _drafts_mod._drafts(target, sources=sources)
         if errors:
             return [], "; ".join(errors)
         selected = [draft for draft in drafts if draft.lint.valid]
     else:
         selected = []
         for draft_id in draft_ids or []:
-            draft, error = _find_draft(target, draft_id, sources=sources)
+            draft, error = _drafts_mod._find_draft(target, draft_id, sources=sources)
             if draft is None:
                 return [], error or f"handoff draft not found: {draft_id}"
             selected.append(draft)
@@ -148,9 +149,10 @@ def _receipt_payload_for_drafts(
 ) -> dict[str, Any]:
     owner_label = _safe_label(owner)
     run_id = _safe_label(
-        run_id or f"{owner_label}-handoff-ingest-{_timestamp_id()}", fallback=f"handoff-ingest-{_timestamp_id()}"
+        run_id or f"{owner_label}-handoff-ingest-{_drafts_mod._timestamp_id()}",
+        fallback=f"handoff-ingest-{_drafts_mod._timestamp_id()}",
     )
-    now = _iso_from_timestamp()
+    now = _drafts_mod._iso_from_timestamp()
     inbox_paths = sorted({str(draft.path.parent) for draft in drafts})
     handoff_paths = [str(draft.path) for draft in drafts]
     payload: dict[str, Any] = {
@@ -185,7 +187,7 @@ def _receipt_payload_for_drafts(
                 payload["routed_document_targets"].append(
                     {"handoff_path": str(draft.path), "target": draft.target_document}
                 )
-    return _normalize_ingest_receipt(target, payload)
+    return _drafts_mod._normalize_ingest_receipt(target, payload)
 
 
 def _receipt_plan_payload(
@@ -217,7 +219,7 @@ def _receipt_plan_payload(
         safe_summary=safe_summary,
         log_path=log_path,
     )
-    path = _ingest_receipt_path(target, str(receipt["run_id"]))
+    path = _drafts_mod._ingest_receipt_path(target, str(receipt["run_id"]))
     return {
         "target": str(target),
         "status": status,
@@ -226,7 +228,7 @@ def _receipt_plan_payload(
         "receipt_path": str(path),
         "drafts": [draft.as_dict() for draft in drafts],
         "run": receipt,
-        "summary": _receipt_summary(receipt),
+        "summary": _drafts_mod._receipt_summary(receipt),
     }, None
 
 
@@ -314,7 +316,7 @@ def receipt_record(
         return 2
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload["run"], indent=2, sort_keys=True) + "\n")
-    archives = _refresh_archive_ingest_outcomes(target)
+    archives = _drafts_mod._refresh_archive_ingest_outcomes(target)
     written = dict(payload)
     written["would_write"] = True
     written["written"] = True
@@ -337,7 +339,7 @@ def reconcile(*, target: Path, sources: Path | None = None, json_output: bool = 
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    config, sources_path, errors, _ = _load_source_config_for_drafts(target, sources=sources)
+    config, sources_path, errors, _ = _drafts_mod._load_source_config_for_drafts(target, sources=sources)
     if errors:
         print(f"error: {'; '.join(errors)}", file=sys.stderr)
         return 2
@@ -353,11 +355,11 @@ def reconcile(*, target: Path, sources: Path | None = None, json_output: bool = 
     except OSError as exc:
         print(f"error: cannot read ingestor log: {exc}", file=sys.stderr)
         return 1
-    receipt = _parse_ingestor_log_receipt(target, config, log_path, text)
-    path = _ingest_receipt_path(target, str(receipt["run_id"]))
+    receipt = _sources_mod._parse_ingestor_log_receipt(target, config, log_path, text)
+    path = _drafts_mod._ingest_receipt_path(target, str(receipt["run_id"]))
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
-    archives = _refresh_archive_ingest_outcomes(target)
+    archives = _drafts_mod._refresh_archive_ingest_outcomes(target)
     payload = {
         "target": str(target),
         "sources_path": str(sources_path) if sources_path else None,

--- a/src/brigade/handoff_cmd/sources.py
+++ b/src/brigade/handoff_cmd/sources.py
@@ -19,9 +19,21 @@ from ..config import load_config as load_brigade_config
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import drafts as _drafts_mod
+from . import issue_ops as _issue_ops_mod
+from .models import (
+    DEFAULT_STALE_AFTER_MINUTES,
+    DEFAULT_WARNING_PATTERNS,
+    HandoffIssue,
+    IGNORED_HANDOFF_NAMES,
+    InboxHealth,
+    IngestorConfig,
+    IngestorHealth,
+    MAX_INGESTOR_WARNING_SIGNALS,
+    SourceConfig,
+    WRITER_INBOXES,
+    WatchedInbox,
+)
 
 
 def _source_config_for_checks(target: Path, sources_path: Path | None) -> SourceConfig | None:
@@ -38,7 +50,7 @@ def _parse_ingestor_log_issues(log_path: Path) -> list[HandoffIssue]:
         lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError as exc:
         return [
-            _make_issue(
+            _issue_ops_mod._make_issue(
                 category="missing-log",
                 kind="incident",
                 text=f"Read handoff ingestor log at {log_path}",
@@ -75,7 +87,7 @@ def _parse_ingestor_log_issues(log_path: Path) -> list[HandoffIssue]:
             issues.append(_issue_from_log_line("source-unreachable", "incident", stripped, line_number, log_path))
     if has_warning_summary and has_no_reply_or_update:
         issues.append(
-            _make_issue(
+            _issue_ops_mod._make_issue(
                 category="hidden-warning",
                 kind="incident",
                 text="Fix handoff ingestor no-reply output that can hide warnings",
@@ -173,8 +185,8 @@ def _parse_ingestor_log_receipt(target: Path, config: SourceConfig, log_path: Pa
     )
     receipt = {
         "run_id": run_id,
-        "started_at": _iso_from_timestamp(timestamp),
-        "completed_at": _iso_from_timestamp(timestamp),
+        "started_at": _drafts_mod._iso_from_timestamp(timestamp),
+        "completed_at": _drafts_mod._iso_from_timestamp(timestamp),
         "source_root": str(target),
         "inbox_paths": inbox_paths,
         "processed_handoff_paths": processed,
@@ -190,7 +202,7 @@ def _parse_ingestor_log_receipt(target: Path, config: SourceConfig, log_path: Pa
         "safe_summary": safe_summary,
         "log_path": str(log_path),
     }
-    return _normalize_ingest_receipt(target, receipt)
+    return _drafts_mod._normalize_ingest_receipt(target, receipt)
 
 
 def _split_outcome_line(value: str) -> tuple[str | None, str | None]:
@@ -212,7 +224,7 @@ def _issue_from_log_line(category: str, kind: str, line: str, line_number: int, 
     subject, detail = _split_issue_line(line)
     repair = _repair_for_issue(category, line)
     text = _text_for_issue(category, subject, detail)
-    return _make_issue(
+    return _issue_ops_mod._make_issue(
         category=category,
         kind=kind,
         text=text,

--- a/tests/fixtures/mypy_override_baseline.txt
+++ b/tests/fixtures/mypy_override_baseline.txt
@@ -4,8 +4,6 @@ brigade.cli.run
 brigade.daily_cmd
 brigade.daily_cmd.*
 brigade.doctor
-brigade.handoff_cmd
-brigade.handoff_cmd.*
 brigade.learn_cmd
 brigade.mcp_adapters
 brigade.mcp_cmd


### PR DESCRIPTION
## What

Family 5 of 7 for #1228 phase 2. Every `handoff_cmd` submodule that copied `models`'s globals at import time (`globals().update(vars(_family_base))`) now imports what it uses explicitly; siblings that import each other use `_<module>_mod` aliases so partially initialized modules resolve at call time and no alias can shadow a same-named function through the facade's `_sync_module_globals()`. The facade `__init__.py` is unchanged.

`brigade.handoff_cmd` and `brigade.handoff_cmd.*` leave the mypy override and `tests/fixtures/mypy_override_baseline.txt`; the errors that surface are fixed with bind-once narrowing, no `type: ignore` added.

## Verify

mypy exit 0, ruff check and format clean, size-ratchet baseline ok; handoff, ingest, facade, and ratchet suites: 127 passed (receipt `20260827-142559-work-verify-4c22aa`: handoff_cmd, phase-257 facades, override and size ratchets) and 74 passed (receipt `20260827-142614-work-verify-0f53c0`: handoff, injection lint, readability, ingest, research handoff, dashboard handoffs).

Workers: agy_flash (Gemini 3.7 Flash via Antigravity) did the whole family in one pass: conversion, `_mod` aliases for the cyclic siblings, override removal; mypy was already clean afterwards, so no narrowing follow-up was needed.

Refs #1228
