### PR TITLE
feat(grokbot): add first-party connector packs

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -59,7 +59,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade roster`: 4 command path(s)
 - `brigade route`: 1 command path(s)
 - `brigade run`: 1 command path(s)
-- `brigade run-cloud`: 24 command path(s)
+- `brigade run-cloud`: 32 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
 - `brigade runs`: 18 command path(s)
 - `brigade scrub`: 1 command path(s)
@@ -485,6 +485,14 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade run-cloud grokbot fail`
 - `brigade run-cloud grokbot feed`
 - `brigade run-cloud grokbot install-service`
+- `brigade run-cloud grokbot pack canary`
+- `brigade run-cloud grokbot pack doctor`
+- `brigade run-cloud grokbot pack install-service`
+- `brigade run-cloud grokbot pack list`
+- `brigade run-cloud grokbot pack remove`
+- `brigade run-cloud grokbot pack setup`
+- `brigade run-cloud grokbot pack show`
+- `brigade run-cloud grokbot pack update`
 - `brigade run-cloud grokbot reconcile-findings`
 - `brigade run-cloud grokbot reconcile-reports`
 - `brigade run-cloud grokbot renew`

--- a/docs/grokbot-mcp.md
+++ b/docs/grokbot-mcp.md
@@ -56,6 +56,24 @@ The routine sequence for a worker is: list, claim, validate role and repository,
 
 `doctor` reports sanitized dependency, configuration, permissions, queue, and endpoint checks. It returns nonzero after setup until the listener starts because the endpoint check cannot connect. Run it again after the listener starts. A canary needs the listener already running.
 
+## Connector packs
+
+The three queue roles are also packaged as first-party connector packs. The registry is closed: Brigade does not load user-supplied pack manifests. Pack commands default to preview. `--apply` may write only private local config and an explicitly selected unit file. Pack commands do not start, stop, or reload services, and they never store bearer values.
+
+```bash
+brigade run cloud grokbot pack list
+brigade run cloud grokbot pack show --id operator
+brigade run cloud grokbot pack setup --id operator --bearer-file /run/brigade/grokbot-operator.token
+brigade run cloud grokbot pack setup --id operator --bearer-file /run/brigade/grokbot-operator.token --apply
+brigade run cloud grokbot pack doctor --id operator
+brigade run cloud grokbot pack install-service --id operator
+brigade run cloud grokbot pack canary --id operator
+brigade run cloud grokbot pack update --id operator
+brigade run cloud grokbot pack remove --id operator
+```
+
+Default pack binds do not collide: operator `127.0.0.1:8766`, repository-scout `127.0.0.1:8767`, and implementation-worker `127.0.0.1:8768`. Custom `--bind` values that reuse another pack's packaged default or installed port are refused without printing config contents. Apply writes the pack instance store and the legacy role store together; a failed second write restores both to their prior bytes and modes, or to absent on first install, and only after each restored target is verified. A failed restore or verification raises `rollback-failed` without printing config contents. Each pack keeps the same exact tool inventory and credential reference as its legacy role. The existing `--instance` commands remain supported.
+
 ## Report snapshots
 
 `grokbot_queue_complete` accepts an optional `report_text` string. Send it only for a Repository Scout job whose expected artifact kind is `report`. The text must be non-empty UTF-8 and at most 12,000 bytes. The completion `artifact` remains `{"kind": "report", "path": "<repo-relative path>", "sha256": "<hex>"}`, and `sha256` must be the SHA-256 of those exact UTF-8 bytes. Draft-PR and branch completions reject `report_text`.

--- a/docs/phase-grokbot-one-repository-distribution.md
+++ b/docs/phase-grokbot-one-repository-distribution.md
@@ -63,10 +63,9 @@ connector bearer values.
 
 ## CLI direction
 
-The current queue commands remain under `brigade run cloud grokbot`. Later
-slices extend that namespace with first-party lifecycle commands. Exact parser
-names are finalized in their implementation PRs, but the supported operations
-are fixed:
+The current queue commands remain under `brigade run cloud grokbot`. Connector
+packs use the same namespace under `brigade run cloud grokbot pack`. The
+supported operations are fixed:
 
 - configure a role or connector without storing secret values
 - inspect configuration and endpoint health
@@ -95,11 +94,20 @@ This slice does not migrate a live connector or disable the sidecar.
 
 ### PR 2: connector-pack registry and lifecycle
 
-1. Define a versioned first-party pack manifest.
-2. Add setup, doctor, service rendering, canary, update, and removal operations.
-3. Reject duplicate ports, overlapping public routes, unsafe binds, weak file
-   permissions, missing secret references, and tool inventory drift.
-4. Keep secrets outside Brigade state and repository content.
+1. Define a versioned first-party pack manifest
+   (`brigade.grokbot.connector-pack.v1`) and local instance config
+   (`brigade.grokbot.connector-instance.v1`).
+2. Add preview-first `brigade run cloud grokbot pack` commands for list, show,
+   setup, doctor, canary, install-service, update, and remove.
+3. Reject duplicate pack IDs, duplicate ports, overlapping non-empty public
+   routes, unsafe or non-loopback default binds, invalid versions, missing or
+   weak secret references, and declared tool inventory that differs from the
+   runtime allowlist.
+4. Keep secrets outside Brigade state and repository content. The first
+   packaged packs are the existing queue roles, with isolated default ports
+   8766, 8767, and 8768. Legacy `setup` / `doctor` / `canary` /
+   `install-service` remain compatible. This slice does not start, stop, or
+   reload services.
 
 ### PR 3: first-party connector packs
 

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -197,6 +197,56 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_install.add_argument("--out", type=Path, default=None, help="Directory to render the unit into.")
     p_install.add_argument("--force", action="store_true", help="Allow overwriting this role's own unit file.")
 
