### PR TITLE
feat(grokbot): reconcile automation findings

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -59,7 +59,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade roster`: 4 command path(s)
 - `brigade route`: 1 command path(s)
 - `brigade run`: 1 command path(s)
-- `brigade run-cloud`: 22 command path(s)
+- `brigade run-cloud`: 24 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
 - `brigade runs`: 18 command path(s)
 - `brigade scrub`: 1 command path(s)
@@ -478,12 +478,14 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade run-cloud grokbot cancel`
 - `brigade run-cloud grokbot claim`
 - `brigade run-cloud grokbot complete`
+- `brigade run-cloud grokbot convert-findings`
 - `brigade run-cloud grokbot doctor`
 - `brigade run-cloud grokbot enqueue`
 - `brigade run-cloud grokbot expire`
 - `brigade run-cloud grokbot fail`
 - `brigade run-cloud grokbot feed`
 - `brigade run-cloud grokbot install-service`
+- `brigade run-cloud grokbot reconcile-findings`
 - `brigade run-cloud grokbot reconcile-reports`
 - `brigade run-cloud grokbot renew`
 - `brigade run-cloud grokbot scout-feed`

--- a/docs/grokbot-mcp.md
+++ b/docs/grokbot-mcp.md
@@ -155,6 +155,26 @@ Idempotency markers live under `.brigade/cloud/grokbot/reconcile/` on the queue 
 
 The command does not schedule itself and does not add a tool to any MCP inventory. Apply currently requires POSIX descriptor primitives and fails closed on Windows; preview remains available there.
 
+## Automation findings
+
+Generic one-shot finding relay stays out of the listener. A producer writes a private manifest and Brigade delivers untrusted findings to the canonical owner's review inbox. The command never edits canonical memory, `MEMORY.md`, or memory cards, and it does not call Fleet Hub.
+
+The manifest is a regular file owned by the current user, mode `0600`, and not a symlink. Schema `brigade.grokbot.findings.v1` requires an `entries` array. Each entry has exactly `producer`, `finding_id`, `revision`, `observed_at`, `severity`, `title`, `body`, `source_ref`, `source_digest`, and `content_digest`. Unexpected fields, including secret-shaped keys, are rejected. Identity is `producer` plus `finding_id`. Severity is `info`, `low`, `medium`, `warning`, `high`, `critical`, or `unknown`. `observed_at` is either an empty string for a legacy unknown time or a timezone-aware ISO timestamp. `source_digest` is a `sha256:` lowercase hex digest and is not required to hash the body, so a live revision digest can be represented unchanged. `content_digest` must equal `sha256` of canonical UTF-8 title + NUL + body. `source_ref` is an opaque bounded reference: length and control characters are checked, and consecutive dots are allowed. `adapt_live_finding` converts a live fleet or backup normalized record (extra `trust` / `delivery` labels and a raw 64-hex `source_digest`) into this exact-key shape without rewriting live severity, time, digest, or body values. Live `reason` / `summary` values may be up to 16,384 UTF-8 bytes. The adapter derives `title` as `[UNTRUSTED] {producer} {finding_id}` sliced to 120 characters, matching the live relay `proposalTitle` rule, and preserves the full body. The private manifest may contain title and body; command output, delivery markers, Brigade receipts, and Fleet Hub projections must not.
+
+The supported batch conversion path is the CLI. Input schema `brigade.grokbot.live-findings.v1` is a regular owner-only mode-`0600` file with an `entries` array of at most 50 live normalized records. The command preflights every entry through `adapt_live_finding`, rejects duplicate identities, sorts by `producer`, `finding_id`, and `revision`, and writes schema `brigade.grokbot.findings.v1` atomically as mode `0600`. Any invalid later entry, unsafe permission, destination symlink, or symlink in any input or output parent component fails closed: the command does not read through the link and writes nothing. POSIX conversion walks every parent component with descriptor-relative `O_NOFOLLOW`. Windows writes fail closed; Windows reads use the same no-follow parent walk when available and fail closed otherwise. Command output prints counts and identity handles only.
+
+```bash
+brigade run cloud grokbot convert-findings --target /srv/brigade --input /path/to/live-findings.json --output /path/to/findings.json
+brigade run cloud grokbot reconcile-findings --target /srv/brigade --owner /srv/owner --manifest /path/to/findings.json
+brigade run cloud grokbot reconcile-findings --target /srv/brigade --owner /srv/owner --manifest /path/to/findings.json --apply --limit 1
+```
+
+The first command is preview-only and writes nothing. `--apply` preflights the entire manifest, then writes at most `--limit` deterministic drafts or recovery repairs to `memory/handoff-inbox`. `--limit` is 1 through 50 and defaults to 1. Recovery writes count against the same limit. Selection sorts by `producer`, `finding_id`, and `revision` before classification or delivery. A later revision may create a replacement draft with a non-colliding filename. Repeating the same revision is idempotent. Conflicting markers, existing drafts with different bytes, unsafe permissions, symlink traversal, digest mismatches, and malformed later entries fail closed before any write. Preview walks `.brigade`, `cloud`, and `grokbot` with `O_NOFOLLOW` and refuses those parent symlinks. Manifest input paths walk every parent component the same way.
+
+Each draft uses the standard Memory Handoff sections, marks the content as untrusted and review-only, and quotes every producer-controlled title and body line. Delivery markers live under `.brigade/cloud/grokbot/findings/` on the queue target, mode `0700`/`0600`. Marker JSON stores schema, identity, revision, source digest, content digest, draft relative path, draft SHA-256, and a timezone-aware `delivered_at` only.
+
+Concurrent apply serializes on the existing Grok Bot queue lock. Apply requires POSIX descriptor primitives and fails closed on Windows; preview remains available there. The command does not schedule itself and does not add a tool to any MCP inventory. Custom inbox paths are out of scope.
+
 ## Current limits
 
 `setup` writes non-secret configuration and bearer references only. The operator still provisions Grok Bot routines and secrets. This work does not commission a Grok Bot and does not prove weekly quota attribution. A report snapshot is at most 12,000 UTF-8 bytes. The MCP request ceiling is 80,000 bytes.

--- a/docs/phase-grokbot-one-repository-distribution.md
+++ b/docs/phase-grokbot-one-repository-distribution.md
@@ -1,0 +1,166 @@
+# Grok Bot one-repository distribution
+
+## Status
+
+Approved by the operator on 2026-08-27 and tracked in #1255.
+
+## Existing state
+
+#1130 proved that Brigade can queue bounded work, Grok Bot can run it on its
+cloud computer, and Brigade can reconcile a report or pull request. #1163
+moved the role-scoped queue adapter into `brigade-cli` and removed the second
+repository from the coder-lane install path.
+
+The remaining dependency on `grokbot-dispatch-mcp` is operational. It still
+contains generic automation relay behavior and the current Cerebro, Fleet
+Steward, Backup Steward, and Obsidian connectors. That leaves two installers,
+two update paths, and two documentation sets for one Brigade feature family.
+
+## Product contract
+
+Brigade owns the supported Grok Bot integration from install through removal:
+
+- one source repository
+- one Python package and optional dependency extra
+- one CLI namespace
+- one release and update stream
+- one documentation set
+
+The runtime remains split into role-scoped processes. Each process keeps its
+own credentials, port, exact tool inventory, health state, and restart policy.
+The Fleet Hub stays private and is never mounted behind a public connector.
+
+## State and trust boundaries
+
+The canonical owner reviews all durable findings before memory ingestion.
+Rocinante remains the canonical memory owner.
+
+An automation producer may emit a bounded finding descriptor. The descriptor
+contains routing metadata, a stable source identifier, timestamps, a content
+digest, and a local artifact reference. It does not contain report text,
+instructions, credentials, tokens, or arbitrary environment data.
+
+The relay verifies the descriptor and artifact, creates one deterministic
+Memory Handoff draft in the owner's review inbox, and records an idempotent
+delivery receipt. The finding remains untrusted automation output until the
+owner's normal review and ingestion flow accepts it.
+
+Fleet Hub may carry safe coordination projections, such as finding handles and
+delivery state. It must not carry finding text, report text, credentials, or
+connector bearer values.
+
+## CLI direction
+
+The current queue commands remain under `brigade run cloud grokbot`. Later
+slices extend that namespace with first-party lifecycle commands. Exact parser
+names are finalized in their implementation PRs, but the supported operations
+are fixed:
+
+- configure a role or connector without storing secret values
+- inspect configuration and endpoint health
+- render or install an isolated service
+- run bounded local and public canaries
+- update a connector pack with a versioned migration
+- preview and apply removal
+
+Profiles may group supported components for setup, but a profile never combines
+their processes or credentials.
+
+## Delivery sequence
+
+### PR 1: AutomationFinding relay and owner delivery
+
+1. Add failing tests for the finding schema, file ownership and permissions,
+   digest verification, idempotency, deterministic draft paths, delivery
+   receipts, redacted output, and concurrent apply.
+2. Implement a preview-first local import and owner-delivery module.
+3. Add CLI parsing and safe JSON and text projections.
+4. Add service rendering and doctor checks without adding a daemon dependency.
+5. Document producer and owner contracts.
+
+This slice does not migrate a live connector or disable the sidecar.
+
+### PR 2: connector-pack registry and lifecycle
+
+1. Define a versioned first-party pack manifest.
+2. Add setup, doctor, service rendering, canary, update, and removal operations.
+3. Reject duplicate ports, overlapping public routes, unsafe binds, weak file
+   permissions, missing secret references, and tool inventory drift.
+4. Keep secrets outside Brigade state and repository content.
+
+### PR 3: first-party connector packs
+
+Move the supported Cerebro, Fleet Steward, Backup Steward, and Obsidian
+connectors into Brigade. Preserve their current external URLs during rollout.
+Keep each connector isolated. Split this work when one pull request would make
+review or rollback unsafe.
+
+### PR 4: cutover and retirement
+
+1. Preview and apply a reversible state migration to Brigade-owned paths.
+2. Run local and public edge parity canaries for each component.
+3. Prove that one Grok Bot finding reaches Rocinante's review inbox exactly
+   once and follows normal memory ingestion.
+4. Disable legacy services after parity passes and retain a time-bounded
+   rollback path.
+5. Remove the supported-user dependency on `grokbot-dispatch-mcp` and archive
+   it after the soak period.
+
+## Compatibility
+
+- Current Grok Bot connector URLs remain stable during the migration.
+- Existing queue tool names, schemas, roles, and lease behavior remain stable.
+- Existing operator, Repository Scout, and Implementation Worker services stay
+  available throughout the work.
+- State migration is preview-first and refuses symlinks, unsafe permissions,
+  conflicting destination records, and digest mismatches.
+- A failed migration leaves the legacy service enabled and its source state
+  unchanged.
+
+## Security requirements
+
+- Do not store GitHub PATs, Cloudflare credentials, Gmail credentials, origin
+  bearers, or Fleet Hub node tokens in Brigade config, queue records, finding
+  descriptors, receipts, logs, or repository fixtures.
+- Default every listener to loopback.
+- Require an explicit public route, Cloudflare Access, and a separate origin
+  bearer for a remote connector.
+- Enforce each connector's tool allowlist in discovery and direct dispatch.
+- Bound request bytes, artifact bytes, processing time, and per-run mutation.
+- Keep preview as the default for imports, migrations, and removal.
+- Treat all Grok Bot output as untrusted until owner review.
+
+## Non-goals
+
+- One listener process for all connectors.
+- One shared connector credential.
+- A public Fleet Hub endpoint.
+- Personal host paths or secret values in the public repository.
+- Unrestricted tools or mutation authority for every bot.
+- Automatic canonical-memory edits.
+
+## Acceptance
+
+1. A clean environment installs all supported Grok Bot components from
+   `brigade-cli` without cloning another repository.
+2. Brigade configures, diagnoses, renders services for, canaries, updates, and
+   removes every supported component.
+3. Existing coder-lane canaries remain green.
+4. Each migrated connector rejects missing edge identity and missing origin
+   bearer, exposes its exact tool inventory, and passes one bounded functional
+   canary.
+5. One AutomationFinding reaches the owner's review inbox exactly once with a
+   delivery receipt. Report text does not enter Fleet Hub or Brigade receipts.
+6. Rocinante receives the handoff through the normal memory path without a
+   manual request to Grok Bot.
+7. Disabling the old sidecar does not break supported Brigade functionality.
+
+## Verification and review
+
+Each slice follows tests-first development and runs its focused tests through
+`brigade work verify run`. Before a pull request is marked ready, run
+`./scripts/verify` through the same Brigade work loop. Record the outcome and
+write a Memory Handoff for durable behavior or migration findings.
+
+Use `Refs #1255` on intermediate pull requests. The final retirement pull
+request uses `Fixes #1255` only after every acceptance item has live evidence.

