### PR TITLE
fix(work): warn on plan_coverage when the task ledger is unavailable

### DIFF
--- a/src/brigade/work_cmd/session/run_status.py
+++ b/src/brigade/work_cmd/session/run_status.py
@@ -574,21 +574,25 @@ def doctor(*, target: Path) -> int:
         )
 
     if ledger is None:
-        plan_coverage: dict[str, Any] = {"significant_without_plan": 0, "task_ids": []}
-    else:
-        plan_coverage = ledger_mod._plan_coverage_payload(effective_target)
-    significant_count = int(plan_coverage.get("significant_without_plan", 0) or 0)
-    if significant_count > 0:
-        raw_task_ids = plan_coverage.get("task_ids")
-        task_ids_list: list[Any] = raw_task_ids if isinstance(raw_task_ids, list) else []
-        plan_sample = ", ".join(str(item) for item in task_ids_list[:5])
         helpers._doctor_line(
             constants.WARN,
             "plan_coverage",
-            f"{significant_count} significant pending task(s) without a plan artifact: {plan_sample}",
+            "cannot be checked because the task ledger is unavailable",
         )
     else:
-        helpers._doctor_line(constants.OK, "plan_coverage", "significant pending tasks have plan artifacts")
+        plan_coverage = ledger_mod._plan_coverage_payload(effective_target)
+        significant_count = int(plan_coverage.get("significant_without_plan", 0) or 0)
+        if significant_count > 0:
+            raw_task_ids = plan_coverage.get("task_ids")
+            task_ids_list: list[Any] = raw_task_ids if isinstance(raw_task_ids, list) else []
+            plan_sample = ", ".join(str(item) for item in task_ids_list[:5])
+            helpers._doctor_line(
+                constants.WARN,
+                "plan_coverage",
+                f"{significant_count} significant pending task(s) without a plan artifact: {plan_sample}",
+            )
+        else:
+            helpers._doctor_line(constants.OK, "plan_coverage", "significant pending tasks have plan artifacts")
 
     workflow_rules = _workflow_rule_health(effective_target)
     helpers._doctor_line(str(workflow_rules["status"]), str(workflow_rules["name"]), workflow_rules["detail"])

--- a/tests/test_work_cmd_session.py
+++ b/tests/test_work_cmd_session.py
@@ -988,6 +988,30 @@ def test_work_doctor_warns_for_plan_coverage(tmp_path, monkeypatch, capsys):
     assert "[ok] plan_coverage: significant pending tasks have plan artifacts" in out
 
 
+def test_work_doctor_does_not_ok_plan_coverage_when_ledger_unavailable(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    dogfood_cmd.init(target=tmp_path)
+    monkeypatch.setattr(work_cmd.helpers.shutil, "which", lambda name: "/usr/bin/codex" if name == "codex" else None)
+    monkeypatch.setattr(localio, "check_git_ignored", lambda repo, path: "yes")
+
+    calls = {"n": 0}
+
+    def _raise_first_ledger(_target):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise work_cmd.TaskLedgerError("task ledger is unreadable", reason="corrupt_ledger")
+        return {"version": 1, "tasks": [], "edges": []}
+
+    monkeypatch.setattr(work_cmd.ledger, "_read_task_ledger", _raise_first_ledger)
+    capsys.readouterr()
+
+    assert work_cmd.doctor(target=tmp_path) == 1
+    out = capsys.readouterr().out
+    assert "[fail] task_ledger:" in out
+    assert "[ok] plan_coverage:" not in out
+    assert "[warn] plan_coverage:" in out
+
+
 def test_brief_payload_includes_plan_coverage(tmp_path, capsys):
     _init_git_repo(tmp_path)
     task_id = _plan_task_id(tmp_path, capsys)


### PR DESCRIPTION
Fixes #1247. When `_read_task_ledger` fails and `ledger` is `None`, doctor previously fell back to a zeroed coverage dict and printed `OK` for `plan_coverage` even though coverage was never checked. It now emits WARN for that path; the ledger failure stays separately recorded. New test makes `_read_task_ledger` raise and asserts the WARN.

Implemented by a `brigade run` cursor_grok worker seat; independently verified: `tests/test_work_cmd_session.py` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)