+    from .. import grokbot_packs
+
+    pack_ids = tuple(pack["id"] for pack in grokbot_packs.list_packs())
+    p_pack = grokbot_sub.add_parser("pack", help="Inspect and manage first-party Grok Bot connector packs.")
+    pack_sub = p_pack.add_subparsers(dest="grokbot_pack_command", metavar="<pack-command>")
+    pack_sub.required = True
+
+    def add_pack_id(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--target", type=Path, default=Path("."))
+        command.add_argument("--id", required=True, choices=pack_ids, dest="pack_id")
+        command.add_argument("--json", action="store_true")
+
+    p_pack_list = pack_sub.add_parser("list", help="List packaged first-party connector packs.")
+    add_target(p_pack_list)
+
+    p_pack_show = pack_sub.add_parser("show", help="Show one packaged connector pack.")
+    add_pack_id(p_pack_show)
+
+    p_pack_setup = pack_sub.add_parser("setup", help="Preview or apply non-secret pack instance configuration.")
+    add_pack_id(p_pack_setup)
+    p_pack_setup.add_argument("--bind", default=None, help="Listener host:port. Defaults to the pack loopback port.")
+    p_pack_setup.add_argument("--allow-host", action="append", default=[], help="Explicit allowed Host value.")
+    p_pack_setup.add_argument("--allow-origin", action="append", default=[], help="Explicit allowed Origin value.")
+    pack_secret = p_pack_setup.add_mutually_exclusive_group(required=True)
+    pack_secret.add_argument("--bearer-file", type=Path, help="Path of a protected bearer file (reference only).")
+    pack_secret.add_argument("--bearer-env", help="Name of the environment variable holding the bearer.")
+    p_pack_setup.add_argument("--apply", action="store_true", help="Write local config. Default is preview only.")
+
+    p_pack_doctor = pack_sub.add_parser("doctor", help="Sanitized pack diagnostics.")
+    add_pack_id(p_pack_doctor)
+
+    p_pack_canary = pack_sub.add_parser("canary", help="Bounded non-mutating pack authentication and inventory check.")
+    add_pack_id(p_pack_canary)
+
+    p_pack_install = pack_sub.add_parser("install-service", help="Render or install a pack-scoped systemd unit.")
+    add_pack_id(p_pack_install)
+    p_pack_install.add_argument("--out", type=Path, default=None, help="Directory to render the unit into.")
+    p_pack_install.add_argument("--force", action="store_true", help="Allow overwriting this pack's own unit file.")
+
+    p_pack_update = pack_sub.add_parser("update", help="Preview or apply a compatible pack version update.")
+    add_pack_id(p_pack_update)
+    p_pack_update.add_argument("--apply", action="store_true", help="Write local config. Default is preview only.")
+
+    p_pack_remove = pack_sub.add_parser("remove", help="Preview or apply removal of owned pack config and unit files.")
+    add_pack_id(p_pack_remove)
+    p_pack_remove.add_argument(
+        "--out", type=Path, default=None, help="Owned unit directory previously written by install-service."
+    )
+    p_pack_remove.add_argument("--apply", action="store_true", help="Delete owned files. Default is preview only.")
+
     p.set_defaults(func=dispatch)
 
 
@@ -315,6 +365,8 @@ def _dispatch_grokbot(args, target: Path) -> int:
     from .. import grokbot_jobs, grokbot_mcp
 
     command = args.grokbot_command
+    if command == "pack":
+        return _dispatch_grokbot_pack(args, target)
     if command in {"setup", "doctor", "canary", "install-service"}:
         return _dispatch_grokbot_ops(args, target)
     if command == "feed":
@@ -551,6 +603,86 @@ def _print_reconcile_result(result: dict) -> None:
     print("grokbot reconcile-reports: " + " ".join(parts))
     for job in result.get("jobs", []):
         print(f"job {job['job_id']} state={job['state']}")
+
+
+def _dispatch_grokbot_pack(args, target: Path) -> int:
+    """Preview-first connector-pack lifecycle without printing secret values."""
+    from .. import grokbot_mcp, grokbot_ops, grokbot_packs
+
+    command = args.grokbot_pack_command
+    try:
+        if command == "list":
+            result = {"packs": grokbot_packs.list_packs()}
+        elif command == "show":
+            result = grokbot_packs.show_pack(args.pack_id)
+        elif command == "setup":
+            setup_kwargs = {
+                "bind": args.bind,
+                "allowed_hosts": args.allow_host,
+                "allowed_origins": args.allow_origin,
+                "bearer_env": args.bearer_env,
+                "bearer_file": args.bearer_file,
+            }
+            result = (
+                grokbot_packs.apply_setup(target, args.pack_id, **setup_kwargs)
+                if args.apply
+                else grokbot_packs.preview_setup(target, args.pack_id, **setup_kwargs)
+            )
+        elif command == "doctor":
+            checks = grokbot_packs.doctor(target, args.pack_id)
+            if args.json:
+                print(json.dumps({"checks": checks}, indent=2, sort_keys=True))
+            else:
+                for check in checks:
+                    print(f"{check['check']}: {check['status']}")
+            return 1 if any(check["status"] != "ok" for check in checks) else 0
+        elif command == "canary":
+            result = grokbot_packs.canary(target, args.pack_id)
+            if args.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                print(f"canary: {'ok' if result['ok'] else 'fail'}")
+                if not result["ok"]:
+                    print(f"reason: {result.get('reason', 'unknown')}")
+            return 0 if result["ok"] else 1
+        elif command == "install-service":
+            if args.out is None:
+                sys.stdout.write(grokbot_packs.render_install_service(target, args.pack_id))
+                return 0
+            result = grokbot_packs.apply_install_service(target, args.pack_id, out_dir=Path(args.out), force=args.force)
+        elif command == "update":
+            result = (
+                grokbot_packs.apply_update(target, args.pack_id)
+                if args.apply
+                else grokbot_packs.preview_update(target, args.pack_id)
+            )
+        elif command == "remove":
+            result = (
+                grokbot_packs.apply_remove(target, args.pack_id, unit_dir=args.out)
+                if args.apply
+                else grokbot_packs.preview_remove(target, args.pack_id, unit_dir=args.out)
+            )
+        else:
+            print(f"error: unknown Grok Bot pack command: {command}", file=sys.stderr)
+            return 2
+    except grokbot_packs.PackError as exc:
+        print(f"error: {exc.reason}", file=sys.stderr)
+        return 2
+    except grokbot_mcp.ConfigurationError:
+        print("error: Grok Bot configuration is invalid", file=sys.stderr)
+        return 2
+    except grokbot_ops.ServiceRenderError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except (OSError, ValueError):
+        print("error: Grok Bot pack operation failed", file=sys.stderr)
+        return 2
+
+    if args.json or command in {"list", "show"}:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    print(f"grokbot pack {command}: apply={result.get('apply', False)} pack={result.get('pack_id', args.pack_id)}")
+    return 0
 
 
 def _dispatch_grokbot_ops(args, target: Path) -> int:

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -103,6 +103,15 @@ class ListenerConfig:
         return f"grokbot-{self.instance}"
 
 
+def tools_for_instance(instance: str) -> frozenset[str]:
+    """Return the exact runtime allowlist for one packaged queue role."""
+    if instance == "operator":
+        return OPERATOR_TOOLS
+    if instance in INSTANCES:
+        return WORKER_TOOLS
+    raise ConfigurationError("invalid")
+
+
 def parse_bind(value: str) -> tuple[str, int]:
     """Parse a deliberately small host:port surface without IPv6 ambiguity."""
     if not isinstance(value, str) or value.count(":") != 1:
@@ -175,7 +184,7 @@ class GrokbotAdapter:
             raise AdapterError() from None
 
     def _tools(self) -> frozenset[str]:
-        return OPERATOR_TOOLS if self.config.instance == "operator" else WORKER_TOOLS
+        return tools_for_instance(self.config.instance)
 
     def _call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         if name == "grokbot_queue_list":

--- a/src/brigade/grokbot_ops.py
+++ b/src/brigade/grokbot_ops.py
@@ -284,6 +284,27 @@ def write_unit(
     return path
 
 
+def remove_regular_file(path: Path) -> None:
+    """Unlink one regular file without following a symlink or reparse point."""
+    parent = _open_parent_nofollow(path, create=False)
+    try:
+        if os.name == "posix":
+            existing = os.stat(path.name, dir_fd=parent, follow_symlinks=False)
+            if stat.S_ISLNK(existing.st_mode):
+                raise OSError("output is a symlink")
+            if not stat.S_ISREG(existing.st_mode):
+                raise OSError("output is not a regular file")
+            os.unlink(path.name, dir_fd=parent)
+            return
+        if _path_is_symlink(path):
+            raise OSError("output is a reparse point")
+        from .work_cmd import nt_dirfd
+
+        nt_dirfd.unlink_child(parent, path.name)
+    finally:
+        os.close(parent)
+
+
 def _path_is_symlink(path: Path) -> bool:
     """Return whether a final path component is a link or Windows reparse point."""
     try:

--- a/src/brigade/grokbot_packs.py
+++ b/src/brigade/grokbot_packs.py
@@ -1,0 +1,671 @@
+"""First-party Grok Bot connector-pack registry and preview-first lifecycle.
+
+The registry is closed: only packaged queue-role manifests are accepted. Local
+instance config stores secret references, never secret values. Apply may write
+owned config and an explicitly selected unit file. This module does not start,
+stop, or reload services.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from . import grokbot_mcp, grokbot_ops
+
+PACK_SCHEMA = "brigade.grokbot.connector-pack.v1"
+INSTANCE_SCHEMA = "brigade.grokbot.connector-instance.v1"
+INSTANCE_DIR = Path(".brigade") / "grokbot" / "packs"
+PACK_KEYS = frozenset({"schema", "id", "version", "kind", "instance", "default_bind", "public_route", "tools"})
+INSTANCE_KEYS = frozenset(
+    {
+        "schema",
+        "pack_id",
+        "pack_version",
+        "bind",
+        "allowed_hosts",
+        "allowed_origins",
+        "public_route",
+        "bearer",
+    }
+)
+DEFAULT_BINDS = {
+    "implementation-worker": "127.0.0.1:8768",
+    "operator": "127.0.0.1:8766",
+    "repository-scout": "127.0.0.1:8767",
+}
+VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+PACK_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
+PUBLIC_ROUTE_RE = re.compile(r"^$|^/[A-Za-z0-9._~-]+(?:/[A-Za-z0-9._~-]+)*$")
+SECRET_BEARER_KEYS = frozenset({"value", "token", "secret", "password", "bearer"})
+
+
+class PackError(ValueError):
+    """A rejected pack registry or lifecycle request."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+def _queue_pack(instance: str) -> dict[str, Any]:
+    return {
+        "schema": PACK_SCHEMA,
+        "id": instance,
+        "version": "1.0.0",
+        "kind": "queue-role",
+        "instance": instance,
+        "default_bind": DEFAULT_BINDS[instance],
+        "public_route": "",
+        "tools": sorted(grokbot_mcp.tools_for_instance(instance)),
+    }
+
+
+_PACKAGED = tuple(_queue_pack(instance) for instance in sorted(DEFAULT_BINDS))
+
+
+def packaged_manifests() -> tuple[dict[str, Any], ...]:
+    """Return copies of the closed first-party pack manifests."""
+    return tuple(dict(pack) for pack in _PACKAGED)
+
+
+def instance_config_path(target: Path, pack_id: str) -> Path:
+    return target / INSTANCE_DIR / f"{pack_id}.json"
+
+
+def list_packs() -> list[dict[str, Any]]:
+    return [dict(pack) for pack in validate_registry(packaged_manifests())]
+
+
+def show_pack(pack_id: str) -> dict[str, Any]:
+    for pack in list_packs():
+        if pack["id"] == pack_id:
+            return pack
+    raise PackError("unknown-pack")
+
+
+def validate_registry(manifests: Iterable[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
+    """Validate exact-key first-party manifests and cross-pack collisions."""
+    validated: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    seen_ports: set[int] = set()
+    routes: list[str] = []
+    for raw in manifests:
+        pack = _validate_pack(raw)
+        if pack["id"] in seen_ids:
+            raise PackError("duplicate-pack-id")
+        host, port = _parse_default_bind(pack["default_bind"])
+        if not grokbot_mcp._is_loopback(host):
+            raise PackError("unsafe-bind")
+        if port in seen_ports:
+            raise PackError("duplicate-port")
+        route = pack["public_route"]
+        if any(_routes_overlap(route, existing) for existing in routes):
+            raise PackError("overlapping-public-route")
+        seen_ids.add(pack["id"])
+        seen_ports.add(port)
+        routes.append(route)
+        validated.append(pack)
+    return tuple(sorted(validated, key=lambda item: item["id"]))
+
+
+def preview_setup(
+    target: Path,
+    pack_id: str,
+    *,
+    bind: str | None = None,
+    allowed_hosts: list[str] | None = None,
+    allowed_origins: list[str] | None = None,
+    bearer_env: str | None = None,
+    bearer_file: Path | None = None,
+    bearer: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _setup(
+        target,
+        pack_id,
+        apply=False,
+        bind=bind,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+        bearer_env=bearer_env,
+        bearer_file=bearer_file,
+        bearer=bearer,
+    )
+
+
+def apply_setup(
+    target: Path,
+    pack_id: str,
+    *,
+    bind: str | None = None,
+    allowed_hosts: list[str] | None = None,
+    allowed_origins: list[str] | None = None,
+    bearer_env: str | None = None,
+    bearer_file: Path | None = None,
+    bearer: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _setup(
+        target,
+        pack_id,
+        apply=True,
+        bind=bind,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+        bearer_env=bearer_env,
+        bearer_file=bearer_file,
+        bearer=bearer,
+    )
+
+
+def doctor(target: Path, pack_id: str) -> list[dict[str, str]]:
+    pack = show_pack(pack_id)
+    return grokbot_ops.doctor(target, pack["instance"])
+
+
+def canary(target: Path, pack_id: str) -> dict[str, Any]:
+    pack = show_pack(pack_id)
+    return grokbot_ops.canary(target, pack["instance"])
+
+
+def render_install_service(target: Path, pack_id: str) -> str:
+    pack = show_pack(pack_id)
+    try:
+        config = grokbot_ops.load_config(target, pack["instance"])
+        return grokbot_ops.render_unit(config, python=sys.executable, exec_root=target)
+    except (grokbot_mcp.ConfigurationError, grokbot_ops.ServiceRenderError, OSError) as exc:
+        raise PackError("unsafe-path") from exc
+
+
+def apply_install_service(
+    target: Path,
+    pack_id: str,
+    *,
+    out_dir: Path,
+    force: bool = False,
+) -> dict[str, Any]:
+    pack = show_pack(pack_id)
+    try:
+        config = grokbot_ops.load_config(target, pack["instance"])
+        path = grokbot_ops.write_unit(config, out_dir, exec_root=target, force=force)
+    except (grokbot_mcp.ConfigurationError, grokbot_ops.ServiceRenderError, OSError) as exc:
+        raise PackError("unsafe-path") from exc
+    return {"action": "install-service", "apply": True, "pack_id": pack_id, "unit": path.name}
+
+
+def preview_update(target: Path, pack_id: str) -> dict[str, Any]:
+    return _update(target, pack_id, apply=False)
+
+
+def apply_update(target: Path, pack_id: str) -> dict[str, Any]:
+    return _update(target, pack_id, apply=True)
+
+
+def preview_remove(target: Path, pack_id: str, *, unit_dir: Path | None = None) -> dict[str, Any]:
+    return _remove(target, pack_id, apply=False, unit_dir=unit_dir)
+
+
+def apply_remove(target: Path, pack_id: str, *, unit_dir: Path | None = None) -> dict[str, Any]:
+    return _remove(target, pack_id, apply=True, unit_dir=unit_dir)
+
+
+def _setup(
+    target: Path,
+    pack_id: str,
+    *,
+    apply: bool,
+    bind: str | None,
+    allowed_hosts: list[str] | None,
+    allowed_origins: list[str] | None,
+    bearer_env: str | None,
+    bearer_file: Path | None,
+    bearer: dict[str, Any] | None,
+) -> dict[str, Any]:
+    pack = show_pack(pack_id)
+    reference = _bearer_reference(bearer_env=bearer_env, bearer_file=bearer_file, bearer=bearer)
+    chosen_bind = bind or pack["default_bind"]
+    _parse_default_bind(chosen_bind)
+    hosts = sorted(set(allowed_hosts or []))
+    origins = sorted(set(allowed_origins or []))
+    payload = {
+        "schema": INSTANCE_SCHEMA,
+        "pack_id": pack_id,
+        "pack_version": pack["version"],
+        "bind": chosen_bind,
+        "allowed_hosts": hosts,
+        "allowed_origins": origins,
+        "public_route": pack["public_route"],
+        "bearer": reference,
+    }
+    _validate_instance_config(payload, pack_id)
+    _assert_setup_bind_available(target, pack_id, chosen_bind)
+    writes = [
+        str(instance_config_path(Path("."), pack_id)),
+        str(grokbot_ops.config_path(Path("."), pack["instance"])),
+    ]
+    result = {"action": "setup", "apply": apply, "pack_id": pack_id, "bind": chosen_bind, "writes": writes}
+    if not apply:
+        return result
+    _apply_setup_configs(
+        target,
+        pack_id,
+        instance=pack["instance"],
+        payload=payload,
+        bind=chosen_bind,
+        hosts=hosts,
+        origins=origins,
+        reference=reference,
+    )
+    return result
+
+
+def _apply_setup_configs(
+    target: Path,
+    pack_id: str,
+    *,
+    instance: str,
+    payload: dict[str, Any],
+    bind: str,
+    hosts: list[str],
+    origins: list[str],
+    reference: Mapping[str, str],
+) -> None:
+    pack_path = instance_config_path(target, pack_id)
+    legacy_path = grokbot_ops.config_path(target, instance)
+    _assert_config_destination_safe(pack_path)
+    _assert_config_destination_safe(legacy_path)
+    pack_snapshot = _snapshot_regular_file(pack_path)
+    legacy_snapshot = _snapshot_regular_file(legacy_path)
+    try:
+        _write_instance_config(target, pack_id, payload)
+        grokbot_ops.save_config(
+            target,
+            instance=instance,
+            bind=bind,
+            allowed_hosts=hosts,
+            allowed_origins=origins,
+            bearer_env=reference["name"] if reference["kind"] == "env" else None,
+            bearer_file=Path(reference["path"]) if reference["kind"] == "file" else None,
+        )
+    except (grokbot_mcp.ConfigurationError, OSError, PackError) as exc:
+        rollback_failed = False
+        for dest, snap in ((pack_path, pack_snapshot), (legacy_path, legacy_snapshot)):
+            try:
+                _restore_regular_file(dest, snap)
+            except PackError:
+                rollback_failed = True
+            if not _matches_regular_file_snapshot(dest, snap):
+                rollback_failed = True
+        if rollback_failed:
+            raise PackError("rollback-failed") from exc
+        if isinstance(exc, PackError):
+            raise
+        raise PackError("unsafe-path") from exc
+
+
+def _update(target: Path, pack_id: str, *, apply: bool) -> dict[str, Any]:
+    pack = show_pack(pack_id)
+    config = _load_instance_config(target, pack_id)
+    installed = _parse_version(config["pack_version"])
+    packaged = _parse_version(pack["version"])
+    if installed[0] != packaged[0] or installed > packaged:
+        raise PackError("incompatible-version")
+    result = {
+        "action": "update",
+        "apply": apply,
+        "pack_id": pack_id,
+        "from_version": config["pack_version"],
+        "to_version": pack["version"],
+    }
+    if not apply or config["pack_version"] == pack["version"]:
+        return result
+    updated = dict(config)
+    updated["pack_version"] = pack["version"]
+    _write_instance_config(target, pack_id, updated)
+    return result
+
+
+def _remove(target: Path, pack_id: str, *, apply: bool, unit_dir: Path | None) -> dict[str, Any]:
+    pack = show_pack(pack_id)
+    paths = _removal_paths(target, pack, unit_dir)
+    result = {
+        "action": "remove",
+        "apply": apply,
+        "pack_id": pack_id,
+        "paths": [str(path.relative_to(target) if _is_relative_to(path, target) else path.name) for path in paths],
+    }
+    if not apply:
+        return result
+    for path in paths:
+        try:
+            grokbot_ops.remove_regular_file(path)
+        except OSError as exc:
+            raise PackError("unsafe-path") from exc
+    return result
+
+
+def _removal_paths(target: Path, pack: Mapping[str, Any], unit_dir: Path | None) -> list[Path]:
+    if unit_dir is not None and not _owned_unit_dir(unit_dir, pack["instance"]):
+        raise PackError("outside-owned-path")
+    candidates: list[tuple[Path, bool]] = []
+    pack_path = instance_config_path(target, pack["id"])
+    if _exists_or_link(pack_path):
+        candidates.append((pack_path, True))
+    legacy = grokbot_ops.config_path(target, pack["instance"])
+    if _exists_or_link(legacy):
+        candidates.append((legacy, True))
+    if unit_dir is not None:
+        candidates.append((unit_dir / grokbot_ops.unit_name(pack["instance"]), False))
+    paths: list[Path] = []
+    for path, config_file in candidates:
+        _assert_removable(path, config_file=config_file)
+        paths.append(path)
+    return paths
+
+
+def _owned_unit_dir(unit_dir: Path, instance: str) -> bool:
+    if unit_dir.is_symlink() or not unit_dir.is_dir():
+        return False
+    unit = unit_dir / grokbot_ops.unit_name(instance)
+    return unit.is_file() and not unit.is_symlink()
+
+
+def _assert_removable(path: Path, *, config_file: bool) -> None:
+    if grokbot_ops._path_is_symlink(path) or path.is_symlink():
+        raise PackError("symlink")
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise PackError("unsafe-path") from exc
+    if not stat.S_ISREG(info.st_mode):
+        raise PackError("unsafe-path")
+    if config_file and stat.S_IMODE(info.st_mode) & 0o077:
+        raise PackError("unsafe-permissions")
+    parent = -1
+    try:
+        parent = grokbot_ops._open_parent_nofollow(path, create=False)
+    except OSError as exc:
+        raise PackError("unsafe-path") from exc
+    finally:
+        if parent != -1:
+            os.close(parent)
+
+
+def _exists_or_link(path: Path) -> bool:
+    return path.exists() or path.is_symlink()
+
+
+def _assert_config_destination_safe(path: Path) -> None:
+    if grokbot_ops._path_is_symlink(path) or path.is_symlink():
+        raise PackError("unsafe-path")
+    parent = -1
+    try:
+        parent = grokbot_ops._open_parent_nofollow(path, create=False)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise PackError("unsafe-path") from exc
+    finally:
+        if parent != -1:
+            os.close(parent)
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise PackError("unsafe-path") from exc
+    if not stat.S_ISREG(info.st_mode):
+        raise PackError("unsafe-path")
+
+
+def _snapshot_regular_file(path: Path) -> tuple[str, int] | None:
+    if grokbot_ops._path_is_symlink(path) or path.is_symlink():
+        raise PackError("unsafe-path")
+    try:
+        text = grokbot_ops._read_regular_text(path)
+        mode = stat.S_IMODE(path.lstat().st_mode)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise PackError("unsafe-path") from exc
+    return text, mode
+
+
+def _restore_regular_file(path: Path, snapshot: tuple[str, int] | None) -> None:
+    if snapshot is None:
+        if grokbot_ops._path_is_symlink(path) or path.is_symlink():
+            raise PackError("unsafe-path")
+        try:
+            grokbot_ops.remove_regular_file(path)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise PackError("unsafe-path") from exc
+        return
+    if _matches_regular_file_snapshot(path, snapshot):
+        return
+    text, mode = snapshot
+    try:
+        grokbot_ops._write_text_nofollow_atomic(path, text, mode=mode)
+    except OSError as exc:
+        raise PackError("unsafe-path") from exc
+
+
+def _matches_regular_file_snapshot(path: Path, snapshot: tuple[str, int] | None) -> bool:
+    """Return True only when existence, exact contents, and mode match the snapshot."""
+    try:
+        current = _snapshot_regular_file(path)
+    except PackError:
+        return False
+    if current is None or snapshot is None:
+        return current is None and snapshot is None
+    current_text, current_mode = current
+    expected_text, expected_mode = snapshot
+    return current_text.encode("utf-8") == expected_text.encode("utf-8") and current_mode == expected_mode
+
+
+def _assert_setup_bind_available(target: Path, pack_id: str, chosen_bind: str) -> None:
+    """Refuse a bind whose port is owned by another packaged or installed instance."""
+    _host, chosen_port = _parse_default_bind(chosen_bind)
+    if chosen_port in _occupied_setup_ports(target, exclude_pack_id=pack_id):
+        raise PackError("duplicate-port")
+
+
+def _occupied_setup_ports(target: Path, *, exclude_pack_id: str) -> set[int]:
+    ports: set[int] = set()
+    for pack in list_packs():
+        if pack["id"] == exclude_pack_id:
+            continue
+        _host, port = _parse_default_bind(pack["default_bind"])
+        ports.add(port)
+        pack_port = _bind_port_from_existing_config(instance_config_path(target, pack["id"]))
+        if pack_port is not None:
+            ports.add(pack_port)
+        legacy_port = _bind_port_from_existing_config(grokbot_ops.config_path(target, pack["instance"]))
+        if legacy_port is not None:
+            ports.add(legacy_port)
+    return ports
+
+
+def _bind_port_from_existing_config(path: Path) -> int | None:
+    """Read one bind port from a first-party config without following unsafe paths."""
+    if grokbot_ops._path_is_symlink(path) or path.is_symlink():
+        raise PackError("unsafe-path")
+    try:
+        raw = grokbot_ops._read_regular_text(path)
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeDecodeError) as exc:
+        raise PackError("unsafe-path") from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PackError("unsafe-path") from exc
+    if not isinstance(payload, dict):
+        raise PackError("unsafe-path")
+    bind = payload.get("bind")
+    if not isinstance(bind, str):
+        raise PackError("unsafe-path")
+    _host, port = _parse_default_bind(bind)
+    return port
+
+
+def _write_instance_config(target: Path, pack_id: str, payload: dict[str, Any]) -> None:
+    path = instance_config_path(target, pack_id)
+    try:
+        grokbot_ops._write_text_nofollow_atomic(
+            path,
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            mode=0o600,
+        )
+    except OSError as exc:
+        raise PackError("unsafe-path") from exc
+
+
+def _load_instance_config(target: Path, pack_id: str) -> dict[str, Any]:
+    path = instance_config_path(target, pack_id)
+    try:
+        payload = json.loads(grokbot_ops._read_regular_text(path))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PackError("unsafe-path") from exc
+    if not isinstance(payload, dict):
+        raise PackError("unexpected-key")
+    return _validate_instance_config(payload, pack_id)
+
+
+def _validate_pack(raw: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, Mapping) or set(raw) != PACK_KEYS:
+        raise PackError("unexpected-key")
+    pack_id = raw.get("id")
+    version = raw.get("version")
+    instance = raw.get("instance")
+    kind = raw.get("kind")
+    route = raw.get("public_route")
+    tools = raw.get("tools")
+    if raw.get("schema") != PACK_SCHEMA:
+        raise PackError("unexpected-key")
+    if not isinstance(pack_id, str) or not PACK_ID_RE.fullmatch(pack_id):
+        raise PackError("unexpected-key")
+    if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
+        raise PackError("invalid-version")
+    if kind != "queue-role" or instance != pack_id or instance not in grokbot_mcp.INSTANCES:
+        raise PackError("unexpected-key")
+    if not isinstance(route, str) or not PUBLIC_ROUTE_RE.fullmatch(route):
+        raise PackError("overlapping-public-route" if route else "unexpected-key")
+    if not isinstance(tools, list) or any(not isinstance(name, str) for name in tools):
+        raise PackError("inventory-mismatch")
+    if set(tools) != grokbot_mcp.tools_for_instance(instance) or len(tools) != len(set(tools)):
+        raise PackError("inventory-mismatch")
+    bind = raw.get("default_bind")
+    if not isinstance(bind, str):
+        raise PackError("unsafe-bind")
+    _parse_default_bind(bind)
+    return {
+        "schema": PACK_SCHEMA,
+        "id": pack_id,
+        "version": version,
+        "kind": kind,
+        "instance": instance,
+        "default_bind": bind,
+        "public_route": route,
+        "tools": sorted(tools),
+    }
+
+
+def _validate_instance_config(payload: Mapping[str, Any], pack_id: str) -> dict[str, Any]:
+    if set(payload) != INSTANCE_KEYS or payload.get("schema") != INSTANCE_SCHEMA:
+        raise PackError("unexpected-key")
+    if payload.get("pack_id") != pack_id:
+        raise PackError("unexpected-key")
+    version = payload.get("pack_version")
+    if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
+        raise PackError("invalid-version")
+    bind = payload.get("bind")
+    if not isinstance(bind, str):
+        raise PackError("unsafe-bind")
+    _parse_default_bind(bind)
+    hosts = payload.get("allowed_hosts")
+    origins = payload.get("allowed_origins")
+    route = payload.get("public_route")
+    if not isinstance(hosts, list) or not isinstance(origins, list):
+        raise PackError("unexpected-key")
+    if any(not grokbot_mcp._valid_host(value) for value in hosts):
+        raise PackError("unexpected-key")
+    if any(not grokbot_mcp._valid_origin(value) for value in origins):
+        raise PackError("unexpected-key")
+    if not isinstance(route, str) or not PUBLIC_ROUTE_RE.fullmatch(route):
+        raise PackError("unexpected-key")
+    _validate_bearer_reference(payload.get("bearer"))
+    return dict(payload)
+
+
+def _bearer_reference(
+    *,
+    bearer_env: str | None,
+    bearer_file: Path | None,
+    bearer: dict[str, Any] | None,
+) -> dict[str, str]:
+    if bearer is not None:
+        if bearer_env is not None or bearer_file is not None:
+            raise PackError("missing-secret-reference")
+        return _validate_bearer_reference(bearer)
+    if (bearer_env is None) == (bearer_file is None):
+        raise PackError("missing-secret-reference")
+    if bearer_env is not None:
+        return _validate_bearer_reference({"kind": "env", "name": bearer_env})
+    assert bearer_file is not None
+    return _validate_bearer_reference({"kind": "file", "path": str(bearer_file.expanduser().resolve())})
+
+
+def _validate_bearer_reference(reference: object) -> dict[str, str]:
+    if not isinstance(reference, dict) or set(reference) & SECRET_BEARER_KEYS:
+        raise PackError("weak-secret-reference")
+    kind = reference.get("kind")
+    if kind == "env" and set(reference) == {"kind", "name"}:
+        name = reference.get("name")
+        if isinstance(name, str) and grokbot_mcp.ENVIRONMENT_NAME_RE.fullmatch(name):
+            return {"kind": "env", "name": name}
+    if kind == "file" and set(reference) == {"kind", "path"}:
+        path = reference.get("path")
+        if isinstance(path, str) and path and "\x00" not in path:
+            grokbot_ops._systemd_quote(path)
+            return {"kind": "file", "path": path}
+    raise PackError("weak-secret-reference")
+
+
+def _parse_default_bind(value: str) -> tuple[str, int]:
+    try:
+        host, port = grokbot_mcp.parse_bind(value)
+    except grokbot_mcp.ConfigurationError as exc:
+        raise PackError("unsafe-bind") from exc
+    if not grokbot_mcp._is_loopback(host):
+        raise PackError("unsafe-bind")
+    return host, port
+
+
+def _parse_version(value: str) -> tuple[int, int, int]:
+    if not VERSION_RE.fullmatch(value):
+        raise PackError("invalid-version")
+    major, minor, patch = value.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def _routes_overlap(left: str, right: str) -> bool:
+    if not left or not right:
+        return False
+    left_parts = left.split("/")
+    right_parts = right.split("/")
+    length = min(len(left_parts), len(right_parts))
+    return left_parts[:length] == right_parts[:length]
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True

--- a/tests/test_grokbot_packs.py
+++ b/tests/test_grokbot_packs.py
@@ -1,0 +1,601 @@
+"""Tests for the first-party Grok Bot connector-pack registry and lifecycle."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, grokbot_mcp, grokbot_ops, grokbot_packs
+
+SECRET = "not-a-real-token"
+PACK_IDS = ("implementation-worker", "operator", "repository-scout")
+
+
+def _reject(reason: str):
+    return pytest.raises(grokbot_packs.PackError, match=reason)
+
+
+def _queue_tools(instance: str) -> list[str]:
+    return sorted(grokbot_mcp.tools_for_instance(instance))
+
+
+def _manifest(**overrides: object) -> dict[str, object]:
+    instance = str(overrides.get("instance", "operator"))
+    payload: dict[str, object] = {
+        "schema": grokbot_packs.PACK_SCHEMA,
+        "id": instance,
+        "version": "1.0.0",
+        "kind": "queue-role",
+        "instance": instance,
+        "default_bind": grokbot_packs.DEFAULT_BINDS[instance],
+        "public_route": "",
+        "tools": _queue_tools(instance),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _pack_argv(target: Path, command: str, *extra: str) -> list[str]:
+    return ["run", "cloud", "grokbot", "pack", command, "--target", str(target), *extra]
+
+
+def _write_secret_file(path: Path) -> Path:
+    path.write_text(SECRET + "\n", encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def test_registry_is_closed_deterministic_and_exact_key_validated():
+    packs = grokbot_packs.list_packs()
+    assert [pack["id"] for pack in packs] == list(PACK_IDS)
+    assert [pack["id"] for pack in grokbot_packs.list_packs()] == [pack["id"] for pack in packs]
+    assert not hasattr(grokbot_packs, "register_pack")
+    for pack in packs:
+        assert set(pack) == grokbot_packs.PACK_KEYS
+        assert pack["schema"] == grokbot_packs.PACK_SCHEMA
+        assert pack["kind"] == "queue-role"
+        shown = grokbot_packs.show_pack(pack["id"])
+        assert shown == pack
+        assert set(shown["tools"]) == grokbot_mcp.tools_for_instance(pack["instance"])
+
+
+def test_registry_ignores_user_supplied_pack_files(tmp_path: Path):
+    rogue = tmp_path / grokbot_packs.INSTANCE_DIR / "cerebro.json"
+    rogue.parent.mkdir(parents=True)
+    rogue.write_text(json.dumps(_manifest(id="cerebro", instance="operator")), encoding="utf-8")
+    assert [pack["id"] for pack in grokbot_packs.list_packs()] == list(PACK_IDS)
+    with _reject("unknown-pack"):
+        grokbot_packs.show_pack("cerebro")
+
+
+def test_registry_rejects_duplicate_pack_ids():
+    with _reject("duplicate-pack-id"):
+        grokbot_packs.validate_registry([_manifest(), _manifest(id="operator", default_bind="127.0.0.1:8799")])
+
+
+def test_registry_rejects_duplicate_ports():
+    with _reject("duplicate-port"):
+        grokbot_packs.validate_registry(
+            [
+                _manifest(),
+                _manifest(id="repository-scout", instance="repository-scout", default_bind="127.0.0.1:8766"),
+            ]
+        )
+
+
+def test_registry_rejects_overlapping_nonempty_public_routes():
+    left = _manifest(public_route="/steward")
+    right = _manifest(
+        id="repository-scout",
+        instance="repository-scout",
+        default_bind="127.0.0.1:8767",
+        public_route="/steward/status",
+    )
+    with _reject("overlapping-public-route"):
+        grokbot_packs.validate_registry([left, right])
+    grokbot_packs.validate_registry(
+        [
+            _manifest(public_route=""),
+            _manifest(id="repository-scout", instance="repository-scout", default_bind="127.0.0.1:8767"),
+        ]
+    )
+
+
+def test_registry_rejects_unsafe_or_non_loopback_default_binds():
+    for bind in ("0.0.0.0:8766", "192.168.1.10:8766", "example.com:8766", "127.0.0.1:0"):
+        with _reject("unsafe-bind"):
+            grokbot_packs.validate_registry([_manifest(default_bind=bind)])
+
+
+def test_registry_rejects_invalid_versions():
+    for version in ("1", "1.0", "v1.0.0", "01.0.0", "1.0.0-beta", "latest", ""):
+        with _reject("invalid-version"):
+            grokbot_packs.validate_registry([_manifest(version=version)])
+
+
+def test_registry_rejects_declared_tool_inventory_drift():
+    with _reject("inventory-mismatch"):
+        grokbot_packs.validate_registry([_manifest(tools=["grokbot_queue_list"])])
+    with _reject("inventory-mismatch"):
+        grokbot_packs.validate_registry([_manifest(tools=_queue_tools("operator") + ["hidden_tool"])])
+
+
+def test_registry_rejects_unexpected_pack_keys():
+    with _reject("unexpected-key"):
+        grokbot_packs.validate_registry([_manifest(note="no")])
+
+
+def test_first_party_queue_packs_keep_isolated_ports_tools_and_credentials():
+    packs = {pack["id"]: pack for pack in grokbot_packs.list_packs()}
+    ports = {grokbot_mcp.parse_bind(pack["default_bind"])[1] for pack in packs.values()}
+    assert ports == {8766, 8767, 8768}
+    assert packs["operator"]["tools"] == _queue_tools("operator")
+    assert packs["repository-scout"]["tools"] == _queue_tools("repository-scout")
+    assert packs["implementation-worker"]["tools"] == _queue_tools("implementation-worker")
+    assert packs["operator"]["tools"] != packs["repository-scout"]["tools"]
+    assert grokbot_packs.instance_config_path(Path("/tmp/target"), "operator") != grokbot_packs.instance_config_path(
+        Path("/tmp/target"), "repository-scout"
+    )
+    assert grokbot_ops.config_path(Path("/tmp/target"), "operator") != grokbot_ops.config_path(
+        Path("/tmp/target"), "repository-scout"
+    )
+
+
+def test_setup_preview_writes_nothing_and_apply_uses_mode_0600(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    preview = grokbot_packs.preview_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    assert preview["apply"] is False
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+    assert not grokbot_ops.config_path(tmp_path, "operator").exists()
+
+    applied = grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "operator")
+    legacy_path = grokbot_ops.config_path(tmp_path, "operator")
+    assert applied["apply"] is True
+    assert pack_path.is_file()
+    assert pack_path.stat().st_mode & 0o777 == 0o600
+    assert legacy_path.is_file()
+    assert legacy_path.stat().st_mode & 0o777 == 0o600
+    pack_config = json.loads(pack_path.read_text(encoding="utf-8"))
+    assert set(pack_config) == grokbot_packs.INSTANCE_KEYS
+    assert SECRET not in json.dumps(pack_config)
+    assert pack_config["bearer"] == {"kind": "env", "name": "TEST_GROKBOT_BEARER"}
+    assert pack_config["bind"] == "127.0.0.1:8766"
+    assert grokbot_ops.load_config(tmp_path, "operator")["instance"] == "operator"
+
+
+def test_setup_rejects_missing_and_weak_secret_references(tmp_path: Path):
+    with _reject("missing-secret-reference"):
+        grokbot_packs.apply_setup(tmp_path, "operator")
+    with _reject("missing-secret-reference"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER", bearer_file=tmp_path / "t")
+    with _reject("weak-secret-reference"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="not valid")
+    with _reject("weak-secret-reference"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bearer={"kind": "env", "name": "TEST", "value": SECRET})
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+
+
+def test_setup_is_idempotent_and_keeps_role_default_ports(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    first = grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    second = grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    assert first["bind"] == second["bind"] == "127.0.0.1:8766"
+    scout = grokbot_packs.apply_setup(tmp_path, "repository-scout", bearer_env="TEST_GROKBOT_BEARER")
+    worker = grokbot_packs.apply_setup(tmp_path, "implementation-worker", bearer_env="TEST_GROKBOT_BEARER")
+    assert scout["bind"] == "127.0.0.1:8767"
+    assert worker["bind"] == "127.0.0.1:8768"
+
+
+def test_setup_refuses_bind_owned_by_another_packaged_default(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    with _reject("duplicate-port"):
+        grokbot_packs.preview_setup(tmp_path, "operator", bind="127.0.0.1:8767", bearer_env="TEST_GROKBOT_BEARER")
+    with _reject("duplicate-port"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8767", bearer_env="TEST_GROKBOT_BEARER")
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+    assert not grokbot_ops.config_path(tmp_path, "operator").exists()
+
+
+def test_setup_refuses_bind_owned_by_another_installed_custom_bind(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "repository-scout", bind="127.0.0.1:8799", bearer_env="TEST_GROKBOT_BEARER")
+    before = grokbot_packs.instance_config_path(tmp_path, "repository-scout").read_bytes()
+    with _reject("duplicate-port"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8799", bearer_env="TEST_GROKBOT_BEARER")
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+    assert not grokbot_ops.config_path(tmp_path, "operator").exists()
+    assert grokbot_packs.instance_config_path(tmp_path, "repository-scout").read_bytes() == before
+
+
+def test_setup_same_instance_custom_bind_is_idempotent(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    first = grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8799", bearer_env="TEST_GROKBOT_BEARER")
+    second = grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8799", bearer_env="TEST_GROKBOT_BEARER")
+    assert first["bind"] == second["bind"] == "127.0.0.1:8799"
+    scout = grokbot_packs.apply_setup(tmp_path, "repository-scout", bearer_env="TEST_GROKBOT_BEARER")
+    assert scout["bind"] == "127.0.0.1:8767"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX no-follow parent walk")
+def test_setup_refuses_unsafe_existing_config_paths_without_exposing_contents(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    decoy = tmp_path / "decoy.json"
+    decoy.write_text(
+        json.dumps({"bind": "127.0.0.1:8799", "bearer": {"value": SECRET}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    scout_pack = grokbot_packs.instance_config_path(tmp_path, "repository-scout")
+    scout_pack.parent.mkdir(parents=True)
+    scout_pack.symlink_to(decoy)
+    with _reject("unsafe-path") as caught:
+        grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8790", bearer_env="TEST_GROKBOT_BEARER")
+    assert SECRET not in str(caught.value)
+    assert SECRET not in caught.value.reason
+    assert decoy.read_text(encoding="utf-8").endswith("\n")
+    assert SECRET in decoy.read_text(encoding="utf-8")
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+
+    scout_pack.unlink()
+    scout_legacy = grokbot_ops.config_path(tmp_path, "repository-scout")
+    scout_legacy.symlink_to(decoy)
+    with _reject("unsafe-path") as caught:
+        grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8790", bearer_env="TEST_GROKBOT_BEARER")
+    assert SECRET not in str(caught.value)
+    assert SECRET not in caught.value.reason
+    assert decoy.read_text(encoding="utf-8").count(SECRET) == 1
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+
+
+def _fail_legacy_config_write(monkeypatch: pytest.MonkeyPatch, target: Path, instance: str) -> None:
+    real_write = grokbot_ops._write_text_nofollow_atomic
+    legacy = grokbot_ops.config_path(target, instance)
+
+    def write_or_fail(path: Path, data: str, **kwargs: object) -> None:
+        if Path(path) == legacy:
+            raise OSError("disk full")
+        real_write(path, data, **kwargs)
+
+    monkeypatch.setattr(grokbot_ops, "_write_text_nofollow_atomic", write_or_fail)
+
+
+def _grokbot_config_files(target: Path) -> list[Path]:
+    root = target / ".brigade" / "grokbot"
+    if not root.exists():
+        return []
+    return sorted(path for path in root.rglob("*") if path.is_file())
+
+
+def test_setup_first_install_failure_leaves_neither_config_store(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    _fail_legacy_config_write(monkeypatch, tmp_path, "operator")
+    with _reject("unsafe-path"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+    assert not grokbot_ops.config_path(tmp_path, "operator").exists()
+    assert _grokbot_config_files(tmp_path) == []
+
+
+def test_setup_update_failure_preserves_existing_bytes_and_modes(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "operator")
+    legacy_path = grokbot_ops.config_path(tmp_path, "operator")
+    prior_pack = pack_path.read_bytes()
+    prior_legacy = legacy_path.read_bytes()
+    prior_pack_mode = pack_path.stat().st_mode & 0o777
+    prior_legacy_mode = legacy_path.stat().st_mode & 0o777
+    assert prior_pack != b""
+    assert prior_legacy != b""
+
+    _fail_legacy_config_write(monkeypatch, tmp_path, "operator")
+    with _reject("unsafe-path"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8799", bearer_env="TEST_GROKBOT_BEARER")
+    assert pack_path.read_bytes() == prior_pack
+    assert legacy_path.read_bytes() == prior_legacy
+    assert pack_path.stat().st_mode & 0o777 == prior_pack_mode
+    assert legacy_path.stat().st_mode & 0o777 == prior_legacy_mode
+    assert _grokbot_config_files(tmp_path) == [legacy_path, pack_path]
+
+
+def _assert_error_hides_secrets_and_paths(
+    caught: pytest.ExceptionInfo[grokbot_packs.PackError],
+    *paths: Path,
+    hidden: str = SECRET,
+) -> None:
+    rendered = str(caught.value)
+    assert hidden not in rendered
+    assert hidden not in caught.value.reason
+    for path in paths:
+        assert str(path) not in rendered
+        assert str(path) not in caught.value.reason
+        if path.is_file():
+            assert path.read_text(encoding="utf-8") not in rendered
+
+
+def test_setup_rollback_restore_failure_raises_rollback_failed(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "operator")
+    legacy_path = grokbot_ops.config_path(tmp_path, "operator")
+    _fail_legacy_config_write(monkeypatch, tmp_path, "operator")
+
+    real_restore = grokbot_packs._restore_regular_file
+
+    def restore_or_fail(path: Path, snapshot: tuple[str, int] | None) -> None:
+        if Path(path) == pack_path:
+            raise grokbot_packs.PackError("unsafe-path")
+        real_restore(path, snapshot)
+
+    monkeypatch.setattr(grokbot_packs, "_restore_regular_file", restore_or_fail)
+    with _reject("rollback-failed") as caught:
+        grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8799", bearer_env="TEST_GROKBOT_BEARER")
+    _assert_error_hides_secrets_and_paths(caught, pack_path, legacy_path)
+    assert caught.value.reason == "rollback-failed"
+
+
+def test_setup_rollback_verification_mismatch_raises_rollback_failed(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "operator")
+    legacy_path = grokbot_ops.config_path(tmp_path, "operator")
+    prior_pack = pack_path.read_bytes()
+    prior_legacy = legacy_path.read_bytes()
+    prior_pack_mode = pack_path.stat().st_mode & 0o777
+    _fail_legacy_config_write(monkeypatch, tmp_path, "operator")
+
+    real_restore = grokbot_packs._restore_regular_file
+
+    def restore_then_mismatch(path: Path, snapshot: tuple[str, int] | None) -> None:
+        real_restore(path, snapshot)
+        if Path(path) == pack_path:
+            path.write_bytes(b'{"tampered":true}\n')
+            path.chmod(prior_pack_mode)
+
+    monkeypatch.setattr(grokbot_packs, "_restore_regular_file", restore_then_mismatch)
+    with _reject("rollback-failed") as caught:
+        grokbot_packs.apply_setup(tmp_path, "operator", bind="127.0.0.1:8799", bearer_env="TEST_GROKBOT_BEARER")
+    _assert_error_hides_secrets_and_paths(caught, pack_path, legacy_path)
+    assert caught.value.reason == "rollback-failed"
+    assert '{"tampered":true}' not in str(caught.value)
+    assert pack_path.read_bytes() != prior_pack
+    assert legacy_path.read_bytes() == prior_legacy
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX no-follow parent walk")
+def test_setup_and_removal_refuse_descriptor_unsafe_paths(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    config_parent = tmp_path / ".brigade"
+    config_parent.symlink_to(outside, target_is_directory=True)
+    with _reject("unsafe-path"):
+        grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    assert list(outside.iterdir()) == []
+
+    config_parent.unlink()
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "operator")
+    decoy = tmp_path / "decoy.json"
+    decoy.write_text("keep me\n", encoding="utf-8")
+    pack_path.unlink()
+    pack_path.symlink_to(decoy)
+    with _reject("symlink"):
+        grokbot_packs.apply_remove(tmp_path, "operator")
+    assert decoy.read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_update_preview_writes_nothing_and_apply_stays_compatible(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    preview = grokbot_packs.preview_update(tmp_path, "operator")
+    assert preview["apply"] is False
+    assert (
+        json.loads(grokbot_packs.instance_config_path(tmp_path, "operator").read_text(encoding="utf-8"))["pack_version"]
+        == "1.0.0"
+    )
+
+    monkeypatch.setattr(
+        grokbot_packs,
+        "_PACKAGED",
+        tuple(
+            pack if pack["id"] != "operator" else {**pack, "version": "1.2.0"}
+            for pack in grokbot_packs.packaged_manifests()
+        ),
+    )
+    applied = grokbot_packs.apply_update(tmp_path, "operator")
+    assert applied["apply"] is True
+    config = json.loads(grokbot_packs.instance_config_path(tmp_path, "operator").read_text(encoding="utf-8"))
+    assert config["pack_version"] == "1.2.0"
+    assert config["bind"] == "127.0.0.1:8766"
+    assert config["bearer"] == {"kind": "env", "name": "TEST_GROKBOT_BEARER"}
+
+    monkeypatch.setattr(
+        grokbot_packs,
+        "_PACKAGED",
+        tuple(
+            pack if pack["id"] != "operator" else {**pack, "version": "2.0.0"}
+            for pack in grokbot_packs.packaged_manifests()
+        ),
+    )
+    with _reject("incompatible-version"):
+        grokbot_packs.apply_update(tmp_path, "operator")
+    assert (
+        json.loads(grokbot_packs.instance_config_path(tmp_path, "operator").read_text(encoding="utf-8"))["pack_version"]
+        == "1.2.0"
+    )
+
+
+def test_removal_preview_writes_nothing_and_apply_stays_in_owned_scope(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    unit_dir = tmp_path / "units"
+    grokbot_packs.apply_install_service(tmp_path, "operator", out_dir=unit_dir)
+    neighbor = tmp_path / grokbot_ops.CONFIG_DIR / "keep-me.json"
+    neighbor.write_text("{}\n", encoding="utf-8")
+    unit_neighbor = unit_dir / "unrelated.service"
+    unit_neighbor.write_text("keep\n", encoding="utf-8")
+
+    preview = grokbot_packs.preview_remove(tmp_path, "operator", unit_dir=unit_dir)
+    assert preview["apply"] is False
+    assert grokbot_packs.instance_config_path(tmp_path, "operator").is_file()
+    assert grokbot_ops.config_path(tmp_path, "operator").is_file()
+    assert (unit_dir / grokbot_ops.unit_name("operator")).is_file()
+
+    applied = grokbot_packs.apply_remove(tmp_path, "operator", unit_dir=unit_dir)
+    assert applied["apply"] is True
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+    assert not grokbot_ops.config_path(tmp_path, "operator").exists()
+    assert not (unit_dir / grokbot_ops.unit_name("operator")).exists()
+    assert neighbor.is_file()
+    assert unit_neighbor.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_removal_refuses_unsafe_permissions_and_outside_paths(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "operator")
+    pack_path.chmod(0o644)
+    with _reject("unsafe-permissions"):
+        grokbot_packs.apply_remove(tmp_path, "operator")
+    assert pack_path.is_file()
+
+    pack_path.chmod(0o600)
+    outside = tmp_path / "outside-units"
+    with _reject("outside-owned-path"):
+        grokbot_packs.apply_remove(tmp_path, "operator", unit_dir=outside / "nested")
+    assert pack_path.is_file()
+
+
+def test_doctor_and_canary_are_sanitized_and_non_mutating(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    token_file = _write_secret_file(tmp_path / "token.txt")
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "repository-scout",
+        bearer_file=token_file,
+    )
+    before = grokbot_ops.config_path(tmp_path, "operator").read_text(encoding="utf-8")
+    checks = grokbot_packs.doctor(tmp_path, "operator")
+    canary = grokbot_packs.canary(tmp_path, "operator")
+    rendered = json.dumps({"checks": checks, "canary": canary})
+    assert SECRET not in rendered
+    assert str(token_file) not in rendered
+    assert all(set(check) == {"check", "status"} for check in checks)
+    assert canary["ok"] is False
+    assert grokbot_ops.config_path(tmp_path, "operator").read_text(encoding="utf-8") == before
+
+
+def test_cli_preview_is_default_and_redacts_secrets(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    assert cli.main(_pack_argv(tmp_path, "list", "--json")) == 0
+    listed = json.loads(capsys.readouterr().out)
+    assert [pack["id"] for pack in listed["packs"]] == list(PACK_IDS)
+
+    assert cli.main(_pack_argv(tmp_path, "show", "--id", "operator", "--json")) == 0
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["id"] == "operator"
+    assert SECRET not in capsys.readouterr().out
+
+    assert (
+        cli.main(_pack_argv(tmp_path, "setup", "--id", "operator", "--bearer-env", "TEST_GROKBOT_BEARER", "--json"))
+        == 0
+    )
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["apply"] is False
+    assert SECRET not in json.dumps(preview)
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+
+    assert (
+        cli.main(
+            _pack_argv(
+                tmp_path, "setup", "--id", "operator", "--bearer-env", "TEST_GROKBOT_BEARER", "--apply", "--json"
+            )
+        )
+        == 0
+    )
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["apply"] is True
+    assert SECRET not in json.dumps(applied)
+    assert grokbot_packs.instance_config_path(tmp_path, "operator").is_file()
+
+    assert cli.main(_pack_argv(tmp_path, "doctor", "--id", "operator")) == 1
+    doctor_out = capsys.readouterr()
+    assert SECRET not in doctor_out.out + doctor_out.err
+    assert "config" in doctor_out.out
+
+    assert cli.main(_pack_argv(tmp_path, "canary", "--id", "operator")) == 1
+    canary_out = capsys.readouterr()
+    assert SECRET not in canary_out.out + canary_out.err
+
+    assert cli.main(_pack_argv(tmp_path, "install-service", "--id", "operator")) == 0
+    unit_text = capsys.readouterr().out
+    assert "[Unit]" in unit_text
+    assert SECRET not in unit_text
+
+    assert cli.main(_pack_argv(tmp_path, "update", "--id", "operator", "--json")) == 0
+    assert json.loads(capsys.readouterr().out)["apply"] is False
+
+    assert cli.main(_pack_argv(tmp_path, "remove", "--id", "operator", "--json")) == 0
+    assert json.loads(capsys.readouterr().out)["apply"] is False
+    assert grokbot_packs.instance_config_path(tmp_path, "operator").is_file()
+
+    assert cli.main(_pack_argv(tmp_path, "remove", "--id", "operator", "--apply")) == 0
+    assert SECRET not in capsys.readouterr().out
+    assert not grokbot_packs.instance_config_path(tmp_path, "operator").exists()
+
+
+def test_parser_inventory_includes_pack_lifecycle_and_legacy_commands():
+    from brigade.roadmap_cmd import _cli_command_paths
+
+    paths = _cli_command_paths()
+    for command in (
+        "pack list",
+        "pack show",
+        "pack setup",
+        "pack doctor",
+        "pack canary",
+        "pack install-service",
+        "pack update",
+        "pack remove",
+        "setup",
+        "doctor",
+        "canary",
+        "install-service",
+    ):
+        assert f"brigade run-cloud grokbot {command}" in paths
+
+
+def test_legacy_lifecycle_stays_compatible_with_pack_config(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    assert (
+        cli.main(
+            [
+                "run",
+                "cloud",
+                "grokbot",
+                "setup",
+                "--target",
+                str(tmp_path),
+                "--instance",
+                "operator",
+                "--bearer-env",
+                "TEST_GROKBOT_BEARER",
+            ]
+        )
+        == 0
+    )
+    assert grokbot_ops.load_config(tmp_path, "operator")["bind"] == "127.0.0.1:8766"
+    doctor = grokbot_packs.doctor(tmp_path, "operator")
+    assert any(check["check"] == "config" and check["status"] == "ok" for check in doctor)
+
+    assert grokbot_packs.apply_setup(tmp_path, "repository-scout", bearer_env="TEST_GROKBOT_BEARER")["apply"] is True
+    assert grokbot_ops.load_config(tmp_path, "repository-scout")["bind"] == "127.0.0.1:8767"
+    assert (
+        cli.main(["run", "cloud", "grokbot", "doctor", "--target", str(tmp_path), "--instance", "repository-scout"])
+        == 1
+    )


### PR DESCRIPTION
## Summary

- add a closed, versioned connector-pack registry for the three existing Grok Bot queue roles
- add preview-first setup, diagnostics, canary, service rendering, update, and removal commands under `brigade run cloud grokbot pack`
- reject port and route collisions, unsafe binds and paths, weak secret references, tool inventory drift, and partial configuration writes
- preserve the existing queue-role CLI and keep service activation outside this change

## Why

This is PR 2 of #1255. It establishes Brigade as the distribution and lifecycle boundary for first-party Grok Bot connectors before the existing Cerebro, Fleet, Backup, and Obsidian connectors move into the repository.

## Verification

- `./scripts/verify-focused tests/test_grokbot_packs.py`: 29 passed
- `./scripts/verify`: passed
- Brigade receipt: `20260827-224616-work-verify-9b24be`
- independent review: no remaining Critical or Important findings

## Safety boundaries

- secret values are never stored in pack manifests or local Brigade config
- setup rolls back and verifies both config stores, or reports `rollback-failed`
- commands do not start, stop, reload, or modify live services
- existing external connectors are not migrated or disabled in this PR

Refs #1255
