### PR TITLE
fix(harness): treat state and receipt drift as non-current in doctor

### DIFF
--- a/src/brigade/harness_profile_cmd.py
+++ b/src/brigade/harness_profile_cmd.py
@@ -13,6 +13,14 @@ from typing import Any, Callable
 
 from . import __version__ as BRIGADE_VERSION
 from . import brief_sections, harness_profiles, localio, managed_block, mcp_adapters, mcp_cmd, skills_cmd
+from .harness_profile_doctor import (
+    _doctor_receipt_item,
+    _expected_profile_state,
+    _receipt_item,
+    _receipt_ownership,
+    _state_item,
+    _uninstall_receipt_conflict,
+)
 from .projection import kernel as projection
 from .toml_compat import TOMLDecodeError as _TOMLDecodeError
 from .toml_compat import loads as _toml_loads
@@ -1479,23 +1487,6 @@ def _result(
     }
 
 
-def _receipt_ownership(state: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "instruction_fingerprint": state.get("instructions", {}).get("digest"),
-        "skills": state.get("skills", {}),
-        "generated_fingerprints": {
-            name: record.get("digest") or record.get("entry_fingerprint")
-            for name, record in sorted(state.get("generated", {}).items())
-            if isinstance(record, dict)
-        },
-        "mcp_fingerprints": {
-            name: record.get("projected_fingerprint")
-            for name, record in sorted(state["mcp"].items())
-            if isinstance(record, dict)
-        },
-    }
-
-
 def _receipt(
     profile, *, operation: str, items: list[dict[str, Any]], state: dict[str, Any], applied: bool
 ) -> dict[str, Any]:
@@ -1515,139 +1506,6 @@ def _receipt(
         else [],
         "ownership_fingerprints": _receipt_ownership(state),
     }
