### PR TITLE
types(security_cmd): replace the namespace copy with explicit imports (#1228 phase 2, 7/7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,6 @@ module = [
     "brigade.phases_cmd.constants",
     "brigade.phases_cmd.session_lifecycle",
     "brigade.phases_cmd.session_ops",
-    "brigade.security_cmd",
-    "brigade.security_cmd.*",
     "brigade.work_cmd.backup",
     "brigade.work_cmd.imports",
     "brigade.work_cmd.reviews",

--- a/src/brigade/security_cmd/commands.py
+++ b/src/brigade/security_cmd/commands.py
@@ -23,9 +23,23 @@ from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import reports as _reports_mod
+from . import scan_engine as _scan_engine_mod
+from . import suppression as _suppression_mod
+from . import template_audit_ops as _template_audit_ops_mod
+from .config import _effective_policy, load_config, write_config, write_default_config
+from .models import (
+    POLICIES,
+    SEVERITY_ORDER,
+    _closeouts_root,
+    _merge_fingerprint_migration_map,
+    _read_closeouts,
+    _read_fingerprint_migration_map,
+    _sanitize_finding_for_output,
+    config_path,
+    default_artifacts_dir,
+    inspect_evidence_bundle,
+)
 
 
 def show_config(*, target: Path, json_output: bool = False) -> int:
@@ -34,7 +48,7 @@ def show_config(*, target: Path, json_output: bool = False) -> int:
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     try:
-        payload = _config_payload(target)
+        payload = _scan_engine_mod._config_payload(target)
     except ValueError as exc:
         print(f"error: invalid security config: {exc}", file=sys.stderr)
         return 2
@@ -78,7 +92,7 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
         else set()
     )
     if accepted_fingerprints:
-        accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
+        accepted_fingerprints = _scan_engine_mod._expand_suppression_fingerprints(accepted_fingerprints, migration_map)
     config_ok = True
     try:
         loaded = load_config(target)
@@ -114,7 +128,7 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
         )
     else:
         checks.append({"status": "fail", "name": "security_evidence", "detail": str(bundle.get("reason"))})
-    template_audit_payload = template_privacy_payload(target)
+    template_audit_payload = _template_audit_ops_mod.template_privacy_payload(target)
     if template_audit_payload["finding_count"]:
         top_template = (
             template_audit_payload["top_finding"] if isinstance(template_audit_payload.get("top_finding"), dict) else {}
@@ -134,7 +148,7 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
                 "detail": f"{template_audit_payload['scanned_file_count']} public file(s) checked",
             }
         )
