### PR TITLE
fix(skills): unique inbox proposals, locked transitions, changelog escape

### DIFF
--- a/src/brigade/skills_cmd/inbox.py
+++ b/src/brigade/skills_cmd/inbox.py
@@ -197,6 +197,21 @@ def _resolve_proposal(target: Path, proposal_id: str) -> tuple[str | None, dict[
     return matches[0][0], matches[0][1], None
 
 
+def _load_anchored_proposal(state_anchor: Any, name: str) -> dict[str, Any] | None:
+    """Re-read one proposal.json through the held state-root anchor."""
+    raw = _registry_mod._read_state_file_bytes(state_anchor, "skills", "inbox", name, "proposal.json")
+    if raw is None:
+        return None
+    try:
+        meta = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    meta.setdefault("proposal_id", name)
+    return meta
+
+
 def inbox_add(
     *,
     target: Path,
@@ -214,7 +229,7 @@ def inbox_add(
     metadata = _registry_mod._read_json(source_dir / "skill.json")
     resolved_skill_id = _registry_mod._slug(skill_id or str(metadata.get("id") or source_dir.name))
     created = _now()
-    proposal_id = f"{created[:19].replace(':', '').replace('-', '')}-{resolved_skill_id}"
+    proposal_id = f"{created[:19].replace(':', '').replace('-', '')}-{resolved_skill_id}-{uuid.uuid4().hex[:8]}"
     proposal_rel = ("skills", "inbox", _registry_mod._slug(proposal_id))
     proposal_dir = target / ".brigade" / "skills" / "inbox" / _registry_mod._slug(proposal_id)
     skill_dest = _proposal_skill_path(proposal_dir)
@@ -356,6 +371,14 @@ def inbox_accept(*, target: Path, proposal_id: str, force: bool = False, json_ou
         return 2
     try:
         with _registry_mod._held_state_root(target) as state_anchor:
+            current = _load_anchored_proposal(state_anchor, name)
+            if current is None:
+                print(f"error: skill proposal not found: {proposal_id}", file=sys.stderr)
+                return 2
+            if current.get("status") != "pending" and not force:
+                print(f"error: skill proposal is not pending: {current.get('status')}", file=sys.stderr)
+                return 2
+            proposal = current
             # The proposal's skill tree is read back through the anchor and
             # staged from those collected bytes; a symlinked proposal
             # component can never redirect the import outside the held state
@@ -405,6 +428,14 @@ def inbox_reject(*, target: Path, proposal_id: str, reason: str, json_output: bo
         return 2
     try:
         with _registry_mod._held_state_root(target) as state_anchor:
+            current = _load_anchored_proposal(state_anchor, name)
+            if current is None:
+                print(f"error: skill proposal not found: {proposal_id}", file=sys.stderr)
+                return 2
+            if current.get("status") != "pending":
+                print(f"error: skill proposal is not pending: {current.get('status')}", file=sys.stderr)
+                return 2
+            proposal = current
             proposal.update({"status": "rejected", "rejected_at": _now(), "reason": reason})
             _registry_mod._write_state_file(
                 state_anchor, "skills", "inbox", name, "proposal.json", data=_registry_mod._json_bytes(proposal)

--- a/src/brigade/skills_cmd/registry.py
+++ b/src/brigade/skills_cmd/registry.py
@@ -369,12 +369,12 @@ def _changelog_payload(skill_dir: Path, metadata: dict[str, Any], *, contain: bo
     candidates: list[Path] = []
     if isinstance(configured, str) and configured.strip():
         configured_path = Path(configured).expanduser()
-        # Contained mode (state-root served content) never reaches outside the
-        # skill directory for auxiliary files: an absolute or escaping
-        # changelog_path would launder outside file content into payloads.
+        # Never reach outside the skill directory for auxiliary files: an
+        # absolute or escaping changelog_path would launder outside file
+        # content into payloads, including path-based linting (contain=False).
         escapes = configured_path.is_absolute() or ".." in configured_path.parts
-        if not (contain and escapes):
-            candidates.append(configured_path if configured_path.is_absolute() else skill_dir / configured_path)
+        if not escapes:
+            candidates.append(skill_dir / configured_path)
     candidates.append(skill_dir / "CHANGELOG.md")
     path = next((candidate for candidate in candidates if candidate.is_file()), None)
     headings: list[str] = []

--- a/tests/test_skills_cmd.py
+++ b/tests/test_skills_cmd.py
@@ -590,6 +590,85 @@ def test_skills_inbox_add_diff_accept_and_reject(tmp_path, capsys):
     assert rejected["reason"] == "duplicate"
 
 
+def test_inbox_add_same_second_distinct_proposals(tmp_path, capsys):
+    source = _write_skill(tmp_path / "source")
+
+    assert skills_cmd.inbox_add(target=tmp_path, source=source, summary="first", json_output=True) == 0
+    first = json.loads(capsys.readouterr().out)
+    assert skills_cmd.inbox_add(target=tmp_path, source=source, summary="second", json_output=True) == 0
+    second = json.loads(capsys.readouterr().out)
+
+    assert first["proposal_id"] != second["proposal_id"]
+    inbox = tmp_path / ".brigade" / "skills" / "inbox"
+    assert (inbox / first["proposal_id"]).is_dir()
+    assert (inbox / second["proposal_id"]).is_dir()
+    assert first["status"] == "pending"
+    assert second["status"] == "pending"
+
+
+def test_inbox_reject_after_accept_fails(tmp_path, capsys):
+    source = _write_skill(tmp_path / "source")
+    assert skills_cmd.inbox_add(target=tmp_path, source=source, summary="review me", json_output=True) == 0
+    proposal_id = json.loads(capsys.readouterr().out)["proposal_id"]
+    assert skills_cmd.inbox_accept(target=tmp_path, proposal_id=proposal_id, json_output=True) == 0
+    capsys.readouterr()
+
+    rc = skills_cmd.inbox_reject(target=tmp_path, proposal_id=proposal_id, reason="too late")
+
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "pending" in captured.err
+    meta = json.loads((tmp_path / ".brigade" / "skills" / "inbox" / proposal_id / "proposal.json").read_text())
+    assert meta["status"] == "accepted"
+    assert (tmp_path / ".brigade" / "skills" / "registry" / "security-review" / "SKILL.md").is_file()
+
+
+def test_inbox_accept_rereads_current_state(tmp_path, capsys, monkeypatch):
+    source = _write_skill(tmp_path / "source")
+    assert skills_cmd.inbox_add(target=tmp_path, source=source, summary="review me", json_output=True) == 0
+    proposal_id = json.loads(capsys.readouterr().out)["proposal_id"]
+    meta_path = tmp_path / ".brigade" / "skills" / "inbox" / proposal_id / "proposal.json"
+    holds = {"n": 0}
+    real_held = skills_cmd._held_state_root
+
+    @contextlib.contextmanager
+    def flip_before_accept_hold(target):
+        holds["n"] += 1
+        if holds["n"] == 2:
+            current = json.loads(meta_path.read_text())
+            current["status"] = "rejected"
+            current["reason"] = "flipped-before-lock"
+            meta_path.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        with real_held(target) as anchor:
+            yield anchor
+
+    monkeypatch.setattr(skills_cmd, "_held_state_root", flip_before_accept_hold)
+
+    rc = skills_cmd.inbox_accept(target=tmp_path, proposal_id=proposal_id)
+
+    assert rc == 2
+    assert "pending" in capsys.readouterr().err
+    meta = json.loads(meta_path.read_text())
+    assert meta["status"] == "rejected"
+    assert meta["reason"] == "flipped-before-lock"
+    assert not (tmp_path / ".brigade" / "skills" / "registry" / "security-review").exists()
+
+
+def test_changelog_payload_rejects_escaping_path_when_not_contained(tmp_path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Skill\n")
+    secret = tmp_path / "secret-changelog.md"
+    secret.write_text("# Secret heading\n\noutside file\n")
+
+    payload = skills_cmd._changelog_payload(skill_dir, {"changelog_path": "../secret-changelog.md"}, contain=False)
+
+    assert payload["present"] is False
+    assert payload["path"] is None
+    assert payload["fingerprint"] is None
+    assert payload["headings"] == []
+
+
 def test_skills_cli_inbox_and_adapters(tmp_path, capsys):
     source = _write_skill(tmp_path / "source")
     assert cli.main(["skills", "inbox", "add", str(source), "--target", str(tmp_path), "--json"]) == 0


### PR DESCRIPTION
Fixes #1258 - the three pre-existing findings CodeRabbit surfaced on the skills_cmd package split (#1256):

1. **Proposal ID collisions**: `inbox_add` now appends `uuid4().hex[:8]` to `proposal_rel`, so two adds for the same skill in the same second no longer collide (previously `created[:19]` dropped microseconds).
2. **Unvalidated state transitions**: `inbox_accept`/`inbox_reject` re-read `proposal.json` under the state-root anchor before each update; rejection is only permitted from `pending` (rejecting an accepted proposal fails with a clear error instead of stranding the imported registry skill), and acceptance revalidates against the current record before importing.
3. **changelog_path escape under contain=False**: `_changelog_payload` applies the skill_dir escape check regardless of `contain`, so path-based lint can no longer be pointed at files outside the skill dir.

Implemented by a `brigade run` cursor_grok worker seat; independently verified: `tests/test_skills_cmd.py` full file exit 0 (79 new test lines cover all three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)