-
-
-def _uninstall_receipt_conflict(profile, state: dict[str, Any]) -> dict[str, Any] | None:
-    """Return a conflict item unless the sync receipt attests to ``state``."""
-    path = profile.receipt_path
-    item = {"surface": "profile-receipt", "path": str(path), "status": "conflict", "action": "preserve"}
-    if not path.exists():
-        return item | {"detail": "profile receipt is missing"}
-    try:
-        receipt = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return item | {"detail": "profile receipt is unreadable"}
-    if not isinstance(receipt, dict):
-        return item | {"detail": "profile receipt is not an object"}
-    if receipt.get("version") != 1 or receipt.get("harness") != profile.harness or receipt.get("operation") != "sync":
-        return item | {"detail": "profile receipt does not match this profile"}
-    if receipt.get("ownership_fingerprints") != _receipt_ownership(state):
-        return item | {"detail": "profile receipt ownership fingerprints drifted"}
-    return None
-
-
-def _state_item(path: Path, *, before: dict[str, Any], after: dict[str, Any], remove: bool = False) -> dict[str, Any]:
-    if remove:
-        return {
-            "surface": "ownership-state",
-            "path": str(path),
-            "status": "present" if path.exists() else "absent",
-            "action": "remove" if path.exists() else "none",
-        }
-    return {
-        "surface": "ownership-state",
-        "path": str(path),
-        "status": "current" if before == after and path.exists() else "stale",
-        "action": "none" if before == after and path.exists() else ("create" if not path.exists() else "update"),
-    }
-
-
-def _receipt_item(path: Path, *, state_action: str, remove: bool = False) -> dict[str, Any]:
-    if remove:
-        return {
-            "surface": "profile-receipt",
-            "path": str(path),
-            "status": "present" if path.exists() else "absent",
-            "action": "remove" if path.exists() else "none",
-        }
-    action = "none" if state_action == "none" and path.exists() else ("create" if not path.exists() else "update")
-    return {
-        "surface": "profile-receipt",
-        "path": str(path),
-        "status": "current" if action == "none" else "stale",
-        "action": action,
-    }
-
-
-def _doctor_receipt_item(profile, state: dict[str, Any], *, state_action: str) -> dict[str, Any]:
-    """Classify the sync receipt for doctor/--check, including attestation drift."""
-    item = _receipt_item(profile.receipt_path, state_action=state_action)
-    if item["action"] != "none":
-        return item
-    conflict = _uninstall_receipt_conflict(profile, state)
-    if conflict is None:
-        return item
-    return {
-        "surface": "profile-receipt",
-        "path": str(profile.receipt_path),
-        "status": "stale",
-        "action": "update",
-        "detail": conflict["detail"],
-    }
-
-
-def _expected_profile_state(
-    state: dict[str, Any],
-    *,
-    instruction: SurfacePlan,
-    instruction_existed: bool,
-    depth: dict[str, Any],
-    skill_plan: dict[str, Any],
-    generated_plan: dict[str, Any],
-    hook_plan: dict[str, Any] | None,
-    mcp_next: dict[str, Any],
-    profile,
-) -> dict[str, Any]:
-    """Build the ownership state a conflict-free sync would persist."""
-    proposed = json.loads(json.dumps(state))
-    if instruction.status != "conflict":
-        old_instruction = state.get("instructions", {})
-        created_file = (
-            old_instruction.get("created_file", not instruction_existed)
-            if isinstance(old_instruction, dict)
-            else not instruction_existed
-        )
-        if instruction.desired_digest:
-            instruction_record: dict[str, Any] = {
-                "digest": instruction.desired_digest,
-                "created_file": created_file,
-                _INSTRUCTION_REQUIRED_PROFILE_KEY: depth["required_profile"],
-                _INSTRUCTION_EFFECTIVE_PROFILE_KEY: depth["effective_profile"],
-            }
-            if isinstance(old_instruction, dict) and old_instruction.get("created_directories"):
-                instruction_record["created_directories"] = list(old_instruction["created_directories"])
-            if isinstance(old_instruction, dict) and old_instruction.get(_LEGACY_MIGRATED):
-                instruction_record[_LEGACY_MIGRATED] = True
-            proposed["instructions"] = instruction_record
-        else:
-            proposed["instructions"] = {}
-    proposed["skills"] = skill_plan["next"]
-    proposed["generated"] = generated_plan["next"]
-    if hook_plan is not None:
-        proposed["generated"][_HOOK_STATE_KEY] = hook_plan["next"]
-    proposed["mcp"] = mcp_next
-    proposed["package_version"] = BRIGADE_VERSION
-    instruction_dirs = (
-        _missing_directories(profile.user_root, instruction.path)
-        if instruction.action in {"create", "update"} and profile.instruction_mode == "managed-file"
-        else []
-    )
-    if instruction_dirs and isinstance(proposed.get("instructions"), dict):
-        existing = proposed["instructions"].get("created_directories", [])
-        proposed["instructions"]["created_directories"] = sorted(set(existing) | set(instruction_dirs))
-    created_dirs: dict[str, list[str]] = {}
-    for path, _data, skill_id, _relative in skill_plan["writes"]:
-        created_dirs.setdefault(skill_id, []).extend(_missing_skill_directories(profile, path))
-    for skill_id, directories in created_dirs.items():
-        existing = proposed["skills"][skill_id].setdefault("created_directories", [])
-        proposed["skills"][skill_id]["created_directories"] = sorted(set(existing) | set(directories))
-    generated_dirs: dict[str, list[str]] = {}
-    for path, _text, _executable, relative in generated_plan["writes"]:
-        generated_dirs.setdefault(relative, []).extend(_missing_directories(profile.user_root, path))
-    for relative, directories in generated_dirs.items():
-        existing = proposed["generated"][relative].setdefault("created_directories", [])
-        proposed["generated"][relative]["created_directories"] = sorted(set(existing) | set(directories))
-    return proposed
 
 
 def _prune_created_directories(paths: list[Path], root: Path) -> list[str]:

--- a/src/brigade/harness_profile_cmd.py
+++ b/src/brigade/harness_profile_cmd.py
@@ -1569,6 +1569,87 @@ def _receipt_item(path: Path, *, state_action: str, remove: bool = False) -> dic
     }
 
 