--- a/docs/phase-grokbot-one-repository-distribution.md
+++ b/docs/phase-grokbot-one-repository-distribution.md
@@ -35,10 +35,22 @@ The Fleet Hub stays private and is never mounted behind a public connector.
 The canonical owner reviews all durable findings before memory ingestion.
 Rocinante remains the canonical memory owner.
 
-An automation producer may emit a bounded finding descriptor. The descriptor
-contains routing metadata, a stable source identifier, timestamps, a content
-digest, and a local artifact reference. It does not contain report text,
-instructions, credentials, tokens, or arbitrary environment data.
+An automation producer may emit a bounded finding descriptor. The private
+producer manifest (`brigade.grokbot.findings.v1`) carries routing metadata,
+identity, timestamps, a content digest, a local source reference, and may
+include title and body because it is the approved private producer artifact.
+The generic entry represents live fleet and backup values without weakening
+validation: severities include `warning` and `unknown`, `observed_at` may be
+empty, `source_digest` is a `sha256:` digest that is not forced to hash the
+body, and `content_digest` is the required title + NUL + body integrity check.
+Instructions, credentials, tokens, and arbitrary environment data stay out.
+Finding title and body never enter Brigade receipts, delivery markers, CLI
+output, or Fleet Hub projections. Live fleet `reason` and backup `summary`
+values may reach the live maximum; `adapt_live_finding` derives the generic
+title with the live relay `proposalTitle` rule and keeps the full body.
+`source_ref` is an opaque bounded reference and may contain consecutive dots.
+The supported batch conversion path is
+`brigade run cloud grokbot convert-findings --input <live.json> --output <findings.json>`.
 
 The relay verifies the descriptor and artifact, creates one deterministic
 Memory Handoff draft in the owner's review inbox, and records an idempotent
@@ -75,7 +87,8 @@ their processes or credentials.
    receipts, redacted output, and concurrent apply.
 2. Implement a preview-first local import and owner-delivery module.
 3. Add CLI parsing and safe JSON and text projections.
-4. Add service rendering and doctor checks without adding a daemon dependency.
+4. Do not add a new daemon or service-rendering command. The existing systemd
+   timer can call the one-shot command after cutover.
 5. Document producer and owner contracts.
 
 This slice does not migrate a live connector or disable the sidecar.

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -99,6 +99,24 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_reconcile.add_argument("--limit", type=int, default=1, help="Maximum new drafts (1-50). Defaults to 1.")
     p_reconcile.add_argument("--apply", action="store_true", help="Write drafts and markers. Default is preview only.")
 
+    p_findings = grokbot_sub.add_parser(
+        "reconcile-findings",
+        help="Preview or draft canonical-owner Memory Handoffs from a private findings manifest.",
+    )
+    add_target(p_findings)
+    p_findings.add_argument("--owner", type=Path, required=True, help="Owner workspace that receives handoff drafts.")
+    p_findings.add_argument("--manifest", type=Path, required=True, help="Path to the private findings manifest.")
+    p_findings.add_argument("--limit", type=int, default=1, help="Maximum new drafts (1-50). Defaults to 1.")
+    p_findings.add_argument("--apply", action="store_true", help="Write drafts and markers. Default is preview only.")
+
+    p_convert = grokbot_sub.add_parser(
+        "convert-findings",
+        help="Convert live normalized findings into a private generic manifest.",
+    )
+    add_target(p_convert)
+    p_convert.add_argument("--input", type=Path, required=True, help="Path to the live normalized findings file.")
+    p_convert.add_argument("--output", type=Path, required=True, help="Path to write the generic findings manifest.")
+
     for name, help_text in (("claim", "Claim a queued job."), ("renew", "Renew a current job lease.")):
         command = grokbot_sub.add_parser(name, help=help_text)
         add_target(command)
@@ -305,6 +323,10 @@ def _dispatch_grokbot(args, target: Path) -> int:
         return _dispatch_grokbot_scout_feed(args, target)
     if command == "reconcile-reports":
         return _dispatch_grokbot_reconcile(args, target)
+    if command == "reconcile-findings":
+        return _dispatch_grokbot_findings(args, target)
+    if command == "convert-findings":
+        return _dispatch_grokbot_convert_findings(args)
     if command == "serve":
         from .. import grokbot_mcp
 
@@ -454,6 +476,65 @@ def _dispatch_grokbot_reconcile(args, target: Path) -> int:
         return 0
     _print_reconcile_result(result)
     return 0