-    raw_harness_wiring = harness_wiring_payload(target)
+    raw_harness_wiring = _template_audit_ops_mod.harness_wiring_payload(target)
     raw_harness_findings = [item for item in raw_harness_wiring.get("findings", []) if isinstance(item, dict)]
     include_templates = (
         bool(
@@ -152,9 +166,9 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
         matched_harness_findings = [
             item
             for item in eligible_harness_findings
-            if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+            if _scan_engine_mod._finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
         ]
-        migrated_closeout = _migrate_closeout_fingerprints(latest_closeout, matched_harness_findings)
+        migrated_closeout = _scan_engine_mod._migrate_closeout_fingerprints(latest_closeout, matched_harness_findings)
         if migrated_closeout is not None:
             latest_closeout = migrated_closeout
             accepted_fingerprints = {
@@ -162,16 +176,18 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
                 for fingerprint in latest_closeout.get("source_fingerprints", [])
                 if isinstance(fingerprint, str) and fingerprint
             }
-            accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
+            accepted_fingerprints = _scan_engine_mod._expand_suppression_fingerprints(
+                accepted_fingerprints, migration_map
+            )
     active_harness_findings = [
         item
         for item in eligible_harness_findings
-        if not _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+        if not _scan_engine_mod._finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
     ]
     quieted_harness_findings = [
         item
         for item in eligible_harness_findings
-        if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+        if _scan_engine_mod._finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
     ]
     harness_wiring = {
         **raw_harness_wiring,
@@ -206,7 +222,7 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
     suppression_cache: dict[str, Any] | None = None
     try:
         if suppression_cache_only:
-            suppression_cache = suppression_health_cache(target)
+            suppression_cache = _suppression_mod.suppression_health_cache(target)
             if suppression_cache["status"] == "ok":
                 suppression = suppression_cache["health"]
             else:
@@ -220,7 +236,7 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
                 )
                 suppression = None
         else:
-            suppression = suppression_health(target)
+            suppression = _suppression_mod.suppression_health(target)
     except ValueError as exc:
         checks.append({"status": "fail", "name": "security_suppressions", "detail": str(exc)})
     else:
@@ -250,9 +266,11 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
     open_finding_count: int | None = None
     if bundle.get("ready"):
         try:
-            report = _load_report(default_artifacts_dir(target))
+            report = _reports_mod._load_report(default_artifacts_dir(target))
             raw_open_findings = [
-                item for item in _report_findings_for_review(target, report) if item.get("status") != "suppressed"
+                item
+                for item in _reports_mod._report_findings_for_review(target, report)
+                if item.get("status") != "suppressed"
             ]
         except (OSError, TypeError, ValueError, json.JSONDecodeError):
             checks.append(
@@ -267,10 +285,12 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
             quieted_findings = [
                 item
                 for item in raw_open_findings
-                if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+                if _scan_engine_mod._finding_matches_fingerprints(
+                    item, accepted_fingerprints, migration_map=migration_map
+                )
             ]
             if isinstance(latest_closeout, dict) and quieted_findings:
-                migrated_closeout = _migrate_closeout_fingerprints(latest_closeout, quieted_findings)
+                migrated_closeout = _scan_engine_mod._migrate_closeout_fingerprints(latest_closeout, quieted_findings)
                 if migrated_closeout is not None:
                     latest_closeout = migrated_closeout
                     accepted_fingerprints = {
@@ -278,11 +298,15 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
                         for fingerprint in latest_closeout.get("source_fingerprints", [])
                         if isinstance(fingerprint, str) and fingerprint
                     }
-                    accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
+                    accepted_fingerprints = _scan_engine_mod._expand_suppression_fingerprints(
+                        accepted_fingerprints, migration_map
+                    )
             records = [
                 item
                 for item in raw_open_findings
-                if not _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+                if not _scan_engine_mod._finding_matches_fingerprints(
+                    item, accepted_fingerprints, migration_map=migration_map
+                )
             ]
             open_finding_count = len(records)
             if records:
@@ -402,8 +426,8 @@ def closeout(
         return 2
     artifacts_dir = output_dir.expanduser().resolve() if output_dir is not None else default_artifacts_dir(target)
     try:
-        report = _load_report(artifacts_dir)
-        records = _report_findings_for_review(target, report)
+        report = _reports_mod._load_report(artifacts_dir)
+        records = _reports_mod._report_findings_for_review(target, report)
     except FileNotFoundError as exc:
         print(f"error: security report not found: {exc}", file=sys.stderr)
         return 2
@@ -461,7 +485,7 @@ def closeout(
         "findings": finding_records,
         "path": str(_closeouts_root(target) / closeout_id / "closeout.json"),
     }
-    _write_json(Path(payload["path"]), payload)
+    _write_json(Path(str(payload["path"])), payload)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -499,7 +523,7 @@ def scan(
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
-    report = scan_target(
+    report = _scan_engine_mod.scan_target(
         target,
         include_templates=effective.include_templates,
         suppressions=effective.suppressions,
@@ -512,7 +536,7 @@ def scan(
     if effective.config_loaded:
         loaded = load_config(target)
         if loaded is not None:
-            migrated_config, suppression_migrations = _migrate_legacy_suppressions(loaded, report)
+            migrated_config, suppression_migrations = _scan_engine_mod._migrate_legacy_suppressions(loaded, report)
             if suppression_migrations:
                 if _merge_fingerprint_migration_map(target, suppression_migrations):
                     write_config(target, migrated_config)
@@ -546,23 +570,23 @@ def scan(
         report["candidate_commit"] = candidate_commit.stdout.strip()
     if suppression_migrations:
         report["suppression_migrations"] = suppression_migrations
-    _write_suppression_health_cache_from_report(target, effective, report)
+    _suppression_mod._write_suppression_health_cache_from_report(target, effective, report)
     configured_output_dir = target / effective.output_path
     requested_output_dir = output_dir
     if requested_output_dir is None and (import_findings or effective.config_loaded):
         requested_output_dir = configured_output_dir
     if requested_output_dir is not None:
-        artifacts_dir = write_evidence_bundle(report, requested_output_dir)
+        artifacts_dir = _scan_engine_mod.write_evidence_bundle(report, requested_output_dir)
         report["artifacts"] = str(artifacts_dir)
     imported: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     if import_findings and report["findings"]:
         evidence_path = Path(report["artifacts"]) / "security-report.json" if report.get("artifacts") else None
-        imported, skipped = _import_findings(target, report["findings"], evidence_path=evidence_path)
+        imported, skipped = _scan_engine_mod._import_findings(target, report["findings"], evidence_path=evidence_path)
         report["imported_findings"] = len(imported)
         report["skipped_duplicate_imports"] = len(skipped)
         if requested_output_dir is not None:
-            artifacts_dir = write_evidence_bundle(report, requested_output_dir)
+            artifacts_dir = _scan_engine_mod.write_evidence_bundle(report, requested_output_dir)
             report["artifacts"] = str(artifacts_dir)
 
     if json_output:
@@ -597,7 +621,7 @@ def scan(
             for option in finding.get("response_options") or []:
                 print(f"  response_option: {option}")
 
-    return 1 if _should_fail(report["findings"], effective.fail_on) else 0
+    return 1 if _scan_engine_mod._should_fail(report["findings"], effective.fail_on) else 0
 
 
 def init(*, target: Path, force: bool = False) -> int:

--- a/src/brigade/security_cmd/config.py
+++ b/src/brigade/security_cmd/config.py
@@ -23,9 +23,27 @@ from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from .models import (
+    ARTIFACTS_REL_PATH,
+    AUTHORITY_STORE_ISOLATION_EXTERNAL_KEY,
+    AUTHORITY_STORE_ISOLATION_OFF,
+    AUTHORITY_STORE_ISOLATION_VALUES,
+    CONFIG_AUTHORITY_STORE_KEYS,
+    CONFIG_ENRICHMENT_KEYS,
+    CONFIG_SUPPRESSIONS_KEYS,
+    CONFIG_TOP_LEVEL_KEYS,
+    DEFAULT_EXCLUDE_PATHS,
+    ENRICHMENT_PROVIDERS,
+    EffectivePolicy,
+    POLICIES,
+    SCAN_PROFILES,
+    SECURITY_CHECKS,
+    SEVERITY_ORDER,
+    SecurityConfig,
+    SecurityEnrichmentConfig,
+    config_path,
+    default_artifacts_dir,
+)
 
 
 def _parse_toml_value(raw: str) -> object:
@@ -81,9 +99,10 @@ def _read_toml_object(path: Path) -> _SecurityToml:
             if table not in {"suppressions", "suppression_reasons", "enrichment", "authority_store"}:
                 raise ValueError(f"invalid security config line {line_number}: unsupported table [{table}]")
             current_section = table
-            current = data.setdefault(table, {})
-            if not isinstance(current, dict):
+            section_data = data.setdefault(table, {})
+            if not isinstance(section_data, dict):
                 raise ValueError(f"invalid security config line {line_number}: {table} must be a table")
+            current = section_data
             continue
         if "=" not in line:
             raise ValueError(f"invalid security config line {line_number}: expected key = value")
@@ -476,10 +495,11 @@ def write_config(target: Path, config: SecurityConfig) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     fingerprints = ", ".join(_toml_string(item) for item in config.suppressions)
     enrichment = config.enrichment
+    fail_on_value = config.fail_on if config.fail_on is not None else str(POLICIES[config.policy]["fail_on"])
     lines = [
         f"policy = {_toml_string(config.policy)}",
         f"scan_profile = {_toml_string(config.scan_profile)}",
-        f"fail_on = {_toml_string(config.fail_on or POLICIES[config.policy]['fail_on'])}",
+        f"fail_on = {_toml_string(fail_on_value)}",
         f"include_templates = {str(config.include_templates if config.include_templates is not None else POLICIES[config.policy]['include_templates']).lower()}",
         f"enabled_checks = [{', '.join(_toml_string(item) for item in config.enabled_checks)}]",
         f"include_paths = [{', '.join(_toml_string(item) for item in config.include_paths)}]",
@@ -528,10 +548,10 @@ def _clean_reason(reason: str) -> str:
 
 
 def _gitignore_selection(target: Path):
-    from .config import load_config
+    from ..config import load_config as _load_workspace_config
     from ..selection import Selection
 
-    loaded = load_config(target)
+    loaded = _load_workspace_config(target)
     if loaded is not None:
         return loaded.selection
     return Selection(depth="repo", harnesses=[], owner="this-repo", includes=[])

--- a/src/brigade/security_cmd/enrichment.py
+++ b/src/brigade/security_cmd/enrichment.py
@@ -22,9 +22,18 @@ from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import reports as _reports_mod
+from .config import load_config
+from .models import (
+    ENRICHMENT_MARKDOWN_END,
+    ENRICHMENT_MARKDOWN_START,
+    ENRICHMENT_PROVIDERS,
+    INDICATOR_GITHUB_ACTION_RE,
+    INDICATOR_NPX_RE,
+    INDICATOR_URL_RE,
+    SecurityEnrichmentConfig,
+    default_artifacts_dir,
+)
 
 
 def _load_enrichment_payload(output_dir: Path) -> dict[str, Any] | None:
@@ -380,7 +389,7 @@ def enrich(
             cache_path=config.cache_path,
         )
     try:
-        report = _load_report_file(report_file)
+        report = _reports_mod._load_report_file(report_file)
     except FileNotFoundError as exc:
         print(f"error: security report not found: {exc}", file=sys.stderr)
         return 2

--- a/src/brigade/security_cmd/reports.py
+++ b/src/brigade/security_cmd/reports.py
@@ -22,9 +22,17 @@ from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import enrichment as _enrichment_mod
+from . import scan_engine as _scan_engine_mod
+from .config import load_config
+from .models import (
+    FINGERPRINT_RE,
+    SEVERITY_ORDER,
+    SecurityConfig,
+    _read_fingerprint_migration_map,
+    _sanitize_finding_for_output,
+    default_artifacts_dir,
+)
 
 
 def _load_report(output_dir: Path) -> dict[str, Any]:
@@ -56,9 +64,11 @@ def _report_findings_for_review(target: Path, report: dict[str, Any]) -> list[di
             continue
         record = _sanitize_finding_for_output(finding)
         record["status"] = (
-            "suppressed" if _finding_matches_fingerprints(finding, suppressed, migration_map=migration_map) else "open"
+            "suppressed"
+            if _scan_engine_mod._finding_matches_fingerprints(finding, suppressed, migration_map=migration_map)
+            else "open"
         )
-        reason = _suppression_reason_for_finding(
+        reason = _scan_engine_mod._suppression_reason_for_finding(
             finding, suppressions=suppressed, reasons=reasons, migration_map=migration_map
         )
         if reason:
@@ -69,7 +79,7 @@ def _report_findings_for_review(target: Path, report: dict[str, Any]) -> list[di
             continue
         record = _sanitize_finding_for_output(finding)
         record["status"] = "suppressed"
-        reason = _suppression_reason_for_finding(
+        reason = _scan_engine_mod._suppression_reason_for_finding(
             finding, suppressions=suppressed, reasons=reasons, migration_map=migration_map
         )
         if reason:
@@ -111,7 +121,7 @@ def review(*, target: Path, output_dir: Path | None = None, json_output: bool = 
         "open_count": len([item for item in records if item.get("status") != "suppressed"]),
         "suppressed_count": len([item for item in records if item.get("status") == "suppressed"]),
     }
-    enrichment = _load_enrichment_payload(artifacts_dir)
+    enrichment = _enrichment_mod._load_enrichment_payload(artifacts_dir)
     if enrichment is not None:
         payload["enrichment"] = enrichment
     if json_output:
@@ -169,7 +179,7 @@ def _identifier_match_candidates(identifier: str, migration_map: dict[str, str] 
     if FINGERPRINT_RE.fullmatch(fingerprint):
         candidates.add(fingerprint)
     if migration_map and FINGERPRINT_RE.fullmatch(fingerprint):
-        aliases = _expand_suppression_fingerprints({fingerprint}, migration_map)
+        aliases = _scan_engine_mod._expand_suppression_fingerprints({fingerprint}, migration_map)
         candidates.update(aliases)
         candidates.update(f"security-{alias}" for alias in aliases)
     return candidates
@@ -190,7 +200,7 @@ def _diff_finding_alias_keys(
         if legacy:
             keys.add(legacy)
         if migration_map:
-            keys = _expand_suppression_fingerprints(keys, migration_map)
+            keys = _scan_engine_mod._expand_suppression_fingerprints(keys, migration_map)
     if keys:
         return keys
     return {_diff_finding_key(record)}
@@ -308,7 +318,7 @@ def sarif(
     except (ValueError, json.JSONDecodeError) as exc:
         print(f"error: invalid security report: {exc}", file=sys.stderr)
         return 2
-    payload = _sarif_report(report)
+    payload = _scan_engine_mod._sarif_report(report)
     destination = (
         output_path.expanduser().resolve() if output_path is not None else artifacts_dir / "security-report.sarif"
     )

--- a/src/brigade/security_cmd/scan_detectors.py
+++ b/src/brigade/security_cmd/scan_detectors.py
@@ -22,9 +22,32 @@ from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import scan_engine as _scan_engine_mod
+from . import template_audit_ops as _template_audit_ops_mod
+from .models import (
+    DESTRUCTIVE_RE,
+    ENV_DUMP_RE,
+    FileClassification,
+    GITHUB_ACTION_FLOATING_REFS,
+    HARNESS_ALLOWED_URL_RE,
+    HARNESS_COMMAND_KEYS,
+    HARNESS_PATH_KEYS,
+    HARNESS_ROOTS,
+    HARNESS_URL_KEYS,
+    MCP_BROAD_PATHS,
+    MCP_HIGH_RISK_COMMANDS,
+    MCP_SENSITIVE_ARG_RE,
+    MCP_SERVER_COUNT_WARN,
+    MCP_SHELL_META_RE,
+    PINNED_ACTION_RE,
+    PYTHON_URL_DEP_RE,
+    REMOTE_SHELL_RE,
+    TEMPLATE_PRIVATE_PATH_RE,
+    TEMPLATE_PRIVATE_URL_RE,
+    TOML_TABLE_RE,
+    UNPINNED_ACTION_RE,
+    UNPINNED_NPX_RE,
+)
 
 
 def _line_number_for(text: str, needle: str) -> int:
@@ -62,7 +85,7 @@ def _scan_mcp_document(
     if not isinstance(servers, dict):
         return
     if len(servers) > MCP_SERVER_COUNT_WARN:
-        _finding(
+        _scan_engine_mod._finding(
             findings,
             target=target,
             path=path,
@@ -83,7 +106,7 @@ def _scan_mcp_document(
         args = server.get("args", [])
         command_name = Path(command).name if isinstance(command, str) else None
         if command_name in MCP_HIGH_RISK_COMMANDS:
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -98,7 +121,7 @@ def _scan_mcp_document(
         if isinstance(command, str) and command == "npx" and isinstance(args, list):
             package = _first_npx_package(args)
             if package and "@" not in package:
-                _finding(
+                _scan_engine_mod._finding(
                     findings,
                     target=target,
                     path=path,
@@ -115,7 +138,7 @@ def _scan_mcp_document(
                 if not isinstance(arg, str):
                     continue
                 if MCP_SHELL_META_RE.search(arg):
-                    _finding(
+                    _scan_engine_mod._finding(
                         findings,
                         target=target,
                         path=path,
@@ -128,7 +151,7 @@ def _scan_mcp_document(
                         classification=classification,
                     )
                 if arg in MCP_BROAD_PATHS:
-                    _finding(
+                    _scan_engine_mod._finding(
                         findings,
                         target=target,
                         path=path,
@@ -141,7 +164,7 @@ def _scan_mcp_document(
                         classification=classification,
                     )
                 if MCP_SENSITIVE_ARG_RE.search(arg):
-                    _finding(
+                    _scan_engine_mod._finding(
                         findings,
                         target=target,
                         path=path,
@@ -158,8 +181,10 @@ def _scan_mcp_document(
             for key, value in env.items():
                 if not isinstance(key, str) or not isinstance(value, str):
                     continue
-                if re.search(r"(?i)(TOKEN|SECRET|PASSWORD|API_KEY)", key) and not _is_placeholder(value):
-                    _finding(
+                if re.search(
+                    r"(?i)(TOKEN|SECRET|PASSWORD|API_KEY)", key
+                ) and not _template_audit_ops_mod._is_placeholder(value):
+                    _scan_engine_mod._finding(
                         findings,
                         target=target,
                         path=path,
@@ -167,13 +192,13 @@ def _scan_mcp_document(
                         severity="high",
                         category="mcp",
                         title="MCP hardcoded environment secret",
-                        evidence=_redact_secret_evidence(f"{server_name}.env.{key}={value}"),
+                        evidence=_template_audit_ops_mod._redact_secret_evidence(f"{server_name}.env.{key}={value}"),
                         suggestion="Load MCP secrets from local environment or secret storage instead of checked-in config.",
                         classification=classification,
                     )
         url = server.get("url")
         if isinstance(url, str) and url.startswith(("http://", "https://")):
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -186,7 +211,7 @@ def _scan_mcp_document(
                 classification=classification,
             )
         if _server_timeout(server) is None:
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -295,7 +320,7 @@ def _scan_harness_string(
     key_path: tuple[str, ...],
     classification: FileClassification,
 ) -> None:
-    if _is_placeholder(value):
+    if _template_audit_ops_mod._is_placeholder(value):
         return
     key = _harness_semantic_key(key_path)
     if key in HARNESS_PATH_KEYS:
@@ -371,7 +396,7 @@ def _scan_harness_path_value(
     line_number = _harness_line_number(text, value, key_path)
     evidence = _harness_evidence(key_path, value)
     if value in {"~", "$HOME", "/", "/home", "/Users"}:
-        _finding(
+        _scan_engine_mod._finding(
             findings,
             target=target,
             path=path,
@@ -384,7 +409,7 @@ def _scan_harness_path_value(
             classification=classification,
         )
     if Path(value).is_absolute() or TEMPLATE_PRIVATE_PATH_RE.search(value):
-        _finding(
+        _scan_engine_mod._finding(
             findings,
             target=target,
             path=path,
@@ -397,7 +422,7 @@ def _scan_harness_path_value(
             classification=classification,
         )
     if ".." in parts:
-        _finding(
+        _scan_engine_mod._finding(
             findings,
             target=target,
             path=path,
@@ -422,7 +447,7 @@ def _scan_harness_command_value(
     classification: FileClassification,
 ) -> None:
     if REMOTE_SHELL_RE.search(value):
-        _finding(
+        _scan_engine_mod._finding(
             findings,
             target=target,
             path=path,
@@ -435,7 +460,7 @@ def _scan_harness_command_value(
             classification=classification,
         )
     elif MCP_SHELL_META_RE.search(value):
-        _finding(
+        _scan_engine_mod._finding(
             findings,
             target=target,
             path=path,
@@ -475,7 +500,7 @@ def _scan_harness_url_value(
     if TEMPLATE_PRIVATE_URL_RE.search(value):
         title = "Harness wiring contains private-looking URL"
         suggestion = "Replace private hostnames with placeholders before committing harness wiring."
-    _finding(
+    _scan_engine_mod._finding(
         findings,
         target=target,
         path=path,
@@ -528,7 +553,7 @@ def _scan_package_json(
         line_number = _line_number_for(text, f'"{name}"')
         evidence = f"scripts.{name}: {command}"
         if REMOTE_SHELL_RE.search(command):
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -541,7 +566,7 @@ def _scan_package_json(
                 classification=classification,
             )
         if DESTRUCTIVE_RE.search(command):
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -555,7 +580,7 @@ def _scan_package_json(
             )
         npx_match = UNPINNED_NPX_RE.search(command)
         if npx_match and "@" not in npx_match.group(1):
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -568,7 +593,7 @@ def _scan_package_json(
                 classification=classification,
             )
         if ENV_DUMP_RE.search(command):
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -591,7 +616,7 @@ def _scan_github_actions(
     for line_number, line in enumerate(text.splitlines(), start=1):
         stripped = line.strip()
         if stripped.startswith("pull_request_target:") or stripped == "- pull_request_target":
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -604,7 +629,7 @@ def _scan_github_actions(
                 classification=classification,
             )
         if stripped.startswith("permissions: write-all"):
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -618,7 +643,7 @@ def _scan_github_actions(
             )
         action_match = UNPINNED_ACTION_RE.search(stripped)
         if action_match:
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -636,7 +661,7 @@ def _scan_github_actions(
             if ref.lower() in GITHUB_ACTION_FLOATING_REFS or (
                 not ref.startswith("v") and not re.fullmatch(r"[a-fA-F0-9]{40}", ref)
             ):
-                _finding(
+                _scan_engine_mod._finding(
                     findings,
                     target=target,
                     path=path,
@@ -667,7 +692,7 @@ def _scan_python_project(
         if PYTHON_URL_DEP_RE.search(stripped) and _python_url_dependency_candidate(
             path.name, current_section, stripped
         ):
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,
@@ -680,7 +705,7 @@ def _scan_python_project(
                 classification=classification,
             )
         if "setup_requires" in stripped or "dependency_links" in stripped:
-            _finding(
+            _scan_engine_mod._finding(
                 findings,
                 target=target,
                 path=path,

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -21,9 +21,42 @@ from ..selection import WRITER_INBOXES
 from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import scan_detectors as _scan_detectors_mod
+from . import template_audit_ops as _template_audit_ops_mod
+from .config import load_config
+from .models import (
+    AUTO_APPROVE_RE,
+    DESTRUCTIVE_RE,
+    ENV_ASSIGNMENT_RE,
+    ENV_DUMP_RE,
+    FileClassification,
+    HTTP_MCP_RE,
+    PLAINTEXT_PASSWORD_RE,
+    POLICIES,
+    REMOTE_SHELL_RE,
+    SECRET_VALUE_RE,
+    SECURITY_CHECKS,
+    SESSION_CHAT_PARTS,
+    SEVERITY_ORDER,
+    SKIP_DIRS,
+    SKIP_PREFIXES,
+    SecurityConfig,
+    TEXT_SUFFIXES,
+    UNPINNED_NPX_RE,
+    _coalesce_findings,
+    _env_assignment_value,
+    _escape_finding_markdown,
+    _is_attribute_secret_value,
+    _is_runtime_secret_value,
+    _is_secret_path_assignment,
+    _is_security_scanner_literal,
+    _match_value_is_quoted,
+    _read_fingerprint_migration_map,
+    _sanitize_finding_for_output,
+    _should_skip_harness_wiring_path,
+    _strip_internal_finding_keys,
+    config_path,
+)
 
 
 def _rule_id(category: str, title: str) -> str:
@@ -227,7 +260,7 @@ def _secret_response_options(path: Path, target: Path) -> list[str]:
 
 
 def _normalized_matched_content(evidence: str) -> str:
-    return _short(evidence, limit=96)
+    return _template_audit_ops_mod._short(evidence, limit=96)
 
 
 def _fingerprint(
@@ -246,7 +279,7 @@ def _fingerprint(
 
 
 def _legacy_fingerprint(*, category: str, title: str, rel_path: str, line: int, evidence: str) -> str:
-    stable = "\n".join([category, title, rel_path, str(line), _short(evidence, limit=96)])
+    stable = "\n".join([category, title, rel_path, str(line), _template_audit_ops_mod._short(evidence, limit=96)])
     return hashlib.sha256(stable.encode()).hexdigest()[:16]
 
 
@@ -595,7 +628,7 @@ def _finding(
 ) -> None:
     rel = path.relative_to(target)
     file_classification = classification or _classification_for(path, target)
-    safe_excerpt = _short(evidence)
+    safe_excerpt = _template_audit_ops_mod._short(evidence)
     matched_content = _normalized_matched_content(evidence)
     rule = _rule_id(category, title)
     findings.append(
@@ -628,7 +661,7 @@ def _first_committed_secret_match(pattern: re.Pattern[str], line: str) -> re.Mat
         value = match.group(2)
         if _is_secret_path_assignment(match):
             continue
-        if _is_placeholder(value):
+        if _template_audit_ops_mod._is_placeholder(value):
             continue
         if not _match_value_is_quoted(line, match) and _is_runtime_secret_value(value):
             continue
@@ -688,8 +721,10 @@ def _scan_line(
                 if session_chat
                 else "Move the value into local environment or secret storage and commit only a placeholder.",
             )
-        if _contains_private_key_material(line) or (
-            _first_committed_env_assignment(line) is not None and not password_emitted and not _is_placeholder(line)
+        if _template_audit_ops_mod._contains_private_key_material(line) or (
+            _first_committed_env_assignment(line) is not None
+            and not password_emitted
+            and not _template_audit_ops_mod._is_placeholder(line)
         ):
             consider_secret(
                 "Session chat contains exposed credential" if session_chat else "Possible sensitive secret material",
@@ -706,7 +741,7 @@ def _scan_line(
             severity="high",
             category="secrets",
             title=title,
-            evidence=_redact_secret_evidence(line),
+            evidence=_template_audit_ops_mod._redact_secret_evidence(line),
             suggestion=suggestion,
             classification=file_classification,
             response_options=_secret_response_options(path, target),
@@ -760,7 +795,7 @@ def _scan_line(
             severity="high",
             category="secrets",
             title="Environment dump or exfiltration pattern",
-            evidence=_redact_secret_evidence(line),
+            evidence=_template_audit_ops_mod._redact_secret_evidence(line),
             suggestion="Avoid dumping environment variables near file redirection or network commands.",
             classification=file_classification,
             response_options=_secret_response_options(path, target),
@@ -961,12 +996,22 @@ def scan_target(
                 line=line,
                 classification=classification,
             )
-        _scan_mcp_document(findings, target=target, path=path, text=text, classification=classification)
+        _scan_detectors_mod._scan_mcp_document(
+            findings, target=target, path=path, text=text, classification=classification
+        )
         if not _should_skip_harness_wiring_path(path, target):
-            _scan_harness_wiring_document(findings, target=target, path=path, text=text, classification=classification)
-        _scan_package_json(findings, target=target, path=path, text=text, classification=classification)
-        _scan_github_actions(findings, target=target, path=path, text=text, classification=classification)
-        _scan_python_project(findings, target=target, path=path, text=text, classification=classification)
+            _scan_detectors_mod._scan_harness_wiring_document(
+                findings, target=target, path=path, text=text, classification=classification
+            )
+        _scan_detectors_mod._scan_package_json(
+            findings, target=target, path=path, text=text, classification=classification
+        )
+        _scan_detectors_mod._scan_github_actions(
+            findings, target=target, path=path, text=text, classification=classification
+        )
+        _scan_detectors_mod._scan_python_project(
+            findings, target=target, path=path, text=text, classification=classification
+        )
     _assign_fingerprints(findings)
     findings = _filter_findings(
         findings,

--- a/src/brigade/security_cmd/suppression.py
+++ b/src/brigade/security_cmd/suppression.py
@@ -22,9 +22,18 @@ from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import reports as _reports_mod
+from . import scan_engine as _scan_engine_mod
+from .config import _clean_reason, _effective_policy, _load_config_or_default, load_config, write_config
+from .models import (
+    EffectivePolicy,
+    FINGERPRINT_RE,
+    SUPPRESSION_HEALTH_CACHE_VERSION,
+    SecurityConfig,
+    _read_fingerprint_migration_map,
+    default_artifacts_dir,
+    suppression_health_cache_path,
+)
 
 
 def suppress(*, target: Path, fingerprint: str, reason: str, json_output: bool = False) -> int:
@@ -36,7 +45,7 @@ def suppress(*, target: Path, fingerprint: str, reason: str, json_output: bool =
     cleaned_reason = _clean_reason(reason)
     finding: dict[str, Any] | None = None
     if not FINGERPRINT_RE.match(fingerprint):
-        finding, message = _resolve_finding_record(target, fingerprint)
+        finding, message = _reports_mod._resolve_finding_record(target, fingerprint)
         if finding is None or not FINGERPRINT_RE.match(str(finding.get("fingerprint") or "")):
             print(f"error: {message or 'finding id or fingerprint is invalid'}", file=sys.stderr)
             return 2
@@ -56,7 +65,7 @@ def suppress(*, target: Path, fingerprint: str, reason: str, json_output: bool =
     related_aliases = {legacy for legacy, primary in migration_map.items() if primary == fingerprint}
     if finding is not None:
         related_aliases.update(
-            _configured_suppression_aliases(
+            _scan_engine_mod._configured_suppression_aliases(
                 finding, suppressions=set(suppressions), reasons=reasons, migration_map=migration_map
             )
         )
@@ -115,7 +124,7 @@ def unsuppress(*, target: Path, fingerprint: str, json_output: bool = False) -> 
     fingerprint = fingerprint.strip()
     finding: dict[str, Any] | None = None
     if not FINGERPRINT_RE.match(fingerprint):
-        finding, message = _resolve_finding_record(target, fingerprint)
+        finding, message = _reports_mod._resolve_finding_record(target, fingerprint)
         if finding is None or not FINGERPRINT_RE.match(str(finding.get("fingerprint") or "")):
             print(f"error: {message or 'finding id or fingerprint is invalid'}", file=sys.stderr)
             return 2
@@ -129,14 +138,14 @@ def unsuppress(*, target: Path, fingerprint: str, json_output: bool = False) -> 
     fingerprint = migration_map.get(fingerprint, fingerprint)
     configured_aliases: tuple[str, ...]
     if finding is not None:
-        configured_aliases = _configured_suppression_aliases(
+        configured_aliases = _scan_engine_mod._configured_suppression_aliases(
             finding,
             suppressions=set(config.suppressions),
             reasons=config.suppression_reasons,
             migration_map=migration_map,
         )
     else:
-        configured = _expand_suppression_fingerprints(
+        configured = _scan_engine_mod._expand_suppression_fingerprints(
             set(config.suppressions) | set(config.suppression_reasons),
             migration_map,
         )
@@ -202,8 +211,10 @@ def _file_sha256(path: Path) -> str | None:
 
 def _candidate_file_records(target: Path, effective: EffectivePolicy) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
-    for path in _iter_scan_files(target, include_paths=effective.include_paths, exclude_paths=effective.exclude_paths):
-        classification = _classification_for(path, target)
+    for path in _scan_engine_mod._iter_scan_files(
+        target, include_paths=effective.include_paths, exclude_paths=effective.exclude_paths
+    ):
+        classification = _scan_engine_mod._classification_for(path, target)
         if not effective.include_templates and classification.confidence == "template":
             continue
         try:
@@ -225,7 +236,7 @@ def _candidate_file_records(target: Path, effective: EffectivePolicy) -> list[di
             if path.name == "TEMPLATE.md":
                 continue
             rel = str(path.relative_to(target))
-            if not _scan_path_selected(
+            if not _scan_engine_mod._scan_path_selected(
                 rel,
                 include_paths=effective.include_paths,
                 exclude_paths=effective.exclude_paths,
@@ -280,7 +291,7 @@ def _active_fingerprint_aliases(report: dict[str, Any]) -> set[str]:
     for finding in list(report.get("findings") or []) + list(report.get("suppressed_findings") or []):
         if not isinstance(finding, dict):
             continue
-        active.update(_safe_fingerprint_aliases(finding))
+        active.update(_scan_engine_mod._safe_fingerprint_aliases(finding))
     return active
 
 
@@ -381,7 +392,7 @@ def suppression_health(target: Path) -> dict[str, Any]:
     if not config.suppressions:
         return {"suppression_count": 0, "missing_reasons": [], "stale": []}
     effective = _effective_policy(target, policy=None, fail_on=None, include_templates=None)
-    report = scan_target(
+    report = _scan_engine_mod.scan_target(
         target,
         include_templates=effective.include_templates,
         suppressions=(),

--- a/src/brigade/security_cmd/template_audit_ops.py
+++ b/src/brigade/security_cmd/template_audit_ops.py
@@ -22,9 +22,21 @@ from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
 from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
-from . import models as _family_base
-
-globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+from . import scan_detectors as _scan_detectors_mod
+from . import scan_engine as _scan_engine_mod
+from .models import (
+    ENV_ASSIGNMENT_RE,
+    PLAINTEXT_PASSWORD_RE,
+    PRIVATE_KEY_RE,
+    SECRET_VALUE_RE,
+    SECURITY_CHECKS,
+    TEMPLATE_ALLOWLIST_RE,
+    TEMPLATE_AUDIT_ROOTS,
+    TEMPLATE_PRIVATE_PATH_RE,
+    TEMPLATE_PRIVATE_URL_RE,
+    TEXT_SUFFIXES,
+    _should_skip_harness_wiring_path,
+)
 
 
 def _short(text: str, limit: int = 160) -> str:
@@ -98,7 +110,7 @@ def _template_audit_finding(
         "title": title,
         "severity": "high" if category == "secret" else "medium",
         "safe_excerpt": evidence,
-        "surface": _surface_for(path, target),
+        "surface": _scan_engine_mod._surface_for(path, target),
         "confidence": "template" if "templates" in path.parts else "docs",
     }
     payload["fingerprint"] = hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()[:16]
@@ -190,25 +202,25 @@ def harness_wiring_payload(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
     findings: list[dict[str, Any]] = []
     scanned_files: list[str] = []
-    for path in _iter_scan_files(target):
+    for path in _scan_engine_mod._iter_scan_files(target):
         if _should_skip_harness_wiring_path(path, target):
             continue
-        if not _is_harness_wiring_document(path, target):
+        if not _scan_detectors_mod._is_harness_wiring_document(path, target):
             continue
         try:
             text = path.read_text(errors="replace")
         except OSError:
             continue
         scanned_files.append(str(path.relative_to(target)))
-        _scan_harness_wiring_document(
+        _scan_detectors_mod._scan_harness_wiring_document(
             findings,
             target=target,
             path=path,
             text=text,
-            classification=_classification_for(path, target),
+            classification=_scan_engine_mod._classification_for(path, target),
         )
-    _assign_fingerprints(findings)
-    findings = _filter_findings(
+    _scan_engine_mod._assign_fingerprints(findings)
+    findings = _scan_engine_mod._filter_findings(
         findings,
         enabled_checks=SECURITY_CHECKS,
         include_paths=(),

--- a/tests/fixtures/mypy_override_baseline.txt
+++ b/tests/fixtures/mypy_override_baseline.txt
@@ -17,8 +17,6 @@ brigade.phases_cmd.checks_actions
 brigade.phases_cmd.constants
 brigade.phases_cmd.session_lifecycle
 brigade.phases_cmd.session_ops
-brigade.security_cmd
-brigade.security_cmd.*
 brigade.work_cmd.backup
 brigade.work_cmd.imports
 brigade.work_cmd.reviews


### PR DESCRIPTION
## What

Family 7 of 7 for #1228 phase 2. Every `security_cmd` submodule that copied `models`'s globals at import time (`globals().update(vars(_family_base))`) now imports what it uses explicitly; siblings that import each other use `_<module>_mod` aliases so partially initialized modules resolve at call time and no alias can shadow a same-named function through the facade's `_sync_module_globals()`. The facade `__init__.py` is unchanged.

`brigade.security_cmd` and `brigade.security_cmd.*` leave the mypy override and `tests/fixtures/mypy_override_baseline.txt`; the errors that surface are fixed with bind-once narrowing, no `type: ignore` added.

## Verify

mypy exit 0, ruff check and format clean, size-ratchet baseline ok; security, facade, and ratchet suites: 142 passed (security_cmd, phase-257 facades, override and size ratchets) and 137 passed after the formatter pass (receipt `20260827-144824-work-verify-52f92b`).

Workers: agy_flash (Gemini 3.7 Flash via Antigravity) did the conversion and `_mod` aliases in one pass; mypy was already clean afterwards, so no narrowing follow-up. Self-review: 92 alias call-site rewrites, no detector regex, threshold, suppression rule, or path validation changed; the only non-alias edit is `Path(str(payload["path"]))`.

Refs #1228