+def _doctor_receipt_item(profile, state: dict[str, Any], *, state_action: str) -> dict[str, Any]:
+    """Classify the sync receipt for doctor/--check, including attestation drift."""
+    item = _receipt_item(profile.receipt_path, state_action=state_action)
+    if item["action"] != "none":
+        return item
+    conflict = _uninstall_receipt_conflict(profile, state)
+    if conflict is None:
+        return item
+    return {
+        "surface": "profile-receipt",
+        "path": str(profile.receipt_path),
+        "status": "stale",
+        "action": "update",
+        "detail": conflict["detail"],
+    }
+
+
+def _expected_profile_state(
+    state: dict[str, Any],
+    *,
+    instruction: SurfacePlan,
+    instruction_existed: bool,
+    depth: dict[str, Any],
+    skill_plan: dict[str, Any],
+    generated_plan: dict[str, Any],
+    hook_plan: dict[str, Any] | None,
+    mcp_next: dict[str, Any],
+    profile,
+) -> dict[str, Any]:
+    """Build the ownership state a conflict-free sync would persist."""
+    proposed = json.loads(json.dumps(state))
+    if instruction.status != "conflict":
+        old_instruction = state.get("instructions", {})
+        created_file = (
+            old_instruction.get("created_file", not instruction_existed)
+            if isinstance(old_instruction, dict)
+            else not instruction_existed
+        )
+        if instruction.desired_digest:
+            instruction_record: dict[str, Any] = {
+                "digest": instruction.desired_digest,
+                "created_file": created_file,
+                _INSTRUCTION_REQUIRED_PROFILE_KEY: depth["required_profile"],
+                _INSTRUCTION_EFFECTIVE_PROFILE_KEY: depth["effective_profile"],
+            }
+            if isinstance(old_instruction, dict) and old_instruction.get("created_directories"):
+                instruction_record["created_directories"] = list(old_instruction["created_directories"])
+            if isinstance(old_instruction, dict) and old_instruction.get(_LEGACY_MIGRATED):
+                instruction_record[_LEGACY_MIGRATED] = True
+            proposed["instructions"] = instruction_record
+        else:
+            proposed["instructions"] = {}
+    proposed["skills"] = skill_plan["next"]
+    proposed["generated"] = generated_plan["next"]
+    if hook_plan is not None:
+        proposed["generated"][_HOOK_STATE_KEY] = hook_plan["next"]
+    proposed["mcp"] = mcp_next
+    proposed["package_version"] = BRIGADE_VERSION
+    instruction_dirs = (
+        _missing_directories(profile.user_root, instruction.path)
+        if instruction.action in {"create", "update"} and profile.instruction_mode == "managed-file"
+        else []
+    )
+    if instruction_dirs and isinstance(proposed.get("instructions"), dict):
+        existing = proposed["instructions"].get("created_directories", [])
+        proposed["instructions"]["created_directories"] = sorted(set(existing) | set(instruction_dirs))
+    created_dirs: dict[str, list[str]] = {}
+    for path, _data, skill_id, _relative in skill_plan["writes"]:
+        created_dirs.setdefault(skill_id, []).extend(_missing_skill_directories(profile, path))
+    for skill_id, directories in created_dirs.items():
+        existing = proposed["skills"][skill_id].setdefault("created_directories", [])
+        proposed["skills"][skill_id]["created_directories"] = sorted(set(existing) | set(directories))
+    generated_dirs: dict[str, list[str]] = {}
+    for path, _text, _executable, relative in generated_plan["writes"]:
+        generated_dirs.setdefault(relative, []).extend(_missing_directories(profile.user_root, path))
+    for relative, directories in generated_dirs.items():
+        existing = proposed["generated"][relative].setdefault("created_directories", [])
+        proposed["generated"][relative]["created_directories"] = sorted(set(existing) | set(directories))
+    return proposed
+
+
 def _prune_created_directories(paths: list[Path], root: Path) -> list[str]:
     removed: list[str] = []
     for path in sorted(set(paths), reverse=True):
