### PR TITLE
types(daily_cmd): replace the namespace copy with explicit imports (#1228 phase 2, 6/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "brigade.cli.run",
-    "brigade.daily_cmd",
-    "brigade.daily_cmd.*",
     "brigade.doctor",
     "brigade.handoff_cmd",
     "brigade.handoff_cmd.*",

--- a/src/brigade/daily_cmd/approvals.py
+++ b/src/brigade/daily_cmd/approvals.py
@@ -38,9 +38,18 @@ from .. import runguard
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
-from . import config as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .config import (
+    DEFAULT_CONFIG,
+    SCHEMA_VERSION,
+    _approvals_root,
+    _fingerprint,
+    _load_config,
+    _runs_root,
+    _slug,
+)
+from . import candidates as _candidates_mod
+from . import run_loop as _run_loop_mod
+from . import status_plan as _status_plan_mod
 
 _APPROVAL_REFERENCE_FIELDS = (
     "approval_id",
@@ -112,7 +121,7 @@ def _approval_store_lock(target: Path, approval_id: str) -> Iterator[None]:
 
 
 def _read_approvals(target: Path) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
-    return _iter_receipts(_approvals_root(target), "approval.json")
+    return _run_loop_mod._iter_receipts(_approvals_root(target), "approval.json")
 
 
 def _write_approval_unlocked(target: Path, approval: dict[str, Any]) -> dict[str, Any]:
@@ -163,7 +172,7 @@ def _ensure_approval(
             "source_plan_id": plan_data.get("plan_id"),
             "selected_action_id": action.get("action_id"),
             "selected_action": action,
-            "selected_adapter": _adapter_for(action),
+            "selected_adapter": _candidates_mod._adapter_for(action),
             "source_subsystem": action.get("source_subsystem"),
             "source_local_id": action.get("source_local_id"),
             "source_fingerprint": action.get("source_fingerprint"),
@@ -183,20 +192,24 @@ def _ensure_approval(
 
 
 def _current_action_for_approval(target: Path, approval: dict[str, Any]) -> dict[str, Any] | None:
-    selected_action = approval.get("selected_action") if isinstance(approval.get("selected_action"), dict) else {}
+    selected_action = raw_action if isinstance((raw_action := approval.get("selected_action")), dict) else {}
     action_type = str(selected_action.get("action_type") or "")
     source_id = str(approval.get("source_local_id") or selected_action.get("source_local_id") or "")
     candidate_builders = {
-        "run-task": _pending_task_candidates,
-        "promote-import": _pending_import_candidates,
-        "start-center-action": _center_action_candidates,
-        "import-readiness-issues": _readiness_candidates,
-        "import-handoff-issues": _handoff_ingest_candidates,
-        "build-operator-report": _report_candidate,
+        "run-task": _candidates_mod._pending_task_candidates,
+        "promote-import": _candidates_mod._pending_import_candidates,
+        "start-center-action": _candidates_mod._center_action_candidates,
+        "import-readiness-issues": _candidates_mod._readiness_candidates,
+        "import-handoff-issues": _candidates_mod._handoff_ingest_candidates,
+        "build-operator-report": _candidates_mod._report_candidate,
     }
     builder = candidate_builders.get(action_type)
     if builder is None:
-        return selected_action if selected_action and not _evidence_blockers(target, selected_action) else None
+        return (
+            selected_action
+            if selected_action and not _status_plan_mod._evidence_blockers(target, selected_action)
+            else None
+        )
     for action in builder(target):
         if action.get("source_local_id") == source_id:
             return action
@@ -213,7 +226,7 @@ def _approval_blockers(target: Path, approval: dict[str, Any], config: dict[str,
     if approval.get("config_fingerprint") != _config_fingerprint(config):
         blockers.append("daily config changed since approval")
     action = approval.get("selected_action") if isinstance(approval.get("selected_action"), dict) else None
-    blockers.extend(_evidence_blockers(target, action))
+    blockers.extend(_status_plan_mod._evidence_blockers(target, action))
     current = _current_action_for_approval(target, approval)
     if current is None:
         blockers.append("selected action is no longer available")
@@ -413,9 +426,7 @@ def record_redeemed_action_completed(
         daily_run_id = run_receipt.get("run_id")
         completed_at = run_receipt.get("completed_at")
         action_id = approval.get("selected_action_id")
-        selected_action = (
-            run_receipt.get("selected_action") if isinstance(run_receipt.get("selected_action"), Mapping) else {}
-        )
+        selected_action = raw_action if isinstance((raw_action := run_receipt.get("selected_action")), Mapping) else {}
         if (
             run_receipt.get("status") != "completed"
             or run_receipt.get("approval_id") != approval_id
@@ -454,7 +465,7 @@ def _redeemed_reconciliation_blockers(
     selected_action = approval.get("selected_action")
     if not isinstance(selected_action, dict) or not selected_action:
         blockers.append("daily approval selected action is malformed")
-    elif approval.get("selected_adapter") != _adapter_for(selected_action):
+    elif approval.get("selected_adapter") != _candidates_mod._adapter_for(selected_action):
         blockers.append("daily approval adapter changed since approval")
     return blockers
 
@@ -493,8 +504,8 @@ def _validate_redeemed_for_run_unlocked(
     if not isinstance(action_receipt, Mapping) or action_receipt.get("state") != "completed":
         raise ApprovalClaimError("daily approval has no completed action receipt to reconcile")
     if action_receipt.get("owner_run_id") != run_id:
-        owner = action_receipt.get("owner_run_id")
-        owner_text = owner if isinstance(owner, str) and owner else "another run"
+        raw_owner = action_receipt.get("owner_run_id")
+        owner_text = str(raw_owner) if raw_owner else "another run"
         raise ApprovalClaimError(f"daily approval completed action receipt belongs to {owner_text}")
     daily_run_id = action_receipt.get("daily_run_id")
     completed_at = action_receipt.get("completed_at")
@@ -508,14 +519,13 @@ def _validate_redeemed_for_run_unlocked(
     ):
         raise ApprovalClaimError("daily approval completed action receipt is malformed")
     run_receipt = _read_json(_runs_root(target) / daily_run_id / "run.json")
+    if not isinstance(run_receipt, Mapping):
+        raise ApprovalClaimError("daily approval completed action receipt no longer matches its run")
     selected_action = (
-        run_receipt.get("selected_action")
-        if isinstance(run_receipt, Mapping) and isinstance(run_receipt.get("selected_action"), Mapping)
-        else {}
+        raw_sel_action if isinstance((raw_sel_action := run_receipt.get("selected_action")), Mapping) else {}
     )
     if (
-        not isinstance(run_receipt, Mapping)
-        or run_receipt.get("status") != "completed"
+        run_receipt.get("status") != "completed"
         or run_receipt.get("run_id") != daily_run_id
         or run_receipt.get("approval_id") != approval_id
         or run_receipt.get("selected_action_id") != approval.get("selected_action_id")

--- a/src/brigade/daily_cmd/candidates.py
+++ b/src/brigade/daily_cmd/candidates.py
@@ -35,9 +35,14 @@ from .. import (
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
-from . import config as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .config import (
+    SCHEMA_VERSION,
+    _bounded_status_call,
+    _fingerprint,
+    _load_config,
+    _safe_text,
+)
+from . import status_plan as _status_plan_mod
 
 
 def _priority_score(priority: object) -> int:
@@ -146,13 +151,13 @@ def _pending_import_candidates(target: Path) -> list[dict[str, Any]]:
         acceptance = (
             [str(value) for value in item.get("acceptance", [])] if isinstance(item.get("acceptance"), list) else []
         )
-        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        metadata = raw_meta if isinstance((raw_meta := item.get("metadata")), dict) else {}
         has_provenance = bool(
             metadata.get("source_fingerprint") or metadata.get("scanner_run_id") or item.get("source")
         )
         noisy_source = dismissed_by_source[source] >= max(3, promoted_by_source[source] * 3)
         deferred = bool(metadata.get("deferred") or metadata.get("deferred_at") or item.get("deferred_at"))
-        stale = _is_stale(item.get("created_at"), 72)
+        stale = _status_plan_mod._is_stale(item.get("created_at"), 72)
         quality_item = quality_by_id.get(import_id, {})
         quality_score = int(quality_item.get("quality_score") or 0) if isinstance(quality_item, dict) else 0
         score = 220 + _priority_score(item.get("priority")) + quality_score
@@ -268,7 +273,7 @@ def _daily_readiness_finding(
 def _daily_readiness_payload(target: Path) -> dict[str, Any]:
     from .. import release_cmd
 
-    status_data = _daily_center_status_payload(target)
+    status_data = _status_plan_mod._daily_center_status_payload(target)
     findings: list[dict[str, Any]] = []
     pending_tasks = int(status_data.get("pending_task_count") or 0)
     pending_imports = int(status_data.get("pending_import_count") or 0)
@@ -403,7 +408,7 @@ def _health_issue_candidates(target: Path) -> list[dict[str, Any]]:
     health_sources = [
         ("handoff", handoff_cmd.draft_queue_payload(target), "brigade handoff doctor", 150),
         ("memory-care", memory_cmd.health(target), "brigade memory care doctor", 140),
-        ("security", _daily_security_health(target), "brigade security doctor", 135),
+        ("security", _status_plan_mod._daily_security_health(target), "brigade security doctor", 135),
         ("tools", tools_cmd.health(target), "brigade tools doctor", 130),
     ]
     for subsystem, health, command, base_score in health_sources:
@@ -439,7 +444,7 @@ def _notification_candidates(target: Path) -> list[dict[str, Any]]:
     health = notifications_cmd.health(target)
     if int(health.get("issue_count") or 0) <= 0:
         return []
-    top = health.get("top_issue") if isinstance(health.get("top_issue"), dict) else {}
+    top = raw_top if isinstance((raw_top := health.get("top_issue")), dict) else {}
     command = str(health.get("suggested_next_command") or "brigade notifications setup plan")
     if command.startswith("agent-notify "):
         command = "brigade notifications setup plan"
@@ -571,12 +576,12 @@ def _phase_ledger_issues_captured_by_report(phase_health: dict[str, Any]) -> boo
     issue_count = int(phase_health.get("issue_count") or 0)
     if issue_count <= 0:
         return False
-    latest_report = phase_health.get("latest_report") if isinstance(phase_health.get("latest_report"), dict) else {}
-    latest_compare = (
-        phase_health.get("latest_report_compare") if isinstance(phase_health.get("latest_report_compare"), dict) else {}
-    )
+    latest_report = raw_rep if isinstance((raw_rep := phase_health.get("latest_report")), dict) else {}
+    latest_compare = raw_comp if isinstance((raw_comp := phase_health.get("latest_report_compare")), dict) else {}
     report_issue_count = latest_report.get("issue_count")
     compare_issue_count = latest_compare.get("issue_count")
+    if report_issue_count is None or compare_issue_count is None:
+        return False
     try:
         return int(report_issue_count) == issue_count and int(compare_issue_count) == 0
     except (TypeError, ValueError):
@@ -591,17 +596,17 @@ def _phase_session_candidates(target: Path) -> list[dict[str, Any]]:
         next_payload = phases_cmd._session_next_payload(target, session)
     except ValueError:
         return []
-    step = next_payload.get("next_step") if isinstance(next_payload.get("next_step"), dict) else {}
+    step = raw_step if isinstance((raw_step := next_payload.get("next_step")), dict) else {}
     step_type = str(step.get("step_type") or "session")
     if step_type == "session_reviewed":
         return []
     session_id = str(session.get("session_id") or "latest")
     candidates: list[dict[str, Any]] = []
-    checkpoint = next_payload.get("checkpoint") if isinstance(next_payload.get("checkpoint"), dict) else None
+    checkpoint = raw_cp if isinstance((raw_cp := next_payload.get("checkpoint")), dict) else None
     if checkpoint and int(checkpoint.get("issue_count") or 0) > 0:
-        latest = checkpoint.get("latest_checkpoint") if isinstance(checkpoint.get("latest_checkpoint"), dict) else {}
+        latest = raw_latest if isinstance((raw_latest := checkpoint.get("latest_checkpoint")), dict) else {}
         checkpoint_id = str(latest.get("checkpoint_id") or "latest")
-        top_issue = checkpoint.get("top_issue") if isinstance(checkpoint.get("top_issue"), dict) else {}
+        top_issue = raw_top if isinstance((raw_top := checkpoint.get("top_issue")), dict) else {}
         candidates.append(
             _candidate(
                 target=target,
@@ -799,8 +804,8 @@ def _candidate_blockers(target: Path, config: dict[str, Any], action: dict[str, 
     remote = _remote_mutation_reason(action.get("suggested_next_command"))
     if remote:
         safety.append(remote)
-    config_blockers = _config_blockers(config, action)
-    evidence_blockers = _evidence_blockers(target, action)
+    config_blockers = _status_plan_mod._config_blockers(config, action)
+    evidence_blockers = _status_plan_mod._evidence_blockers(target, action)
     quality: list[str] = []
     if not action.get("acceptance"):
         quality.append("missing acceptance criteria")

--- a/src/brigade/daily_cmd/closeout_ops.py
+++ b/src/brigade/daily_cmd/closeout_ops.py
@@ -35,9 +35,12 @@ from .. import (
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
-from . import config as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .config import (
+    RUN_STATUSES,
+    _load_config,
+    _safe_text,
+)
+from . import run_loop as _run_loop_mod
 
 
 def _changed_files_summary(target: Path) -> dict[str, Any]:
@@ -74,7 +77,7 @@ def _changed_files_summary(target: Path) -> dict[str, Any]:
 
 
 def _verification_expectation(config: dict[str, Any], run_receipt: dict[str, Any]) -> dict[str, Any]:
-    action = run_receipt.get("selected_action") if isinstance(run_receipt.get("selected_action"), dict) else {}
+    action = raw_action if isinstance((raw_action := run_receipt.get("selected_action")), dict) else {}
     action_type = str(action.get("action_type") or "")
     required = False
     if action_type == "run-task":
@@ -147,7 +150,7 @@ def closeout(
         print(f"error: invalid daily closeout status: {status}", file=sys.stderr)
         return 2
     target = target.expanduser().resolve()
-    receipt = _latest_run(target)
+    receipt = _run_loop_mod._latest_run(target)
     if receipt is None:
         print("error: no daily run receipt found", file=sys.stderr)
         return 1
@@ -157,7 +160,11 @@ def closeout(
     verification_blockers: list[str] = []
     if verification_expectation["required"] and not latest_verification:
         verification_blockers.append("verification receipt required by daily config")
-    elif verification_expectation["required"] and latest_verification.get("status") != "completed":
+    elif (
+        verification_expectation["required"]
+        and latest_verification is not None
+        and latest_verification.get("status") != "completed"
+    ):
         verification_blockers.append(f"latest verification did not complete: {latest_verification.get('run_id')}")
     receipt["closeout_status"] = status
     receipt["closeout_reason"] = reason
@@ -185,8 +192,8 @@ def closeout(
             print(f"error: handoff lint failed: {exc}", file=sys.stderr)
             return 1
         receipt["handoff_path"] = str(handoff_path)
-    _record_run(target, receipt)
-    _record_telemetry_event(
+    _run_loop_mod._record_run(target, receipt)
+    _run_loop_mod._record_telemetry_event(
         target,
         {
             "type": "daily-closeout",

--- a/src/brigade/daily_cmd/hardening.py
+++ b/src/brigade/daily_cmd/hardening.py
@@ -35,9 +35,26 @@ from .. import (
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
-from . import config as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .config import (
+    HARDENING_PHASE_TITLES,
+    HARDENING_WORKSTREAMS,
+    RUN_STATUSES,
+    SCHEMA_VERSION,
+    _approvals_root,
+    _config_path,
+    _fingerprint,
+    _hardening_closeouts_root,
+    _hardening_phases,
+    _load_config,
+    _plans_root,
+    _runs_root,
+    _slug,
+    _telemetry_root,
+)
+from . import approvals as _approvals_mod
+from . import run_loop as _run_loop_mod
+from . import status_plan as _status_plan_mod
+from . import telemetry_ops as _telemetry_ops_mod
 
 
 def hardening_plan_payload(target: Path) -> dict[str, Any]:
@@ -105,12 +122,14 @@ def _hardening_finding(
         "metadata": metadata or {},
     }
     payload["source_fingerprint"] = _fingerprint(payload)
-    payload["finding_id"] = f"daily-hardening-{_slug(workstream)}-{_slug(name)}-{payload['source_fingerprint'][:10]}"
+    payload["finding_id"] = (
+        f"daily-hardening-{_slug(workstream)}-{_slug(name)}-{str(payload['source_fingerprint'])[:10]}"
+    )
     return payload
 
 
 def _latest_hardening_closeout(target: Path) -> dict[str, Any] | None:
-    closeouts, _ = _iter_receipts(_hardening_closeouts_root(target), "closeout.json")
+    closeouts, _ = _run_loop_mod._iter_receipts(_hardening_closeouts_root(target), "closeout.json")
     return closeouts[0] if closeouts else None
 
 
@@ -173,11 +192,11 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
     findings: list[dict[str, Any]] = []
     config, config_checks = _load_config(target)
-    runs, run_errors = _iter_receipts(_runs_root(target), "run.json")
-    plans, plan_errors = _iter_receipts(_plans_root(target), "plan.json")
+    runs, run_errors = _run_loop_mod._iter_receipts(_runs_root(target), "run.json")
+    plans, plan_errors = _run_loop_mod._iter_receipts(_plans_root(target), "plan.json")
     latest_run = runs[0] if runs else None
-    daily_health = health(target)
-    telemetry_data = telemetry_payload(target)
+    daily_health = _telemetry_ops_mod.health(target)
+    telemetry_data = _telemetry_ops_mod.telemetry_payload(target)
     config_issues = [check for check in config_checks if check.get("status") != "ok"]
     if any(check.get("status") == "fail" for check in config_checks):
         findings.append(
@@ -264,16 +283,17 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
                 },
             )
         )
-    approvals = daily_health.get("approvals") if isinstance(daily_health.get("approvals"), dict) else {}
-    approval_items, approval_errors = _read_approvals(target)
+    approvals = raw_app if isinstance((raw_app := daily_health.get("approvals")), dict) else {}
+    approval_items, approval_errors = _approvals_mod._read_approvals(target)
     approval_counts = Counter(str(item.get("status") or "unknown") for item in approval_items)
     stale_approvals = [
         item
         for item in approval_items
         if item.get("status") in {"pending", "approved"}
         and (
-            _age_hours(item.get("created_at")) is not None
-            and (_age_hours(item.get("created_at")) or 0) > int(config.get("stale_run_threshold_hours") or 24)
+            _status_plan_mod._age_hours(item.get("created_at")) is not None
+            and (_status_plan_mod._age_hours(item.get("created_at")) or 0)
+            > int(config.get("stale_run_threshold_hours") or 24)
         )
     ]
     if (
@@ -312,7 +332,7 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
                 metadata={"checks": telemetry_data.get("checks"), "metrics": telemetry_data.get("metrics")},
             )
         )
-    protocol_data = protocol_payload(target)
+    protocol_data = _telemetry_ops_mod.protocol_payload(target)
     protocol_steps = {str(item.get("step")) for item in protocol_data.get("steps", []) if isinstance(item, dict)}
     required_protocol_steps = {"status", "plan", "review", "approval", "run", "closeout", "recover"}
     if not required_protocol_steps <= protocol_steps:
@@ -407,7 +427,7 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
         item
         for item in pending_imports
         if not (
-            (item.get("metadata") if isinstance(item.get("metadata"), dict) else {}).get("source_fingerprint")
+            (raw_meta if isinstance((raw_meta := item.get("metadata")), dict) else {}).get("source_fingerprint")
             or item.get("source")
         )
     ]
@@ -438,7 +458,7 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
     inbox_hygiene = work_cmd._inbox_hygiene_payload(target)
     inbox_quality = work_cmd._inbox_quality_payload(target)
     if int(inbox_hygiene.get("issue_count") or 0) > 0:
-        top = inbox_hygiene.get("top_issue") if isinstance(inbox_hygiene.get("top_issue"), dict) else {}
+        top = raw_top if isinstance((raw_top := inbox_hygiene.get("top_issue")), dict) else {}
         findings.append(
             _hardening_finding(
                 workstream="inbox-evidence-quality",
@@ -450,7 +470,7 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
                 evidence_refs=[str(work_cmd._imports_path(target))],
             )
         )
-    quality_counts = inbox_quality.get("issue_counts") if isinstance(inbox_quality.get("issue_counts"), dict) else {}
+    quality_counts = raw_qc if isinstance((raw_qc := inbox_quality.get("issue_counts")), dict) else {}
     noisy_or_deferred = (
         int(quality_counts.get("noisy_source") or 0)
         + int(quality_counts.get("deferred") or 0)
@@ -515,7 +535,7 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
     repo_health = repos_cmd.health(target)
     repo_daily_use = repos_cmd.daily_use_health(target)
     if int(repo_health.get("issue_count") or 0) > 0:
-        top = repo_health.get("top_issue") if isinstance(repo_health.get("top_issue"), dict) else {}
+        top = raw_repo_top if isinstance((raw_repo_top := repo_health.get("top_issue")), dict) else {}
         findings.append(
             _hardening_finding(
                 workstream="repo-fleet-daily-use",

--- a/src/brigade/daily_cmd/run_loop.py
+++ b/src/brigade/daily_cmd/run_loop.py
@@ -35,9 +35,17 @@ from .. import (
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
-from . import config as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .config import (
+    SCHEMA_VERSION,
+    _load_config,
+    _plans_root,
+    _runs_root,
+    _schema,
+    _telemetry_root,
+)
+from . import approvals as _approvals_mod
+from . import candidates as _candidates_mod
+from . import status_plan as _status_plan_mod
 
 
 def _latest_run(target: Path) -> dict[str, Any] | None:
@@ -137,9 +145,7 @@ def _invoke_context_build(target: Path, action: dict[str, Any]) -> tuple[str | N
                 if run.get("status") in {"failed", "blocked"}
             ][:5]
             excluded = (
-                context_payload.get("excluded_private_evidence")
-                if isinstance(context_payload.get("excluded_private_evidence"), list)
-                else []
+                raw_excl if isinstance((raw_excl := context_payload.get("excluded_private_evidence")), list) else []
             )
             for item in (
                 "raw scanner output",
@@ -171,11 +177,12 @@ def _blocked_run(
     receipt["completed_at"] = _now().isoformat()
     receipt["next_recommended_command"] = next_command
     receipt["blockers"].extend(blockers)
+    raw_adapter = receipt.get("adapter_result")
     adapter = (
-        receipt.get("adapter_result")
-        if isinstance(receipt.get("adapter_result"), dict)
-        else _adapter_result(
-            receipt.get("selected_action") if isinstance(receipt.get("selected_action"), dict) else None
+        raw_adapter
+        if isinstance(raw_adapter, dict)
+        else _candidates_mod._adapter_result(
+            raw_sel if isinstance((raw_sel := receipt.get("selected_action")), dict) else None
         )
     )
     adapter["status"] = "blocked"
@@ -220,8 +227,9 @@ def run(
     target = target.expanduser().resolve()
     config, _ = _load_config(target)
     approval: dict[str, Any] | None = None
+    plan_data: dict[str, Any]
     if approval_id:
-        approval = _find_approval(target, approval_id)
+        approval = _approvals_mod._find_approval(target, approval_id)
         if approval is not None and isinstance(approval.get("selected_action"), dict):
             plan_data = {
                 "plan_id": approval.get("source_plan_id"),
@@ -229,19 +237,20 @@ def run(
                 "path": None,
             }
         else:
-            plan_data = plan_payload(target, record=True)
+            plan_data = _status_plan_mod.plan_payload(target, record=True)
             plan_data["approval_load_error"] = f"approval not found: {approval_id}"
     elif plan_id and not replan:
-        plan_data = _resolve_plan(target, plan_id)
-        if plan_data is None:
-            plan_data = plan_payload(target, record=True)
+        if (resolved := _resolve_plan(target, plan_id)) is None:
+            plan_data = _status_plan_mod.plan_payload(target, record=True)
             plan_data["plan_load_error"] = f"plan not found: {plan_id}"
+        else:
+            plan_data = resolved
     else:
-        plan_data = plan_payload(target, record=True)
-    action = plan_data.get("selected_action") if isinstance(plan_data.get("selected_action"), dict) else None
+        plan_data = _status_plan_mod.plan_payload(target, record=True)
+    action = raw_action if isinstance((raw_action := plan_data.get("selected_action")), dict) else None
     run_id = f"{_now().strftime('%Y%m%d-%H%M%S')}-daily-run-{uuid4().hex[:6]}"
     started = _now().isoformat()
-    receipt = {
+    receipt: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "schema": _schema("daily-run"),
         "target": str(target),
@@ -256,7 +265,7 @@ def run(
         "receipts_created": [str(Path(str(plan_data.get("path") or "")) / "plan.json")]
         if plan_data.get("path")
         else [],
-        "adapter_result": _adapter_result(action, status="running" if action else "blocked"),
+        "adapter_result": _candidates_mod._adapter_result(action, status="running" if action else "blocked"),
         "work_session_id": None,
         "task_id": None,
         "context_pack_id": None,
@@ -278,7 +287,7 @@ def run(
     if (
         plan_id
         and not replan
-        and _is_stale(plan_data.get("created_at"), int(config.get("stale_plan_threshold_hours") or 12))
+        and _status_plan_mod._is_stale(plan_data.get("created_at"), int(config.get("stale_plan_threshold_hours") or 12))
     ):
         return _blocked_run(
             target=target,
@@ -296,29 +305,29 @@ def run(
             next_command="brigade daily plan",
         )
     approval_granted = approved or approval is not None
-    config_blockers = _config_blockers(config, action, approved=approval_granted)
+    config_blockers = _status_plan_mod._config_blockers(config, action, approved=approval_granted)
     if approval is not None:
-        approval_blockers = _approval_blockers(target, approval, config)
+        approval_blockers = _approvals_mod._approval_blockers(target, approval, config)
         if config_blockers or approval_blockers:
             return _blocked_run(
                 target=target, receipt=receipt, blockers=[*config_blockers, *approval_blockers], json_output=json_output
             )
-    evidence_blockers = _evidence_blockers(target, action)
+    evidence_blockers = _status_plan_mod._evidence_blockers(target, action)
     if config_blockers or evidence_blockers:
         return _blocked_run(
             target=target, receipt=receipt, blockers=[*config_blockers, *evidence_blockers], json_output=json_output
         )
     if action.get("approval_required") and not approval_granted:
-        approval = _ensure_approval(target, plan_data, action, config)
+        approval = _approvals_mod._ensure_approval(target, plan_data, action, config)
         from .. import runs_cmd
 
         approval_id = str(approval.get("approval_id") or "")
-        with _approval_store_lock(target, approval_id):
-            current_approval = _find_approval(target, approval_id)
+        with _approvals_mod._approval_store_lock(target, approval_id):
+            current_approval = _approvals_mod._find_approval(target, approval_id)
             if current_approval is None:
-                raise ApprovalClaimError(f"daily approval not found: {approval_id}")
+                raise _approvals_mod.ApprovalClaimError(f"daily approval not found: {approval_id}")
             if runs_cmd._attach_approval_pause_request(target, "daily", current_approval):
-                _write_approval_unlocked(target, current_approval)
+                _approvals_mod._write_approval_unlocked(target, current_approval)
             approval = current_approval
         blockers = [str(action.get("approval_reason") or "explicit approval required")]
         if approval.get("status") not in {"pending", "approved"}:
@@ -339,7 +348,7 @@ def run(
             str(context_cmd._packs_root(target) / context_pack_id / "context.json")
         )
     if approval is not None:
-        _consume_approval(target, approval, run_id)
+        _approvals_mod._consume_approval(target, approval, run_id)
     rc = 0
     action_type = str(action.get("action_type"))
     if action_type == "run-task":
@@ -462,10 +471,10 @@ def run(
     receipt["next_recommended_command"] = "brigade daily closeout"
     _record_run(target, receipt)
     if rc == 0 and approval is not None:
-        record_redeemed_action_completed(
+        _approvals_mod.record_redeemed_action_completed(
             target,
             str(approval.get("approval_id") or ""),
-            _approval_claim_reference(approval),
+            _approvals_mod._approval_claim_reference(approval),
             receipt,
         )
     _record_telemetry_event(

--- a/src/brigade/daily_cmd/status_plan.py
+++ b/src/brigade/daily_cmd/status_plan.py
@@ -36,9 +36,18 @@ from .. import (
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
-from . import config as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .config import (
+    RISK_LEVELS,
+    SCHEMA_VERSION,
+    _bounded_status_call,
+    _config_path,
+    _load_config,
+    _plans_root,
+    _schema,
+)
+from . import approvals as _approvals_mod
+from . import candidates as _candidates_mod
+from . import telemetry_ops as _telemetry_ops_mod
 
 
 def _config_blockers(config: dict[str, Any], action: dict[str, Any] | None, *, approved: bool = False) -> list[str]:
@@ -68,7 +77,7 @@ def _evidence_blockers(target: Path, action: dict[str, Any] | None) -> list[str]
         return ["no selected action"]
     action_type = str(action.get("action_type"))
     source_id = str(action.get("source_local_id") or "")
-    metadata = action.get("metadata") if isinstance(action.get("metadata"), dict) else {}
+    metadata = raw_meta if isinstance((raw_meta := action.get("metadata")), dict) else {}
     if action_type == "run-task":
         task_id = str(metadata.get("task_id") or source_id)
         if not any(str(task.get("id")) == task_id for task in work_cmd._pending_tasks(target)):
@@ -256,7 +265,7 @@ def status_payload(target: Path) -> dict[str, Any]:
     center, check = _bounded_status_call("center-status", lambda: _daily_center_status_payload(target), {})
     status_section_checks.append(check)
     readiness, check = _bounded_status_call(
-        "center-readiness", lambda: _daily_readiness_payload(target), {"blockers": []}
+        "center-readiness", lambda: _candidates_mod._daily_readiness_payload(target), {"blockers": []}
     )
     status_section_checks.append(check)
     config, config_checks = _load_config(target)
@@ -277,12 +286,12 @@ def status_payload(target: Path) -> dict[str, Any]:
         if isinstance(operator_report_health, dict) and key in operator_report_health
     }
     del operator_report_health
-    candidates = _all_candidates(
+    candidates = _candidates_mod._all_candidates(
         target,
         diagnostics=status_section_checks,
         operator_report_health=slim_report_health,
     )
-    selected = _selected(candidates)
+    selected = _candidates_mod._selected(candidates)
     del candidates
     handoffs = center.get("handoff_drafts") if isinstance(center.get("handoff_drafts"), dict) else {}
     memory = center.get("memory_care") if isinstance(center.get("memory_care"), dict) else {}
@@ -304,7 +313,9 @@ def status_payload(target: Path) -> dict[str, Any]:
         "issue_count": 0,
         "top_issue": None,
     }
-    daily_health, check = _bounded_status_call("daily-health", lambda: health(target), daily_health_fallback)
+    daily_health, check = _bounded_status_call(
+        "daily-health", lambda: _telemetry_ops_mod.health(target), daily_health_fallback
+    )
     status_section_checks.append(check)
     phase_health, check = _bounded_status_call("phase-health", lambda: phases_cmd.health(target), {})
     status_section_checks.append(check)
@@ -400,12 +411,16 @@ def status(*, target: Path, json_output: bool = False) -> int:
 def plan_payload(target: Path, *, record: bool = False) -> dict[str, Any]:
     target = target.expanduser().resolve()
     config, config_checks = _load_config(target)
-    candidates = _all_candidates(target)
-    selected = _selected(candidates)
+    candidates = _candidates_mod._all_candidates(target)
+    selected = _candidates_mod._selected(candidates)
     selected_id = selected.get("action_id") if selected else None
-    candidate_explanations = [_candidate_explanation(target, config, action, selected_id) for action in candidates]
+    candidate_explanations = [
+        _candidates_mod._candidate_explanation(target, config, action, selected_id) for action in candidates
+    ]
     selection_blockers = (
-        _candidate_blockers(target, config, selected) if selected else _candidate_blockers(target, config, None)
+        _candidates_mod._candidate_blockers(target, config, selected)
+        if selected
+        else _candidates_mod._candidate_blockers(target, config, None)
     )
     created = _now().isoformat()
     plan_id = f"{_now().strftime('%Y%m%d-%H%M%S')}-daily-plan-{uuid4().hex[:6]}"
@@ -478,9 +493,11 @@ def plan(*, target: Path, record: bool = False, json_output: bool = False) -> in
 def _review_payload(target: Path, selected: dict[str, Any] | None = None) -> dict[str, Any]:
     target = target.expanduser().resolve()
     config, config_checks = _load_config(target)
-    action = selected or _selected(_all_candidates(target))
+    action = selected or _candidates_mod._selected(_candidates_mod._all_candidates(target))
     explain = (
-        _candidate_explanation(target, config, action, action.get("action_id") if action else None) if action else None
+        _candidates_mod._candidate_explanation(target, config, action, action.get("action_id") if action else None)
+        if action
+        else None
     )
     context_plan = None
     context_would_build = bool(action and action.get("context_kind") and config.get("allow_context_pack_build", True))
@@ -489,7 +506,7 @@ def _review_payload(target: Path, selected: dict[str, Any] | None = None) -> dic
         approval_request = next(
             (
                 approval
-                for approval in _matching_approvals(target, action, config)
+                for approval in _approvals_mod._matching_approvals(target, action, config)
                 if approval.get("status") in {"pending", "approved"}
             ),
             None,
@@ -507,7 +524,7 @@ def _review_payload(target: Path, selected: dict[str, Any] | None = None) -> dic
         "config": config,
         "config_checks": config_checks,
         "selected_action": action,
-        "selected_adapter": _adapter_for(action),
+        "selected_adapter": _candidates_mod._adapter_for(action),
         "source_subsystem": action.get("source_subsystem") if action else None,
         "source_local_id": action.get("source_local_id") if action else None,
         "safe_summary": action.get("safe_summary") if action else None,

--- a/src/brigade/daily_cmd/telemetry_ops.py
+++ b/src/brigade/daily_cmd/telemetry_ops.py
@@ -35,14 +35,31 @@ from .. import (
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
-from . import config as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .config import (
+    DEFAULT_CONFIG,
+    SCHEMA_VERSION,
+    _approvals_archive_root,
+    _approvals_root,
+    _config_path,
+    _fingerprint,
+    _load_config,
+    _plans_root,
+    _repairs_root,
+    _runs_root,
+    _schemas,
+    _telemetry_root,
+    _unblocks_root,
+    _write_config,
+)
+from . import approvals as _approvals_mod
+from . import candidates as _candidates_mod
+from . import run_loop as _run_loop_mod
+from . import status_plan as _status_plan_mod
 
 
 def approvals_payload(target: Path, *, limit: int = 50) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    approvals, errors = _read_approvals(target)
+    approvals, errors = _approvals_mod._read_approvals(target)
     return {
         "schema_version": SCHEMA_VERSION,
         "schema": {"name": "daily-approvals", "version": SCHEMA_VERSION},
@@ -65,7 +82,7 @@ def approvals_list(*, target: Path, limit: int = 50, json_output: bool = False) 
 
 def approvals_show(*, target: Path, approval_id: str, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    approval = _find_approval(target, approval_id)
+    approval = _approvals_mod._find_approval(target, approval_id)
     if approval is None:
         print(f"error: approval not found: {approval_id}", file=sys.stderr)
         return 1
@@ -87,8 +104,8 @@ def _review_approval(
         print(f"error: invalid approval status: {status}", file=sys.stderr)
         return 2
     target = target.expanduser().resolve()
-    with _approval_store_lock(target, approval_id):
-        approval = _find_approval(target, approval_id)
+    with _approvals_mod._approval_store_lock(target, approval_id):
+        approval = _approvals_mod._find_approval(target, approval_id)
         if approval is None:
             print(f"error: approval not found: {approval_id}", file=sys.stderr)
             return 1
@@ -98,7 +115,7 @@ def _review_approval(
         approval["status"] = status
         approval["reviewed_at"] = _now().isoformat()
         approval["review_reason"] = reason
-        _write_approval_unlocked(target, approval)
+        _approvals_mod._write_approval_unlocked(target, approval)
     if json_output:
         print(json.dumps(approval, indent=2, sort_keys=True))
     else:
@@ -122,23 +139,23 @@ def approvals_hold(*, target: Path, approval_id: str, reason: str, json_output: 
 def approvals_compare_payload(target: Path, approval_id: str) -> dict[str, Any]:
     target = target.expanduser().resolve()
     config, _ = _load_config(target)
-    approval = _find_approval(target, approval_id)
+    approval = _approvals_mod._find_approval(target, approval_id)
     issues: list[dict[str, Any]] = []
     current = None
     if approval is None:
         issues.append({"status": "fail", "name": "approval_missing", "detail": approval_id})
     else:
-        current = _current_action_for_approval(target, approval)
-        if approval.get("config_fingerprint") != _config_fingerprint(config):
+        current = _approvals_mod._current_action_for_approval(target, approval)
+        if approval.get("config_fingerprint") != _approvals_mod._config_fingerprint(config):
             issues.append({"status": "warn", "name": "approval_config_changed", "detail": approval_id})
         if current is None:
             issues.append({"status": "warn", "name": "approval_missing_source_evidence", "detail": approval_id})
         elif current.get("source_fingerprint") != approval.get("source_fingerprint"):
             issues.append({"status": "warn", "name": "approval_source_fingerprint_changed", "detail": approval_id})
-        if current is not None and _adapter_for(current) != approval.get("selected_adapter"):
+        if current is not None and _candidates_mod._adapter_for(current) != approval.get("selected_adapter"):
             issues.append({"status": "warn", "name": "approval_adapter_changed", "detail": approval_id})
         selected_action = approval.get("selected_action") if isinstance(approval.get("selected_action"), dict) else {}
-        matches = _matching_approvals(target, selected_action, config) if selected_action else []
+        matches = _approvals_mod._matching_approvals(target, selected_action, config) if selected_action else []
         newer = [
             item
             for item in matches
@@ -178,15 +195,15 @@ def approvals_compare(*, target: Path, approval_id: str, json_output: bool = Fal
 
 def approvals_archive(*, target: Path, consumed: bool = False, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    approvals, errors = _read_approvals(target)
+    approvals, errors = _approvals_mod._read_approvals(target)
     archiveable = {"consumed", "rejected", "superseded"} if consumed else set()
     archived: list[dict[str, Any]] = []
     for approval in approvals:
         if approval.get("status") not in archiveable:
             continue
         approval_id = str(approval.get("approval_id") or "")
-        with _approval_store_lock(target, approval_id):
-            current = _find_approval(target, approval_id)
+        with _approvals_mod._approval_store_lock(target, approval_id):
+            current = _approvals_mod._find_approval(target, approval_id)
             if current is None or current.get("status") not in archiveable:
                 continue
             source = _approvals_root(target) / approval_id
@@ -254,8 +271,8 @@ def schema(*, target: Path, json_output: bool = False) -> int:
 
 def history_payload(target: Path, *, limit: int = 20) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    runs, run_errors = _iter_receipts(_runs_root(target), "run.json")
-    plans, plan_errors = _iter_receipts(_plans_root(target), "plan.json")
+    runs, run_errors = _run_loop_mod._iter_receipts(_runs_root(target), "run.json")
+    plans, plan_errors = _run_loop_mod._iter_receipts(_plans_root(target), "plan.json")
     return {
         "schema_version": SCHEMA_VERSION,
         "schema": {"name": "daily-history", "version": SCHEMA_VERSION},
@@ -282,7 +299,7 @@ def history(*, target: Path, limit: int = 20, json_output: bool = False) -> int:
 def show(*, target: Path, run_id: str = "latest", json_output: bool = False) -> int:
     target = target.expanduser().resolve()
     if run_id == "latest":
-        payload = _latest_run(target)
+        payload = _run_loop_mod._latest_run(target)
     else:
         payload = _read_json(_runs_root(target) / run_id / "run.json")
     if payload is None:
@@ -302,9 +319,9 @@ def health(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
     config, config_checks = _load_config(target)
     checks = list(config_checks)
-    runs, run_errors = _iter_receipts(_runs_root(target), "run.json")
-    plans, plan_errors = _iter_receipts(_plans_root(target), "plan.json")
-    approvals, approval_errors = _read_approvals(target)
+    runs, run_errors = _run_loop_mod._iter_receipts(_runs_root(target), "run.json")
+    plans, plan_errors = _run_loop_mod._iter_receipts(_plans_root(target), "plan.json")
+    approvals, approval_errors = _approvals_mod._read_approvals(target)
     telemetry_events, telemetry_errors = _telemetry_events(target)
     phase_health = phases_cmd.health(target)
     latest_phase_session = phases_cmd._latest_session(target)
@@ -322,22 +339,24 @@ def health(target: Path) -> dict[str, Any]:
     run_hours = int(config.get("stale_run_threshold_hours") or 12)
     latest_plan = plans[0] if plans else None
     latest_run = runs[0] if runs else None
-    if latest_plan and _is_stale(latest_plan.get("created_at"), plan_hours):
+    if latest_plan and _status_plan_mod._is_stale(latest_plan.get("created_at"), plan_hours):
         checks.append({"status": "warn", "name": "daily_stale_plan", "detail": str(latest_plan.get("plan_id"))})
     if latest_run:
-        if latest_run.get("status") in {"running", "planned"} and _is_stale(latest_run.get("started_at"), run_hours):
+        if latest_run.get("status") in {"running", "planned"} and _status_plan_mod._is_stale(
+            latest_run.get("started_at"), run_hours
+        ):
             checks.append({"status": "warn", "name": "daily_stale_run", "detail": str(latest_run.get("run_id"))})
         if latest_run.get("status") == "blocked":
             checks.append({"status": "warn", "name": "daily_blocked_run", "detail": str(latest_run.get("run_id"))})
         if (
             latest_run.get("status") in {"completed", "failed", "blocked"}
             and not latest_run.get("closeout_status")
-            and _is_stale(latest_run.get("completed_at") or latest_run.get("started_at"), run_hours)
+            and _status_plan_mod._is_stale(latest_run.get("completed_at") or latest_run.get("started_at"), run_hours)
         ):
             checks.append({"status": "warn", "name": "daily_unclosed_run", "detail": str(latest_run.get("run_id"))})
     for run_receipt in runs[:10]:
         action = run_receipt.get("selected_action") if isinstance(run_receipt.get("selected_action"), dict) else None
-        for blocker in _evidence_blockers(target, action):
+        for blocker in _status_plan_mod._evidence_blockers(target, action):
             checks.append({"status": "warn", "name": "daily_missing_evidence", "detail": blocker})
             break
     pending_approvals = [approval for approval in approvals if approval.get("status") == "pending"]
@@ -346,7 +365,7 @@ def health(target: Path) -> dict[str, Any]:
     rejected_approvals = [approval for approval in approvals if approval.get("status") == "rejected"]
     top_pending = pending_approvals[0] if pending_approvals else None
     for approval in pending_approvals:
-        if _is_stale(approval.get("created_at"), run_hours):
+        if _status_plan_mod._is_stale(approval.get("created_at"), run_hours):
             checks.append(
                 {"status": "warn", "name": "daily_stale_pending_approval", "detail": str(approval.get("approval_id"))}
             )
@@ -371,8 +390,8 @@ def health(target: Path) -> dict[str, Any]:
                 "detail": str(rejected_approvals[0].get("approval_id")),
             }
         )
-    if phase_health.get("issue_count") and not _phase_ledger_issues_captured_by_report(phase_health):
-        top_phase_issue = phase_health.get("top_issue") if isinstance(phase_health.get("top_issue"), dict) else {}
+    if phase_health.get("issue_count") and not _candidates_mod._phase_ledger_issues_captured_by_report(phase_health):
+        top_phase_issue = raw_top if isinstance((raw_top := phase_health.get("top_issue")), dict) else {}
         checks.append(
             {
                 "status": "warn",
@@ -385,7 +404,7 @@ def health(target: Path) -> dict[str, Any]:
             {"status": "warn", "name": "phase_session_active", "detail": str(latest_phase_session.get("session_id"))}
         )
     for approval in approvals:
-        current = _current_action_for_approval(target, approval)
+        current = _approvals_mod._current_action_for_approval(target, approval)
         if current is None and approval.get("status") in {"pending", "approved"}:
             checks.append(
                 {
@@ -439,19 +458,28 @@ def health(target: Path) -> dict[str, Any]:
 
 def doctor(*, target: Path, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    payload = {
+    h = health(target)
+    payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "schema": {"name": "daily-doctor", "version": SCHEMA_VERSION},
         "target": str(target),
-        "health": health(target),
+        "health": h,
     }
-    payload["checks"] = payload["health"]["checks"]
-    payload["issue_count"] = payload["health"]["issue_count"]
-    payload["top_issue"] = payload["health"]["top_issue"]
+    checks = raw_checks if isinstance((raw_checks := h.get("checks")), list) else []
+    payload["checks"] = checks
+    payload["issue_count"] = h.get("issue_count")
+    payload["top_issue"] = h.get("top_issue")
     lines: list[str] = [f"daily doctor: {target}"]
-    lines.extend(f"[{check.get('status')}] {check.get('name')}: {check.get('detail')}" for check in payload["checks"])
+    lines.extend(
+        f"[{check.get('status')}] {check.get('name')}: {check.get('detail')}"
+        for check in checks
+        if isinstance(check, dict)
+    )
     return emit(
-        payload, json_output, lines, 1 if any(check.get("status") == "fail" for check in payload["checks"]) else 0
+        payload,
+        json_output,
+        lines,
+        1 if any(isinstance(check, dict) and check.get("status") == "fail" for check in checks) else 0,
     )
 
 
@@ -554,7 +582,7 @@ def repair(*, target: Path, json_output: bool = False) -> int:
 
 def unblock_payload(target: Path, *, dry_run: bool = False) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    latest = _latest_run(target)
+    latest = _run_loop_mod._latest_run(target)
     config, _ = _load_config(target)
     created_imports: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
@@ -567,7 +595,7 @@ def unblock_payload(target: Path, *, dry_run: bool = False) -> dict[str, Any]:
     )
     if action and action.get("approval_required"):
         plan_data = {"plan_id": latest.get("plan_id") if isinstance(latest, dict) else None}
-        approval_request = _ensure_approval(target, plan_data, action, config)
+        approval_request = _approvals_mod._ensure_approval(target, plan_data, action, config)
     elif latest:
         records = [
             {
@@ -623,8 +651,8 @@ def unblock(*, target: Path, dry_run: bool = False, json_output: bool = False) -
 
 def resume(*, target: Path, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    latest = _latest_run(target)
-    payload = {
+    latest = _run_loop_mod._latest_run(target)
+    payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "schema": {"name": "daily-resume", "version": SCHEMA_VERSION},
         "target": str(target),
@@ -638,7 +666,7 @@ def resume(*, target: Path, json_output: bool = False) -> int:
         payload["blockers"].append("no daily run to resume")
     else:
         approval_id = latest.get("approval_id")
-        approval = _find_approval(target, str(approval_id)) if approval_id else None
+        approval = _approvals_mod._find_approval(target, str(approval_id)) if approval_id else None
         if isinstance(approval, dict) and approval.get("status") == "approved":
             payload["action_taken"] = "run-approved-approval"
             payload["next_recommended_command"] = f"brigade daily run --approval {approval_id}"
@@ -669,31 +697,31 @@ def resume(*, target: Path, json_output: bool = False) -> int:
 
 
 def _telemetry_events(target: Path) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
-    return _iter_receipts(_telemetry_root(target) / "events", "event.json")
+    return _run_loop_mod._iter_receipts(_telemetry_root(target) / "events", "event.json")
 
 
 def telemetry_payload(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
     events, errors = _telemetry_events(target)
-    runs, _ = _iter_receipts(_runs_root(target), "run.json")
-    approvals, _ = _read_approvals(target)
+    runs, _ = _run_loop_mod._iter_receipts(_runs_root(target), "run.json")
+    approvals, _ = _approvals_mod._read_approvals(target)
     statuses = Counter(str(run.get("status") or "unknown") for run in runs)
     action_types = Counter(
         str((run.get("selected_action") or {}).get("action_type") or "unknown")
         for run in runs
         if isinstance(run.get("selected_action"), dict)
     )
-    blocker_counts = Counter()
+    blocker_counts: Counter[str] = Counter()
     for run in runs:
         for blocker in run.get("blockers", []) if isinstance(run.get("blockers"), list) else []:
             blocker_counts[str(blocker)] += 1
     closed_ages: list[float] = []
     for run in runs:
-        completed = _parse_time(run.get("completed_at"))
-        reviewed = _parse_time(run.get("reviewed_at"))
+        completed = _status_plan_mod._parse_time(run.get("completed_at"))
+        reviewed = _status_plan_mod._parse_time(run.get("reviewed_at"))
         if completed and reviewed:
             closed_ages.append((reviewed - completed).total_seconds() / 3600)
-    metrics = {
+    metrics: dict[str, Any] = {
         "event_count": len(events),
         "run_count": len(runs),
         "selected_action_types": dict(action_types),

--- a/tests/fixtures/mypy_override_baseline.txt
+++ b/tests/fixtures/mypy_override_baseline.txt
@@ -1,6 +1,4 @@
 brigade.cli.run
-brigade.daily_cmd
-brigade.daily_cmd.*
 brigade.doctor
 brigade.handoff_cmd
 brigade.handoff_cmd.*


### PR DESCRIPTION
## What

Family 6 of 7 for #1228 phase 2. Every `daily_cmd` submodule that copied `config`'s globals at import time (`globals().update(vars(_family_base))`) now imports what it uses explicitly; siblings that import each other use `_<module>_mod` aliases so partially initialized modules resolve at call time and no alias can shadow a same-named function through the facade's `_sync_module_globals()`. The facade `__init__.py` is unchanged.

`brigade.daily_cmd` and `brigade.daily_cmd.*` leave the mypy override and `tests/fixtures/mypy_override_baseline.txt`; the errors that surface are fixed with bind-once narrowing, no `type: ignore` added.

## Verify

mypy exit 0, ruff check and format clean, size-ratchet baseline ok; daily-driver, facade, and ratchet suites: 141 passed, 1 skipped (receipt `20260827-143949-work-verify-65b50b`; daily-driver, care (two host-specific crontab syntax tests deselected, see #1212), center readiness, phase-257 facades, override and size ratchets).

Workers: agy_flash (Gemini 3.7 Flash via Antigravity) for the conversion and `_mod` aliases; cursor_grok for the 150-error narrowing pass in run_loop.py and telemetry_ops.py.

Refs #1228
