### PR TITLE
feat(grokbot): add first-party Cerebro connector

### DIFF
--- a/docs/grokbot-mcp.md
+++ b/docs/grokbot-mcp.md
@@ -58,13 +58,15 @@ The routine sequence for a worker is: list, claim, validate role and repository,
 
 ## Connector packs
 
-The three queue roles are also packaged as first-party connector packs. The registry is closed: Brigade does not load user-supplied pack manifests. Pack commands default to preview. `--apply` may write only private local config and an explicitly selected unit file. Pack commands do not start, stop, or reload services, and they never store bearer values.
+The three queue roles and the Cerebro Memory connector are packaged as first-party connector packs. The registry is closed: Brigade does not load user-supplied pack manifests. Pack commands default to preview. `--apply` may write only private local config and an explicitly selected unit file. Pack commands do not start, stop, or reload services, and they never store bearer values. Cerebro setup also stores absolute CLI executable and workdir references. Pack manifests, config previews and results, doctor, canary, errors, receipts, and checked-in docs do not reveal those machine-specific paths. The generated local unit may include the already-validated workdir only as a systemd `ReadWritePaths` entry so `ProtectSystem=strict` can still persist proposals. The CLI executable path, bearer value, and secret material stay out of the unit.
 
 ```bash
 brigade run cloud grokbot pack list
 brigade run cloud grokbot pack show --id operator
 brigade run cloud grokbot pack setup --id operator --bearer-file /run/brigade/grokbot-operator.token
 brigade run cloud grokbot pack setup --id operator --bearer-file /run/brigade/grokbot-operator.token --apply
+brigade run cloud grokbot pack setup --id cerebro-memory --bearer-file /run/brigade/grokbot-cerebro.token --cli-executable /usr/local/bin/cerebro-agents --workdir /var/lib/cerebro-agents
+brigade run cloud grokbot pack setup --id cerebro-memory --bearer-file /run/brigade/grokbot-cerebro.token --cli-executable /usr/local/bin/cerebro-agents --workdir /var/lib/cerebro-agents --apply
 brigade run cloud grokbot pack doctor --id operator
 brigade run cloud grokbot pack install-service --id operator
 brigade run cloud grokbot pack canary --id operator
@@ -72,7 +74,7 @@ brigade run cloud grokbot pack update --id operator
 brigade run cloud grokbot pack remove --id operator
 ```
 
-Default pack binds do not collide: operator `127.0.0.1:8766`, repository-scout `127.0.0.1:8767`, and implementation-worker `127.0.0.1:8768`. Custom `--bind` values that reuse another pack's packaged default or installed port are refused without printing config contents. Apply writes the pack instance store and the legacy role store together; a failed second write restores both to their prior bytes and modes, or to absent on first install, and only after each restored target is verified. A failed restore or verification raises `rollback-failed` without printing config contents. Each pack keeps the same exact tool inventory and credential reference as its legacy role. The existing `--instance` commands remain supported.
+Default pack binds do not collide: operator `127.0.0.1:8766`, repository-scout `127.0.0.1:8767`, implementation-worker `127.0.0.1:8768`, and cerebro-memory `127.0.0.1:8770`. Custom `--bind` values that reuse another pack's packaged default or installed port are refused without printing config contents. Queue-role apply writes the pack instance store and the legacy role store together; a failed second write restores both to their prior bytes and modes, or to absent on first install, and only after each restored target is verified. Connector apply writes only the pack instance store. A failed restore or verification raises `rollback-failed` without printing config contents. Queue-role packs keep the same exact tool inventory and credential reference as their legacy roles. Cerebro exposes `cerebro_search`, `cerebro_show`, `cerebro_propose`, `cerebro_proposal_status`, and `cerebro_health`. The existing `--instance` commands remain supported.
 
 ## Report snapshots
 

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -157,10 +157,12 @@ def register(sub: argparse._SubParsersAction) -> None:
 
     p_grokbot_serve = grokbot_sub.add_parser("serve", help="Run the role-scoped Grok Bot MCP listener.")
     p_grokbot_serve.add_argument("--target", type=Path, default=Path("."))
+    serve_identity = p_grokbot_serve.add_mutually_exclusive_group(required=True)
+    serve_identity.add_argument("--instance", choices=("operator", "repository-scout", "implementation-worker"))
+    serve_identity.add_argument("--pack", choices=("cerebro-memory",))
     p_grokbot_serve.add_argument(
-        "--instance", required=True, choices=("operator", "repository-scout", "implementation-worker")
+        "--bind", default=None, help="Listener host:port. Defaults to the role or pack loopback."
     )
-    p_grokbot_serve.add_argument("--bind", default="127.0.0.1:8766", help="Listener host:port. Defaults to loopback.")
     p_grokbot_serve.add_argument("--allow-host", action="append", default=[], help="Explicit allowed Host value.")
     p_grokbot_serve.add_argument("--allow-origin", action="append", default=[], help="Explicit allowed Origin value.")
     secret_group = p_grokbot_serve.add_mutually_exclusive_group(required=True)
@@ -223,6 +225,18 @@ def register(sub: argparse._SubParsersAction) -> None:
     pack_secret = p_pack_setup.add_mutually_exclusive_group(required=True)
     pack_secret.add_argument("--bearer-file", type=Path, help="Path of a protected bearer file (reference only).")
     pack_secret.add_argument("--bearer-env", help="Name of the environment variable holding the bearer.")
+    p_pack_setup.add_argument(
+        "--cli-executable",
+        type=Path,
+        default=None,
+        help="Absolute Cerebro CLI executable. Required for connector packs.",
+    )
+    p_pack_setup.add_argument(
+        "--workdir",
+        type=Path,
+        default=None,
+        help="Absolute Cerebro work directory. Required for connector packs.",
+    )
     p_pack_setup.add_argument("--apply", action="store_true", help="Write local config. Default is preview only.")
 
     p_pack_doctor = pack_sub.add_parser("doctor", help="Sanitized pack diagnostics.")
@@ -383,22 +397,42 @@ def _dispatch_grokbot(args, target: Path) -> int:
         from .. import grokbot_mcp
 
         try:
-            config = grokbot_mcp.build_listener_config(
-                target=target,
-                instance=args.instance,
-                bind=args.bind,
-                allowed_hosts=args.allow_host,
-                allowed_origins=args.allow_origin,
-                bearer_file=args.bearer_file,
-                bearer_env=args.bearer_env,
-            )
-            grokbot_mcp.run_listener(config)
+            if getattr(args, "pack", None):
+                from .. import grokbot_cerebro
+
+                cerebro_config, tools = grokbot_cerebro.build_listener_from_target(
+                    target,
+                    bind=args.bind,
+                    allowed_hosts=args.allow_host,
+                    allowed_origins=args.allow_origin,
+                    bearer_file=args.bearer_file,
+                    bearer_env=args.bearer_env,
+                )
+                grokbot_cerebro.run_listener(cerebro_config, tools)
+            else:
+                config = grokbot_mcp.build_listener_config(
+                    target=target,
+                    instance=args.instance,
+                    bind=args.bind or "127.0.0.1:8766",
+                    allowed_hosts=args.allow_host,
+                    allowed_origins=args.allow_origin,
+                    bearer_file=args.bearer_file,
+                    bearer_env=args.bearer_env,
+                )
+                grokbot_mcp.run_listener(config)
         except grokbot_mcp.OptionalDependencyError:
             print("error: Grok Bot listener requires pip install brigade-cli[grokbot]", file=sys.stderr)
             return 2
         except grokbot_mcp.ConfigurationError:
             print("error: Grok Bot listener configuration is invalid", file=sys.stderr)
             return 2
+        except Exception as exc:
+            from .. import grokbot_cerebro, grokbot_packs
+
+            if isinstance(exc, (grokbot_cerebro.CerebroError, grokbot_packs.PackError)):
+                print("error: Grok Bot listener configuration is invalid", file=sys.stderr)
+                return 2
+            raise
         return 0
     try:
         if command == "enqueue":
@@ -622,6 +656,8 @@ def _dispatch_grokbot_pack(args, target: Path) -> int:
                 "allowed_origins": args.allow_origin,
                 "bearer_env": args.bearer_env,
                 "bearer_file": args.bearer_file,