+
+
+def _dispatch_grokbot_findings(args, target: Path) -> int:
+    """Preview or draft canonical-owner handoffs without printing finding text."""
+    from .. import grokbot_findings
+
+    try:
+        if args.apply:
+            result = grokbot_findings.apply(target, args.owner, args.manifest, limit=args.limit)
+        else:
+            result = grokbot_findings.preview(target, args.owner, args.manifest, limit=args.limit)
+    except grokbot_findings.FindingsError as exc:
+        print(f"error: {exc.reason}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    _print_findings_result(result)
+    return 0
+
+
+def _dispatch_grokbot_convert_findings(args) -> int:
+    """Convert live records into a generic manifest without printing finding text."""
+    from .. import grokbot_findings
+
+    try:
+        result = grokbot_findings.convert_live_findings(args.input, args.output)
+    except grokbot_findings.FindingsError as exc:
+        print(f"error: {exc.reason}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    _print_convert_findings_result(result)
+    return 0
+
+
+def _print_convert_findings_result(result: dict) -> None:
+    """Render conversion counts and safe identity handles only."""
+    print(f"grokbot convert-findings: converted={result['converted']}")
+    for finding in result.get("findings", []):
+        print(f"finding {finding['producer']} {finding['finding_id']} revision={finding['revision']}")
+
+
+def _print_findings_result(result: dict) -> None:
+    """Render findings counts and safe identity handles only."""
+    parts = [
+        f"eligible={result['eligible']}",
+        f"known={result['known']}",
+        f"created={result['created']}",
+        f"limit={result['limit']}",
+    ]
+    if "skipped" in result:
+        parts.insert(2, f"skipped={result['skipped']}")
+    print("grokbot reconcile-findings: " + " ".join(parts))
+    for finding in result.get("findings", []):
+        print(f"finding {finding['producer']} {finding['finding_id']} revision={finding['revision']}")
 
 
 def _print_reconcile_result(result: dict) -> None:

--- a/src/brigade/grokbot_findings.py
+++ b/src/brigade/grokbot_findings.py
@@ -1,0 +1,837 @@
+"""Preview-first local delivery of untrusted Grok Bot automation findings.
+
+A producer writes a private ``brigade.grokbot.findings.v1`` manifest. Preview
+is the default. Apply writes at most ``limit`` deterministic Memory Handoff
+drafts into the canonical owner's review inbox and records delivery markers
+under the local Grok Bot queue. Finding title and body never appear in
+command output, markers, or other Brigade receipts.
+
+The generic entry shape accepts live fleet and backup values: severities
+``info``, ``low``, ``medium``, ``warning``, ``high``, ``critical``, and
+``unknown``; ``observed_at`` as an empty string or a timezone-aware ISO
+timestamp; and ``source_digest`` as a ``sha256:`` hex digest that is not
+required to hash the body. ``content_digest`` is the required integrity
+check over canonical UTF-8 title + NUL + body. ``adapt_live_finding``
+converts the live sidecar's extra ``trust`` / ``delivery`` labels and raw
+revision hex digest into that approved exact-key shape without rewriting
+live severity, time, or digest values. Live ``reason`` / ``summary`` values
+may reach the live maximum; the adapter derives the generic title with the
+same bounded ``proposalTitle`` rule the live relay uses and keeps the full
+body. ``convert_live_findings`` is the supported batch conversion path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import stat
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from . import grokbot_jobs, grokbot_ops, grokbot_reconcile, handoff_cmd
+from .handoff_cmd.models import DEFAULT_DRAFT_DOCUMENT, NO_CARD_ACTION
+
+FINDINGS_SCHEMA = "brigade.grokbot.findings.v1"
+LIVE_FINDINGS_SCHEMA = "brigade.grokbot.live-findings.v1"
+REQUIRED_MANIFEST_KEYS = frozenset({"schema", "entries"})
+REQUIRED_ENTRY_KEYS = frozenset(
+    {
+        "producer",
+        "finding_id",
+        "revision",
+        "observed_at",
+        "severity",
+        "title",
+        "body",
+        "source_ref",
+        "source_digest",
+        "content_digest",
+    }
+)
+LIVE_ENTRY_KEYS = frozenset(REQUIRED_ENTRY_KEYS - {"content_digest"})
+LIVE_OPTIONAL_KEYS = frozenset({"trust", "delivery"})
+MARKER_KEYS = frozenset(
+    {
+        "schema",
+        "identity",
+        "revision",
+        "source_digest",
+        "content_digest",
+        "draft_path",
+        "draft_sha256",
+        "delivered_at",
+    }
+)
+IDENTITY_KEYS = frozenset({"producer", "finding_id"})
+SEVERITIES = frozenset({"info", "low", "medium", "warning", "high", "critical", "unknown"})
+FINDINGS_DIRNAME = "findings"
+REVIEW_INBOX = grokbot_reconcile.REVIEW_INBOX
+MIN_LIMIT = grokbot_reconcile.MIN_LIMIT
+MAX_LIMIT = grokbot_reconcile.MAX_LIMIT
+DEFAULT_LIMIT = grokbot_reconcile.DEFAULT_LIMIT
+MAX_MANIFEST_BYTES = 786432
+MAX_ENTRIES = 50
+MAX_TITLE_CHARS = 200
+PROPOSAL_TITLE_CHARS = 120
+LIVE_MAX_TITLE_BYTES = 16_384
+MAX_BODY_BYTES = grokbot_jobs.MAX_REPORT_BYTES
+MAX_SOURCE_REF_CHARS = 512
+MAX_OBSERVED_AT_CHARS = 64
+MARKER_MAX_BYTES = 4096
+SECURE_OWNER_WRITE_AVAILABLE = grokbot_reconcile.SECURE_OWNER_WRITE_AVAILABLE
+
+
+class FindingsError(ValueError):
+    """A rejected findings request with a stable machine-readable reason."""
+
+    def __init__(self, reason: str, index: int | None = None):
+        self.reason = reason
+        self.index = index
+        super().__init__(reason)
+
+
+def draft_filename(producer: str, finding_id: str, revision: str) -> str:
+    """Return the deterministic inbox draft name for one identity and revision."""
+    return f"finding-{_identity_digest(producer, finding_id, revision)}.md"
+
+
+def marker_filename(producer: str, finding_id: str, revision: str) -> str:
+    """Return the deterministic queue marker name for one identity and revision."""
+    return f"{_identity_digest(producer, finding_id, revision)}.json"
+
+
+def content_digest(title: str, body: str) -> str:
+    """Return ``sha256:`` of canonical UTF-8 title + NUL + body."""
+    return "sha256:" + hashlib.sha256(f"{title}\0{body}".encode("utf-8")).hexdigest()
+
+
+def proposal_title(producer: str, finding_id: str) -> str:
+    """Return the live-relay ``proposalTitle`` for one producer and finding."""
+    title = f"[UNTRUSTED] {producer} {finding_id}"
+    return title if len(title) <= PROPOSAL_TITLE_CHARS else title[:PROPOSAL_TITLE_CHARS]
+
+
+def adapt_live_finding(entry: object, *, index: int = 0) -> dict[str, str]:
+    """Convert a live fleet or backup normalized record into the approved entry.
+
+    Live sidecar records keep extra ``trust`` / ``delivery`` labels, emit
+    ``source_digest`` as a raw revision hex digest, and omit ``content_digest``.
+    This adapter preserves live severity, observed_at, digest, and body values.
+    It prefixes a bare 64-hex digest with ``sha256:``, derives a bounded title
+    with the live relay ``proposalTitle`` rule, and adds the required content
+    digest. Unexpected keys are rejected.
+    """
+    if not isinstance(entry, dict):
+        raise FindingsError("invalid-entry", index=index)
+    extra = set(entry) - LIVE_ENTRY_KEYS - LIVE_OPTIONAL_KEYS
+    if extra or LIVE_ENTRY_KEYS - set(entry):
+        raise FindingsError("invalid-entry", index=index)
+    trust = entry.get("trust")
+    delivery = entry.get("delivery")
+    if trust is not None and trust != "untrusted":
+        raise FindingsError("invalid-entry", index=index)
+    if delivery is not None and delivery != "review-only":
+        raise FindingsError("invalid-entry", index=index)
+    producer = entry["producer"]
+    finding_id = entry["finding_id"]
+    title = entry["title"]
+    body = entry["body"]
+    if not isinstance(producer, str) or not isinstance(finding_id, str):
+        raise FindingsError("invalid-entry", index=index)
+    if not isinstance(title, str) or not isinstance(body, str):
+        raise FindingsError("invalid-entry", index=index)
+    _validate_live_title(title, index=index)
+    derived_title = proposal_title(producer, finding_id)
+    source_digest = entry["source_digest"]
+    if isinstance(source_digest, str) and grokbot_jobs.LOWER_HEX_64_RE.fullmatch(source_digest):
+        source_digest = f"sha256:{source_digest}"
+    return _validate_entry(
+        {
+            "producer": producer,
+            "finding_id": finding_id,
+            "revision": entry["revision"],
+            "observed_at": entry["observed_at"],
+            "severity": entry["severity"],
+            "title": derived_title,
+            "body": body,
+            "source_ref": entry["source_ref"],
+            "source_digest": source_digest,
+            "content_digest": content_digest(derived_title, body),
+        },
+        index=index,
+    )
+
+
+def convert_live_findings(source: Path, destination: Path) -> dict[str, Any]:
+    """Convert live normalized records into a mode-0600 generic manifest."""
+    payload = _load_live_manifest(source)
+    adapted: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for index, entry in enumerate(payload["entries"]):
+        item = adapt_live_finding(entry, index=index)
+        identity = (item["producer"], item["finding_id"])
+        if identity in seen:
+            raise FindingsError("duplicate-identity", index=index)
+        seen.add(identity)
+        adapted.append(item)
+    adapted = _sorted_entries(adapted)
+    _write_manifest_atomic(destination, {"schema": FINDINGS_SCHEMA, "entries": adapted})
+    return {
+        "converted": len(adapted),
+        "findings": [_handle(item) for item in adapted],
+    }
+
+
+def preview(
+    target: Path,
+    owner: Path,
+    manifest: Path,
+    limit: int = DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """Validate a findings manifest and count deliveries without writing."""
+    _validate_owner(owner)
+    limit = _validate_limit(limit)
+    payload = load_manifest(manifest)
+    eligible, known = _classify(target, owner, payload["entries"])
+    return {
+        "eligible": len(eligible),
+        "known": len(known),
+        "created": 0,
+        "limit": limit,
+        "findings": [_handle(entry) for entry in eligible[:limit]],
+    }
+
+
+def apply(
+    target: Path,
+    owner: Path,
+    manifest: Path,
+    limit: int = DEFAULT_LIMIT,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Write at most ``limit`` owner-review drafts and matching queue markers."""
+    owner_path = _validate_owner(owner)
+    limit = _validate_limit(limit)
+    payload = load_manifest(manifest)
+    if not SECURE_OWNER_WRITE_AVAILABLE:  # pragma: no cover - exercised on Windows.
+        raise FindingsError("secure-owner-write-unavailable")
+    created: list[dict[str, str]] = []
+    recovered = 0
+    try:
+        with grokbot_jobs._storage_paths(target) as storage, grokbot_jobs._queue_lock(storage):
+            findings_dir, extra_fd = _open_findings(storage)
+            try:
+                eligible, known, recoverable = _classify_locked(findings_dir, owner_path, payload["entries"])
+                recoverable_ids = {(item["producer"], item["finding_id"]) for item in recoverable}
+                eligible_ids = {(item["producer"], item["finding_id"]) for item in eligible}
+                for entry in payload["entries"]:
+                    identity = (entry["producer"], entry["finding_id"])
+                    if identity not in recoverable_ids and identity not in eligible_ids:
+                        continue
+                    if len(created) + recovered >= limit:
+                        break
+                    handle, status = _deliver_one(findings_dir, owner_path, entry, now)
+                    if status == "created":
+                        created.append(handle)
+                    else:
+                        recovered += 1
+            finally:
+                if extra_fd is not None:
+                    os.close(extra_fd)
+    except grokbot_jobs.GrokbotJobError as exc:
+        raise FindingsError(exc.reason) from exc
+    except grokbot_reconcile.ReconcileError as exc:
+        raise FindingsError(exc.reason) from exc
+    return {
+        "eligible": len(eligible),
+        "known": len(known),
+        "created": len(created),
+        "skipped": len(known) + recovered,
+        "limit": limit,
+        "findings": created,
+    }
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    """Load a private findings file after checking ownership, mode, and schema."""
+    try:
+        payload = json.loads(_read_manifest_snapshot(path))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FindingsError("malformed-manifest") from exc
+    if not isinstance(payload, dict):
+        raise FindingsError("malformed-manifest")
+    if set(payload) != REQUIRED_MANIFEST_KEYS:
+        if payload.get("schema") != FINDINGS_SCHEMA:
+            raise FindingsError("invalid-schema")
+        raise FindingsError("malformed-manifest")
+    if payload["schema"] != FINDINGS_SCHEMA:
+        raise FindingsError("invalid-schema")
+    entries = payload["entries"]
+    if not isinstance(entries, list) or len(entries) > MAX_ENTRIES:
+        raise FindingsError("malformed-manifest")
+    seen: set[tuple[str, str]] = set()
+    validated: list[dict[str, str]] = []
+    for index, entry in enumerate(entries):
+        item = _validate_entry(entry, index=index)
+        identity = (item["producer"], item["finding_id"])
+        if identity in seen:
+            raise FindingsError("duplicate-identity", index=index)
+        seen.add(identity)
+        validated.append(item)
+    payload["entries"] = _sorted_entries(validated)
+    return payload
+
+
+def _validate_owner(owner: Path) -> Path:
+    try:
+        return grokbot_reconcile._validate_owner(owner)
+    except grokbot_reconcile.ReconcileError as exc:
+        raise FindingsError(exc.reason) from exc
+
+
+def _validate_limit(limit: object) -> int:
+    try:
+        return grokbot_reconcile._validate_limit(limit)
+    except grokbot_reconcile.ReconcileError as exc:
+        raise FindingsError(exc.reason) from exc
+
+
+def _validate_entry(entry: object, *, index: int) -> dict[str, str]:
+    if not isinstance(entry, dict) or set(entry) != REQUIRED_ENTRY_KEYS:
+        raise FindingsError("invalid-entry", index=index)
+    producer = _bounded_identifier(entry["producer"], reason="invalid-producer", index=index)
+    finding_id = _bounded_identifier(entry["finding_id"], reason="invalid-finding-id", index=index)
+    revision = _bounded_identifier(entry["revision"], reason="invalid-revision", index=index)
+    observed_at = _validate_observed_at(entry["observed_at"], index=index)
+    severity = entry["severity"]
+    if not isinstance(severity, str) or severity not in SEVERITIES:
+        raise FindingsError("invalid-severity", index=index)
+    title = _bounded_text(entry["title"], reason="invalid-title", maximum=MAX_TITLE_CHARS, index=index)
+    body = _bounded_body(entry["body"], index=index)
+    source_ref = _validate_source_ref(entry["source_ref"], index=index)
+    source_digest = entry["source_digest"]
+    if not isinstance(source_digest, str) or not grokbot_jobs.TASK_HASH_RE.fullmatch(source_digest):
+        raise FindingsError("invalid-source-digest", index=index)
+    digest = entry["content_digest"]
+    if not isinstance(digest, str) or not grokbot_jobs.TASK_HASH_RE.fullmatch(digest):
+        raise FindingsError("invalid-content-digest", index=index)
+    if digest != content_digest(title, body):
+        raise FindingsError("digest-mismatch", index=index)
+    return {
+        "producer": producer,
+        "finding_id": finding_id,
+        "revision": revision,
+        "observed_at": observed_at,
+        "severity": severity,
+        "title": title,
+        "body": body,
+        "source_ref": source_ref,
+        "source_digest": source_digest,
+        "content_digest": digest,
+    }
+
+
+def _bounded_identifier(value: object, *, reason: str, index: int) -> str:
+    if not isinstance(value, str) or not grokbot_jobs.OPAQUE_ID_RE.fullmatch(value):
+        raise FindingsError(reason, index=index)
+    return value
+
+
+def _bounded_text(value: object, *, reason: str, maximum: int, index: int) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > maximum or "\x00" in value:
+        raise FindingsError(reason, index=index)
+    return value
+
+
+def _bounded_body(value: object, *, index: int) -> str:
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise FindingsError("invalid-body", index=index)
+    if len(value.encode("utf-8")) > MAX_BODY_BYTES:
+        raise FindingsError("invalid-body", index=index)
+    return value
+
+
+def _validate_observed_at(value: object, *, index: int) -> str:
+    return _validate_aware_timestamp(value, reason="invalid-observed-at", index=index, allow_empty=True)
+
+
+def _validate_aware_timestamp(
+    value: object,
+    *,
+    reason: str,
+    index: int | None = None,
+    allow_empty: bool = False,
+) -> str:
+    if not isinstance(value, str) or "\x00" in value or len(value) > MAX_OBSERVED_AT_CHARS:
+        raise FindingsError(reason, index=index)
+    if value == "":
+        if allow_empty:
+            return value
+        raise FindingsError(reason, index=index)
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise FindingsError(reason, index=index) from exc
+    if parsed.tzinfo is None:
+        raise FindingsError(reason, index=index)
+    return value
+
+
+def _validate_live_title(value: str, *, index: int) -> None:
+    if "\x00" in value or len(value.encode("utf-8")) > LIVE_MAX_TITLE_BYTES:
+        raise FindingsError("invalid-title", index=index)
+
+
+def _validate_source_ref(value: object, *, index: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > MAX_SOURCE_REF_CHARS
+        or "\x00" in value
+        or "\n" in value
+        or "\r" in value
+    ):
+        raise FindingsError("invalid-source-ref", index=index)
+    return value
+
+
+def _load_live_manifest(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(_read_manifest_snapshot(path))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FindingsError("malformed-manifest") from exc
+    if not isinstance(payload, dict):
+        raise FindingsError("malformed-manifest")
+    if payload.get("schema") != LIVE_FINDINGS_SCHEMA:
+        raise FindingsError("invalid-schema")
+    if set(payload) != REQUIRED_MANIFEST_KEYS:
+        raise FindingsError("malformed-manifest")
+    entries = payload["entries"]
+    if not isinstance(entries, list) or len(entries) > MAX_ENTRIES:
+        raise FindingsError("malformed-manifest")
+    return payload
+
+
+def _manifest_name(path: Path) -> str:
+    name = Path(path).name
+    if not name or name in {".", ".."} or "/" in name or "\x00" in name:
+        raise FindingsError("unsafe-manifest")
+    return name
+
+
+def _open_manifest_parent(path: Path) -> int:
+    """Hold ``path.parent`` after refusing every symlink parent component."""
+    try:
+        return grokbot_ops._open_parent_nofollow(Path(path).expanduser(), create=False)
+    except OSError as exc:
+        raise FindingsError("unsafe-manifest") from exc
+
+
+def _open_manifest_file(parent_fd: int, name: str, flags: int, mode: int = 0o600) -> int:
+    """Open one child name relative to a no-follow parent descriptor."""
+    if os.name == "posix":
+        return os.open(name, flags | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0), mode, dir_fd=parent_fd)
+    from .work_cmd import nt_dirfd  # pragma: no cover - exercised on Windows.
+
+    return nt_dirfd.open_file(parent_fd, name, flags, mode)  # pragma: no cover - exercised on Windows.
+
+
+def _write_manifest_atomic(path: Path, payload: dict[str, Any]) -> None:
+    if not SECURE_OWNER_WRITE_AVAILABLE:  # pragma: no cover - exercised on Windows.
+        raise FindingsError("secure-owner-write-unavailable")
+    destination = Path(path).expanduser()
+    name = _manifest_name(destination)
+    data = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    parent_fd: int | None = None
+    descriptor: int | None = None
+    temporary = f".{name}.{secrets.token_hex(12)}.tmp"
+    temporary_created = False
+    try:
+        if destination.is_symlink():
+            raise FindingsError("unsafe-manifest")
+        parent_fd = _open_manifest_parent(destination)
+        if not stat.S_ISDIR(os.fstat(parent_fd).st_mode):
+            raise FindingsError("unsafe-manifest")
+        descriptor = _open_manifest_file(
+            parent_fd,
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        temporary_created = True
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise FindingsError("unsafe-manifest")
+        os.fchmod(descriptor, 0o600)
+        grokbot_jobs._write_all(descriptor, data)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(temporary, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        temporary_created = False
+        os.fsync(parent_fd)
+    except FindingsError:
+        raise
+    except OSError as exc:
+        raise FindingsError("unsafe-manifest") from exc
+    finally:
+        cleanup_error: OSError | None = None
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                cleanup_error = exc
+        if temporary_created and parent_fd is not None:
+            try:
+                os.unlink(temporary, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                cleanup_error = exc
+        if parent_fd is not None:
+            try:
+                os.close(parent_fd)
+            except OSError as exc:
+                cleanup_error = exc
+        if cleanup_error is not None:
+            raise FindingsError("unsafe-manifest") from cleanup_error
+
+
+def _read_manifest_snapshot(path: Path) -> bytes:
+    destination = Path(path).expanduser()
+    name = _manifest_name(destination)
+    parent_fd: int | None = None
+    descriptor: int | None = None
+    try:
+        parent_fd = _open_manifest_parent(destination)
+        descriptor = _open_manifest_file(parent_fd, name, os.O_RDONLY)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise FindingsError("unsafe-manifest")
+        owner_uid = getattr(os, "getuid", None)
+        if owner_uid is not None and info.st_uid != owner_uid():
+            raise FindingsError("unsafe-manifest")
+        if (info.st_mode & 0o777) != 0o600:
+            raise FindingsError("unsafe-manifest")
+        return grokbot_jobs._read_bounded_bytes(descriptor, MAX_MANIFEST_BYTES)
+    except grokbot_jobs.GrokbotJobError as exc:
+        if exc.reason == "report-too-large":
+            raise FindingsError("oversized-manifest") from exc
+        raise FindingsError("unsafe-manifest") from exc
+    except FindingsError:
+        raise
+    except OSError as exc:
+        raise FindingsError("unsafe-manifest") from exc
+    finally:
+        cleanup_error: OSError | None = None
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                cleanup_error = exc
+        if parent_fd is not None:
+            try:
+                os.close(parent_fd)
+            except OSError as exc:
+                cleanup_error = exc
+        if cleanup_error is not None:
+            raise FindingsError("unsafe-manifest") from cleanup_error
+
+
+def _identity_digest(producer: str, finding_id: str, revision: str) -> str:
+    payload = f"{producer}\0{finding_id}\0{revision}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sorted_entries(entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    return sorted(entries, key=lambda item: (item["producer"], item["finding_id"], item["revision"]))
+
+
+def _handle(entry: dict[str, str]) -> dict[str, str]:
+    return {
+        "producer": entry["producer"],
+        "finding_id": entry["finding_id"],
+        "revision": entry["revision"],
+    }
+
+
+def _queue_root(target: Path) -> Path:
+    return Path(target).expanduser() / ".brigade" / "cloud" / "grokbot"
+
+
+def _classify(
+    target: Path,
+    owner: Path,
+    entries: list[dict[str, str]],
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    directory = _open_findings_readonly(target)
+    try:
+        eligible, known, _recoverable = _classify_locked(directory, owner, entries)
+        return eligible, known
+    finally:
+        if directory is not None and directory.descriptor is not None:
+            os.close(directory.descriptor)
+
+
+def _classify_locked(
+    directory: grokbot_jobs._Directory | None,
+    owner: Path,
+    entries: list[dict[str, str]],
+) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
+    eligible: list[dict[str, str]] = []
+    known: list[dict[str, str]] = []
+    recoverable: list[dict[str, str]] = []
+    for entry in entries:
+        status = _classify_one(directory, owner, entry)
+        if status == "eligible":
+            eligible.append(entry)
+        elif status == "known":
+            known.append(entry)
+        else:
+            recoverable.append(entry)
+    return eligible, known, recoverable
+
+
+def _classify_one(
+    directory: grokbot_jobs._Directory | None,
+    owner: Path,
+    entry: dict[str, str],
+) -> str:
+    text = _render_handoff(entry)
+    name = draft_filename(entry["producer"], entry["finding_id"], entry["revision"])
+    expected_path = f"{REVIEW_INBOX}/{name}"
+    expected_digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    marker = _read_marker(directory, entry) if directory is not None else None
+    existing = _existing_handoff(owner, name)
+    if marker is not None:
+        if marker["identity"] != {"producer": entry["producer"], "finding_id": entry["finding_id"]}:
+            raise FindingsError("marker-conflict")
+        if marker["revision"] != entry["revision"]:
+            raise FindingsError("marker-conflict")
+        if marker["source_digest"] != entry["source_digest"]:
+            raise FindingsError("digest-mismatch")
+        if marker["content_digest"] != entry["content_digest"]:
+            raise FindingsError("digest-mismatch")
+        if marker["draft_path"] != expected_path or marker["draft_sha256"] != expected_digest:
+            raise FindingsError("marker-conflict")
+        if existing is not None and existing != text:
+            raise FindingsError("draft-conflict")
+        if existing is None:
+            return "recover-draft"
+        return "known"
+    if existing is not None and existing != text:
+        raise FindingsError("draft-conflict")
+    if existing is not None:
+        return "recover-marker"
+    return "eligible"
+
+
+def _deliver_one(
+    directory: grokbot_jobs._Directory,
+    owner: Path,
+    entry: dict[str, str],
+    now: datetime | None,
+) -> tuple[dict[str, str], str]:
+    text = _render_handoff(entry)
+    name = draft_filename(entry["producer"], entry["finding_id"], entry["revision"])
+    try:
+        status = grokbot_reconcile._write_handoff(owner, Path(REVIEW_INBOX), name, text)
+    except grokbot_reconcile.ReconcileError as exc:
+        raise FindingsError(exc.reason) from exc
+    _write_marker(directory, entry, text, now)
+    return _handle(entry), status
+
+
+def _render_handoff(entry: dict[str, str]) -> str:
+    title = f"Untrusted automation finding {entry['producer']}/{entry['finding_id']}"
+    summary = (
+        "This Memory Handoff carries untrusted automation output from a producer "
+        "finding. It is review-only. Route it to canonical-owner review rather "
+        "than auto-edit canonical memory, MEMORY.md, or memory cards."
+    )
+    suggested = (
+        "Untrusted automation output. Review-only. Route this finding to "
+        "canonical-owner review rather than auto-edit canonical memory.\n\n"
+        "Quoted title:\n\n"
+        + grokbot_reconcile._quote_report(entry["title"])
+        + "\n\nQuoted body:\n\n"
+        + grokbot_reconcile._quote_report(entry["body"])
+    )
+    return handoff_cmd.drafts._render_handoff_draft(
+        handoff_type="research",
+        title=title,
+        summary=summary,
+        facts=[
+            f"producer: {entry['producer']}",
+            f"finding_id: {entry['finding_id']}",
+            f"revision: {entry['revision']}",
+            f"observed_at: {entry['observed_at']}",
+            f"severity: {entry['severity']}",
+            f"source_ref: {entry['source_ref']}",
+            f"source_digest: {entry['source_digest']}",
+            f"content_digest: {entry['content_digest']}",
+        ],
+        evidence=[
+            f"findings manifest delivery for {entry['producer']}/{entry['finding_id']} revision {entry['revision']}"
+        ],
+        action=NO_CARD_ACTION,
+        target_card=None,
+        target_document=DEFAULT_DRAFT_DOCUMENT,
+        suggested_content=suggested,
+    )
+
+
+def _existing_handoff(owner: Path, name: str) -> str | None:
+    if not SECURE_OWNER_WRITE_AVAILABLE:  # pragma: no cover - exercised on Windows.
+        return None
+    descriptors: list[int] = []
+    try:
+        current = os.open(owner, grokbot_reconcile._directory_flags())
+        descriptors.append(current)
+        for part in Path(REVIEW_INBOX).parts:
+            try:
+                child = os.open(part, grokbot_reconcile._directory_flags(), dir_fd=current)
+            except FileNotFoundError:
+                return None
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise FindingsError("unsafe-storage")
+            descriptors.append(child)
+            current = child
+        try:
+            return grokbot_reconcile._read_existing_handoff_at(current, name)
+        except grokbot_reconcile.ReconcileError as exc:
+            raise FindingsError(exc.reason) from exc
+    except FindingsError:
+        raise
+    except OSError as exc:
+        raise FindingsError("unsafe-storage") from exc
+    finally:
+        close_error: OSError | None = None
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                close_error = exc
+        if close_error is not None:
+            raise FindingsError("unsafe-storage") from close_error
+
+
+def _open_findings(storage: grokbot_jobs._Storage) -> tuple[grokbot_jobs._Directory, int | None]:
+    if storage.root.descriptor is None:  # pragma: no cover - exercised on Windows.
+        path = storage.root.path / FINDINGS_DIRNAME
+        grokbot_jobs._ensure_directory(path)
+        return grokbot_jobs._Directory(path, None), None
+    descriptor = grokbot_jobs._open_or_create_directory(storage.root.descriptor, FINDINGS_DIRNAME)
+    return grokbot_jobs._Directory(storage.root.path / FINDINGS_DIRNAME, descriptor), descriptor
+
+
+def _open_findings_readonly(target: Path) -> grokbot_jobs._Directory | None:
+    names = (".brigade", "cloud", "grokbot", FINDINGS_DIRNAME)
+    if os.name != "posix":  # pragma: no cover - exercised on Windows.
+        current = Path(target).expanduser()
+        for name in names:
+            current = current / name
+            try:
+                info = current.lstat()
+            except FileNotFoundError:
+                return None
+            except OSError as exc:
+                raise FindingsError("unsafe-storage") from exc
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                raise FindingsError("unsafe-storage")
+        return grokbot_jobs._Directory(current, None)
+    descriptors: list[int] = []
+    try:
+        parent_fd = grokbot_jobs._open_directory_path(Path(target).expanduser().absolute())
+        descriptors.append(parent_fd)
+        for name in names:
+            try:
+                child_fd = grokbot_jobs._open_existing_directory(parent_fd, name)
+            except FileNotFoundError:
+                return None
+            descriptors.append(child_fd)
+            parent_fd = child_fd
+        findings_fd = descriptors.pop()
+        return grokbot_jobs._Directory(_queue_root(target) / FINDINGS_DIRNAME, findings_fd)
+    except grokbot_jobs.GrokbotJobError as exc:
+        raise FindingsError(exc.reason) from exc
+    except OSError as exc:
+        raise FindingsError("unsafe-storage") from exc
+    finally:
+        close_error: OSError | None = None
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                close_error = exc
+        if close_error is not None:
+            raise FindingsError("unsafe-storage") from close_error
+
+
+def _read_marker(directory: grokbot_jobs._Directory, entry: dict[str, str]) -> dict[str, Any] | None:
+    name = marker_filename(entry["producer"], entry["finding_id"], entry["revision"])
+    try:
+        data = grokbot_jobs._read_bytes_file(
+            directory,
+            name,
+            maximum=MARKER_MAX_BYTES,
+            missing_reason="marker-missing",
+        )
+    except grokbot_jobs.GrokbotJobError as exc:
+        if exc.reason == "marker-missing":
+            return None
+        raise FindingsError(exc.reason) from exc
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FindingsError("corrupt-storage") from exc
+    if not isinstance(payload, dict) or set(payload) != MARKER_KEYS or payload.get("schema") != FINDINGS_SCHEMA:
+        raise FindingsError("corrupt-storage")
+    identity = payload.get("identity")
+    if not isinstance(identity, dict) or set(identity) != IDENTITY_KEYS:
+        raise FindingsError("corrupt-storage")
+    if not isinstance(identity.get("producer"), str) or not isinstance(identity.get("finding_id"), str):
+        raise FindingsError("corrupt-storage")
+    if not isinstance(payload.get("revision"), str) or not grokbot_jobs.OPAQUE_ID_RE.fullmatch(payload["revision"]):
+        raise FindingsError("corrupt-storage")
+    if not isinstance(payload.get("source_digest"), str) or not grokbot_jobs.TASK_HASH_RE.fullmatch(
+        payload["source_digest"]
+    ):
+        raise FindingsError("corrupt-storage")
+    if not isinstance(payload.get("content_digest"), str) or not grokbot_jobs.TASK_HASH_RE.fullmatch(
+        payload["content_digest"]
+    ):
+        raise FindingsError("corrupt-storage")
+    if not isinstance(payload.get("draft_path"), str) or not isinstance(payload.get("draft_sha256"), str):
+        raise FindingsError("corrupt-storage")
+    if not grokbot_jobs.LOWER_HEX_64_RE.fullmatch(payload["draft_sha256"]):
+        raise FindingsError("corrupt-storage")
+    _validate_aware_timestamp(payload.get("delivered_at"), reason="corrupt-storage")
+    return payload
+
+
+def _write_marker(
+    directory: grokbot_jobs._Directory,
+    entry: dict[str, str],
+    text: str,
+    now: datetime | None,
+) -> None:
+    name = marker_filename(entry["producer"], entry["finding_id"], entry["revision"])
+    grokbot_jobs._write_json_file(
+        directory,
+        name,
+        {
+            "schema": FINDINGS_SCHEMA,
+            "identity": {"producer": entry["producer"], "finding_id": entry["finding_id"]},
+            "revision": entry["revision"],
+            "source_digest": entry["source_digest"],
+            "content_digest": entry["content_digest"],
+            "draft_path": f"{REVIEW_INBOX}/{draft_filename(entry['producer'], entry['finding_id'], entry['revision'])}",
+            "draft_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "delivered_at": grokbot_jobs._now_iso(now),
+        },
+    )

--- a/tests/test_grokbot_findings.py
+++ b/tests/test_grokbot_findings.py
@@ -1,0 +1,1137 @@
+"""Producer-neutral Grok Bot automation-finding delivery."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from itertools import permutations
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, grokbot_findings
+
+
+NOW = datetime(2026, 8, 27, 15, 0, tzinfo=timezone.utc)
+PRIVATE_TITLE = "PRIVATE_FINDING_TITLE_TOKEN"
+PRIVATE_BODY = "PRIVATE_FINDING_BODY_TOKEN_alpha\n## Injected Heading\nUntrusted automation body.\n"
+LIVE_REASON_MAX_BYTES = 16_384
+LIVE_SUMMARY_MAX_BYTES = 4_096
+PROPOSAL_TITLE_MAX_CHARS = 120
+
+
+def _proposal_title(producer: str, finding_id: str) -> str:
+    title = f"[UNTRUSTED] {producer} {finding_id}"
+    return title if len(title) <= PROPOSAL_TITLE_MAX_CHARS else title[:PROPOSAL_TITLE_MAX_CHARS]
+
+
+def _digest(text: str = PRIVATE_BODY) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _content_digest(title: str = PRIVATE_TITLE, body: str = PRIVATE_BODY) -> str:
+    return "sha256:" + hashlib.sha256(f"{title}\0{body}".encode("utf-8")).hexdigest()
+
+
+def _revision_digest(seed: str = "fleet-revision") -> str:
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _live_fleet_record() -> dict[str, object]:
+    revision = _revision_digest("fleet-control-plane")
+    return {
+        "producer": "fleet",
+        "finding_id": "control-plane:unreachable",
+        "revision": revision,
+        "observed_at": "",
+        "severity": "unknown",
+        "title": PRIVATE_TITLE,
+        "body": PRIVATE_BODY,
+        "source_ref": "fleet:control-plane:unreachable",
+        "source_digest": revision,
+        "trust": "untrusted",
+        "delivery": "review-only",
+    }
+
+
+def _live_backup_record() -> dict[str, object]:
+    revision = _revision_digest("backup-stale-lock")
+    return {
+        "producer": "backup",
+        "finding_id": "configuration-nas:stale-lock",
+        "revision": revision,
+        "observed_at": "2026-08-27T15:00:00Z",
+        "severity": "warning",
+        "title": PRIVATE_TITLE,
+        "body": PRIVATE_BODY,
+        "source_ref": "backup:configuration-nas:stale-lock",
+        "source_digest": revision,
+        "trust": "untrusted",
+        "delivery": "review-only",
+    }
+
+
+def _approved_live_entry(
+    *,
+    producer: str = "fleet",
+    finding_id: str = "control-plane:unreachable",
+    revision: str | None = None,
+    observed_at: str = "",
+    severity: str = "unknown",
+    source_ref: str = "fleet:control-plane:unreachable",
+    source_digest: str | None = None,
+) -> dict[str, object]:
+    revision_hex = revision or _revision_digest("fleet-control-plane")
+    return {
+        "producer": producer,
+        "finding_id": finding_id,
+        "revision": revision_hex,
+        "observed_at": observed_at,
+        "severity": severity,
+        "title": PRIVATE_TITLE,
+        "body": PRIVATE_BODY,
+        "source_ref": source_ref,
+        "source_digest": source_digest or f"sha256:{revision_hex}",
+        "content_digest": _content_digest(),
+    }
+
+
+def _entry(
+    *,
+    producer: str = "cerebro-research",
+    finding_id: str = "finding-alpha",
+    revision: str = "1",
+    title: str = PRIVATE_TITLE,
+    body: str = PRIVATE_BODY,
+    source_ref: str = "cerebro://vault/findings/alpha",
+) -> dict[str, object]:
+    return {
+        "producer": producer,
+        "finding_id": finding_id,
+        "revision": revision,
+        "observed_at": "2026-08-27T15:00:00Z",
+        "severity": "high",
+        "title": title,
+        "body": body,
+        "source_ref": source_ref,
+        "source_digest": _digest(body),
+        "content_digest": _content_digest(title, body),
+    }
+
+
+def _manifest(*entries: dict[str, object]) -> dict[str, object]:
+    return {"schema": "brigade.grokbot.findings.v1", "entries": list(entries)}
+
+
+def _write_manifest(path: Path, payload: dict[str, object], *, mode: int = 0o600) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(mode)
+    return path
+
+
+def _queue_root(queue: Path) -> Path:
+    return queue / ".brigade" / "cloud" / "grokbot"
+
+
+def _review_inbox(owner: Path) -> Path:
+    return owner / "memory" / "handoff-inbox"
+
+
+def _draft_name(entry: dict[str, object]) -> str:
+    return grokbot_findings.draft_filename(
+        str(entry["producer"]),
+        str(entry["finding_id"]),
+        str(entry["revision"]),
+    )
+
+
+def _marker_name(entry: dict[str, object]) -> str:
+    return grokbot_findings.marker_filename(
+        str(entry["producer"]),
+        str(entry["finding_id"]),
+        str(entry["revision"]),
+    )
+
+
+def _handle(entry: dict[str, object]) -> dict[str, str]:
+    return {
+        "producer": str(entry["producer"]),
+        "finding_id": str(entry["finding_id"]),
+        "revision": str(entry["revision"]),
+    }
+
+
+def test_preview_counts_valid_entries_and_writes_nothing(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    first = _entry()
+    second = _entry(finding_id="finding-beta", source_ref="cerebro://vault/findings/beta")
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(first, second))
+
+    result = grokbot_findings.preview(queue, owner, manifest)
+
+    assert result == {
+        "eligible": 2,
+        "known": 0,
+        "created": 0,
+        "limit": 1,
+        "findings": [_handle(first)],
+    }
+    dumped = json.dumps(result, sort_keys=True)
+    assert PRIVATE_TITLE not in dumped
+    assert PRIVATE_BODY not in dumped
+    assert "PRIVATE_FINDING_BODY_TOKEN_alpha" not in dumped
+    assert "Injected Heading" not in dumped
+    assert not _review_inbox(owner).exists()
+    assert not (_queue_root(queue) / "findings").exists()
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        (
+            {
+                "schema": "brigade.grokbot.findings.v0",
+                "entries": [_entry()],
+            },
+            "invalid-schema",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.findings.v1",
+                "approved": True,
+                "entries": [_entry()],
+            },
+            "malformed-manifest",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.findings.v1",
+                "api_token": "secret-value",
+                "entries": [_entry()],
+            },
+            "malformed-manifest",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.findings.v1",
+                "entries": [{**_entry(), "api_token": "secret-value"}],
+            },
+            "invalid-entry",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.findings.v1",
+                "entries": [_entry(), _entry(revision="2")],
+            },
+            "duplicate-identity",
+        ),
+        (
+            {
+                "schema": "brigade.grokbot.findings.v1",
+                "entries": [{**_entry(), "content_digest": "sha256:" + ("ab" * 32)}],
+            },
+            "digest-mismatch",
+        ),
+    ],
+)
+def test_preview_rejects_malformed_manifests_without_writing(tmp_path: Path, payload: dict[str, object], reason: str):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    manifest = _write_manifest(tmp_path / "findings.json", payload)
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.preview(queue, owner, manifest)
+
+    assert exc.value.reason == reason
+    assert not _review_inbox(owner).exists()
+    assert not (_queue_root(queue) / "findings").exists()
+
+
+def test_preview_rejects_group_readable_manifest_without_writing(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(_entry()), mode=0o640)
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.preview(queue, owner, manifest)
+
+    assert exc.value.reason == "unsafe-manifest"
+    assert not _review_inbox(owner).exists()
+
+
+def test_preview_rejects_symlink_manifest_without_writing(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    real = _write_manifest(tmp_path / "real.json", _manifest(_entry()))
+    link = tmp_path / "findings.json"
+    link.symlink_to(real)
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.preview(queue, owner, link)
+
+    assert exc.value.reason == "unsafe-manifest"
+    assert not _review_inbox(owner).exists()
+
+
+def test_preview_rejects_oversized_manifest_without_writing(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    manifest = tmp_path / "findings.json"
+    manifest.write_bytes(b"{" + (b"a" * grokbot_findings.MAX_MANIFEST_BYTES) + b"}")
+    manifest.chmod(0o600)
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.preview(queue, owner, manifest)
+
+    assert exc.value.reason == "oversized-manifest"
+    assert not _review_inbox(owner).exists()
+
+
+@pytest.mark.parametrize("limit", [0, 51, -1, True, 1.5, "1"])
+def test_preview_rejects_invalid_limits_without_writing(tmp_path: Path, limit: object):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(_entry()))
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.preview(queue, owner, manifest, limit=limit)  # type: ignore[arg-type]
+
+    assert exc.value.reason == "invalid-limit"
+    assert not _review_inbox(owner).exists()
+
+
+def test_apply_writes_one_quoted_handoff_and_a_private_marker(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry, _entry(finding_id="finding-beta")))
+
+    result = grokbot_findings.apply(queue, owner, manifest, now=NOW)
+
+    assert result == {
+        "eligible": 2,
+        "known": 0,
+        "created": 1,
+        "skipped": 0,
+        "limit": 1,
+        "findings": [_handle(entry)],
+    }
+    dumped = json.dumps(result, sort_keys=True)
+    assert PRIVATE_TITLE not in dumped
+    assert "PRIVATE_FINDING_BODY_TOKEN_alpha" not in dumped
+
+    inbox = _review_inbox(owner)
+    drafts = list(inbox.glob("*.md"))
+    assert [path.name for path in drafts] == [_draft_name(entry)]
+    text = drafts[0].read_text(encoding="utf-8")
+    assert "## Recommended memory action\n\nno-card" in text
+    assert "untrusted" in text.casefold()
+    assert "review-only" in text.casefold() or "review only" in text.casefold()
+    assert "canonical" in text.casefold()
+    assert entry["producer"] in text
+    assert entry["finding_id"] in text
+    assert entry["revision"] in text
+    assert entry["observed_at"] in text
+    assert entry["severity"] in text
+    assert entry["source_ref"] in text
+    assert entry["source_digest"] in text
+    assert entry["content_digest"] in text
+    assert f"> {PRIVATE_TITLE}" in text
+    assert "> PRIVATE_FINDING_BODY_TOKEN_alpha" in text
+    assert "> ## Injected Heading" in text
+    assert f"\n{PRIVATE_TITLE}\n" not in text
+    assert "\n## Injected Heading\n" not in text
+    assert "do not auto-edit canonical memory" in text.casefold() or "rather than auto-edit" in text.casefold()
+    assert inbox.stat().st_mode & 0o777 == 0o700
+    assert drafts[0].stat().st_mode & 0o777 == 0o600
+
+    marker = _queue_root(queue) / "findings" / _marker_name(entry)
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert set(payload) == {
+        "schema",
+        "identity",
+        "revision",
+        "source_digest",
+        "content_digest",
+        "draft_path",
+        "draft_sha256",
+        "delivered_at",
+    }
+    assert payload["schema"] == "brigade.grokbot.findings.v1"
+    assert payload["identity"] == {"producer": entry["producer"], "finding_id": entry["finding_id"]}
+    assert payload["revision"] == entry["revision"]
+    assert payload["source_digest"] == entry["source_digest"]
+    assert payload["content_digest"] == entry["content_digest"]
+    assert payload["draft_path"] == f"memory/handoff-inbox/{_draft_name(entry)}"
+    assert payload["draft_sha256"] == hashlib.sha256(text.encode("utf-8")).hexdigest()
+    assert payload["delivered_at"] == "2026-08-27T15:00:00Z"
+    assert PRIVATE_TITLE not in json.dumps(payload)
+    assert PRIVATE_BODY not in json.dumps(payload)
+    assert marker.stat().st_mode & 0o777 == 0o600
+    assert marker.parent.stat().st_mode & 0o777 == 0o700
+    assert not (_review_inbox(owner) / _draft_name(_entry(finding_id="finding-beta"))).exists()
+
+
+def test_same_revision_is_idempotent(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+    first = grokbot_findings.apply(queue, owner, manifest, now=NOW)
+    draft = _review_inbox(owner) / _draft_name(entry)
+    before = draft.read_text(encoding="utf-8")
+
+    second = grokbot_findings.apply(queue, owner, manifest, now=NOW)
+    preview = grokbot_findings.preview(queue, owner, manifest)
+
+    assert first["created"] == 1
+    assert second == {
+        "eligible": 0,
+        "known": 1,
+        "created": 0,
+        "skipped": 1,
+        "limit": 1,
+        "findings": [],
+    }
+    assert preview["eligible"] == 0
+    assert preview["known"] == 1
+    assert preview["created"] == 0
+    assert list(_review_inbox(owner).glob("*.md")) == [draft]
+    assert draft.read_text(encoding="utf-8") == before
+
+
+def test_revision_change_writes_a_non_colliding_replacement_draft(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    first = _entry(revision="1")
+    second = _entry(revision="2", body=PRIVATE_BODY + "revision two\n")
+    grokbot_findings.apply(queue, owner, _write_manifest(tmp_path / "first.json", _manifest(first)), now=NOW)
+
+    result = grokbot_findings.apply(queue, owner, _write_manifest(tmp_path / "second.json", _manifest(second)), now=NOW)
+
+    assert result["created"] == 1
+    assert result["findings"] == [_handle(second)]
+    names = sorted(path.name for path in _review_inbox(owner).glob("*.md"))
+    assert names == sorted((_draft_name(first), _draft_name(second)))
+    assert _draft_name(first) != _draft_name(second)
+    assert (_queue_root(queue) / "findings" / _marker_name(first)).is_file()
+    assert (_queue_root(queue) / "findings" / _marker_name(second)).is_file()
+
+
+def test_malformed_later_entry_fails_closed_before_any_write(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    later = _entry(finding_id="finding-beta")
+    later.pop("body")
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(_entry(), later))
+
+    with pytest.raises(grokbot_findings.FindingsError, match="^invalid-entry$"):
+        grokbot_findings.apply(queue, owner, manifest, now=NOW)
+
+    assert not _review_inbox(owner).exists()
+    assert (
+        not (_queue_root(queue) / "findings").exists() or list((_queue_root(queue) / "findings").glob("*.json")) == []
+    )
+
+
+def test_conflicting_marker_fails_closed_before_any_write(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    first = _entry()
+    second = _entry(finding_id="finding-beta", source_ref="cerebro://vault/findings/beta")
+    findings_dir = _queue_root(queue) / "findings"
+    findings_dir.mkdir(parents=True)
+    (findings_dir / _marker_name(second)).write_text(
+        json.dumps(
+            {
+                "schema": "brigade.grokbot.findings.v1",
+                "identity": {"producer": second["producer"], "finding_id": second["finding_id"]},
+                "revision": second["revision"],
+                "source_digest": "sha256:" + ("ab" * 32),
+                "content_digest": "sha256:" + ("ef" * 32),
+                "draft_path": "memory/handoff-inbox/other.md",
+                "draft_sha256": "cd" * 32,
+                "delivered_at": "2026-08-27T15:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(grokbot_findings.FindingsError, match="^(marker-conflict|digest-mismatch)$"):
+        grokbot_findings.apply(
+            queue, owner, _write_manifest(tmp_path / "findings.json", _manifest(first, second)), now=NOW
+        )
+
+    assert not _review_inbox(owner).exists()
+    assert not (_queue_root(queue) / "findings" / _marker_name(first)).exists()
+
+
+def test_existing_draft_with_different_bytes_fails_closed(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    inbox = _review_inbox(owner)
+    inbox.mkdir(parents=True)
+    draft = inbox / _draft_name(entry)
+    draft.write_text("different draft bytes\n", encoding="utf-8")
+
+    with pytest.raises(grokbot_findings.FindingsError, match="^draft-conflict$"):
+        grokbot_findings.apply(queue, owner, _write_manifest(tmp_path / "findings.json", _manifest(entry)), now=NOW)
+
+    assert draft.read_text(encoding="utf-8") == "different draft bytes\n"
+    assert not (_queue_root(queue) / "findings" / _marker_name(entry)).exists()
+
+
+def test_existing_handoff_symlink_fails_closed(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    inbox = _review_inbox(owner)
+    inbox.mkdir(parents=True)
+    outside = tmp_path / "outside.md"
+    outside.write_text("do not replace\n", encoding="utf-8")
+    (_review_inbox(owner) / _draft_name(entry)).symlink_to(outside)
+
+    with pytest.raises(grokbot_findings.FindingsError, match="^unsafe-storage$"):
+        grokbot_findings.apply(queue, owner, _write_manifest(tmp_path / "findings.json", _manifest(entry)), now=NOW)
+
+    assert outside.read_text(encoding="utf-8") == "do not replace\n"
+    assert not (_queue_root(queue) / "findings" / _marker_name(entry)).exists()
+
+
+def test_restart_after_draft_without_marker_does_not_duplicate(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+    grokbot_findings.apply(queue, owner, manifest, now=NOW)
+    marker = _queue_root(queue) / "findings" / _marker_name(entry)
+    marker.unlink()
+
+    result = grokbot_findings.apply(queue, owner, manifest, now=NOW)
+
+    assert result["created"] == 0
+    assert result["skipped"] == 1
+    drafts = list(_review_inbox(owner).glob("*.md"))
+    assert [path.name for path in drafts] == [_draft_name(entry)]
+    assert marker.is_file()
+
+
+def _run_findings(queue: Path, owner: Path, manifest: Path, *command: str) -> int:
+    return cli.main(
+        [
+            "run",
+            "cloud",
+            "grokbot",
+            "reconcile-findings",
+            "--target",
+            str(queue),
+            "--owner",
+            str(owner),
+            "--manifest",
+            str(manifest),
+            *command,
+        ]
+    )
+
+
+def test_cli_preview_defaults_to_write_nothing_and_omits_finding_text(tmp_path: Path, capsys):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+
+    assert _run_findings(queue, owner, manifest) == 0
+    captured = capsys.readouterr()
+    assert "eligible=1" in captured.out
+    assert "known=0" in captured.out
+    assert entry["producer"] in captured.out
+    assert entry["finding_id"] in captured.out
+    assert PRIVATE_TITLE not in captured.out
+    assert PRIVATE_BODY not in captured.out
+    assert "Injected Heading" not in captured.out
+    assert captured.err == ""
+    assert not _review_inbox(owner).exists()
+
+
+def test_cli_apply_json_stays_free_of_finding_text(tmp_path: Path, capsys):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+
+    assert _run_findings(queue, owner, manifest, "--apply", "--json") == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["created"] == 1
+    assert payload["findings"][0]["finding_id"] == entry["finding_id"]
+    assert PRIVATE_TITLE not in captured.out
+    assert PRIVATE_BODY not in captured.out
+    assert (_review_inbox(owner) / _draft_name(entry)).is_file()
+
+
+def test_cli_rejects_invalid_limit_without_writing(tmp_path: Path, capsys):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(_entry()))
+
+    assert _run_findings(queue, owner, manifest, "--apply", "--limit", "0") == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: invalid-limit"
+    assert not _review_inbox(owner).exists()
+
+
+def test_reconcile_findings_appears_in_parser_inventory():
+    from brigade.roadmap_cmd import _cli_command_paths
+
+    assert "brigade run-cloud grokbot reconcile-findings" in _cli_command_paths()
+
+
+def _apply_in_process(queue: str, owner: str, manifest: str, connection) -> None:
+    try:
+        result = grokbot_findings.apply(Path(queue), Path(owner), Path(manifest), now=NOW)
+    except grokbot_findings.FindingsError as exc:
+        connection.send({"error": exc.reason})
+    else:
+        connection.send(result)
+    finally:
+        connection.close()
+
+
+def test_concurrent_apply_creates_only_one_draft(tmp_path: Path):
+    from multiprocessing import Pipe, Process
+
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+    first_parent, first_child = Pipe(duplex=False)
+    second_parent, second_child = Pipe(duplex=False)
+    first = Process(target=_apply_in_process, args=(str(queue), str(owner), str(manifest), first_child))
+    second = Process(target=_apply_in_process, args=(str(queue), str(owner), str(manifest), second_child))
+    first.start()
+    second.start()
+    first.join()
+    second.join()
+    results = [first_parent.recv(), second_parent.recv()]
+    created = sum(item.get("created", 0) for item in results if "created" in item)
+    assert created == 1
+    drafts = list(_review_inbox(owner).glob("*.md"))
+    assert [path.name for path in drafts] == [_draft_name(entry)]
+
+
+def test_generic_manifest_accepts_live_compatible_values_without_leaking_text(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _approved_live_entry()
+    assert entry["source_digest"] != _digest(PRIVATE_BODY)
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+
+    result = grokbot_findings.preview(queue, owner, manifest)
+
+    assert result["eligible"] == 1
+    assert result["findings"] == [_handle(entry)]
+    dumped = json.dumps(result, sort_keys=True)
+    assert PRIVATE_TITLE not in dumped
+    assert PRIVATE_BODY not in dumped
+    assert not _review_inbox(owner).exists()
+    assert not (_queue_root(queue) / "findings").exists()
+
+
+@pytest.mark.parametrize("severity", ["info", "low", "medium", "warning", "high", "critical", "unknown"])
+def test_generic_manifest_accepts_live_and_backup_severities(tmp_path: Path, severity: str):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _approved_live_entry(severity=severity)
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+
+    result = grokbot_findings.preview(queue, owner, manifest)
+
+    assert result["eligible"] == 1
+
+
+def test_generic_manifest_rejects_content_digest_mismatch_without_writing(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = {**_approved_live_entry(), "content_digest": "sha256:" + ("cd" * 32)}
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.preview(queue, owner, manifest)
+
+    assert exc.value.reason == "digest-mismatch"
+    assert not _review_inbox(owner).exists()
+    assert not (_queue_root(queue) / "findings").exists()
+
+
+def test_adapt_live_fleet_preserves_unknown_severity_empty_time_and_revision_digest():
+    live = _live_fleet_record()
+    adapted = grokbot_findings.adapt_live_finding(live)
+
+    assert adapted["producer"] == "fleet"
+    assert adapted["finding_id"] == live["finding_id"]
+    assert adapted["revision"] == live["revision"]
+    assert adapted["observed_at"] == ""
+    assert adapted["severity"] == "unknown"
+    assert adapted["source_digest"] == f"sha256:{live['revision']}"
+    assert adapted["source_digest"] != _digest(PRIVATE_BODY)
+    assert adapted["title"] == _proposal_title("fleet", str(live["finding_id"]))
+    assert adapted["body"] == PRIVATE_BODY
+    assert adapted["content_digest"] == _content_digest(adapted["title"], PRIVATE_BODY)
+    assert "trust" not in adapted
+    assert "delivery" not in adapted
+    assert set(adapted) == grokbot_findings.REQUIRED_ENTRY_KEYS
+
+
+def test_adapt_live_backup_preserves_warning_severity_and_revision_digest():
+    live = _live_backup_record()
+    adapted = grokbot_findings.adapt_live_finding(live)
+
+    assert adapted["producer"] == "backup"
+    assert adapted["severity"] == "warning"
+    assert adapted["observed_at"] == live["observed_at"]
+    assert adapted["source_digest"] == f"sha256:{live['revision']}"
+    assert adapted["title"] == _proposal_title("backup", str(live["finding_id"]))
+    assert adapted["body"] == PRIVATE_BODY
+    assert adapted["content_digest"] == _content_digest(adapted["title"], PRIVATE_BODY)
+    assert set(adapted) == grokbot_findings.REQUIRED_ENTRY_KEYS
+
+
+def test_adapt_live_finding_rejects_unexpected_keys():
+    live = {**_live_fleet_record(), "api_token": "secret-value"}
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.adapt_live_finding(live)
+
+    assert exc.value.reason == "invalid-entry"
+
+
+def test_adapted_live_finding_loads_through_the_generic_manifest(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    adapted = grokbot_findings.adapt_live_finding(_live_fleet_record())
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(adapted))
+
+    result = grokbot_findings.apply(queue, owner, manifest, now=NOW)
+
+    assert result["created"] == 1
+    marker = _queue_root(queue) / "findings" / _marker_name(adapted)
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["source_digest"] == adapted["source_digest"]
+    assert payload["content_digest"] == adapted["content_digest"]
+    assert PRIVATE_TITLE not in json.dumps(payload)
+    assert PRIVATE_BODY not in json.dumps(payload)
+
+
+def test_recovery_writes_count_against_the_same_limit(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entries = [
+        _entry(finding_id=f"finding-{index:02d}", source_ref=f"cerebro://vault/findings/{index:02d}")
+        for index in range(50)
+    ]
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(*entries))
+    seeded = grokbot_findings.apply(queue, owner, manifest, limit=50, now=NOW)
+    assert seeded["created"] == 50
+    findings_dir = _queue_root(queue) / "findings"
+    for entry in entries:
+        (findings_dir / _marker_name(entry)).unlink()
+    drafts_before = sorted(path.name for path in _review_inbox(owner).glob("*.md"))
+
+    result = grokbot_findings.apply(queue, owner, manifest, limit=1, now=NOW)
+
+    assert result["created"] == 0
+    assert result["skipped"] == 1
+    markers = sorted(path.name for path in findings_dir.glob("*.json"))
+    assert markers == [_marker_name(entries[0])]
+    assert sorted(path.name for path in _review_inbox(owner).glob("*.md")) == drafts_before
+
+
+def test_selection_is_independent_of_manifest_order(tmp_path: Path):
+    entries = [
+        _entry(producer="zeta-producer", finding_id="finding-z", revision="2", source_ref="cerebro://vault/z"),
+        _entry(producer="alpha-producer", finding_id="finding-b", revision="1", source_ref="cerebro://vault/b"),
+        _entry(producer="alpha-producer", finding_id="finding-a", revision="9", source_ref="cerebro://vault/a"),
+    ]
+    expected = _handle(entries[2])
+    handles: list[dict[str, str]] = []
+    for index, ordered in enumerate(permutations(entries)):
+        queue = tmp_path / f"queue-{index}"
+        owner = tmp_path / f"owner-{index}"
+        queue.mkdir()
+        owner.mkdir()
+        manifest = _write_manifest(tmp_path / f"findings-{index}.json", _manifest(*ordered))
+        preview = grokbot_findings.preview(queue, owner, manifest)
+        applied = grokbot_findings.apply(queue, owner, manifest, now=NOW)
+        handles.append(preview["findings"][0])
+        assert applied["findings"] == [expected]
+        assert preview["findings"] == [expected]
+        assert PRIVATE_TITLE not in json.dumps(preview)
+        assert PRIVATE_BODY not in json.dumps(applied)
+    assert handles == [expected] * 6
+
+
+@pytest.mark.parametrize("delivered_at", ["", "not-a-timestamp", "2026-08-27T15:00:00"])
+def test_corrupt_marker_delivered_at_fails_closed(tmp_path: Path, delivered_at: str):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+    grokbot_findings.apply(queue, owner, manifest, now=NOW)
+    marker = _queue_root(queue) / "findings" / _marker_name(entry)
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["delivered_at"] = delivered_at
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+    marker.chmod(0o600)
+    draft = _review_inbox(owner) / _draft_name(entry)
+    before = draft.read_text(encoding="utf-8")
+
+    with pytest.raises(grokbot_findings.FindingsError) as preview_exc:
+        grokbot_findings.preview(queue, owner, manifest)
+    with pytest.raises(grokbot_findings.FindingsError) as apply_exc:
+        grokbot_findings.apply(queue, owner, manifest, now=NOW)
+
+    assert preview_exc.value.reason == "corrupt-storage"
+    assert apply_exc.value.reason == "corrupt-storage"
+    assert json.loads(marker.read_text(encoding="utf-8"))["delivered_at"] == delivered_at
+    assert draft.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.parametrize("component", [".brigade", "cloud", "grokbot"])
+def test_preview_refuses_symlinked_storage_parents_and_writes_nothing(tmp_path: Path, component: str):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _entry()
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+    grokbot_findings.apply(queue, owner, manifest, now=NOW)
+    if component == ".brigade":
+        real = tmp_path / "outside-brigade"
+        (queue / ".brigade").rename(real)
+        (queue / ".brigade").symlink_to(real)
+        outside = real
+    elif component == "cloud":
+        real = tmp_path / "outside-cloud"
+        (queue / ".brigade" / "cloud").rename(real)
+        (queue / ".brigade" / "cloud").symlink_to(real)
+        outside = real
+    else:
+        real = tmp_path / "outside-grokbot"
+        (queue / ".brigade" / "cloud" / "grokbot").rename(real)
+        (queue / ".brigade" / "cloud" / "grokbot").symlink_to(real)
+        outside = real
+    owner_before = _walk_names(owner)
+    queue_before = _walk_names(queue)
+    outside_before = _walk_names(outside)
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.preview(queue, owner, manifest)
+
+    assert exc.value.reason == "unsafe-storage"
+    assert _walk_names(owner) == owner_before
+    assert _walk_names(queue) == queue_before
+    assert _walk_names(outside) == outside_before
+
+
+def _walk_names(root: Path) -> list[str]:
+    names: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(dirpath)
+        for name in dirnames + filenames:
+            names.append(str((current / name).relative_to(root)))
+    return sorted(names)
+
+
+def test_adapt_live_fleet_accepts_max_reason_and_derives_proposal_title():
+    live = _live_fleet_record()
+    live["title"] = "R" * LIVE_REASON_MAX_BYTES
+
+    adapted = grokbot_findings.adapt_live_finding(live)
+
+    assert adapted["title"] == _proposal_title("fleet", str(live["finding_id"]))
+    assert len(adapted["title"]) <= PROPOSAL_TITLE_MAX_CHARS
+    assert adapted["body"] == PRIVATE_BODY
+    assert adapted["content_digest"] == _content_digest(adapted["title"], PRIVATE_BODY)
+    assert "R" * 200 not in adapted["title"]
+
+
+def test_adapt_live_backup_accepts_max_summary_and_derives_proposal_title():
+    live = _live_backup_record()
+    live["title"] = "S" * LIVE_SUMMARY_MAX_BYTES
+
+    adapted = grokbot_findings.adapt_live_finding(live)
+
+    assert adapted["title"] == _proposal_title("backup", str(live["finding_id"]))
+    assert adapted["body"] == PRIVATE_BODY
+    assert adapted["content_digest"] == _content_digest(adapted["title"], PRIVATE_BODY)
+
+
+def test_adapt_live_proposal_title_is_sliced_to_the_live_relay_limit():
+    live = _live_fleet_record()
+    live["finding_id"] = "a" * 128
+
+    adapted = grokbot_findings.adapt_live_finding(live)
+
+    assert adapted["title"] == _proposal_title("fleet", "a" * 128)
+    assert adapted["title"] == ("[UNTRUSTED] fleet " + ("a" * 128))[:PROPOSAL_TITLE_MAX_CHARS]
+    assert len(adapted["title"]) == PROPOSAL_TITLE_MAX_CHARS
+    assert adapted["body"] == PRIVATE_BODY
+
+
+def test_adapt_live_rejects_title_over_the_live_maximum():
+    live = _live_fleet_record()
+    live["title"] = "R" * (LIVE_REASON_MAX_BYTES + 1)
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.adapt_live_finding(live)
+
+    assert exc.value.reason == "invalid-title"
+
+
+def test_adapt_live_accepts_source_ref_with_consecutive_dots():
+    live = _live_fleet_record()
+    live["finding_id"] = "host..alias:unreachable"
+    live["source_ref"] = "fleet:host..alias:unreachable"
+
+    adapted = grokbot_findings.adapt_live_finding(live)
+
+    assert adapted["finding_id"] == "host..alias:unreachable"
+    assert adapted["source_ref"] == "fleet:host..alias:unreachable"
+
+
+def test_generic_manifest_accepts_source_ref_with_consecutive_dots(tmp_path: Path):
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    entry = _approved_live_entry(
+        finding_id="host..alias:unreachable",
+        source_ref="fleet:host..alias:unreachable",
+    )
+    manifest = _write_manifest(tmp_path / "findings.json", _manifest(entry))
+
+    result = grokbot_findings.preview(queue, owner, manifest)
+
+    assert result["eligible"] == 1
+    assert result["findings"] == [_handle(entry)]
+
+
+@pytest.mark.parametrize(
+    "source_ref",
+    ["fleet:\x00id", "fleet:\nid", "fleet:\rid", "x" * 513],
+)
+def test_source_ref_still_rejects_control_characters_and_overlength(source_ref: str):
+    live = {**_live_fleet_record(), "source_ref": source_ref}
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.adapt_live_finding(live)
+
+    assert exc.value.reason == "invalid-source-ref"
+
+
+def _live_manifest(*entries: dict[str, object]) -> dict[str, object]:
+    return {"schema": "brigade.grokbot.live-findings.v1", "entries": list(entries)}
+
+
+def _run_convert(target: Path, source: Path, destination: Path, *command: str) -> int:
+    return cli.main(
+        [
+            "run",
+            "cloud",
+            "grokbot",
+            "convert-findings",
+            "--target",
+            str(target),
+            "--input",
+            str(source),
+            "--output",
+            str(destination),
+            *command,
+        ]
+    )
+
+
+def test_convert_live_findings_writes_0600_manifest_without_printing_text(tmp_path: Path, capsys):
+    source = _write_manifest(
+        tmp_path / "live.json",
+        _live_manifest(_live_backup_record(), _live_fleet_record()),
+    )
+    destination = tmp_path / "findings.json"
+
+    assert _run_convert(tmp_path, source, destination) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+    fleet = grokbot_findings.adapt_live_finding(_live_fleet_record())
+    backup = grokbot_findings.adapt_live_finding(_live_backup_record())
+
+    assert destination.stat().st_mode & 0o777 == 0o600
+    assert payload == {"schema": "brigade.grokbot.findings.v1", "entries": [backup, fleet]}
+    assert "converted=2" in captured.out
+    assert fleet["producer"] in captured.out
+    assert fleet["finding_id"] in captured.out
+    assert PRIVATE_TITLE not in captured.out
+    assert PRIVATE_BODY not in captured.out
+    assert PRIVATE_TITLE not in captured.err
+    assert PRIVATE_BODY not in captured.err
+    assert "Injected Heading" not in captured.out
+    assert captured.err == ""
+
+
+def test_convert_live_findings_json_stays_free_of_finding_text(tmp_path: Path, capsys):
+    source = _write_manifest(tmp_path / "live.json", _live_manifest(_live_fleet_record()))
+    destination = tmp_path / "findings.json"
+
+    assert _run_convert(tmp_path, source, destination, "--json") == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    live = _live_fleet_record()
+
+    assert payload["converted"] == 1
+    assert payload["findings"] == [_handle(live)]
+    assert PRIVATE_TITLE not in captured.out
+    assert PRIVATE_BODY not in captured.out
+    assert set(payload) == {"converted", "findings"}
+    assert set(payload["findings"][0]) == {"producer", "finding_id", "revision"}
+
+
+def test_convert_live_findings_fails_closed_on_invalid_later_entry(tmp_path: Path, capsys):
+    later = _live_fleet_record()
+    later.pop("body")
+    source = _write_manifest(tmp_path / "live.json", _live_manifest(_live_backup_record(), later))
+    destination = tmp_path / "findings.json"
+
+    assert _run_convert(tmp_path, source, destination) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: invalid-entry"
+    assert not destination.exists()
+
+
+def test_convert_live_findings_refuses_symlink_output_and_writes_nothing(tmp_path: Path):
+    source = _write_manifest(tmp_path / "live.json", _live_manifest(_live_fleet_record()))
+    outside = tmp_path / "outside.json"
+    outside.write_text("do not replace\n", encoding="utf-8")
+    destination = tmp_path / "findings.json"
+    destination.symlink_to(outside)
+
+    assert _run_convert(tmp_path, source, destination) == 2
+    assert outside.read_text(encoding="utf-8") == "do not replace\n"
+    assert destination.is_symlink()
+
+
+def _via_intermediate_parent(tmp_path: Path, *, label: str) -> tuple[Path, Path]:
+    real = tmp_path / f"real-{label}"
+    nested = real / "nested"
+    nested.mkdir(parents=True)
+    hop = tmp_path / f"hop-{label}"
+    hop.mkdir()
+    (hop / "mid").symlink_to(real)
+    return nested, hop / "mid" / "nested"
+
+
+def test_convert_live_findings_refuses_symlinked_intermediate_input_parent_and_reads_nothing(tmp_path: Path, capsys):
+    real_dir, via_dir = _via_intermediate_parent(tmp_path, label="input")
+    source_real = _write_manifest(real_dir / "live.json", _live_manifest(_live_fleet_record()))
+    source = via_dir / "live.json"
+    destination = tmp_path / "findings.json"
+    before = source_real.read_bytes()
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.convert_live_findings(source, destination)
+    assert exc.value.reason == "unsafe-manifest"
+    assert _run_convert(tmp_path, source, destination) == 2
+    captured = capsys.readouterr()
+
+    assert captured.out == ""
+    assert captured.err.strip() == "error: unsafe-manifest"
+    assert PRIVATE_TITLE not in captured.out
+    assert PRIVATE_BODY not in captured.out
+    assert PRIVATE_TITLE not in captured.err
+    assert PRIVATE_BODY not in captured.err
+    assert not destination.exists()
+    assert source_real.read_bytes() == before
+    assert not (via_dir / "findings.json").exists()
+
+
+def test_convert_live_findings_refuses_symlinked_intermediate_output_parent_and_writes_nothing(tmp_path: Path, capsys):
+    source = _write_manifest(tmp_path / "live.json", _live_manifest(_live_fleet_record()))
+    real_dir, via_dir = _via_intermediate_parent(tmp_path, label="output")
+    canary = real_dir / "canary.txt"
+    canary.write_text("keep outside\n", encoding="utf-8")
+    destination = via_dir / "findings.json"
+    outside_before = _walk_names(real_dir.parent)
+
+    with pytest.raises(grokbot_findings.FindingsError) as exc:
+        grokbot_findings.convert_live_findings(source, destination)
+    assert exc.value.reason == "unsafe-manifest"
+    assert _run_convert(tmp_path, source, destination) == 2
+    captured = capsys.readouterr()
+
+    assert captured.out == ""
+    assert captured.err.strip() == "error: unsafe-manifest"
+    assert PRIVATE_TITLE not in captured.out
+    assert PRIVATE_BODY not in captured.out
+    assert PRIVATE_TITLE not in captured.err
+    assert PRIVATE_BODY not in captured.err
+    assert canary.read_text(encoding="utf-8") == "keep outside\n"
+    assert not (real_dir / "findings.json").exists()
+    assert _walk_names(real_dir.parent) == outside_before
+
+
+def test_convert_findings_appears_in_parser_inventory():
+    from brigade.roadmap_cmd import _cli_command_paths
+
+    assert "brigade run-cloud grokbot convert-findings" in _cli_command_paths()


### PR DESCRIPTION
## What changed

- Add a versioned manifest contract for untrusted Grok Bot automation findings.
- Add `brigade run cloud grokbot convert-findings` for bounded conversion of live fleet and backup records.
- Add preview-first `reconcile-findings` delivery into the canonical owner's Memory Handoff review inbox.
- Add deterministic ordering, idempotency markers, interrupted-write recovery, digest checks, and descriptor-safe path handling.
- Document the manifest, conversion, delivery, and safety contracts.

## Why

This is the first implementation slice of #1255. It moves generic automation-finding conversion and review delivery into Brigade so the remaining first-party connector packs can migrate without requiring a second repository.

This PR does not cut over or remove any live service.

## Verification

- `./scripts/verify`
- `./scripts/verify-focused tests/test_grokbot_findings.py` (`67 passed`)
- Independent review found no remaining Critical or Important issue after the path-safety regressions were fixed.

## Safety and rollout

- Input manifests must be owner-only mode `0600` regular files.
- Parent and final path components reject symlink traversal.
- Producer text is quoted as untrusted, review-only content.
- Command output and delivery markers contain identity handles and digests, not finding text or credentials.
- Delivery defaults to preview and writes at most one draft unless the operator raises `--limit` and passes `--apply`.

Refs #1255