@@ -1786,54 +1867,17 @@ def _sync_profile(
     mcp_plan = _mcp_plan(profile, state, workspace, allow_global_stdio=allow_global_stdio, adopt=adopt)
     items.extend(mcp_plan["items"])
     conflicts.extend(mcp_plan["conflicts"])
-    proposed = json.loads(json.dumps(state))
-    if instruction.status != "conflict":
-        old_instruction = state.get("instructions", {})
-        created_file = (
-            old_instruction.get("created_file", not instruction_existed)
-            if isinstance(old_instruction, dict)
-            else not instruction_existed
-        )
-        if instruction.desired_digest:
-            instruction_record: dict[str, Any] = {
-                "digest": instruction.desired_digest,
-                "created_file": created_file,
-                _INSTRUCTION_REQUIRED_PROFILE_KEY: depth["required_profile"],
-                _INSTRUCTION_EFFECTIVE_PROFILE_KEY: depth["effective_profile"],
-            }
-            if isinstance(old_instruction, dict) and old_instruction.get("created_directories"):
-                instruction_record["created_directories"] = list(old_instruction["created_directories"])
-            if isinstance(old_instruction, dict) and old_instruction.get(_LEGACY_MIGRATED):
-                instruction_record[_LEGACY_MIGRATED] = True
-            proposed["instructions"] = instruction_record
-        else:
-            proposed["instructions"] = {}
-    proposed["skills"] = skill_plan["next"]
-    proposed["generated"] = generated_plan["next"]
-    if hook_plan is not None:
-        proposed["generated"][_HOOK_STATE_KEY] = hook_plan["next"]
-    proposed["mcp"] = mcp_plan["next"]
-    proposed["package_version"] = BRIGADE_VERSION
-    instruction_dirs = (
-        _missing_directories(profile.user_root, instruction.path)
-        if instruction.action in {"create", "update"} and profile.instruction_mode == "managed-file"
-        else []
+    proposed = _expected_profile_state(
+        state,
+        instruction=instruction,
+        instruction_existed=instruction_existed,
+        depth=depth,
+        skill_plan=skill_plan,
+        generated_plan=generated_plan,
+        hook_plan=hook_plan,
+        mcp_next=mcp_plan["next"],
+        profile=profile,
     )
-    if instruction_dirs and isinstance(proposed.get("instructions"), dict):
-        existing = proposed["instructions"].get("created_directories", [])
-        proposed["instructions"]["created_directories"] = sorted(set(existing) | set(instruction_dirs))
-    created_dirs: dict[str, list[str]] = {}
-    for path, _data, skill_id, _relative in skill_plan["writes"]:
-        created_dirs.setdefault(skill_id, []).extend(_missing_skill_directories(profile, path))
-    for skill_id, directories in created_dirs.items():
-        existing = proposed["skills"][skill_id].setdefault("created_directories", [])
-        proposed["skills"][skill_id]["created_directories"] = sorted(set(existing) | set(directories))
-    generated_dirs: dict[str, list[str]] = {}
-    for path, _text, _executable, relative in generated_plan["writes"]:
-        generated_dirs.setdefault(relative, []).extend(_missing_directories(profile.user_root, path))
-    for relative, directories in generated_dirs.items():
-        existing = proposed["generated"][relative].setdefault("created_directories", [])
-        proposed["generated"][relative]["created_directories"] = sorted(set(existing) | set(directories))
     state_item = _state_item(profile.state_path, before=state, after=proposed)
     receipt_item = _receipt_item(profile.receipt_path, state_action=state_item["action"])
     items.extend([state_item, receipt_item])
@@ -2321,7 +2365,7 @@ def _doctor_profile(
             receipt_path=profile.receipt_path,
             receipt_state="missing",
         ), False
-    state = loaded.state
+    state = json.loads(json.dumps(loaded.state))
     instruction, depth = _instruction_plan(
         profile,
         state,
@@ -2391,18 +2435,34 @@ def _doctor_profile(
     generated_plan = _generated_plans(profile, state, adopt=False)
     generated_issues = [entry for entry in generated_plan["items"] if entry["status"] != "current"]
     conflicts.extend(generated_issues)
-    hook_items: list[dict[str, Any]] = []
-    if profile.hook is not None:
-        hook_plan = _hook_plan(profile, state, adopt=False)
-        hook_items = hook_plan["items"]
+    hook_plan = _hook_plan(profile, state, adopt=False) if profile.hook is not None else None
+    hook_items = hook_plan["items"] if hook_plan is not None else []
+    if hook_plan is not None:
         conflicts.extend(entry for entry in hook_items if entry["status"] != "current")
+    proposed = _expected_profile_state(
+        state,
+        instruction=instruction,
+        instruction_existed=profile.instruction_path.exists(),
+        depth=depth,
+        skill_plan=skill_plan,
+        generated_plan=generated_plan,
+        hook_plan=hook_plan,
+        mcp_next=state["mcp"],
+        profile=profile,
+    )
+    state_item = _state_item(profile.state_path, before=state, after=proposed)
+    receipt_item = _doctor_receipt_item(profile, state, state_action=state_item["action"])
+    items = [*items_prefix, *skill_plan["items"], *generated_plan["items"], *hook_items, state_item, receipt_item]
+    # Same create/update/remove predicate as sync/uninstall (#1193). Doctor
+    # --check treats pending ownership-state or receipt work as not ready.
+    pending = any(item["action"] in {"create", "update", "remove"} for item in items)
     mcp, mcp_ok = _verify_mcp(profile, state, workspace) if verify_mcp else ({"status": "pending", "items": []}, True)
-    ready = not conflicts and mcp_ok
+    ready = not conflicts and mcp_ok and not pending
     return _result(
         profile,
-        status="current" if ready else "conflict",
+        status="conflict" if conflicts else ("pending" if pending else "current"),
         ready=ready,
-        items=[*items_prefix, *skill_plan["items"], *generated_plan["items"], *hook_items],
+        items=items,
         conflicts=conflicts,
         files_written=[],
         files_removed=[],

--- a/src/brigade/harness_profile_doctor.py
+++ b/src/brigade/harness_profile_doctor.py
@@ -1,0 +1,171 @@
+"""Expected-state comparison and receipt attestation for harness doctor/--check."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from . import __version__ as BRIGADE_VERSION
+
+if TYPE_CHECKING:
+    from .harness_profile_cmd import SurfacePlan
+
+
+def _receipt_ownership(state: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "instruction_fingerprint": state.get("instructions", {}).get("digest"),
+        "skills": state.get("skills", {}),
+        "generated_fingerprints": {
+            name: record.get("digest") or record.get("entry_fingerprint")
+            for name, record in sorted(state.get("generated", {}).items())
+            if isinstance(record, dict)
+        },
+        "mcp_fingerprints": {
+            name: record.get("projected_fingerprint")
+            for name, record in sorted(state["mcp"].items())
+            if isinstance(record, dict)
+        },
+    }
+
+
+def _uninstall_receipt_conflict(profile, state: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a conflict item unless the sync receipt attests to ``state``."""
+    path = profile.receipt_path
+    item = {"surface": "profile-receipt", "path": str(path), "status": "conflict", "action": "preserve"}
+    if not path.exists():
+        return item | {"detail": "profile receipt is missing"}
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return item | {"detail": "profile receipt is unreadable"}
+    if not isinstance(receipt, dict):
+        return item | {"detail": "profile receipt is not an object"}
+    if receipt.get("version") != 1 or receipt.get("harness") != profile.harness or receipt.get("operation") != "sync":
+        return item | {"detail": "profile receipt does not match this profile"}
+    if receipt.get("ownership_fingerprints") != _receipt_ownership(state):
+        return item | {"detail": "profile receipt ownership fingerprints drifted"}
+    return None
+
+
+def _state_item(path: Path, *, before: dict[str, Any], after: dict[str, Any], remove: bool = False) -> dict[str, Any]:
+    if remove:
+        return {
+            "surface": "ownership-state",
+            "path": str(path),
+            "status": "present" if path.exists() else "absent",
+            "action": "remove" if path.exists() else "none",
+        }
+    return {
+        "surface": "ownership-state",
+        "path": str(path),
+        "status": "current" if before == after and path.exists() else "stale",
+        "action": "none" if before == after and path.exists() else ("create" if not path.exists() else "update"),
+    }
+
+
+def _receipt_item(path: Path, *, state_action: str, remove: bool = False) -> dict[str, Any]:
+    if remove:
+        return {
+            "surface": "profile-receipt",
+            "path": str(path),
+            "status": "present" if path.exists() else "absent",
+            "action": "remove" if path.exists() else "none",
+        }
+    action = "none" if state_action == "none" and path.exists() else ("create" if not path.exists() else "update")
+    return {
+        "surface": "profile-receipt",
+        "path": str(path),
+        "status": "current" if action == "none" else "stale",
+        "action": action,
+    }
+
+
+def _doctor_receipt_item(profile, state: dict[str, Any], *, state_action: str) -> dict[str, Any]:
+    """Classify the sync receipt for doctor/--check, including attestation drift."""
+    item = _receipt_item(profile.receipt_path, state_action=state_action)
+    if item["action"] != "none":
+        return item
+    conflict = _uninstall_receipt_conflict(profile, state)
+    if conflict is None:
+        return item
+    return {
+        "surface": "profile-receipt",
+        "path": str(profile.receipt_path),
+        "status": "stale",
+        "action": "update",
+        "detail": conflict["detail"],
+    }
+
+
+def _expected_profile_state(
+    state: dict[str, Any],
+    *,
+    instruction: SurfacePlan,
+    instruction_existed: bool,
+    depth: dict[str, Any],
+    skill_plan: dict[str, Any],
+    generated_plan: dict[str, Any],
+    hook_plan: dict[str, Any] | None,
+    mcp_next: dict[str, Any],
+    profile,
+) -> dict[str, Any]:
+    """Build the ownership state a conflict-free sync would persist."""
+    from .harness_profile_cmd import (
+        _HOOK_STATE_KEY,
+        _INSTRUCTION_EFFECTIVE_PROFILE_KEY,
+        _INSTRUCTION_REQUIRED_PROFILE_KEY,
+        _LEGACY_MIGRATED,
+        _missing_directories,
+        _missing_skill_directories,
+    )
+
+    proposed = json.loads(json.dumps(state))
+    if instruction.status != "conflict":
+        old_instruction = state.get("instructions", {})
+        created_file = (
+            old_instruction.get("created_file", not instruction_existed)
+            if isinstance(old_instruction, dict)
+            else not instruction_existed
+        )
+        if instruction.desired_digest:
+            instruction_record: dict[str, Any] = {
+                "digest": instruction.desired_digest,
+                "created_file": created_file,
+                _INSTRUCTION_REQUIRED_PROFILE_KEY: depth["required_profile"],
+                _INSTRUCTION_EFFECTIVE_PROFILE_KEY: depth["effective_profile"],
+            }
+            if isinstance(old_instruction, dict) and old_instruction.get("created_directories"):
+                instruction_record["created_directories"] = list(old_instruction["created_directories"])
+            if isinstance(old_instruction, dict) and old_instruction.get(_LEGACY_MIGRATED):
+                instruction_record[_LEGACY_MIGRATED] = True
+            proposed["instructions"] = instruction_record
+        else:
+            proposed["instructions"] = {}
+    proposed["skills"] = skill_plan["next"]
+    proposed["generated"] = generated_plan["next"]
+    if hook_plan is not None:
+        proposed["generated"][_HOOK_STATE_KEY] = hook_plan["next"]
+    proposed["mcp"] = mcp_next
+    proposed["package_version"] = BRIGADE_VERSION
+    instruction_dirs = (
+        _missing_directories(profile.user_root, instruction.path)
+        if instruction.action in {"create", "update"} and profile.instruction_mode == "managed-file"
+        else []
+    )
+    if instruction_dirs and isinstance(proposed.get("instructions"), dict):
+        existing = proposed["instructions"].get("created_directories", [])
+        proposed["instructions"]["created_directories"] = sorted(set(existing) | set(instruction_dirs))
+    created_dirs: dict[str, list[str]] = {}
+    for path, _data, skill_id, _relative in skill_plan["writes"]:
+        created_dirs.setdefault(skill_id, []).extend(_missing_skill_directories(profile, path))
+    for skill_id, directories in created_dirs.items():
+        existing = proposed["skills"][skill_id].setdefault("created_directories", [])
+        proposed["skills"][skill_id]["created_directories"] = sorted(set(existing) | set(directories))
+    generated_dirs: dict[str, list[str]] = {}
+    for path, _text, _executable, relative in generated_plan["writes"]:
+        generated_dirs.setdefault(relative, []).extend(_missing_directories(profile.user_root, path))
+    for relative, directories in generated_dirs.items():
+        existing = proposed["generated"][relative].setdefault("created_directories", [])
+        proposed["generated"][relative]["created_directories"] = sorted(set(existing) | set(directories))
+    return proposed

--- a/tests/test_harness_user_scope.py
+++ b/tests/test_harness_user_scope.py
@@ -634,6 +634,72 @@ def test_doctor_reports_drift_without_mutating(tmp_path, monkeypatch, capsys):
     assert row["instruction_ready"] is False
 
 
+def _doctor_json(workspace: Path) -> list[str]:
+    return ["harness", "doctor", "--target", "codex", "--scope", "user", "--workspace", str(workspace), "--json"]
+
+
+def _assert_check_and_doctor_report_drift(workspace: Path, capsys, *, surface: str) -> tuple[dict, dict]:
+    from brigade import cli
+
+    assert cli.main(_sync_base(workspace) + ["--check", "--json"]) == 1
+    checked = json.loads(capsys.readouterr().out)["results"][0]
+    assert checked["status"] != "current"
+    assert checked["ready"] is False
+    assert any(
+        item["surface"] == surface and item["action"] in {"create", "update", "remove"} for item in checked["items"]
+    )
+
+    assert cli.main(_doctor_json(workspace)) == 1
+    doctor = json.loads(capsys.readouterr().out)["results"][0]
+    assert doctor["status"] != "current"
+    assert doctor["ready"] is False
+    assert any(
+        item["surface"] == surface and item["action"] in {"create", "update", "remove"} for item in doctor["items"]
+    )
+    return checked, doctor
+
+
+def test_doctor_and_check_report_state_only_package_version_drift(tmp_path, monkeypatch, capsys):
+    """Issue #1218: install-state.json package_version drift is not current."""
+    from brigade import cli
+
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    assert cli.main(_sync_base(workspace) + ["--write", "--json"]) == 0
+    capsys.readouterr()
+
+    state_path = home / ".codex" / "brigade" / "install-state.json"
+    state = json.loads(state_path.read_text())
+    state["package_version"] = "old"
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+    _assert_check_and_doctor_report_drift(workspace, capsys, surface="ownership-state")
+
+
+@pytest.mark.parametrize("receipt_change", ["missing", "drifted"])
+def test_doctor_and_check_report_receipt_only_drift(tmp_path, monkeypatch, capsys, receipt_change):
+    """Issue #1218: missing or fingerprint-drifted sync receipt is not current."""
+    from brigade import cli
+
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    assert cli.main(_sync_base(workspace) + ["--write", "--json"]) == 0
+    capsys.readouterr()
+
+    receipt = home / ".codex" / "brigade" / "profile-receipt.json"
+    if receipt_change == "missing":
+        receipt.unlink()
+    else:
+        payload = json.loads(receipt.read_text())
+        payload["ownership_fingerprints"]["instruction_fingerprint"] = "drifted"
+        receipt.write_text(json.dumps(payload))
+
+    checked, doctor = _assert_check_and_doctor_report_drift(workspace, capsys, surface="profile-receipt")
+    if receipt_change == "missing":
+        assert checked["receipt_state"] == "missing"
+        assert doctor["receipt_state"] == "missing"
+
+
 def test_uninstall_removes_only_brigade_owned_block(tmp_path, monkeypatch, capsys):
     from brigade import cli
 


### PR DESCRIPTION
Fixes #1218. `_doctor_profile` checked artifact plans only, so a removed or corrupted sync receipt, altered ownership fingerprints, or a changed `install-state.json` package_version still reported `status current, ready true, exit 0` from both `brigade doctor` and `brigade harness sync --check`. It now runs the expected-state comparison and receipt attestation and reports either drift as non-current, consistent with #1193's pending-predicate contract. New tests cover state-only and receipt-only drift on both the `sync --check` and `doctor` paths.

Implemented by a `brigade run` cursor_grok worker seat; independently verified: `test_harness_user_scope.py`, `test_harness_profile_cmd.py`, `test_harness_user_scope_slice2.py` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)