+                "cli_executable": getattr(args, "cli_executable", None),
+                "workdir": getattr(args, "workdir", None),
             }
             result = (
                 grokbot_packs.apply_setup(target, args.pack_id, **setup_kwargs)

--- a/src/brigade/grokbot_cerebro.py
+++ b/src/brigade/grokbot_cerebro.py
@@ -1,0 +1,1283 @@
+"""First-party Cerebro Memory connector adapter.
+
+Ports the closed Cerebro connector contract into Brigade using the optional
+``mcp>=2,<3`` runtime. Child process paths, stdout, and stderr never appear in
+public errors, diagnostics, canaries, units, or receipts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+from weakref import WeakKeyDictionary
+
+from . import grokbot_mcp, grokbot_ops, proc
+
+PACK_ID = "cerebro-memory"
+DEFAULT_BIND = "127.0.0.1:8770"
+TOOLS = frozenset(
+    {
+        "cerebro_search",
+        "cerebro_show",
+        "cerebro_propose",
+        "cerebro_proposal_status",
+        "cerebro_health",
+    }
+)
+UNTRUSTED_VAULT_CONTENT = "untrusted_vault_content"
+ALLOWED_SCOPES = frozenset({"agent-inbox", "agent-work-log"})
+HEALTH_STATUSES = frozenset({"ok", "warning", "error"})
+DELIVERY_STATES = frozenset({"delivered", "delivery_failed_retained", "delivery_failed_unretained"})
+CLI_SCHEMAS = {
+    "search": "cerebro-agents.search.v1",
+    "show": "cerebro-agents.show.v1",
+    "propose": "cerebro-agents.proposal.v1",
+    "status": "cerebro-agents.status.v1",
+    "health": "cerebro-agents.doctor.v1",
+}
+ERROR_MESSAGES = {
+    "invalid_request": "Tool input failed validation",
+    "denied": "Cerebro request was denied",
+    "not_found": "Cerebro resource was not found",
+    "unavailable": "Cerebro observation is unavailable",
+    "timeout": "Cerebro observation timed out",
+    "protocol_error": "Cerebro observation failed",
+    "conflict": "Cerebro request conflicted",
+}
+CHILD_ENVIRONMENT_KEYS = (
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "TMPDIR",
+    "XDG_RUNTIME_DIR",
+    "DBUS_SESSION_BUS_ADDRESS",
+)
+EXEC_MIN_TIMEOUT_MS = 250
+EXEC_MAX_TIMEOUT_MS = 30_000
+EXEC_DEFAULT_TIMEOUT_MS = 15_000
+EXEC_MIN_OUTPUT_BYTES = 1_024
+EXEC_MAX_OUTPUT_BYTES = 262_144
+EXEC_DEFAULT_OUTPUT_BYTES = 65_536
+PUBLIC_RESULT_LIMIT = 131_072
+SHOW_TEXT_LIMIT = 65_536
+RELATIVE_PATH_MAX_BYTES = 512
+MAX_ACTIVE_READS = 4
+MAX_ACTIVE_MUTATIONS = 1
+MAX_REQUEST_BYTES = 16_384
+REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+CONTENT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+ALLOWED_TOP_LEVEL = frozenset(
+    {
+        "schema",
+        "results",
+        "note",
+        "request_id",
+        "id",
+        "proposal_id",
+        "delivered",
+        "duplicate",
+        "phase",
+        "delivery_state",
+        "receipt_ref",
+        "ok",
+        "summary",
+    }
+)
+_CHILD_FAILURES: WeakKeyDictionary["CerebroError", tuple[int, str, str]] = WeakKeyDictionary()
+
+
+class CerebroError(Exception):
+    """Stable public Cerebro failure. Messages never include paths or child output."""
+
+    def __init__(self, code: str, message: str | None = None):
+        self.code = code
+        self.message = message if message is not None else ERROR_MESSAGES[code]
+        super().__init__(self.message)
+
+    def public_error(self) -> dict[str, dict[str, str]]:
+        return {"error": {"code": self.code, "message": ERROR_MESSAGES[self.code]}}
+
+    def __repr__(self) -> str:
+        return f"CerebroError({self.code!r})"
+
+
+class ChildTimeout(Exception):
+    """Internal marker for a timed-out child process."""
+
+
+class ChildOversize(Exception):
+    """Internal marker for stdout/stderr that exceeded the output cap."""
+
+
+class ChildFailure(Exception):
+    """Internal child exit with privately retained bounded output."""
+
+    def __init__(self, exit_code: int, stdout: bytes, stderr: bytes):
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        super().__init__("child failed")
+
+
+@dataclass(frozen=True)
+class ExecRequest:
+    file: str
+    args: tuple[str, ...]
+    cwd: str
+    timeout_ms: int
+    max_buffer_bytes: int
+    env: Mapping[str, str]
+    stdin: bytes | None = None
+    shell: bool = False
+
+
+@dataclass(frozen=True)
+class PrivateExecResult:
+    stdout: str
+
+
+@dataclass(frozen=True)
+class CerebroListenerConfig:
+    target: Path
+    bind_host: str
+    bind_port: int
+    allowed_hosts: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
+    bearer: str
+    cli_executable: str
+    workdir: str
+
+    def __repr__(self) -> str:
+        return f"CerebroListenerConfig(bind_host={self.bind_host!r}, bind_port={self.bind_port})"
+
+
+Runner = Callable[[ExecRequest], PrivateExecResult]
+
+
+def utf8_byte_length(value: str) -> int:
+    return len(value.encode("utf-8"))
+
+
+def truncate_utf8(text: str, max_bytes: int) -> str:
+    result: list[str] = []
+    used = 0
+    for char in text:
+        next_size = utf8_byte_length(char)
+        if used + next_size > max_bytes:
+            break
+        result.append(char)
+        used += next_size
+    return "".join(result)
+
+
+def child_environment(source: Mapping[str, str] | None = None) -> dict[str, str]:
+    env_source = os.environ if source is None else source
+    environment: dict[str, str] = {}
+    for key in CHILD_ENVIRONMENT_KEYS:
+        value = env_source.get(key)
+        if value is not None:
+            environment[key] = value
+    return environment
+
+
+def parse_search_input(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, dict) or not set(raw) <= {"query", "scope", "limit"} or "query" not in raw:
+        raise CerebroError("invalid_request")
+    query = raw["query"]
+    if not isinstance(query, str) or not 1 <= utf8_byte_length(query) <= 512:
+        raise CerebroError("invalid_request")
+    limit = raw.get("limit", 5)
+    if type(limit) is not int or not 1 <= limit <= 10:
+        raise CerebroError("invalid_request")
+    parsed: dict[str, Any] = {"query": query, "limit": limit}
+    if "scope" in raw:
+        if raw["scope"] not in ALLOWED_SCOPES:
+            raise CerebroError("invalid_request")
+        parsed["scope"] = raw["scope"]
+    return parsed
+
+
+def parse_show_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) != {"note_id"}:
+        raise CerebroError("invalid_request")
+    return {"note_id": _note_id(raw["note_id"])}
+
+
+def parse_propose_input(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, dict) or set(raw) != {"request_id", "title", "body", "source_refs"}:
+        raise CerebroError("invalid_request")
+    title = raw["title"]
+    body = raw["body"]
+    refs = raw["source_refs"]
+    if not isinstance(title, str) or not 1 <= len(title) <= 120:
+        raise CerebroError("invalid_request")
+    if not isinstance(body, str) or not 1 <= utf8_byte_length(body) <= 12_288:
+        raise CerebroError("invalid_request")
+    if not isinstance(refs, list) or len(refs) > 16:
+        raise CerebroError("invalid_request")
+    parsed_refs = []
+    for item in refs:
+        if not isinstance(item, dict) or set(item) != {"note_id", "content_hash"}:
+            raise CerebroError("invalid_request")
+        digest = item["content_hash"]
+        if not isinstance(digest, str) or not CONTENT_HASH_RE.fullmatch(digest):
+            raise CerebroError("invalid_request")
+        parsed_refs.append({"note_id": _note_id(item["note_id"]), "content_hash": digest})
+    return {
+        "request_id": _request_id(raw["request_id"]),
+        "title": title,
+        "body": body,
+        "source_refs": parsed_refs,
+    }
+
+
+def parse_status_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) != {"request_id"}:
+        raise CerebroError("invalid_request")
+    return {"request_id": _request_id(raw["request_id"])}
+
+
+def parse_health_input(raw: object) -> dict[str, Any]:
+    if raw != {}:
+        raise CerebroError("invalid_request")
+    return {}
+
+
+def validate_cli_executable(path_text: str) -> str:
+    normalized = _normalize_absolute(path_text)
+    info = _lstat_nofollow(normalized)
+    if not stat.S_ISREG(info.st_mode) or not os.access(normalized, os.X_OK):
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    return normalized
+
+
+def validate_workdir(path_text: str) -> str:
+    normalized = _normalize_absolute(path_text)
+    info = _lstat_nofollow(normalized)
+    if not stat.S_ISDIR(info.st_mode):
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    return normalized
+
+
+def run_exec(request: ExecRequest, *, runner: Runner | None = None) -> PrivateExecResult:
+    if not _bounded_int(request.timeout_ms, EXEC_MIN_TIMEOUT_MS, EXEC_MAX_TIMEOUT_MS):
+        raise CerebroError("invalid_request", "Cerebro execution request is invalid")
+    if not _bounded_int(request.max_buffer_bytes, EXEC_MIN_OUTPUT_BYTES, EXEC_MAX_OUTPUT_BYTES):
+        raise CerebroError("invalid_request", "Cerebro execution request is invalid")
+    env = child_environment(request.env)
+    prepared = ExecRequest(
+        file=request.file,
+        args=tuple(request.args),
+        cwd=request.cwd,
+        timeout_ms=request.timeout_ms,
+        max_buffer_bytes=request.max_buffer_bytes,
+        env=env,
+        stdin=request.stdin,
+        shell=False,
+    )
+    try:
+        return (runner or _subprocess_runner)(prepared)
+    except ChildTimeout:
+        raise CerebroError("timeout", "Cerebro observation timed out") from None
+    except ChildOversize:
+        raise CerebroError("protocol_error", "Cerebro observation was invalid") from None
+    except ChildFailure as exc:
+        error = CerebroError("unavailable", "Cerebro observation is unavailable")
+        _CHILD_FAILURES[error] = (
+            exc.exit_code,
+            _decode_bounded(exc.stdout, request.max_buffer_bytes),
+            _decode_bounded(exc.stderr, request.max_buffer_bytes),
+        )
+        raise error from None
+    except CerebroError:
+        raise
+    except Exception:
+        raise CerebroError("unavailable", "Cerebro observation is unavailable") from None
+
+
+class CerebroTools:
+    """Bounded Cerebro tool surface over a path-free CLI projection."""
+
+    def __init__(
+        self,
+        *,
+        cli_executable: str,
+        workdir: str,
+        env: Mapping[str, str] | None = None,
+        runner: Runner | None = None,
+    ):
+        self._bin = cli_executable
+        self._cwd = workdir
+        self._env = child_environment(env)
+        self._runner = runner
+        self._reads = threading.BoundedSemaphore(MAX_ACTIVE_READS)
+        self._mutations = threading.BoundedSemaphore(MAX_ACTIVE_MUTATIONS)
+
+    def search(self, raw: object) -> dict[str, Any]:
+        return self._guard(lambda: self._search(parse_search_input(raw)))
+
+    def show(self, raw: object) -> dict[str, Any]:
+        return self._guard(lambda: self._show(parse_show_input(raw)))
+
+    def propose(self, raw: object) -> dict[str, Any]:
+        return self._guard(lambda: self._propose(parse_propose_input(raw)))
+
+    def status(self, raw: object) -> dict[str, Any]:
+        return self._guard(lambda: self._status(parse_status_input(raw)))
+
+    def health(self, raw: object) -> dict[str, Any]:
+        parse_health_input(raw)
+        return self._guard(self._health)
+
+    def call_tool(self, name: str, arguments: object) -> dict[str, Any]:
+        handlers = {
+            "cerebro_search": self.search,
+            "cerebro_show": self.show,
+            "cerebro_propose": self.propose,
+            "cerebro_proposal_status": self.status,
+            "cerebro_health": self.health,
+        }
+        handler = handlers.get(name)
+        if handler is None:
+            raise CerebroError("invalid_request")
+        return handler(arguments if arguments is not None else {})
+
+    def tool_inventory(self) -> list[dict[str, str]]:
+        return [{"name": name, "description": _TOOL_DESCRIPTIONS[name]} for name in sorted(TOOLS)]
+
+    def _search(self, parsed: dict[str, Any]) -> dict[str, Any]:
+        args = ["search", "--json", "--limit", str(parsed["limit"])]
+        if "scope" in parsed:
+            args.extend(["--scope", parsed["scope"]])
+        args.extend(["--", parsed["query"]])
+        payload = self._cli_json(args, CLI_SCHEMAS["search"])
+        results = payload.get("results")
+        if not isinstance(results, list):
+            raise CerebroError("protocol_error")
+        return {
+            "results": [
+                item for item in (_project_search_hit(item) for item in results) if item["scope"] in ALLOWED_SCOPES
+            ]
+        }
+
+    def _show(self, parsed: dict[str, str]) -> dict[str, Any]:
+        shown = _project_show(
+            self._cli_json(["show", "--json", "--", parsed["note_id"]], CLI_SCHEMAS["show"]).get("note")
+        )
+        if shown["scope"] not in ALLOWED_SCOPES:
+            raise CerebroError("denied")
+        return shown
+
+    def _propose(self, parsed: dict[str, Any]) -> dict[str, Any]:
+        args = ["propose", "--request-id", parsed["request_id"], "--title", parsed["title"], "--json"]
+        for ref in parsed["source_refs"]:
+            args.extend(["--source-ref", f"{ref['content_hash']}:{ref['note_id']}"])
+        projected = _project_propose(
+            self._cli_json(
+                args, CLI_SCHEMAS["propose"], stdin=parsed["body"].encode("utf-8"), allow_delivery_failure=True
+            )
+        )
+        return {
+            "request_id": projected["request_id"],
+            "proposal_id": projected["proposal_id"],
+            "delivery_state": projected["delivery_state"],
+            "duplicate": projected["duplicate"],
+            "receipt_ref": projected["receipt_ref"],
+        }
+
+    def _status(self, parsed: dict[str, str]) -> dict[str, Any]:
+        return _project_receipt_fields(
+            self._cli_json(["status", "--request-id", parsed["request_id"], "--json"], CLI_SCHEMAS["status"])
+        )
+
+    def _health(self) -> dict[str, Any]:
+        return _project_health(self._cli_json(["doctor", "--json"], CLI_SCHEMAS["health"]))
+
+    def _cli_json(
+        self,
+        args: list[str],
+        schema: str,
+        *,
+        stdin: bytes | None = None,
+        allow_delivery_failure: bool = False,
+    ) -> dict[str, Any]:
+        with self._mutations if args[:1] == ["propose"] else self._reads:
+            try:
+                result = run_exec(
+                    ExecRequest(
+                        file=self._bin,
+                        args=tuple(args),
+                        cwd=self._cwd,
+                        timeout_ms=EXEC_DEFAULT_TIMEOUT_MS,
+                        max_buffer_bytes=EXEC_DEFAULT_OUTPUT_BYTES,
+                        env=self._env,
+                        stdin=stdin,
+                    ),
+                    runner=self._runner,
+                )
+                stdout = result.stdout
+            except CerebroError as exc:
+                child = _CHILD_FAILURES.get(exc)
+                if child is not None and child[0] == 2 and child[2] == "idempotency conflict\n":
+                    raise CerebroError("conflict") from None
+                if allow_delivery_failure and child is not None and child[0] == 5:
+                    stdout = child[1]
+                elif exc.code in ERROR_MESSAGES:
+                    raise
+                else:
+                    raise CerebroError("unavailable") from None
+        return _parse_cli_json(stdout, schema)
+
+    def _guard(self, work: Callable[[], dict[str, Any]]) -> dict[str, Any]:
+        try:
+            result = work()
+            if utf8_byte_length(json.dumps(result, separators=(",", ":"))) > PUBLIC_RESULT_LIMIT:
+                raise CerebroError("protocol_error")
+            return result
+        except CerebroError:
+            raise
+        except Exception:
+            raise CerebroError("protocol_error") from None
+
+
+class CerebroAdapter:
+    """HTTP-facing adapter used by doctor, canary, and the MCP listener."""
+
+    def __init__(self, config: CerebroListenerConfig, tools: CerebroTools):
+        self.config = config
+        self.tools = tools
+
+    def authorized(self, authorization: str | None) -> bool:
+        if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
+            return False
+        bearer = authorization[7:]
+        if not bearer.isascii():
+            return False
+        import hmac
+
+        return hmac.compare_digest(bearer, self.config.bearer)
+
+    def health_payload(self) -> dict[str, object]:
+        return {"ok": True, "service": "grokbot-cerebro-memory"}
+
+    def _tools(self) -> frozenset[str]:
+        return TOOLS
+
+    def tool_inventory(self) -> list[dict[str, str]]:
+        return self.tools.tool_inventory()
+
+    def call_tool(self, name: str, arguments: object) -> dict[str, Any]:
+        try:
+            return self.tools.call_tool(name, arguments)
+        except CerebroError as exc:
+            return exc.public_error()
+
+
+def doctor(target: Path, *, timeout: int = grokbot_ops.DEFAULT_TIMEOUT_SECONDS) -> list[dict[str, str]]:
+    from . import grokbot_packs
+
+    checks: list[dict[str, str]] = []
+
+    def record(name: str, ok: bool) -> None:
+        checks.append({"check": name, "status": "ok" if ok else "fail"})
+
+    try:
+        from mcp.server import MCPServer  # noqa: F401
+
+        record("dependency", True)
+    except ImportError:
+        record("dependency", False)
+
+    try:
+        config, bearer = _load_runtime(target)
+        record("config", True)
+    except (CerebroError, grokbot_packs.PackError, grokbot_mcp.ConfigurationError, OSError, ValueError, KeyError):
+        record("config", False)
+        return checks
+
+    parent = grokbot_packs.instance_config_path(target, PACK_ID).parent
+    record("permissions", os.access(parent, os.W_OK) if parent.is_dir() else False)
+    record("endpoint", _health_check(config, bearer, timeout))
+    return checks
+
+
+def canary(target: Path, *, timeout: int = grokbot_ops.DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    from . import grokbot_packs
+
+    result: dict[str, Any] = {"ok": False, "pack_id": PACK_ID}
+    try:
+        config, bearer = _load_runtime(target)
+    except (CerebroError, grokbot_packs.PackError, grokbot_mcp.ConfigurationError, OSError, ValueError, KeyError):
+        result["reason"] = "config"
+        return result
+
+    base = f"http://{grokbot_ops._connect_host(config.bind_host)}:{config.bind_port}"
+    health = grokbot_ops._request_json(f"{base}/health", bearer, timeout, method="GET")
+    anonymous_status = grokbot_ops._anonymous_health_status(f"{base}/health", timeout)
+    tools_response = grokbot_ops._tools_list(base, bearer, timeout)
+    if health is None or health.get("ok") is not True or health.get("service") != "grokbot-cerebro-memory":
+        result["reason"] = "health"
+        return result
+    if anonymous_status not in {401, 403}:
+        result["reason"] = "auth"
+        return result
+    if tools_response is None:
+        result["reason"] = "inventory-unreachable"
+        return result
+    names = {tool.get("name") for tool in tools_response if isinstance(tool, dict)}
+    if names != set(TOOLS):
+        result["reason"] = "inventory-mismatch"
+        return result
+    probe = _call_health_tool(base, bearer, timeout)
+    if probe is None or probe.get("ok") is not True:
+        result["reason"] = "health"
+        return result
+    result.update(
+        {
+            "ok": True,
+            "health": health,
+            "auth_rejected_without_bearer": True,
+            "tools": sorted(TOOLS),
+        }
+    )
+    return result
+
+
+def render_unit(target: Path, *, python: str | None = None) -> str:
+    instance = _load_validated_instance(target)
+    reference = instance["bearer"]
+    bind = instance["bind"]
+    args = [
+        python or sys.executable,
+        "-m",
+        "brigade",
+        "run",
+        "cloud",
+        "grokbot",
+        "serve",
+        "--pack",
+        PACK_ID,
+        "--target",
+        str(target),
+        "--bind",
+        bind,
+    ]
+    for host in instance.get("allowed_hosts", []):
+        args += ["--allow-host", host]
+    for origin in instance.get("allowed_origins", []):
+        args += ["--allow-origin", origin]
+    if reference["kind"] == "file":
+        args += ["--bearer-file", reference["path"]]
+    elif reference["kind"] == "env":
+        args += ["--bearer-env", reference["name"]]
+    exec_start = " ".join(grokbot_ops._systemd_quote(argument) for argument in args)
+    writable_state = grokbot_ops._systemd_quote(instance["workdir"])
+    return (
+        "# Generated by brigade run cloud grokbot pack install-service.\n"
+        f"# Unit: {grokbot_ops.unit_name(PACK_ID)}\n"
+        "[Unit]\n"
+        "Description=Brigade Grok Bot MCP listener (cerebro-memory)\n"
+        "After=network.target\n\n"
+        "[Service]\n"
+        "Type=simple\n"
+        f"ExecStart={exec_start}\n"
+        "Restart=on-failure\n"
+        "NoNewPrivileges=yes\n"
+        "PrivateTmp=yes\n"
+        "ProtectSystem=strict\n"
+        "ProtectHome=read-only\n\n"
+        f"ReadWritePaths={writable_state}\n\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+def write_unit(target: Path, out_dir: Path, *, force: bool = False, python: str | None = None) -> Path:
+    rendered = render_unit(target, python=python)
+    path = out_dir / grokbot_ops.unit_name(PACK_ID)
+    try:
+        existing = grokbot_ops._read_regular_text(path)
+    except FileNotFoundError:
+        existing = None
+    except OSError as exc:
+        if not force or not grokbot_ops._path_is_symlink(path):
+            raise grokbot_ops.ServiceRenderError(f"refusing unsafe unit path: {path.name}") from exc
+        existing = None
+    if existing == rendered:
+        return path
+    if existing is not None and not force:
+        raise grokbot_ops.ServiceRenderError(f"refusing to overwrite existing unit: {path.name}")
+    try:
+        grokbot_ops._write_text_nofollow_atomic(
+            path,
+            rendered,
+            mode=0o644,
+            replace_symlink=force,
+            replace=force or existing is not None,
+        )
+    except OSError as exc:
+        raise grokbot_ops.ServiceRenderError(f"refusing unsafe unit path: {path.name}") from exc
+    return path
+
+
+def build_app(config: CerebroListenerConfig, tools: CerebroTools) -> Callable[..., Any]:
+    MCPServer, JSONResponse, _, TransportSecuritySettings = grokbot_mcp._load_mcp()
+    adapter = CerebroAdapter(config, tools)
+    server = MCPServer("grokbot-cerebro-memory", version="1")
+
+    @server.custom_route("/health", methods=["GET"])
+    async def health(_: Any) -> Any:
+        return JSONResponse(adapter.health_payload())
+
+    _register_tools(server, adapter)
+    allowed_hosts = list(dict.fromkeys((*grokbot_mcp.SDK_LOOPBACK_ALLOWED_HOSTS, *config.allowed_hosts)))
+    if not grokbot_mcp._is_loopback(config.bind_host):
+        allowed_hosts = list(config.allowed_hosts)
+    app = server.streamable_http_app(
+        json_response=True,
+        stateless_http=True,
+        max_request_body_size=MAX_REQUEST_BYTES,
+        host=config.bind_host,
+        transport_security=TransportSecuritySettings(
+            allowed_hosts=allowed_hosts,
+            allowed_origins=list(config.allowed_origins),
+        ),
+    )
+    return _CerebroGateASGI(app, _CerebroRequestGate(config), adapter)
+
+
+def run_listener(config: CerebroListenerConfig, tools: CerebroTools) -> None:
+    grokbot_mcp._load_mcp()
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover - bundled with mcp at runtime.
+        raise grokbot_mcp.OptionalDependencyError() from exc
+    uvicorn.run(
+        build_app(config, tools), host=config.bind_host, port=config.bind_port, access_log=False, log_level="warning"
+    )
+
+
+def build_listener_from_target(
+    target: Path,
+    *,
+    bind: str | None,
+    allowed_hosts: list[str],
+    allowed_origins: list[str],
+    bearer_file: Path | None,
+    bearer_env: str | None,
+) -> tuple[CerebroListenerConfig, CerebroTools]:
+    from . import grokbot_packs
+
+    instance = grokbot_packs._load_instance_config(target, PACK_ID)
+    chosen_bind = bind or instance["bind"]
+    host, port = grokbot_packs._parse_default_bind(chosen_bind)
+    executable = validate_cli_executable(str(instance["cli_executable"]))
+    workdir = validate_workdir(str(instance["workdir"]))
+    if executable == workdir:
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    bearer = grokbot_mcp.load_bearer(bearer_file=bearer_file, bearer_env=bearer_env)
+    config = CerebroListenerConfig(
+        target=target.expanduser().resolve(),
+        bind_host=host,
+        bind_port=port,
+        allowed_hosts=tuple(allowed_hosts),
+        allowed_origins=tuple(allowed_origins),
+        bearer=bearer,
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    tools = CerebroTools(cli_executable=executable, workdir=workdir, env=os.environ)
+    return config, tools
+
+
+def _register_tools(server: Any, adapter: CerebroAdapter) -> None:
+    def cerebro_search(query: str, scope: str | None = None, limit: int = 5) -> dict[str, Any]:
+        payload: dict[str, Any] = {"query": query, "limit": limit}
+        if scope is not None:
+            payload["scope"] = scope
+        return adapter.call_tool("cerebro_search", payload)
+
+    def cerebro_show(note_id: str) -> dict[str, Any]:
+        return adapter.call_tool("cerebro_show", {"note_id": note_id})
+
+    def cerebro_propose(
+        request_id: str,
+        title: str,
+        body: str,
+        source_refs: list[dict[str, str]],
+    ) -> dict[str, Any]:
+        return adapter.call_tool(
+            "cerebro_propose",
+            {"request_id": request_id, "title": title, "body": body, "source_refs": source_refs},
+        )
+
+    def cerebro_proposal_status(request_id: str) -> dict[str, Any]:
+        return adapter.call_tool("cerebro_proposal_status", {"request_id": request_id})
+
+    def cerebro_health() -> dict[str, Any]:
+        return adapter.call_tool("cerebro_health", {})
+
+    for name, handler in (
+        ("cerebro_search", cerebro_search),
+        ("cerebro_show", cerebro_show),
+        ("cerebro_propose", cerebro_propose),
+        ("cerebro_proposal_status", cerebro_proposal_status),
+        ("cerebro_health", cerebro_health),
+    ):
+        handler.__name__ = name
+        handler.__doc__ = _TOOL_DESCRIPTIONS[name]
+        server.tool(name=name, description=_TOOL_DESCRIPTIONS[name])(handler)
+
+
+class _CerebroRequestGate:
+    def __init__(self, config: CerebroListenerConfig, *, max_request_bytes: int = MAX_REQUEST_BYTES):
+        self.config = config
+        self.max_request_bytes = max_request_bytes
+        self._adapter = CerebroAdapter(
+            config,
+            CerebroTools(cli_executable=config.cli_executable, workdir=config.workdir),
+        )
+
+    def reject_reason(self, headers: Mapping[str, str], body_size: int) -> str | None:
+        if body_size < 0 or body_size > self.max_request_bytes:
+            return "too-large"
+        host = headers.get("host", "").split(":", 1)[0].casefold()
+        if grokbot_mcp._is_loopback(self.config.bind_host) and host in {"localhost", "127.0.0.1", "::1", ""}:
+            pass
+        elif host not in {entry.casefold().split(":", 1)[0] for entry in self.config.allowed_hosts}:
+            return "forbidden"
+        origin = headers.get("origin")
+        if origin is not None and origin not in self.config.allowed_origins:
+            return "forbidden"
+        if not self._adapter.authorized(headers.get("authorization")):
+            return "unauthorized"
+        return None
+
+
+class _CerebroGateASGI:
+    def __init__(self, app: Callable[..., Any], gate: _CerebroRequestGate, adapter: CerebroAdapter):
+        self.app = app
+        self.gate = gate
+        self.adapter = adapter
+
+    async def __call__(self, scope: dict[str, Any], receive: Callable[..., Any], send: Callable[..., Any]) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = {key.decode("latin-1").casefold(): value.decode("latin-1") for key, value in scope.get("headers", [])}
+        content_length = headers.get("content-length")
+        if content_length is not None and (
+            not content_length.isdecimal() or int(content_length) > self.gate.max_request_bytes
+        ):
+            await grokbot_mcp._reject_http(send, 413, "Request body is too large")
+            return
+        reason = self.gate.reject_reason(headers, 0)
+        if reason is not None:
+            await grokbot_mcp._reject_http(
+                send,
+                401 if reason == "unauthorized" else 403,
+                "Unauthorized" if reason == "unauthorized" else "Forbidden",
+            )
+            return
+        body, messages, too_large = await grokbot_mcp._read_bounded_body(receive, self.gate.max_request_bytes)
+        if too_large:
+            await grokbot_mcp._reject_http(send, 413, "Request body is too large")
+            return
+        if scope.get("path") == "/mcp" and _invalid_cerebro_tool_request(body):
+            await grokbot_mcp._reject_tool(send, body)
+            return
+        await self.app(scope, grokbot_mcp._replay_messages(messages, receive), send)
+
+
+def _invalid_cerebro_tool_request(body: bytes) -> bool:
+    try:
+        request = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(request, dict) or request.get("method") != "tools/call":
+        return False
+    params = request.get("params")
+    if not isinstance(params, dict):
+        return True
+    name = params.get("name")
+    if name not in TOOLS:
+        return True
+    arguments = params.get("arguments")
+    parser = {
+        "cerebro_search": parse_search_input,
+        "cerebro_show": parse_show_input,
+        "cerebro_propose": parse_propose_input,
+        "cerebro_proposal_status": parse_status_input,
+        "cerebro_health": parse_health_input,
+    }[name]
+    try:
+        parser(arguments if arguments is not None else {})
+    except CerebroError:
+        return True
+    return False
+
+
+def _load_validated_instance(target: Path) -> dict[str, Any]:
+    from . import grokbot_packs
+
+    payload = grokbot_packs._load_instance_config(target, PACK_ID)
+    executable = validate_cli_executable(str(payload["cli_executable"]))
+    workdir = validate_workdir(str(payload["workdir"]))
+    if executable == workdir:
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    grokbot_packs._parse_default_bind(str(payload["bind"]))
+    grokbot_packs._validate_bearer_reference(payload["bearer"])
+    validated = dict(payload)
+    validated["cli_executable"] = executable
+    validated["workdir"] = workdir
+    return validated
+
+
+def _load_runtime(target: Path) -> tuple[CerebroListenerConfig, str]:
+    from . import grokbot_packs
+
+    payload = _load_validated_instance(target)
+    host, port = grokbot_packs._parse_default_bind(str(payload["bind"]))
+    bearer = grokbot_ops._resolve_bearer(payload["bearer"])
+    config = CerebroListenerConfig(
+        target=target,
+        bind_host=host,
+        bind_port=port,
+        allowed_hosts=tuple(payload["allowed_hosts"]),
+        allowed_origins=tuple(payload["allowed_origins"]),
+        bearer=bearer,
+        cli_executable=payload["cli_executable"],
+        workdir=payload["workdir"],
+    )
+    return config, bearer
+
+
+def _health_check(config: CerebroListenerConfig, bearer: str, timeout: int) -> bool:
+    payload = grokbot_ops._request_json(
+        f"http://{grokbot_ops._connect_host(config.bind_host)}:{config.bind_port}/health",
+        bearer,
+        timeout,
+        method="GET",
+    )
+    return payload is not None and payload.get("ok") is True and payload.get("service") == "grokbot-cerebro-memory"
+
+
+def _call_health_tool(base: str, bearer: str, timeout: int) -> dict[str, Any] | None:
+    try:
+        import asyncio
+
+        return asyncio.run(asyncio.wait_for(_call_health_tool_async(base, bearer), timeout=timeout))
+    except Exception:
+        return None
+
+
+async def _call_health_tool_async(base: str, bearer: str) -> dict[str, Any]:
+    client_session, streamable_http_client, async_client = grokbot_ops._mcp_client_components()
+    async with async_client(headers={"Authorization": f"Bearer {bearer}"}, trust_env=False) as http_client:
+        async with streamable_http_client(f"{base}/mcp", http_client=http_client) as streams:
+            read_stream, write_stream = streams
+            async with client_session(read_stream, write_stream) as session:
+                await session.initialize()
+                result = await session.call_tool("cerebro_health", {})
+    payload = result.structuredContent if getattr(result, "structuredContent", None) else None
+    if isinstance(payload, dict):
+        return payload
+    for block in getattr(result, "content", []) or []:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+    raise CerebroError("protocol_error")
+
+
+_READ_CHUNK_BYTES = 4096
+_CHILD_CLEANUP_SECONDS = 0.5
+
+
+def _close_pipe(stream: Any) -> None:
+    if stream is None:
+        return
+    try:
+        stream.close()
+    except OSError:
+        pass
+
+
+def _write_child_stdin(process: subprocess.Popen[bytes], payload: bytes | None) -> None:
+    if process.stdin is None:
+        return
+    try:
+        if payload is not None:
+            process.stdin.write(payload)
+    except (BrokenPipeError, OSError):
+        pass
+    finally:
+        _close_pipe(process.stdin)
+
+
+def _reap_child_group(process: subprocess.Popen[bytes]) -> None:
+    proc.terminate_process_tree(process, terminate_grace=0.2, kill_grace=0.2)
+    for stream in (process.stdin, process.stdout, process.stderr):
+        _close_pipe(stream)
+
+
+def _join_bounded(threads: tuple[threading.Thread, ...], timeout: float) -> None:
+    deadline = time.monotonic() + max(timeout, 0.0)
+    for thread in threads:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        thread.join(timeout=remaining)
+
+
+def _read_chunk(stream: Any) -> bytes:
+    read1 = getattr(stream, "read1", None)
+    if callable(read1):
+        return read1(_READ_CHUNK_BYTES)
+    fileno = getattr(stream, "fileno", None)
+    if callable(fileno):
+        try:
+            return os.read(fileno(), _READ_CHUNK_BYTES)
+        except BlockingIOError:
+            return b""
+    return stream.read(_READ_CHUNK_BYTES)
+
+
+def _subprocess_runner(request: ExecRequest) -> PrivateExecResult:
+    try:
+        process = subprocess.Popen(
+            [request.file, *request.args],
+            cwd=request.cwd,
+            env=dict(request.env),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,
+            **proc.process_group_kwargs(),
+        )
+    except OSError as exc:
+        raise ChildFailure(-1, b"", b"") from exc
+
+    cap = request.max_buffer_bytes
+    stdout = bytearray()
+    stderr = bytearray()
+    overflowed = threading.Event()
+    wake = threading.Event()
+
+    def read_into(stream: Any, buf: bytearray) -> None:
+        try:
+            while True:
+                chunk = _read_chunk(stream)
+                if not chunk:
+                    return
+                if overflowed.is_set() or len(buf) + len(chunk) > cap:
+                    overflowed.set()
+                    return
+                buf.extend(chunk)
+        except (OSError, ValueError):
+            return
+        finally:
+            wake.set()
+
+    readers = (
+        threading.Thread(target=read_into, args=(process.stdout, stdout), daemon=True),
+        threading.Thread(target=read_into, args=(process.stderr, stderr), daemon=True),
+    )
+    for reader in readers:
+        reader.start()
+    stdin_thread = threading.Thread(target=_write_child_stdin, args=(process, request.stdin), daemon=True)
+    stdin_thread.start()
+
+    deadline = time.monotonic() + (request.timeout_ms / 1000)
+    timed_out = False
+    child_exited_at: float | None = None
+    try:
+        while True:
+            readers_alive = any(reader.is_alive() for reader in readers)
+            if overflowed.is_set() or (process.poll() is not None and not readers_alive):
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            wait_for = remaining
+            if process.poll() is not None:
+                if child_exited_at is None:
+                    child_exited_at = time.monotonic()
+                drain_left = _CHILD_CLEANUP_SECONDS - (time.monotonic() - child_exited_at)
+                if drain_left <= 0:
+                    timed_out = True
+                    break
+                wait_for = min(wait_for, drain_left)
+            wake.clear()
+            readers_alive = any(reader.is_alive() for reader in readers)
+            if overflowed.is_set() or (process.poll() is not None and not readers_alive):
+                break
+            wake.wait(timeout=wait_for)
+    finally:
+        if timed_out or overflowed.is_set():
+            _reap_child_group(process)
+        _join_bounded((*readers, stdin_thread), _CHILD_CLEANUP_SECONDS)
+        if process.poll() is None:
+            _reap_child_group(process)
+            try:
+                process.wait(timeout=_CHILD_CLEANUP_SECONDS)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+
+    if overflowed.is_set():
+        raise ChildOversize()
+    if timed_out:
+        raise ChildTimeout()
+    if process.returncode:
+        raise ChildFailure(int(process.returncode), bytes(stdout), bytes(stderr))
+    return PrivateExecResult(stdout=_decode_bounded(bytes(stdout), cap))
+
+
+def _decode_bounded(data: bytes, maximum: int) -> str:
+    return data[:maximum].decode("utf-8", errors="replace")
+
+
+def _parse_cli_json(stdout: str, schema: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(stdout)
+    except (TypeError, ValueError, UnicodeDecodeError):
+        raise CerebroError("protocol_error") from None
+    if not isinstance(parsed, dict):
+        raise CerebroError("protocol_error")
+    kept: dict[str, Any] = {}
+    for key, value in parsed.items():
+        if key == "checks":
+            continue
+        if key not in ALLOWED_TOP_LEVEL:
+            raise CerebroError("protocol_error")
+        kept[key] = value
+    if kept.get("schema") != schema:
+        raise CerebroError("protocol_error")
+    return kept
+
+
+def _project_search_hit(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise CerebroError("protocol_error")
+    return {
+        "id": _required_string(value.get("id")),
+        "title": _required_string(value.get("title")),
+        "scope": _required_string(value.get("scope")),
+        "relative_path": _required_relative_path(value.get("relative_path")),
+        "content_hash": _required_string(value.get("content_hash")),
+        "updated_at": _required_string(value.get("updated_at")),
+        "tags": _required_tags(value.get("tags")),
+        "snippet": value.get("snippet") if isinstance(value.get("snippet"), str) else "",
+        "score": _required_score(value.get("score")),
+        "trust": UNTRUSTED_VAULT_CONTENT,
+    }
+
+
+def _project_show(note: object) -> dict[str, Any]:
+    if not isinstance(note, dict):
+        raise CerebroError("protocol_error")
+    original = _required_string(note.get("text"))
+    too_big = utf8_byte_length(original) > SHOW_TEXT_LIMIT
+    return {
+        "id": _required_string(note.get("id")),
+        "title": _required_string(note.get("title")),
+        "scope": _required_string(note.get("scope")),
+        "relative_path": _required_relative_path(note.get("relative_path")),
+        "content_hash": _required_string(note.get("content_hash")),
+        "updated_at": _required_string(note.get("updated_at")),
+        "tags": _required_tags(note.get("tags")),
+        "text": truncate_utf8(original, SHOW_TEXT_LIMIT) if too_big else original,
+        "truncated": too_big or note.get("truncated") is True,
+        "trust": UNTRUSTED_VAULT_CONTENT,
+    }
+
+
+def _project_propose(payload: Mapping[str, Any]) -> dict[str, Any]:
+    receipt = _project_receipt_fields(payload)
+    if receipt.get("phase") != "terminal" or "delivery_state" not in receipt or "receipt_ref" not in receipt:
+        raise CerebroError("protocol_error")
+    delivered = payload.get("delivered")
+    if not isinstance(delivered, bool):
+        raise CerebroError("protocol_error")
+    if delivered is not (receipt["delivery_state"] == "delivered"):
+        raise CerebroError("protocol_error")
+    duplicate = payload.get("duplicate")
+    if not isinstance(duplicate, bool):
+        raise CerebroError("protocol_error")
+    return {
+        "request_id": receipt["request_id"],
+        "proposal_id": receipt["proposal_id"],
+        "delivered": delivered,
+        "duplicate": duplicate,
+        "phase": "terminal",
+        "delivery_state": receipt["delivery_state"],
+        "receipt_ref": receipt["receipt_ref"],
+    }
+
+
+def _project_receipt_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
+    phase = payload.get("phase")
+    if phase not in {"in_progress", "terminal"}:
+        raise CerebroError("protocol_error")
+    delivery_state = payload.get("delivery_state")
+    receipt_ref = payload.get("receipt_ref")
+    if delivery_state is not None and (not isinstance(delivery_state, str) or not delivery_state):
+        raise CerebroError("protocol_error")
+    if receipt_ref is not None and (not isinstance(receipt_ref, str) or not receipt_ref):
+        raise CerebroError("protocol_error")
+    proposal = payload.get("proposal_id", payload.get("id"))
+    if phase == "in_progress":
+        if delivery_state is not None or receipt_ref is not None:
+            raise CerebroError("protocol_error")
+        return {
+            "request_id": _required_string(payload.get("request_id")),
+            "proposal_id": _required_string(proposal),
+            "phase": phase,
+        }
+    if delivery_state not in DELIVERY_STATES or receipt_ref is None:
+        raise CerebroError("protocol_error")
+    return {
+        "request_id": _required_string(payload.get("request_id")),
+        "proposal_id": _required_string(proposal),
+        "phase": phase,
+        "delivery_state": delivery_state,
+        "receipt_ref": receipt_ref,
+    }
+
+
+def _project_health(payload: Mapping[str, Any]) -> dict[str, Any]:
+    ok = payload.get("ok")
+    summary = payload.get("summary")
+    if not isinstance(ok, bool) or not isinstance(summary, dict):
+        raise CerebroError("protocol_error")
+    index_age = summary.get("index_age_seconds")
+    if index_age is not None and (type(index_age) is not int or index_age < 0):
+        raise CerebroError("protocol_error")
+    projected: dict[str, Any] = {
+        "cli": _required_health_status(summary.get("cli")),
+        "configuration": _required_health_status(summary.get("configuration")),
+        "index": _required_health_status(summary.get("index")),
+        "proposal_bridge": _required_health_status(summary.get("proposal_bridge")),
+    }
+    if type(index_age) is int:
+        projected["index_age_seconds"] = index_age
+    return {"ok": ok, "summary": projected}
+
+
+def _required_string(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise CerebroError("protocol_error")
+    return value
+
+
+def _required_tags(value: object) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(tag, str) for tag in value):
+        raise CerebroError("protocol_error")
+    return value
+
+
+def _required_score(value: object) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or not _is_finite(value):
+        raise CerebroError("protocol_error")
+    return float(value)
+
+
+def _required_health_status(value: object) -> str:
+    if not isinstance(value, str) or value not in HEALTH_STATUSES:
+        raise CerebroError("protocol_error")
+    return value
+
+
+def _required_relative_path(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise CerebroError("protocol_error")
+    if utf8_byte_length(value) > RELATIVE_PATH_MAX_BYTES or "\0" in value or "\\" in value:
+        raise CerebroError("protocol_error")
+    try:
+        decoded = urllib.parse.unquote(value, errors="strict")
+    except Exception:
+        raise CerebroError("protocol_error") from None
+    if decoded.startswith("/") or re.match(r"^[A-Za-z]:[\\/]", decoded) or "\\" in decoded or "://" in decoded:
+        raise CerebroError("protocol_error")
+    segments = decoded.split("/")
+    if any(segment in {"", ".", ".."} for segment in segments):
+        raise CerebroError("protocol_error")
+    return value
+
+
+def _note_id(value: object) -> str:
+    if not isinstance(value, str) or not 1 <= utf8_byte_length(value) <= 512:
+        raise CerebroError("invalid_request")
+    if "\0" in value or "\n" in value or value.startswith("-"):
+        raise CerebroError("invalid_request")
+    return value
+
+
+def _request_id(value: object) -> str:
+    if not isinstance(value, str) or not 8 <= len(value) <= 64 or not REQUEST_ID_RE.fullmatch(value):
+        raise CerebroError("invalid_request")
+    return value
+
+
+def _normalize_absolute(path_text: str) -> str:
+    if not isinstance(path_text, str) or not path_text or "\0" in path_text:
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    if not os.path.isabs(path_text):
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    parts = path_text.split(os.sep)
+    if any(part in {".", ".."} for part in parts):
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    normalized = os.path.normpath(path_text)
+    if normalized != "/" and normalized.endswith(os.sep):
+        normalized = normalized.rstrip(os.sep)
+    return normalized
+
+
+def _lstat_nofollow(path_text: str) -> os.stat_result:
+    path = Path(path_text)
+    if grokbot_ops._path_is_symlink(path) or path.is_symlink():
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    parent = -1
+    try:
+        parent = grokbot_ops._open_parent_nofollow(path, create=False)
+        info = os.stat(path.name, dir_fd=parent, follow_symlinks=False) if os.name == "posix" else path.lstat()
+    except OSError as exc:
+        raise CerebroError("invalid_request", "Cerebro environment is invalid") from exc
+    finally:
+        if parent != -1:
+            os.close(parent)
+    if stat.S_ISLNK(info.st_mode):
+        raise CerebroError("invalid_request", "Cerebro environment is invalid")
+    return info
+
+
+def _bounded_int(value: object, minimum: int, maximum: int) -> bool:
+    return type(value) is int and minimum <= value <= maximum
+
+
+def _is_finite(value: float) -> bool:
+    return value == value and value not in {float("inf"), float("-inf")}
+
+
+_TOOL_DESCRIPTIONS = {
+    "cerebro_search": "Search cited Cerebro notes",
+    "cerebro_show": "Show a cited Cerebro note",
+    "cerebro_propose": "Propose a Cerebro memory note",
+    "cerebro_proposal_status": "Read a Cerebro proposal receipt",
+    "cerebro_health": "Read path-free Cerebro health",
+}

--- a/src/brigade/grokbot_packs.py
+++ b/src/brigade/grokbot_packs.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
-from . import grokbot_mcp, grokbot_ops
+from . import grokbot_cerebro, grokbot_mcp, grokbot_ops
 
 PACK_SCHEMA = "brigade.grokbot.connector-pack.v1"
 INSTANCE_SCHEMA = "brigade.grokbot.connector-instance.v1"
@@ -39,6 +39,10 @@ DEFAULT_BINDS = {
     "operator": "127.0.0.1:8766",
     "repository-scout": "127.0.0.1:8767",
 }
+CONNECTOR_DEFAULT_BINDS = {
+    "cerebro-memory": "127.0.0.1:8770",
+}
+CONNECTOR_INSTANCE_KEYS = INSTANCE_KEYS | frozenset({"cli_executable", "workdir"})
 VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 PACK_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
 PUBLIC_ROUTE_RE = re.compile(r"^$|^/[A-Za-z0-9._~-]+(?:/[A-Za-z0-9._~-]+)*$")
@@ -66,7 +70,23 @@ def _queue_pack(instance: str) -> dict[str, Any]:
     }
 
 
-_PACKAGED = tuple(_queue_pack(instance) for instance in sorted(DEFAULT_BINDS))
+def _connector_pack(pack_id: str) -> dict[str, Any]:
+    return {
+        "schema": PACK_SCHEMA,
+        "id": pack_id,
+        "version": "1.0.0",
+        "kind": "connector",
+        "instance": pack_id,
+        "default_bind": CONNECTOR_DEFAULT_BINDS[pack_id],
+        "public_route": "",
+        "tools": sorted(grokbot_cerebro.TOOLS if pack_id == "cerebro-memory" else ()),
+    }
+
+
+_PACKAGED = tuple(
+    [_queue_pack(instance) for instance in sorted(DEFAULT_BINDS)]
+    + [_connector_pack(pack_id) for pack_id in sorted(CONNECTOR_DEFAULT_BINDS)]
+)
 
 
 def packaged_manifests() -> tuple[dict[str, Any], ...]:
@@ -124,6 +144,8 @@ def preview_setup(
     bearer_env: str | None = None,
     bearer_file: Path | None = None,
     bearer: dict[str, Any] | None = None,
+    cli_executable: str | Path | None = None,
+    workdir: str | Path | None = None,
 ) -> dict[str, Any]:
     return _setup(
         target,
@@ -135,6 +157,8 @@ def preview_setup(
         bearer_env=bearer_env,
         bearer_file=bearer_file,
         bearer=bearer,
+        cli_executable=cli_executable,
+        workdir=workdir,
     )
 
 
@@ -148,6 +172,8 @@ def apply_setup(
     bearer_env: str | None = None,
     bearer_file: Path | None = None,
     bearer: dict[str, Any] | None = None,
+    cli_executable: str | Path | None = None,
+    workdir: str | Path | None = None,
 ) -> dict[str, Any]:
     return _setup(
         target,
@@ -159,26 +185,48 @@ def apply_setup(
         bearer_env=bearer_env,
         bearer_file=bearer_file,
         bearer=bearer,
+        cli_executable=cli_executable,
+        workdir=workdir,
     )
 
 
 def doctor(target: Path, pack_id: str) -> list[dict[str, str]]:
     pack = show_pack(pack_id)
-    return grokbot_ops.doctor(target, pack["instance"])
+    if pack["kind"] == "queue-role":
+        return grokbot_ops.doctor(target, pack["instance"])
+    from . import grokbot_cerebro
+
+    return grokbot_cerebro.doctor(target)
 
 
 def canary(target: Path, pack_id: str) -> dict[str, Any]:
     pack = show_pack(pack_id)
-    return grokbot_ops.canary(target, pack["instance"])
+    if pack["kind"] == "queue-role":
+        return grokbot_ops.canary(target, pack["instance"])
+    from . import grokbot_cerebro
+
+    return grokbot_cerebro.canary(target)
 
 
 def render_install_service(target: Path, pack_id: str) -> str:
     pack = show_pack(pack_id)
     try:
-        config = grokbot_ops.load_config(target, pack["instance"])
-        return grokbot_ops.render_unit(config, python=sys.executable, exec_root=target)
+        if pack["kind"] == "queue-role":
+            config = grokbot_ops.load_config(target, pack["instance"])
+            return grokbot_ops.render_unit(config, python=sys.executable, exec_root=target)
+        from . import grokbot_cerebro
+
+        return grokbot_cerebro.render_unit(target, python=sys.executable)
+    except PackError:
+        raise
     except (grokbot_mcp.ConfigurationError, grokbot_ops.ServiceRenderError, OSError) as exc:
         raise PackError("unsafe-path") from exc
+    except Exception as exc:
+        from . import grokbot_cerebro
+
+        if isinstance(exc, grokbot_cerebro.CerebroError):
+            raise PackError("unsafe-path") from exc
+        raise
 
 
 def apply_install_service(
@@ -190,10 +238,23 @@ def apply_install_service(
 ) -> dict[str, Any]:
     pack = show_pack(pack_id)
     try:
-        config = grokbot_ops.load_config(target, pack["instance"])
-        path = grokbot_ops.write_unit(config, out_dir, exec_root=target, force=force)
+        if pack["kind"] == "queue-role":
+            config = grokbot_ops.load_config(target, pack["instance"])
+            path = grokbot_ops.write_unit(config, out_dir, exec_root=target, force=force)
+        else:
+            from . import grokbot_cerebro
+
+            path = grokbot_cerebro.write_unit(target, out_dir, force=force)
+    except PackError:
+        raise
     except (grokbot_mcp.ConfigurationError, grokbot_ops.ServiceRenderError, OSError) as exc:
         raise PackError("unsafe-path") from exc
+    except Exception as exc:
+        from . import grokbot_cerebro
+
+        if isinstance(exc, grokbot_cerebro.CerebroError):
+            raise PackError("unsafe-path") from exc
+        raise
     return {"action": "install-service", "apply": True, "pack_id": pack_id, "unit": path.name}
 
 
@@ -224,6 +285,8 @@ def _setup(
     bearer_env: str | None,
     bearer_file: Path | None,
     bearer: dict[str, Any] | None,
+    cli_executable: str | Path | None,
+    workdir: str | Path | None,
 ) -> dict[str, Any]:
     pack = show_pack(pack_id)
     reference = _bearer_reference(bearer_env=bearer_env, bearer_file=bearer_file, bearer=bearer)
@@ -241,12 +304,19 @@ def _setup(
         "public_route": pack["public_route"],
         "bearer": reference,
     }
+    if pack["kind"] == "queue-role":
+        if cli_executable is not None or workdir is not None:
+            raise PackError("unexpected-key")
+    else:
+        payload["cli_executable"] = _connector_path_reference(cli_executable, kind="executable")
+        payload["workdir"] = _connector_path_reference(workdir, kind="directory")
+        if payload["cli_executable"] == payload["workdir"]:
+            raise PackError("unsafe-path")
     _validate_instance_config(payload, pack_id)
     _assert_setup_bind_available(target, pack_id, chosen_bind)
-    writes = [
-        str(instance_config_path(Path("."), pack_id)),
-        str(grokbot_ops.config_path(Path("."), pack["instance"])),
-    ]
+    writes = [str(instance_config_path(Path("."), pack_id))]
+    if pack["kind"] == "queue-role":
+        writes.append(str(grokbot_ops.config_path(Path("."), pack["instance"])))
     result = {"action": "setup", "apply": apply, "pack_id": pack_id, "bind": chosen_bind, "writes": writes}
     if not apply:
         return result
@@ -254,6 +324,7 @@ def _setup(
         target,
         pack_id,
         instance=pack["instance"],
+        kind=pack["kind"],
         payload=payload,
         bind=chosen_bind,
         hosts=hosts,
@@ -268,6 +339,7 @@ def _apply_setup_configs(
     pack_id: str,
     *,
     instance: str,
+    kind: str,
     payload: dict[str, Any],
     bind: str,
     hosts: list[str],
@@ -275,25 +347,28 @@ def _apply_setup_configs(
     reference: Mapping[str, str],
 ) -> None:
     pack_path = instance_config_path(target, pack_id)
-    legacy_path = grokbot_ops.config_path(target, instance)
+    destinations: list[Path] = [pack_path]
     _assert_config_destination_safe(pack_path)
-    _assert_config_destination_safe(legacy_path)
-    pack_snapshot = _snapshot_regular_file(pack_path)
-    legacy_snapshot = _snapshot_regular_file(legacy_path)
+    if kind == "queue-role":
+        legacy_path = grokbot_ops.config_path(target, instance)
+        _assert_config_destination_safe(legacy_path)
+        destinations.append(legacy_path)
+    snapshots = [_snapshot_regular_file(path) for path in destinations]
     try:
         _write_instance_config(target, pack_id, payload)
-        grokbot_ops.save_config(
-            target,
-            instance=instance,
-            bind=bind,
-            allowed_hosts=hosts,
-            allowed_origins=origins,
-            bearer_env=reference["name"] if reference["kind"] == "env" else None,
-            bearer_file=Path(reference["path"]) if reference["kind"] == "file" else None,
-        )
+        if kind == "queue-role":
+            grokbot_ops.save_config(
+                target,
+                instance=instance,
+                bind=bind,
+                allowed_hosts=hosts,
+                allowed_origins=origins,
+                bearer_env=reference["name"] if reference["kind"] == "env" else None,
+                bearer_file=Path(reference["path"]) if reference["kind"] == "file" else None,
+            )
     except (grokbot_mcp.ConfigurationError, OSError, PackError) as exc:
         rollback_failed = False
-        for dest, snap in ((pack_path, pack_snapshot), (legacy_path, legacy_snapshot)):
+        for dest, snap in zip(destinations, snapshots, strict=True):
             try:
                 _restore_regular_file(dest, snap)
             except PackError:
@@ -355,9 +430,10 @@ def _removal_paths(target: Path, pack: Mapping[str, Any], unit_dir: Path | None)
     pack_path = instance_config_path(target, pack["id"])
     if _exists_or_link(pack_path):
         candidates.append((pack_path, True))
-    legacy = grokbot_ops.config_path(target, pack["instance"])
-    if _exists_or_link(legacy):
-        candidates.append((legacy, True))
+    if pack["kind"] == "queue-role":
+        legacy = grokbot_ops.config_path(target, pack["instance"])
+        if _exists_or_link(legacy):
+            candidates.append((legacy, True))
     if unit_dir is not None:
         candidates.append((unit_dir / grokbot_ops.unit_name(pack["instance"]), False))
     paths: list[Path] = []
@@ -485,9 +561,10 @@ def _occupied_setup_ports(target: Path, *, exclude_pack_id: str) -> set[int]:
         pack_port = _bind_port_from_existing_config(instance_config_path(target, pack["id"]))
         if pack_port is not None:
             ports.add(pack_port)
-        legacy_port = _bind_port_from_existing_config(grokbot_ops.config_path(target, pack["instance"]))
-        if legacy_port is not None:
-            ports.add(legacy_port)
+        if pack["kind"] == "queue-role":
+            legacy_port = _bind_port_from_existing_config(grokbot_ops.config_path(target, pack["instance"]))
+            if legacy_port is not None:
+                ports.add(legacy_port)
     return ports
 
 
@@ -552,13 +629,21 @@ def _validate_pack(raw: Mapping[str, Any]) -> dict[str, Any]:
         raise PackError("unexpected-key")
     if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
         raise PackError("invalid-version")
-    if kind != "queue-role" or instance != pack_id or instance not in grokbot_mcp.INSTANCES:
+    if kind == "queue-role":
+        if instance != pack_id or instance not in grokbot_mcp.INSTANCES:
+            raise PackError("unexpected-key")
+        expected_tools = grokbot_mcp.tools_for_instance(instance)
+    elif kind == "connector":
+        if pack_id not in CONNECTOR_DEFAULT_BINDS or instance != pack_id:
+            raise PackError("unexpected-key")
+        expected_tools = grokbot_cerebro.TOOLS if pack_id == "cerebro-memory" else frozenset()
+    else:
         raise PackError("unexpected-key")
     if not isinstance(route, str) or not PUBLIC_ROUTE_RE.fullmatch(route):
         raise PackError("overlapping-public-route" if route else "unexpected-key")
     if not isinstance(tools, list) or any(not isinstance(name, str) for name in tools):
         raise PackError("inventory-mismatch")
-    if set(tools) != grokbot_mcp.tools_for_instance(instance) or len(tools) != len(set(tools)):
+    if set(tools) != expected_tools or len(tools) != len(set(tools)):
         raise PackError("inventory-mismatch")
     bind = raw.get("default_bind")
     if not isinstance(bind, str):
@@ -577,7 +662,9 @@ def _validate_pack(raw: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _validate_instance_config(payload: Mapping[str, Any], pack_id: str) -> dict[str, Any]:
-    if set(payload) != INSTANCE_KEYS or payload.get("schema") != INSTANCE_SCHEMA:
+    pack = show_pack(pack_id)
+    expected_keys = INSTANCE_KEYS if pack["kind"] == "queue-role" else CONNECTOR_INSTANCE_KEYS
+    if set(payload) != expected_keys or payload.get("schema") != INSTANCE_SCHEMA:
         raise PackError("unexpected-key")
     if payload.get("pack_id") != pack_id:
         raise PackError("unexpected-key")
@@ -600,6 +687,11 @@ def _validate_instance_config(payload: Mapping[str, Any], pack_id: str) -> dict[
     if not isinstance(route, str) or not PUBLIC_ROUTE_RE.fullmatch(route):
         raise PackError("unexpected-key")
     _validate_bearer_reference(payload.get("bearer"))
+    if pack["kind"] == "connector":
+        _connector_path_reference(payload.get("cli_executable"), kind="executable")
+        workdir = _connector_path_reference(payload.get("workdir"), kind="directory")
+        if payload.get("cli_executable") == workdir:
+            raise PackError("unsafe-path")
     return dict(payload)
 
 
@@ -635,6 +727,22 @@ def _validate_bearer_reference(reference: object) -> dict[str, str]:
             grokbot_ops._systemd_quote(path)
             return {"kind": "file", "path": path}
     raise PackError("weak-secret-reference")
+
+
+def _connector_path_reference(value: object, *, kind: str) -> str:
+    if value is None:
+        raise PackError("missing-path-reference")
+    if not isinstance(value, (str, Path)) or (isinstance(value, str) and not value):
+        raise PackError("unsafe-path")
+    from . import grokbot_cerebro
+
+    try:
+        text = str(value)
+        if kind == "executable":
+            return grokbot_cerebro.validate_cli_executable(text)
+        return grokbot_cerebro.validate_workdir(text)
+    except grokbot_cerebro.CerebroError as exc:
+        raise PackError("unsafe-path") from exc
 
 
 def _parse_default_bind(value: str) -> tuple[str, int]:

--- a/tests/test_grokbot_cerebro.py
+++ b/tests/test_grokbot_cerebro.py
@@ -1,0 +1,947 @@
+"""Tests for the first-party Cerebro Memory connector adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from brigade import grokbot_cerebro, grokbot_ops, grokbot_packs
+
+SECRET_BIN = "/var/lib/secret-cerebro/bin"
+SECRET_CWD = "/var/lib/secret-cerebro/work"
+SECRET_STDERR = "PRIVATE_STDERR"
+SECRET_STDOUT = "PRIVATE_STDOUT token=secret-stdout"
+SECRET_HOME = "/home/secret-cerebro"
+SECRET_PATH = "/opt/secret-cerebro/bin"
+HASH = f"sha256:{'a' * 64}"
+NOTE_ID = "note-6a6f1603-c279-4bf8-9462-1467f7cb177b"
+UNTRUSTED = grokbot_cerebro.UNTRUSTED_VAULT_CONTENT
+
+
+def _reject(code: str, message: str | None = None):
+    return pytest.raises(grokbot_cerebro.CerebroError, match=message or grokbot_cerebro.ERROR_MESSAGES[code])
+
+
+def _hit(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": NOTE_ID,
+        "title": "Inbox",
+        "scope": "agent-inbox",
+        "relative_path": "00 - Inbox/Agent Notes/inbox.md",
+        "content_hash": HASH,
+        "updated_at": "2026-08-21T00:00:00Z",
+        "tags": ["agent"],
+        "snippet": "cited",
+        "score": 8,
+        "trust": UNTRUSTED,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _note(**overrides: object) -> dict[str, object]:
+    payload = _hit()
+    payload["text"] = "cited"
+    payload.update(overrides)
+    return payload
+
+
+class _FakeRunner:
+    def __init__(self, impl=None):
+        self.calls: list[grokbot_cerebro.ExecRequest] = []
+        self._impl = impl
+
+    def __call__(self, request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        self.calls.append(request)
+        if self._impl is not None:
+            return self._impl(request)
+        if request.args and request.args[0] == "show":
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps({"schema": "cerebro-agents.show.v1", "note": _note()})
+            )
+        return grokbot_cerebro.PrivateExecResult(
+            stdout=json.dumps({"schema": "cerebro-agents.search.v1", "results": []})
+        )
+
+
+def _tools(impl=None) -> tuple[grokbot_cerebro.CerebroTools, _FakeRunner]:
+    runner = _FakeRunner(impl)
+    tools = grokbot_cerebro.CerebroTools(
+        cli_executable=SECRET_BIN,
+        workdir=SECRET_CWD,
+        env={
+            "PATH": SECRET_PATH,
+            "HOME": SECRET_HOME,
+            "GROKBOT_CEREBRO_TOKEN": "C" * 32,
+            "UNRELATED": "must-not-copy",
+        },
+        runner=runner,
+    )
+    return tools, runner
+
+
+def _secrets() -> list[str]:
+    return [SECRET_BIN, SECRET_CWD, SECRET_STDERR, SECRET_STDOUT, SECRET_HOME, SECRET_PATH]
+
+
+def _assert_hidden(value: object, *extra: str) -> None:
+    rendered = value if isinstance(value, str) else json.dumps(value, default=str)
+    for secret in (*_secrets(), *extra):
+        assert secret not in rendered
+
+
+def test_search_defaults_limit_and_rejects_out_of_range_or_extra_fields():
+    assert grokbot_cerebro.parse_search_input({"query": "alpha"}) == {"query": "alpha", "limit": 5}
+    assert grokbot_cerebro.parse_search_input({"query": "alpha", "scope": "agent-inbox", "limit": 10}) == {
+        "query": "alpha",
+        "scope": "agent-inbox",
+        "limit": 10,
+    }
+    for raw in (
+        {"query": ""},
+        {"query": "a" * 513},
+        {"query": "alpha", "limit": 0},
+        {"query": "alpha", "limit": 11},
+        {"query": "alpha", "scope": "brigade-memory"},
+        {"query": "alpha", "include_archived": True},
+        {"query": "alpha", "path": "/vault"},
+        {"query": "alpha", "limit": True},
+    ):
+        with _reject("invalid_request"):
+            grokbot_cerebro.parse_search_input(raw)
+
+
+def test_input_limits_use_utf8_bytes_and_reject_command_path_env_fields():
+    emoji = "\U0001f600"
+    grokbot_cerebro.parse_search_input({"query": "a" * 512})
+    with _reject("invalid_request"):
+        grokbot_cerebro.parse_search_input({"query": "a" * 513})
+    grokbot_cerebro.parse_search_input({"query": emoji * 128})
+    with _reject("invalid_request"):
+        grokbot_cerebro.parse_search_input({"query": emoji * 129})
+
+    propose = {
+        "request_id": "req-1234",
+        "title": "Reconcile",
+        "body": "a" * 12288,
+        "source_refs": [{"note_id": "note-alpha", "content_hash": HASH}],
+    }
+    grokbot_cerebro.parse_propose_input(propose)
+    with _reject("invalid_request"):
+        grokbot_cerebro.parse_propose_input({**propose, "body": "a" * 12289})
+    grokbot_cerebro.parse_propose_input({**propose, "body": emoji * 3072})
+    with _reject("invalid_request"):
+        grokbot_cerebro.parse_propose_input({**propose, "body": emoji * 3073})
+
+    grokbot_cerebro.parse_show_input({"note_id": NOTE_ID})
+    grokbot_cerebro.parse_status_input({"request_id": "req-1234"})
+    grokbot_cerebro.parse_health_input({})
+    for extra in ({"command": "id"}, {"path": "/vault"}, {"env": {}}, {"approval": True}, {"argv": []}):
+        with _reject("invalid_request"):
+            grokbot_cerebro.parse_show_input({"note_id": "note-alpha", **extra})
+        with _reject("invalid_request"):
+            grokbot_cerebro.parse_health_input(extra)
+
+
+def test_truncate_utf8_does_not_split_a_four_byte_emoji():
+    prefix = "a" * 65535
+    text = grokbot_cerebro.truncate_utf8(prefix + "\U0001f600" + "suffix", 65536)
+    assert text == prefix
+    assert grokbot_cerebro.utf8_byte_length(text) == 65535
+    assert "\ufffd" not in text
+
+
+def test_executor_uses_shell_false_allowlist_timeout_and_hides_child_output():
+    recorded: list[grokbot_cerebro.ExecRequest] = []
+
+    def runner(request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        recorded.append(request)
+        return grokbot_cerebro.PrivateExecResult(stdout=SECRET_STDOUT)
+
+    result = grokbot_cerebro.run_exec(
+        grokbot_cerebro.ExecRequest(
+            file=SECRET_BIN,
+            args=("search", "--json", "--", "alpha"),
+            cwd=SECRET_CWD,
+            timeout_ms=grokbot_cerebro.EXEC_DEFAULT_TIMEOUT_MS,
+            max_buffer_bytes=grokbot_cerebro.EXEC_DEFAULT_OUTPUT_BYTES,
+            env={
+                "PATH": SECRET_PATH,
+                "HOME": SECRET_HOME,
+                "USER": "cerebro",
+                "GROKBOT_CEREBRO_TOKEN": "C" * 32,
+                "UNRELATED": "must-not-copy",
+            },
+            stdin=b"Cited note.\n",
+        ),
+        runner=runner,
+    )
+    assert result.stdout == SECRET_STDOUT
+    assert not hasattr(result, "stderr")
+    assert recorded[0].shell is False
+    assert recorded[0].timeout_ms == 15_000
+    assert recorded[0].max_buffer_bytes == 65_536
+    assert recorded[0].stdin == b"Cited note.\n"
+    assert set(recorded[0].env) <= set(grokbot_cerebro.CHILD_ENVIRONMENT_KEYS)
+    assert "GROKBOT_CEREBRO_TOKEN" not in recorded[0].env
+    assert "UNRELATED" not in recorded[0].env
+
+
+def test_executor_maps_failures_to_stable_errors_without_paths_or_stderr():
+    def timeout(_request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        raise grokbot_cerebro.ChildTimeout()
+
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        grokbot_cerebro.run_exec(
+            grokbot_cerebro.ExecRequest(
+                file=SECRET_BIN,
+                args=("search",),
+                cwd=SECRET_CWD,
+                timeout_ms=15_000,
+                max_buffer_bytes=65_536,
+                env={"PATH": SECRET_PATH},
+            ),
+            runner=timeout,
+        )
+    assert caught.value.code == "timeout"
+    assert caught.value.message == "Cerebro observation timed out"
+    _assert_hidden(str(caught.value), "ETIMEDOUT", "spawn")
+
+    def oversize(_request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        raise grokbot_cerebro.ChildOversize()
+
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        grokbot_cerebro.run_exec(
+            grokbot_cerebro.ExecRequest(
+                file=SECRET_BIN,
+                args=("search",),
+                cwd=SECRET_CWD,
+                timeout_ms=15_000,
+                max_buffer_bytes=65_536,
+                env={},
+            ),
+            runner=oversize,
+        )
+    assert caught.value.code == "protocol_error"
+    assert caught.value.message == "Cerebro observation was invalid"
+    _assert_hidden(str(caught.value), SECRET_STDERR)
+
+    def missing(_request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        raise OSError("spawn /var/lib/secret-cerebro/bin ENOENT")
+
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        grokbot_cerebro.run_exec(
+            grokbot_cerebro.ExecRequest(
+                file=SECRET_BIN,
+                args=("search",),
+                cwd=SECRET_CWD,
+                timeout_ms=15_000,
+                max_buffer_bytes=65_536,
+                env={},
+            ),
+            runner=missing,
+        )
+    assert caught.value.code == "unavailable"
+    _assert_hidden(str(caught.value), "ENOENT")
+
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        grokbot_cerebro.run_exec(
+            grokbot_cerebro.ExecRequest(
+                file=SECRET_BIN,
+                args=("search",),
+                cwd=SECRET_CWD,
+                timeout_ms=249,
+                max_buffer_bytes=65_536,
+                env={},
+            ),
+            runner=lambda _request: grokbot_cerebro.PrivateExecResult(stdout=""),
+        )
+    assert caught.value.code == "invalid_request"
+    assert caught.value.message == "Cerebro execution request is invalid"
+
+
+def test_tools_filter_allowed_scopes_and_deny_show_outside_them():
+    def impl(request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        if request.args[0] == "search":
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps(
+                    {
+                        "schema": "cerebro-agents.search.v1",
+                        "results": [
+                            _hit(),
+                            _hit(id="note-hidden", scope="other", title="Hidden"),
+                            _hit(id="note-work", scope="agent-work-log", title="Work"),
+                        ],
+                    }
+                )
+            )
+        return grokbot_cerebro.PrivateExecResult(
+            stdout=json.dumps(
+                {
+                    "schema": "cerebro-agents.show.v1",
+                    "note": _note(scope="brigade-memory", text="SECRET_NOTE_TEXT"),
+                }
+            )
+        )
+
+    tools, runner = _tools(impl)
+    result = tools.search({"query": "handoff"})
+    assert [item["scope"] for item in result["results"]] == ["agent-inbox", "agent-work-log"]
+    _assert_hidden(result, "Hidden", "SECRET_NOTE_TEXT")
+    assert runner.calls[0].args[:2] == ("search", "--json")
+
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        tools.show({"note_id": NOTE_ID})
+    assert caught.value.code == "denied"
+    assert caught.value.message == "Cerebro request was denied"
+    _assert_hidden(str(caught.value), "SECRET_NOTE_TEXT")
+
+
+def test_tools_project_public_propose_and_map_conflict_and_health():
+    propose_count = 0
+
+    def impl(request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        nonlocal propose_count
+        if request.args[0] == "propose":
+            propose_count += 1
+            if propose_count == 3:
+                raise grokbot_cerebro.ChildFailure(2, b"", b"idempotency conflict\n")
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps(
+                    {
+                        "schema": "cerebro-agents.proposal.v1",
+                        "request_id": "req-1234",
+                        "id": NOTE_ID,
+                        "delivered": True,
+                        "duplicate": propose_count > 1,
+                        "phase": "terminal",
+                        "delivery_state": "delivered",
+                        "receipt_ref": "c" * 32,
+                    }
+                )
+            )
+        if request.args[0] == "doctor":
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps(
+                    {
+                        "schema": "cerebro-agents.doctor.v1",
+                        "ok": True,
+                        "summary": {
+                            "cli": "ok",
+                            "configuration": "ok",
+                            "index": "ok",
+                            "proposal_bridge": "ok",
+                            "index_age_seconds": 9,
+                        },
+                        "checks": [{"name": "vault", "status": "ok", "message": SECRET_BIN}],
+                    }
+                )
+            )
+        raise AssertionError(request.args)
+
+    tools, runner = _tools(impl)
+    payload = {
+        "request_id": "req-1234",
+        "title": "Reconcile",
+        "body": "Cited note.\n",
+        "source_refs": [{"note_id": "note-alpha", "content_hash": HASH}],
+    }
+    first = tools.propose(payload)
+    second = tools.propose(payload)
+    assert first == {
+        "request_id": "req-1234",
+        "proposal_id": NOTE_ID,
+        "delivery_state": "delivered",
+        "duplicate": False,
+        "receipt_ref": "c" * 32,
+    }
+    assert second["duplicate"] is True
+    assert set(first) == {"request_id", "proposal_id", "delivery_state", "duplicate", "receipt_ref"}
+    assert runner.calls[0].args == (
+        "propose",
+        "--request-id",
+        "req-1234",
+        "--title",
+        "Reconcile",
+        "--json",
+        "--source-ref",
+        f"{HASH}:note-alpha",
+    )
+    assert runner.calls[0].stdin == b"Cited note.\n"
+
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        tools.propose(payload)
+    assert caught.value.code == "conflict"
+    _assert_hidden(str(caught.value))
+
+    with pytest.raises(grokbot_cerebro.CerebroError):
+        tools.search({"query": "", "path": "/vault"})
+    assert all(call.args[0] != "search" for call in runner.calls)
+
+    health = tools.health({})
+    assert health == {
+        "ok": True,
+        "summary": {
+            "cli": "ok",
+            "configuration": "ok",
+            "index": "ok",
+            "proposal_bridge": "ok",
+            "index_age_seconds": 9,
+        },
+    }
+    _assert_hidden(health, "checks")
+
+
+def test_cli_pins_argv_and_rejects_unsafe_relative_paths_without_echoing_them():
+    tools, runner = _tools()
+    tools.search({"query": "-literal", "limit": 5, "scope": "agent-inbox"})
+    tools.show({"note_id": NOTE_ID})
+    assert runner.calls[0].args == (
+        "search",
+        "--json",
+        "--limit",
+        "5",
+        "--scope",
+        "agent-inbox",
+        "--",
+        "-literal",
+    )
+    assert runner.calls[1].args == ("show", "--json", "--", NOTE_ID)
+    assert runner.calls[0].shell is False
+
+    for relative_path in (
+        "/tmp/attacker-controlled-path",
+        "../secret",
+        "foo/../../etc/passwd",
+        "C:/Windows/note.md",
+        "%2e%2e/%2e%2e/etc/passwd",
+    ):
+
+        def impl(request: grokbot_cerebro.ExecRequest, path: str = relative_path) -> grokbot_cerebro.PrivateExecResult:
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps({"schema": "cerebro-agents.search.v1", "results": [_hit(relative_path=path)]})
+            )
+
+        leaking, _ = _tools(impl)
+        with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+            leaking.search({"query": "handoff"})
+        assert caught.value.code == "protocol_error"
+        _assert_hidden(str(caught.value), relative_path)
+
+
+def test_show_truncates_on_utf8_boundary_and_rewrites_trust():
+    prefix = "a" * 65535
+
+    def impl(_request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        return grokbot_cerebro.PrivateExecResult(
+            stdout=json.dumps(
+                {
+                    "schema": "cerebro-agents.show.v1",
+                    "note": _note(text=prefix + "\U0001f600" + "suffix", status="active"),
+                }
+            )
+        )
+
+    tools, _ = _tools(impl)
+    shown = tools.show({"note_id": NOTE_ID})
+    assert shown["text"] == prefix
+    assert shown["truncated"] is True
+    assert shown["trust"] == UNTRUSTED
+    assert "status" not in shown
+
+
+def test_propose_accepts_exit_5_delivery_failure_and_rejects_in_progress():
+    def failed(_request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        raise grokbot_cerebro.ChildFailure(
+            5,
+            json.dumps(
+                {
+                    "schema": "cerebro-agents.proposal.v1",
+                    "request_id": "req-1234",
+                    "id": NOTE_ID,
+                    "delivered": False,
+                    "duplicate": False,
+                    "phase": "terminal",
+                    "delivery_state": "delivery_failed_retained",
+                    "receipt_ref": "b" * 32,
+                }
+            ).encode("utf-8"),
+            SECRET_STDERR.encode("utf-8"),
+        )
+
+    tools, _ = _tools(failed)
+    result = tools.propose(
+        {
+            "request_id": "req-1234",
+            "title": "Reconcile",
+            "body": "Cited note.\n",
+            "source_refs": [],
+        }
+    )
+    assert result["delivery_state"] == "delivery_failed_retained"
+    assert result["duplicate"] is False
+    _assert_hidden(result)
+
+    def in_progress(_request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        return grokbot_cerebro.PrivateExecResult(
+            stdout=json.dumps(
+                {
+                    "schema": "cerebro-agents.proposal.v1",
+                    "request_id": "req-1234",
+                    "id": NOTE_ID,
+                    "delivered": False,
+                    "duplicate": False,
+                    "phase": "in_progress",
+                }
+            )
+        )
+
+    progressing, _ = _tools(in_progress)
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        progressing.propose(
+            {
+                "request_id": "req-1234",
+                "title": "Reconcile",
+                "body": "Cited note.\n",
+                "source_refs": [],
+            }
+        )
+    assert caught.value.code == "protocol_error"
+
+
+def test_tools_cap_concurrent_reads_at_four_and_mutations_at_one():
+    lock = threading.Lock()
+    active_reads = 0
+    max_reads = 0
+    active_mutations = 0
+    max_mutations = 0
+
+    def impl(request: grokbot_cerebro.ExecRequest) -> grokbot_cerebro.PrivateExecResult:
+        nonlocal active_reads, max_reads, active_mutations, max_mutations
+        mutation = request.args[0] == "propose"
+        with lock:
+            if mutation:
+                active_mutations += 1
+                max_mutations = max(max_mutations, active_mutations)
+            else:
+                active_reads += 1
+                max_reads = max(max_reads, active_reads)
+        time.sleep(0.03)
+        with lock:
+            if mutation:
+                active_mutations -= 1
+            else:
+                active_reads -= 1
+        if mutation:
+            title = request.args[request.args.index("--title") + 1]
+            if title == "Fail":
+                raise grokbot_cerebro.ChildFailure(1, b"", SECRET_STDERR.encode("utf-8"))
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps(
+                    {
+                        "schema": "cerebro-agents.proposal.v1",
+                        "request_id": "req-1234",
+                        "id": NOTE_ID,
+                        "delivered": True,
+                        "duplicate": False,
+                        "phase": "terminal",
+                        "delivery_state": "delivered",
+                        "receipt_ref": "c" * 32,
+                    }
+                )
+            )
+        if request.args[0] == "show":
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps({"schema": "cerebro-agents.show.v1", "note": _note()})
+            )
+        if request.args[0] == "status":
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps(
+                    {
+                        "schema": "cerebro-agents.status.v1",
+                        "request_id": "req-1234",
+                        "proposal_id": NOTE_ID,
+                        "phase": "in_progress",
+                    }
+                )
+            )
+        if request.args[0] == "doctor":
+            return grokbot_cerebro.PrivateExecResult(
+                stdout=json.dumps(
+                    {
+                        "schema": "cerebro-agents.doctor.v1",
+                        "ok": True,
+                        "summary": {"cli": "ok", "configuration": "ok", "index": "ok", "proposal_bridge": "ok"},
+                    }
+                )
+            )
+        return grokbot_cerebro.PrivateExecResult(
+            stdout=json.dumps({"schema": "cerebro-agents.search.v1", "results": []})
+        )
+
+    tools, _ = _tools(impl)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        reads = list(
+            pool.map(
+                lambda item: item[0](item[1]),
+                [
+                    (tools.search, {"query": "one"}),
+                    (tools.search, {"query": "two"}),
+                    (tools.show, {"note_id": NOTE_ID}),
+                    (tools.show, {"note_id": NOTE_ID}),
+                    (tools.status, {"request_id": "req-1234"}),
+                    (tools.status, {"request_id": "req-5678"}),
+                    (tools.health, {}),
+                    (tools.health, {}),
+                ],
+            )
+        )
+    assert len(reads) == 8
+    assert max_reads == 4
+
+    def propose(title: str) -> dict[str, object]:
+        return tools.propose(
+            {
+                "request_id": "req-ok-12" if title != "Fail" else "req-fail1",
+                "title": title,
+                "body": "Cited note.\n",
+                "source_refs": [],
+            }
+        )
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        mutations = list(pool.map(lambda title: _call(propose, title), ["Fail", "Reconcile", "Reconcile"]))
+    assert max_mutations == 1
+    assert sum(1 for item in mutations if item is not None) == 2
+    assert sum(1 for item in mutations if item is None) == 1
+
+
+def _call(func, title: str) -> dict[str, object] | None:
+    try:
+        return func(title)
+    except grokbot_cerebro.CerebroError:
+        return None
+
+
+def _cerebro_paths(tmp_path: Path) -> tuple[Path, Path]:
+    workdir = tmp_path / "cerebro-work"
+    workdir.mkdir()
+    executable = tmp_path / "cerebro-agents"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    return executable, workdir
+
+
+def test_path_validation_rejects_relative_symlink_and_overlapping_paths(tmp_path: Path):
+    executable, workdir = _cerebro_paths(tmp_path)
+    assert grokbot_cerebro.validate_cli_executable(str(executable)) == str(executable)
+    assert grokbot_cerebro.validate_workdir(str(workdir)) == str(workdir)
+    with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+        grokbot_cerebro.validate_cli_executable("cerebro-agents")
+    assert caught.value.code == "invalid_request"
+    _assert_hidden(str(caught.value), "cerebro-agents")
+    with pytest.raises(grokbot_cerebro.CerebroError):
+        grokbot_cerebro.validate_cli_executable(str(workdir))
+    with pytest.raises(grokbot_cerebro.CerebroError):
+        grokbot_cerebro.validate_workdir(str(executable))
+    if os.name == "posix":
+        link = tmp_path / "linked-bin"
+        link.symlink_to(executable)
+        with pytest.raises(grokbot_cerebro.CerebroError) as caught:
+            grokbot_cerebro.validate_cli_executable(str(link))
+        _assert_hidden(str(caught.value), str(link), str(executable))
+
+
+def test_doctor_and_canary_are_sanitized_and_unit_uses_brigade_cli(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", "not-a-real-token")
+    executable, workdir = _cerebro_paths(tmp_path)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    checks = grokbot_cerebro.doctor(tmp_path)
+    canary = grokbot_cerebro.canary(tmp_path)
+    rendered = json.dumps({"checks": checks, "canary": canary})
+    assert "not-a-real-token" not in rendered
+    assert str(executable) not in rendered
+    assert str(workdir) not in rendered
+    assert all(set(check) == {"check", "status"} for check in checks)
+    assert canary["ok"] is False
+
+    unit = grokbot_packs.render_install_service(tmp_path, "cerebro-memory")
+    assert "-m" in unit
+    assert "brigade" in unit
+    assert "run" in unit
+    assert "cloud" in unit
+    assert "grokbot" in unit
+    assert "serve" in unit
+    assert "--pack" in unit
+    assert "cerebro-memory" in unit
+    assert "127.0.0.1:8770" in unit
+    assert str(executable) not in unit
+    assert "not-a-real-token" not in unit
+    assert "node" not in unit.lower()
+    assert "npm" not in unit.lower()
+
+
+def _runner_request(
+    tmp_path: Path,
+    code: str,
+    *,
+    timeout_ms: int = 2000,
+    max_buffer_bytes: int = 1024,
+    stdin: bytes | None = None,
+) -> grokbot_cerebro.ExecRequest:
+    return grokbot_cerebro.ExecRequest(
+        file=sys.executable,
+        args=("-c", code),
+        cwd=str(tmp_path),
+        timeout_ms=timeout_ms,
+        max_buffer_bytes=max_buffer_bytes,
+        env=grokbot_cerebro.child_environment(),
+        stdin=stdin,
+    )
+
+
+def _reap_pid(pid: int) -> None:
+    try:
+        os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+    except OSError:
+        pass
+
+
+def test_subprocess_runner_timeout_does_not_wait_on_pipe_holding_descendant(tmp_path: Path):
+    pid_path = tmp_path / "descendant.pid"
+    descendant = (
+        f"import os,time; from pathlib import Path; Path({str(pid_path)!r}).write_text(str(os.getpid())); time.sleep(8)"
+    )
+    parent = f"import subprocess,sys,time; subprocess.Popen([sys.executable, '-c', {descendant!r}]); time.sleep(8)"
+    started = time.monotonic()
+    try:
+        with pytest.raises(grokbot_cerebro.ChildTimeout):
+            grokbot_cerebro._subprocess_runner(_runner_request(tmp_path, parent, timeout_ms=500))
+        elapsed = time.monotonic() - started
+        assert elapsed < 2.0
+        assert elapsed >= 0.25
+    finally:
+        if pid_path.is_file():
+            try:
+                _reap_pid(int(pid_path.read_text(encoding="utf-8").strip()))
+            except ValueError:
+                pass
+
+
+def test_subprocess_runner_detects_stdout_oversize_without_unbounded_buffer(tmp_path: Path):
+    code = "import sys,time; sys.stdout.buffer.write(b'O' * 2048); sys.stdout.buffer.flush(); time.sleep(8)"
+    started = time.monotonic()
+    with pytest.raises(grokbot_cerebro.ChildOversize):
+        grokbot_cerebro._subprocess_runner(_runner_request(tmp_path, code, timeout_ms=4000, max_buffer_bytes=1024))
+    assert time.monotonic() - started < 2.0
+
+
+def test_subprocess_runner_detects_stderr_oversize_without_unbounded_buffer(tmp_path: Path):
+    code = "import sys,time; sys.stderr.buffer.write(b'E' * 2048); sys.stderr.buffer.flush(); time.sleep(8)"
+    started = time.monotonic()
+    with pytest.raises(grokbot_cerebro.ChildOversize):
+        grokbot_cerebro._subprocess_runner(_runner_request(tmp_path, code, timeout_ms=4000, max_buffer_bytes=1024))
+    assert time.monotonic() - started < 2.0
+
+
+def test_subprocess_runner_keeps_bounded_streams_and_child_failure_mapping(tmp_path: Path):
+    result = grokbot_cerebro._subprocess_runner(
+        _runner_request(tmp_path, "import sys; sys.stdout.write('ok-out'); sys.stderr.write('ok-err')")
+    )
+    assert result.stdout == "ok-out"
+    assert not hasattr(result, "stderr")
+
+    with pytest.raises(grokbot_cerebro.ChildFailure) as failed:
+        grokbot_cerebro._subprocess_runner(
+            _runner_request(
+                tmp_path,
+                "import sys; sys.stdout.write('fail-out'); sys.stderr.write('idempotency conflict\\n'); raise SystemExit(2)",
+            )
+        )
+    assert failed.value.exit_code == 2
+    assert failed.value.stdout == b"fail-out"
+    assert failed.value.stderr == b"idempotency conflict\n"
+
+    with pytest.raises(grokbot_cerebro.CerebroError) as mapped:
+        grokbot_cerebro.run_exec(
+            _runner_request(
+                tmp_path,
+                "import sys; sys.stdout.write('fail-out'); sys.stderr.write('idempotency conflict\\n'); raise SystemExit(2)",
+            )
+        )
+    assert mapped.value.code == "unavailable"
+    assert mapped.value.message == "Cerebro observation is unavailable"
+    retained = grokbot_cerebro._CHILD_FAILURES[mapped.value]
+    assert retained[0] == 2
+    assert retained[1] == "fail-out"
+    assert retained[2] == "idempotency conflict\n"
+    _assert_hidden(str(mapped.value))
+
+
+def test_render_unit_restores_hardening_and_hides_private_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", "not-a-real-token")
+    executable, workdir = _cerebro_paths(tmp_path)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    unit = grokbot_cerebro.render_unit(tmp_path)
+    assert "NoNewPrivileges=yes" in unit
+    assert "PrivateTmp=yes" in unit
+    assert "ProtectSystem=strict" in unit
+    assert "ProtectHome=read-only" in unit
+    assert str(executable) not in unit
+    assert "not-a-real-token" not in unit
+
+
+def test_render_unit_quotes_exact_workdir_read_write_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", "not-a-real-token")
+    workdir = tmp_path / "cerebro work; echo 'hi' & *"
+    workdir.mkdir()
+    executable = tmp_path / "cerebro-agents"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    unit = grokbot_cerebro.render_unit(tmp_path)
+    quoted = grokbot_ops._systemd_quote(str(workdir))
+    lines = [line for line in unit.splitlines() if line.startswith("ReadWritePaths=")]
+    assert lines == [f"ReadWritePaths={quoted}"]
+    assert quoted.startswith('"') and quoted.endswith('"')
+    assert "ProtectSystem=strict" in unit
+    assert "ProtectHome=read-only" in unit
+    assert "NoNewPrivileges=yes" in unit
+    assert "PrivateTmp=yes" in unit
+    assert str(executable) not in unit
+    assert "not-a-real-token" not in unit
+    assert f"ReadWritePaths={grokbot_ops._systemd_quote(str(tmp_path))}" not in unit
+    assert "ReadWritePaths=/" not in unit
+    assert "ReadWritePaths=/home" not in unit
+    assert "ReadWritePaths=~" not in unit
+
+
+def _assert_unit_hardening_and_workdir(unit: str, *, workdir: Path, target: Path, secret: str) -> None:
+    quoted = grokbot_ops._systemd_quote(str(workdir))
+    lines = [line for line in unit.splitlines() if line.startswith("ReadWritePaths=")]
+    assert lines == [f"ReadWritePaths={quoted}"]
+    assert quoted.startswith('"') and quoted.endswith('"')
+    assert "ProtectSystem=strict" in unit
+    assert "ProtectHome=read-only" in unit
+    assert "NoNewPrivileges=yes" in unit
+    assert "PrivateTmp=yes" in unit
+    assert secret not in unit
+    assert f"ReadWritePaths={grokbot_ops._systemd_quote(str(target))}" not in unit
+    assert "ReadWritePaths=/" not in unit
+    assert "ReadWritePaths=/home" not in unit
+    assert "ReadWritePaths=~" not in unit
+
+
+def _forbid_bearer_resolution(monkeypatch: pytest.MonkeyPatch, bearer_file: Path | None = None) -> None:
+    from brigade import grokbot_mcp
+
+    def _boom(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("bearer must not be resolved while rendering a unit")
+
+    monkeypatch.setattr(grokbot_ops, "_resolve_bearer", _boom)
+    monkeypatch.setattr(grokbot_mcp, "load_bearer", _boom)
+    if bearer_file is None:
+        return
+    real_read = Path.read_text
+
+    def guarded_read(self: Path, *args: object, **kwargs: object) -> str:
+        if Path(self).resolve() == bearer_file.resolve():
+            raise AssertionError("secret file must not be read while rendering a unit")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read)
+
+
+def test_render_unit_env_bearer_succeeds_without_current_env_value(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    secret = "not-a-real-token"
+    monkeypatch.delenv("TEST_GROKBOT_BEARER", raising=False)
+    workdir = tmp_path / "cerebro work; echo 'hi' & *"
+    workdir.mkdir()
+    executable = tmp_path / "cerebro-agents"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    checks = grokbot_cerebro.doctor(tmp_path)
+    assert any(check["check"] == "config" and check["status"] == "fail" for check in checks)
+    canary = grokbot_cerebro.canary(tmp_path)
+    assert canary["ok"] is False
+    assert canary.get("reason") == "config"
+    _forbid_bearer_resolution(monkeypatch)
+    unit = grokbot_cerebro.render_unit(tmp_path)
+    assert "--bearer-env" in unit
+    assert "TEST_GROKBOT_BEARER" in unit
+    assert secret not in unit
+    assert str(executable) not in unit
+    _assert_unit_hardening_and_workdir(unit, workdir=workdir, target=tmp_path, secret=secret)
+    written = grokbot_cerebro.write_unit(tmp_path, tmp_path / "units")
+    assert written.read_text(encoding="utf-8") == unit
+
+
+def test_render_unit_file_bearer_succeeds_without_current_secret_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bearer_fixture = "synthetic-bearer-fixture"
+    bearer_file = tmp_path / "bearer.txt"
+    workdir = tmp_path / "cerebro work; echo 'hi' & *"
+    workdir.mkdir()
+    executable = tmp_path / "cerebro-agents"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_file=bearer_file,
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    assert not bearer_file.exists()
+    checks = grokbot_cerebro.doctor(tmp_path)
+    assert any(check["check"] == "config" and check["status"] == "fail" for check in checks)
+    canary = grokbot_cerebro.canary(tmp_path)
+    assert canary["ok"] is False
+    assert canary.get("reason") == "config"
+    _forbid_bearer_resolution(monkeypatch, bearer_file)
+    unit = grokbot_cerebro.render_unit(tmp_path)
+    assert "--bearer-file" in unit
+    assert str(bearer_file.resolve()) in unit
+    assert bearer_fixture not in unit
+    assert str(executable) not in unit
+    _assert_unit_hardening_and_workdir(unit, workdir=workdir, target=tmp_path, secret=bearer_fixture)
+    bearer_file.write_text(bearer_fixture + "\n", encoding="utf-8")
+    bearer_file.chmod(0o600)
+    unit_after = grokbot_cerebro.render_unit(tmp_path)
+    assert unit_after == unit
+    assert bearer_fixture not in unit_after
+    written = grokbot_cerebro.write_unit(tmp_path, tmp_path / "units")
+    assert written.read_text(encoding="utf-8") == unit
+    assert bearer_fixture not in written.read_text(encoding="utf-8")

--- a/tests/test_grokbot_packs.py
+++ b/tests/test_grokbot_packs.py
@@ -11,7 +11,15 @@ import pytest
 from brigade import cli, grokbot_mcp, grokbot_ops, grokbot_packs
 
 SECRET = "not-a-real-token"
-PACK_IDS = ("implementation-worker", "operator", "repository-scout")
+QUEUE_PACK_IDS = ("implementation-worker", "operator", "repository-scout")
+PACK_IDS = ("cerebro-memory", "implementation-worker", "operator", "repository-scout")
+CEREBRO_TOOLS = (
+    "cerebro_health",
+    "cerebro_proposal_status",
+    "cerebro_propose",
+    "cerebro_search",
+    "cerebro_show",
+)
 
 
 def _reject(reason: str):
@@ -56,10 +64,17 @@ def test_registry_is_closed_deterministic_and_exact_key_validated():
     for pack in packs:
         assert set(pack) == grokbot_packs.PACK_KEYS
         assert pack["schema"] == grokbot_packs.PACK_SCHEMA
-        assert pack["kind"] == "queue-role"
         shown = grokbot_packs.show_pack(pack["id"])
         assert shown == pack
-        assert set(shown["tools"]) == grokbot_mcp.tools_for_instance(pack["instance"])
+        if pack["id"] in QUEUE_PACK_IDS:
+            assert pack["kind"] == "queue-role"
+            assert set(shown["tools"]) == grokbot_mcp.tools_for_instance(pack["instance"])
+        else:
+            assert pack["kind"] == "connector"
+            assert pack["id"] == "cerebro-memory"
+            assert shown["tools"] == list(CEREBRO_TOOLS)
+            assert shown["default_bind"] == "127.0.0.1:8770"
+            assert shown["public_route"] == ""
 
 
 def test_registry_ignores_user_supplied_pack_files(tmp_path: Path):
@@ -130,8 +145,9 @@ def test_registry_rejects_unexpected_pack_keys():
 
 def test_first_party_queue_packs_keep_isolated_ports_tools_and_credentials():
     packs = {pack["id"]: pack for pack in grokbot_packs.list_packs()}
-    ports = {grokbot_mcp.parse_bind(pack["default_bind"])[1] for pack in packs.values()}
-    assert ports == {8766, 8767, 8768}
+    queue_ports = {grokbot_mcp.parse_bind(packs[pack_id]["default_bind"])[1] for pack_id in QUEUE_PACK_IDS}
+    assert queue_ports == {8766, 8767, 8768}
+    assert grokbot_mcp.parse_bind(packs["cerebro-memory"]["default_bind"])[1] == 8770
     assert packs["operator"]["tools"] == _queue_tools("operator")
     assert packs["repository-scout"]["tools"] == _queue_tools("repository-scout")
     assert packs["implementation-worker"]["tools"] == _queue_tools("implementation-worker")
@@ -599,3 +615,181 @@ def test_legacy_lifecycle_stays_compatible_with_pack_config(tmp_path: Path, monk
         cli.main(["run", "cloud", "grokbot", "doctor", "--target", str(tmp_path), "--instance", "repository-scout"])
         == 1
     )
+
+
+def _cerebro_paths(tmp_path: Path) -> tuple[Path, Path]:
+    workdir = tmp_path / "cerebro-work"
+    workdir.mkdir()
+    executable = tmp_path / "cerebro-agents"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    return executable, workdir
+
+
+def test_cerebro_pack_is_closed_connector_with_exact_inventory():
+    pack = grokbot_packs.show_pack("cerebro-memory")
+    assert pack["kind"] == "connector"
+    assert pack["instance"] == "cerebro-memory"
+    assert pack["default_bind"] == "127.0.0.1:8770"
+    assert pack["public_route"] == ""
+    assert pack["tools"] == list(CEREBRO_TOOLS)
+    with _reject("unknown-pack"):
+        grokbot_packs.show_pack("cerebro")
+
+
+def test_cerebro_setup_preview_apply_and_queue_role_regression(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    executable, workdir = _cerebro_paths(tmp_path)
+    preview = grokbot_packs.preview_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    assert preview["apply"] is False
+    assert preview["bind"] == "127.0.0.1:8770"
+    assert str(executable) not in json.dumps(preview)
+    assert str(workdir) not in json.dumps(preview)
+    assert not grokbot_packs.instance_config_path(tmp_path, "cerebro-memory").exists()
+    assert not grokbot_ops.config_path(tmp_path, "cerebro-memory").exists()
+
+    applied = grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "cerebro-memory")
+    assert applied["apply"] is True
+    assert pack_path.is_file()
+    assert pack_path.stat().st_mode & 0o777 == 0o600
+    assert not grokbot_ops.config_path(tmp_path, "cerebro-memory").exists()
+    config = json.loads(pack_path.read_text(encoding="utf-8"))
+    assert set(config) == grokbot_packs.CONNECTOR_INSTANCE_KEYS
+    assert SECRET not in json.dumps(config)
+    assert config["cli_executable"] == str(executable)
+    assert config["workdir"] == str(workdir)
+    assert config["bearer"] == {"kind": "env", "name": "TEST_GROKBOT_BEARER"}
+
+    operator = grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    assert operator["bind"] == "127.0.0.1:8766"
+    assert grokbot_ops.config_path(tmp_path, "operator").is_file()
+    assert grokbot_packs.instance_config_path(tmp_path, "operator").is_file()
+
+
+def test_cerebro_setup_requires_path_refs_and_rejects_them_on_queue_roles(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    executable, workdir = _cerebro_paths(tmp_path)
+    with _reject("missing-path-reference"):
+        grokbot_packs.apply_setup(tmp_path, "cerebro-memory", bearer_env="TEST_GROKBOT_BEARER")
+    with _reject("unexpected-key"):
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "operator",
+            bearer_env="TEST_GROKBOT_BEARER",
+            cli_executable=executable,
+            workdir=workdir,
+        )
+    with _reject("unsafe-path") as caught:
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "cerebro-memory",
+            bearer_env="TEST_GROKBOT_BEARER",
+            cli_executable="cerebro-agents",
+            workdir=workdir,
+        )
+    assert "cerebro-agents" not in str(caught.value)
+    assert not grokbot_packs.instance_config_path(tmp_path, "cerebro-memory").exists()
+    assert not grokbot_ops.config_path(tmp_path, "operator").exists()
+
+
+def test_cerebro_setup_refuses_queue_default_port_and_keeps_rollback(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    executable, workdir = _cerebro_paths(tmp_path)
+    with _reject("duplicate-port"):
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "cerebro-memory",
+            bind="127.0.0.1:8766",
+            bearer_env="TEST_GROKBOT_BEARER",
+            cli_executable=executable,
+            workdir=workdir,
+        )
+    grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
+    with _reject("duplicate-port"):
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "operator",
+            bind="127.0.0.1:8770",
+            bearer_env="TEST_GROKBOT_BEARER",
+        )
+    assert grokbot_ops.load_config(tmp_path, "operator")["bind"] == "127.0.0.1:8766"
+
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "cerebro-memory")
+    prior = pack_path.read_bytes()
+    real_write = grokbot_ops._write_text_nofollow_atomic
+
+    def fail_updated_bind(path: Path, data: str, **kwargs: object) -> None:
+        if Path(path) == pack_path and "8791" in data:
+            raise OSError("disk full")
+        real_write(path, data, **kwargs)
+
+    monkeypatch.setattr(grokbot_ops, "_write_text_nofollow_atomic", fail_updated_bind)
+    with _reject("unsafe-path"):
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "cerebro-memory",
+            bind="127.0.0.1:8791",
+            bearer_env="TEST_GROKBOT_BEARER",
+            cli_executable=executable,
+            workdir=workdir,
+        )
+    assert pack_path.read_bytes() == prior
+
+
+def test_cerebro_doctor_canary_and_unit_hide_paths(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    executable, workdir = _cerebro_paths(tmp_path)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "cerebro-memory",
+        bearer_env="TEST_GROKBOT_BEARER",
+        cli_executable=executable,
+        workdir=workdir,
+    )
+    checks = grokbot_packs.doctor(tmp_path, "cerebro-memory")
+    canary = grokbot_packs.canary(tmp_path, "cerebro-memory")
+    unit = grokbot_packs.render_install_service(tmp_path, "cerebro-memory")
+    sanitized = json.dumps({"checks": checks, "canary": canary})
+    assert SECRET not in sanitized
+    assert str(executable) not in sanitized
+    assert str(workdir) not in sanitized
+    assert SECRET not in unit
+    assert str(executable) not in unit
+    assert all(set(check) == {"check", "status"} for check in checks)
+    assert canary["ok"] is False
+    assert "--pack" in unit
+    assert "cerebro-memory" in unit
+    assert "127.0.0.1:8770" in unit
+    assert "NoNewPrivileges=yes" in unit
+    assert "PrivateTmp=yes" in unit
+    assert "ProtectSystem=strict" in unit
+    assert "ProtectHome=read-only" in unit
+    unit_dir = tmp_path / "units"
+    installed = grokbot_packs.apply_install_service(tmp_path, "cerebro-memory", out_dir=unit_dir)
+    assert installed["unit"] == grokbot_ops.unit_name("cerebro-memory")
+    preview = grokbot_packs.preview_remove(tmp_path, "cerebro-memory", unit_dir=unit_dir)
+    assert preview["apply"] is False
+    grokbot_packs.apply_remove(tmp_path, "cerebro-memory", unit_dir=unit_dir)
+    assert not grokbot_packs.instance_config_path(tmp_path, "cerebro-memory").exists()
+    assert not (unit_dir / grokbot_ops.unit_name("cerebro-memory")).exists()
+    assert not grokbot_ops.config_path(tmp_path, "cerebro-memory").exists()


### PR DESCRIPTION
## Summary

- ship Cerebro Memory as a first-party `brigade-cli` Grok Bot connector pack
- port the five Cerebro tools to Brigade's optional Python MCP runtime
- add preview-first setup, sanitized diagnostics, a read-only canary, and hardened systemd unit rendering

## Safety boundaries

- loopback-only listener with bearer authentication and exact tool inventory
- strict request, response, path, scope, and child-process validation
- bounded stdout and stderr capture with process-group cleanup on timeout or overflow
- secret references stay out of manifests, previews, diagnostics, canaries, and receipts
- no live service, Cloudflare route, credential, or private state changes in this PR

## Verification

- `./scripts/verify-focused tests/test_grokbot_cerebro.py tests/test_grokbot_packs.py tests/test_grokbot_ops.py tests/test_grokbot_mcp.py`
- `./scripts/verify`
- independent adversarial review found no remaining Critical or Important issues

Refs #1255
