### PR TITLE
fix(ledger): close six package-split review findings plus Daybreak follow-ups

### DIFF
--- a/src/brigade/work_cmd/ledger/authority_store.py
+++ b/src/brigade/work_cmd/ledger/authority_store.py
@@ -1038,7 +1038,6 @@ def rebind_directory_authority(*, target: Path) -> int:
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    path = _directory_authority_store_path(target)
     try:
         path, payload = _read_external_directory_authority(target)
     except OSError as exc:

--- a/src/brigade/work_cmd/ledger/descriptor_anchors.py
+++ b/src/brigade/work_cmd/ledger/descriptor_anchors.py
@@ -26,6 +26,8 @@ from ...untrusted import scan_handoff_injection_heuristics
 
 from . import authority_store, import_model
 
+_AUTHORITY_SNAPSHOT_READ_CHUNK_BYTES = 1024 * 1024
+
 
 def _record_verifier_owned_directory(
     target: Path, *, components: tuple[str, ...], directory: int, workspace: dict[str, int] | None = None
@@ -150,29 +152,30 @@ def _record_verifier_owned_file(
     """Record durable file identity after the verifier has published the bytes."""
     bound_workspace = authority_store._external_workspace_directory_identity(target) if workspace is None else workspace
     authority_store._require_workspace_directory_identity(target, bound_workspace)
-    path, existing = authority_store._read_external_directory_authority(target)
-    resolved = str(target.expanduser().resolve())
-    authority_store._require_workspace_directory_identity(target, bound_workspace)
-    if existing is None:
-        raise OSError("external directory authority record is missing")
-    if (
-        existing.get("schema_version") != import_model._EXTERNAL_DIRECTORY_AUTHORITY_SCHEMA_VERSION
-        or existing.get("target") != resolved
-        or existing.get("workspace") != bound_workspace
-        or not isinstance(existing.get("directories"), dict)
-    ):
-        raise OSError("external directory authority record is malformed")
-    files = existing.setdefault("files", {})
-    if not isinstance(files, dict):
-        raise OSError("external file authority record is malformed")
-    scope = authority_store._directory_authority_scope(components)
-    identity = _file_identity(descriptor, data)
-    if files.get(scope) == identity:
-        return
-    files[scope] = identity
-    authority_store._write_external_directory_authority(path, existing, workspace=target)
-    if _file_identity(descriptor, data) != identity:
-        raise OSError("file identity changed while recording authority")
+    with inbox_lock.inbox_writer_lock(target):
+        path, existing = authority_store._read_external_directory_authority(target)
+        resolved = str(target.expanduser().resolve())
+        authority_store._require_workspace_directory_identity(target, bound_workspace)
+        if existing is None:
+            raise OSError("external directory authority record is missing")
+        if (
+            existing.get("schema_version") != import_model._EXTERNAL_DIRECTORY_AUTHORITY_SCHEMA_VERSION
+            or existing.get("target") != resolved
+            or existing.get("workspace") != bound_workspace
+            or not isinstance(existing.get("directories"), dict)
+        ):
+            raise OSError("external directory authority record is malformed")
+        files = existing.setdefault("files", {})
+        if not isinstance(files, dict):
+            raise OSError("external file authority record is malformed")
+        scope = authority_store._directory_authority_scope(components)
+        identity = _file_identity(descriptor, data)
+        if files.get(scope) == identity:
+            return
+        files[scope] = identity
+        authority_store._write_external_directory_authority(path, existing, workspace=target)
+        if _file_identity(descriptor, data) != identity:
+            raise OSError("file identity changed while recording authority")
 
 
 def _validate_verifier_owned_file(
@@ -364,28 +367,38 @@ def _open_verifier_owned_directory(
             child = authority_store._dirfd_open_dir(parent, name)
             created = True
         try:
-            if record is None:
-                authority_store._validate_external_directory_authority(target, components, child, workspace=workspace)
-            else:
-                _validate_record_bound_directory(record, components=components, directory=child)
-        except OSError:
-            if record is not None:
-                raise
-            if created:
-                authority_store._record_external_directory_authority(target, components, child, workspace=workspace)
-            elif authority_store._reanchor_external_directory_authority(target, components, child, workspace=workspace):
-                authority_store._validate_external_directory_authority(target, components, child, workspace=workspace)
-            else:
-                # A directory that already existed and is not bound to this
-                # workspace record is never adopted, including on the create
-                # path: a pre-created directory may be an attacker's inode.
-                raise
-        _write_compatibility_directory_anchor(anchor_parent, child, anchor_name=anchor_name)
-        os.close(parent)
-        parent = -1
-        os.close(anchor_parent)
-        anchor_parent = -1
-        return child
+            try:
+                if record is None:
+                    authority_store._validate_external_directory_authority(
+                        target, components, child, workspace=workspace
+                    )
+                else:
+                    _validate_record_bound_directory(record, components=components, directory=child)
+            except OSError:
+                if record is not None:
+                    raise
+                if created:
+                    authority_store._record_external_directory_authority(target, components, child, workspace=workspace)
+                elif authority_store._reanchor_external_directory_authority(
+                    target, components, child, workspace=workspace
+                ):
+                    authority_store._validate_external_directory_authority(
+                        target, components, child, workspace=workspace
+                    )
+                else:
+                    # A directory that already existed and is not bound to this
+                    # workspace record is never adopted, including on the create
+                    # path: a pre-created directory may be an attacker's inode.
+                    raise
+            _write_compatibility_directory_anchor(anchor_parent, child, anchor_name=anchor_name)
+            os.close(parent)
+            parent = -1
+            os.close(anchor_parent)
+            anchor_parent = -1
+            return child
+        except BaseException:
+            os.close(child)
+            raise
     except BaseException:
         if parent != -1:
             os.close(parent)
@@ -817,7 +830,10 @@ def _read_verified_authority_snapshot(target: Path | None) -> dict[str, Any] | N
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
             return None
-        raw = os.read(descriptor, 1024 * 1024)
+        chunks: list[bytes] = []
+        while chunk := os.read(descriptor, _AUTHORITY_SNAPSHOT_READ_CHUNK_BYTES):
+            chunks.append(chunk)
+        raw = b"".join(chunks)
     finally:
         os.close(descriptor)
     try:

--- a/src/brigade/work_cmd/ledger/descriptor_anchors.py
+++ b/src/brigade/work_cmd/ledger/descriptor_anchors.py
@@ -12,6 +12,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import threading
 import time
 from contextlib import contextmanager
 from datetime import datetime
@@ -27,6 +28,24 @@ from ...untrusted import scan_handoff_injection_heuristics
 from . import authority_store, import_model
 
 _AUTHORITY_SNAPSHOT_READ_CHUNK_BYTES = 1024 * 1024
+_FILE_AUTHORITY_UPDATE_LOCKS_GUARD = threading.Lock()
+_FILE_AUTHORITY_UPDATE_LOCKS: dict[str, threading.Lock] = {}
+
+
+def _file_authority_update_lock(target: Path) -> threading.Lock:
+    """Return the in-process lock that serializes one target's file-authority RMW.
+
+    ``inbox_writer_lock`` is process-reentrant, so two threads can both read
+    state S and then publish S+A and S+B; the second atomic replace drops A.
+    This lock is taken around that window in addition to the file lock.
+    """
+    key = str(target.expanduser().resolve())
+    with _FILE_AUTHORITY_UPDATE_LOCKS_GUARD:
+        lock = _FILE_AUTHORITY_UPDATE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _FILE_AUTHORITY_UPDATE_LOCKS[key] = lock
+        return lock
 
 
 def _record_verifier_owned_directory(
@@ -152,7 +171,7 @@ def _record_verifier_owned_file(
     """Record durable file identity after the verifier has published the bytes."""
     bound_workspace = authority_store._external_workspace_directory_identity(target) if workspace is None else workspace
     authority_store._require_workspace_directory_identity(target, bound_workspace)
-    with inbox_lock.inbox_writer_lock(target):
+    with _file_authority_update_lock(target), inbox_lock.inbox_writer_lock(target):
         path, existing = authority_store._read_external_directory_authority(target)
         resolved = str(target.expanduser().resolve())
         authority_store._require_workspace_directory_identity(target, bound_workspace)
@@ -173,6 +192,7 @@ def _record_verifier_owned_file(
         if files.get(scope) == identity:
             return
         files[scope] = identity
+        inbox_lock.verify_inbox_writer_lock(target)
         authority_store._write_external_directory_authority(path, existing, workspace=target)
         if _file_identity(descriptor, data) != identity:
             raise OSError("file identity changed while recording authority")
@@ -344,10 +364,12 @@ def _open_verifier_owned_directory(
                     raise
                 authority_store._dirfd_mkdir(descriptor, component)
                 child = authority_store._dirfd_open_dir(descriptor, component)
-            os.close(descriptor)
+            tmp = descriptor
             descriptor = child
-        anchor_parent = descriptor
+            os.close(tmp)
+        tmp = descriptor
         descriptor = -1
+        anchor_parent = tmp
         parent_name = components[-2]
         try:
             parent = authority_store._dirfd_open_dir(anchor_parent, parent_name)
@@ -358,15 +380,16 @@ def _open_verifier_owned_directory(
             parent = authority_store._dirfd_open_dir(anchor_parent, parent_name)
         name = components[-1]
         created = False
+        child = -1
         try:
-            child = authority_store._dirfd_open_dir(parent, name)
-        except FileNotFoundError:
-            if not create:
-                raise
-            authority_store._dirfd_mkdir(parent, name)
-            child = authority_store._dirfd_open_dir(parent, name)
-            created = True
-        try:
+            try:
+                child = authority_store._dirfd_open_dir(parent, name)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                authority_store._dirfd_mkdir(parent, name)
+                child = authority_store._dirfd_open_dir(parent, name)
+                created = True
             try:
                 if record is None:
                     authority_store._validate_external_directory_authority(
@@ -391,21 +414,30 @@ def _open_verifier_owned_directory(
                     # path: a pre-created directory may be an attacker's inode.
                     raise
             _write_compatibility_directory_anchor(anchor_parent, child, anchor_name=anchor_name)
-            os.close(parent)
+            tmp = parent
             parent = -1
-            os.close(anchor_parent)
+            os.close(tmp)
+            tmp = anchor_parent
             anchor_parent = -1
-            return child
+            os.close(tmp)
+            result = child
+            child = -1
+            return result
         except BaseException:
-            os.close(child)
+            if child != -1:
+                os.close(child)
+                child = -1
             raise
     except BaseException:
         if parent != -1:
             os.close(parent)
+            parent = -1
         if anchor_parent != -1:
             os.close(anchor_parent)
+            anchor_parent = -1
         if descriptor != -1:
             os.close(descriptor)
+            descriptor = -1
         raise
 
 

--- a/src/brigade/work_cmd/ledger/import_model.py
+++ b/src/brigade/work_cmd/ledger/import_model.py
@@ -26,6 +26,8 @@ from ...untrusted import scan_handoff_injection_heuristics
 
 from . import inbox_provenance, queries_handoffs, authority_store, descriptor_anchors, locking
 
+_GITHUB_ISSUE_VIEW_TIMEOUT_SECONDS = 30.0
+
 
 def _metadata(item: Mapping[str, Any]) -> dict[str, Any]:
     value = item.get("metadata")
@@ -678,21 +680,25 @@ def _github_issue_ref(issue: dict[str, Any]) -> str | None:
 def _read_github_issue(target: Path, issue_ref: str) -> tuple[dict[str, Any] | None, list[str], str | None]:
     if shutil.which("gh") is None:
         return None, [], "gh CLI is not available on PATH"
-    result = subprocess.run(
-        [
-            "gh",
-            "issue",
-            "view",
-            issue_ref,
-            "--json",
-            "url,number,title,labels,state,body",
-        ],
-        cwd=target,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "view",
+                issue_ref,
+                "--json",
+                "url,number,title,labels,state,body",
+            ],
+            cwd=target,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=_GITHUB_ISSUE_VIEW_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return None, [], f"gh issue view timed out after {exc.timeout:g}s"
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"gh issue view exited {result.returncode}"
         return None, [], detail

--- a/src/brigade/work_cmd/ledger/tasks_plans.py
+++ b/src/brigade/work_cmd/ledger/tasks_plans.py
@@ -1202,9 +1202,9 @@ def _write_plan_artifact(
             print(f"error: task not found: {task_id}", file=sys.stderr)
             return 1
         resolved_id = str(task.get("id") or resolved_id)
-        existing = _read_plan_receipt(target, resolved_id, kind)
         now = helpers._now().isoformat()
         try:
+            existing = _load_plan_receipt(target, resolved_id, kind)
             if existing is None or "decisions" not in existing:
                 decisions = _normalize_decisions(None, now=now)
             else:

--- a/tests/test_ledger_1233_findings.py
+++ b/tests/test_ledger_1233_findings.py
@@ -1,0 +1,171 @@
+"""#1233: package-split review findings that moved verbatim from ledger.py."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from brigade import work_cmd
+from brigade.security_cmd import AUTHORITY_STORE_ISOLATION_EXTERNAL_KEY
+from brigade.work_cmd import inbox_lock, ledger
+from brigade.work_cmd.ledger import descriptor_anchors
+from tests.work_cmd_test_helpers import _init_git_repo, _plan_task_id
+
+
+def _enable_external_key_isolation(tmp_path: Path) -> None:
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                "",
+                "[authority_store]",
+                f'isolation = "{AUTHORITY_STORE_ISOLATION_EXTERNAL_KEY}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _bind_workspace(tmp_path: Path) -> dict[str, int]:
+    _enable_external_key_isolation(tmp_path)
+    (tmp_path / ".brigade").mkdir(exist_ok=True)
+    workspace = ledger._workspace_directory_identity(tmp_path)
+    root = os.open(tmp_path / ".brigade", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        ledger._record_external_directory_authority(tmp_path, (".brigade",), root, workspace=workspace)
+    finally:
+        os.close(root)
+    return workspace
+
+
+def test_rebind_directory_authority_reports_data_root_oserror(tmp_path: Path, monkeypatch, capsys):
+    def boom(*, env=None, system=None):
+        raise ValueError("component data root requires HOME")
+
+    monkeypatch.setattr(ledger.component_paths, "data_root", boom)
+
+    assert ledger.rebind_directory_authority(target=tmp_path) == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error: ")
+    assert "external directory authority storage is unavailable" in err
+    assert "Traceback" not in err
+
+
+def test_record_verifier_owned_file_holds_inbox_writer_lock(tmp_path: Path, monkeypatch):
+    _bind_workspace(tmp_path)
+    receipt = tmp_path / ".brigade" / "scanners" / "runs" / "run-a" / "receipt.json"
+    receipt.parent.mkdir(parents=True)
+    receipt.write_bytes(b'{"run_id":"run-a"}')
+    original = ledger._write_external_directory_authority
+    held: list[bool] = []
+
+    def wrapped(*args, **kwargs):
+        inbox_lock.verify_inbox_writer_lock(tmp_path)
+        held.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(ledger, "_write_external_directory_authority", wrapped)
+    data = receipt.read_bytes()
+    descriptor = os.open(receipt, os.O_RDONLY | os.O_NOFOLLOW)
+    try:
+        ledger._record_verifier_owned_file(
+            tmp_path,
+            components=(".brigade", "scanners", "runs", "run-a", "receipt.json"),
+            descriptor=descriptor,
+            data=data,
+        )
+    finally:
+        os.close(descriptor)
+    assert held == [True]
+
+
+def test_open_verifier_owned_directory_closes_child_on_exception(tmp_path: Path, monkeypatch):
+    descriptor = ledger._open_verifier_owned_directory(
+        tmp_path,
+        components=(".brigade", "work", "imports", "proofs"),
+        anchor_name=".proofs.authority.json",
+        create=True,
+    )
+    os.close(descriptor)
+
+    opened: list[tuple[str, int]] = []
+    closed: list[int] = []
+    real_open = ledger._dirfd_open_dir
+    real_close = os.close
+
+    def tracking_open(parent: int, name: str) -> int:
+        child = real_open(parent, name)
+        opened.append((name, child))
+        return child
+
+    def tracking_close(fd: int) -> None:
+        closed.append(fd)
+        return real_close(fd)
+
+    monkeypatch.setattr(ledger, "_dirfd_open_dir", tracking_open)
+    monkeypatch.setattr(os, "close", tracking_close)
+    monkeypatch.setattr(
+        ledger,
+        "_write_compatibility_directory_anchor",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("injected")),
+    )
+
+    with pytest.raises(RuntimeError, match="injected"):
+        ledger._open_verifier_owned_directory(
+            tmp_path,
+            components=(".brigade", "work", "imports", "proofs"),
+            anchor_name=".proofs.authority.json",
+            create=True,
+        )
+
+    child_fds = [fd for name, fd in opened if name == "proofs"]
+    assert child_fds
+    assert child_fds[-1] in closed
+
+
+def test_read_verified_authority_snapshot_reads_past_one_chunk(tmp_path: Path, monkeypatch):
+    _bind_workspace(tmp_path)
+    store = ledger._directory_authority_store_path(tmp_path)
+    raw = store.read_bytes()
+    assert len(raw) > 16
+    monkeypatch.setattr(descriptor_anchors, "_AUTHORITY_SNAPSHOT_READ_CHUNK_BYTES", 16)
+
+    record = ledger._read_verified_authority_snapshot(tmp_path)
+    assert record is not None
+    assert isinstance(record.get("directories"), dict)
+    assert record.get("target") == str(tmp_path.expanduser().resolve())
+
+
+def test_plan_write_refuses_corrupt_receipt(tmp_path: Path, capsys):
+    _init_git_repo(tmp_path)
+    task_id = _plan_task_id(tmp_path, capsys)
+    assert work_cmd.task_plan(target=tmp_path, task_id=task_id[:12], write=True) == 0
+    capsys.readouterr()
+    json_path, _ = work_cmd._plan_paths(tmp_path, task_id)
+    json_path.write_text("{not-json")
+
+    assert work_cmd.task_plan(target=tmp_path, task_id=task_id[:12], write=True, title="Overwrite") != 0
+    err = capsys.readouterr().err
+    assert "corrupt" in err
+    assert json_path.read_text() == "{not-json"
+
+
+def test_read_github_issue_timeout_is_read_failure(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(ledger.shutil, "which", lambda name: "/usr/bin/gh" if name == "gh" else None)
+
+    def boom(*args, **kwargs):
+        assert kwargs.get("timeout") is not None
+        raise subprocess.TimeoutExpired(cmd=["gh", "issue", "view"], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(ledger.subprocess, "run", boom)
+    payload, labels, detail = ledger._read_github_issue(tmp_path, "9")
+    assert payload is None
+    assert labels == []
+    assert detail is not None
+    assert "timed out" in detail.lower() or "timeout" in detail.lower()

--- a/tests/test_ledger_1233_findings.py
+++ b/tests/test_ledger_1233_findings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -85,6 +86,92 @@ def test_record_verifier_owned_file_holds_inbox_writer_lock(tmp_path: Path, monk
     assert held == [True]
 
 
+def test_record_verifier_owned_file_concurrent_updates_do_not_lose_writes(tmp_path: Path, monkeypatch):
+    """Two same-process threads must both land; the writer lock alone is reentrant."""
+    _bind_workspace(tmp_path)
+    receipts: list[tuple[tuple[str, ...], Path]] = []
+    for run_id in ("run-a", "run-b"):
+        receipt = tmp_path / ".brigade" / "scanners" / "runs" / run_id / "receipt.json"
+        receipt.parent.mkdir(parents=True)
+        receipt.write_bytes(f'{{"run_id":"{run_id}"}}'.encode())
+        receipts.append(((".brigade", "scanners", "runs", run_id, "receipt.json"), receipt))
+
+    both_read = threading.Event()
+    readers = 0
+    readers_guard = threading.Lock()
+    original_read = ledger._read_external_directory_authority
+
+    def gated_read(*args, **kwargs):
+        nonlocal readers
+        result = original_read(*args, **kwargs)
+        with readers_guard:
+            readers += 1
+            if readers >= 2:
+                both_read.set()
+        both_read.wait(timeout=0.3)
+        return result
+
+    monkeypatch.setattr(ledger, "_read_external_directory_authority", gated_read)
+    errors: list[str] = []
+
+    def record(components: tuple[str, ...], receipt: Path) -> None:
+        data = receipt.read_bytes()
+        descriptor = os.open(receipt, os.O_RDONLY | os.O_NOFOLLOW)
+        try:
+            ledger._record_verifier_owned_file(tmp_path, components=components, descriptor=descriptor, data=data)
+        except BaseException as exc:
+            errors.append(repr(exc))
+        finally:
+            os.close(descriptor)
+
+    threads = [threading.Thread(target=record, args=item) for item in receipts]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    assert errors == []
+    _path, payload = original_read(tmp_path)
+    assert payload is not None
+    files = payload.get("files")
+    assert isinstance(files, dict)
+    scopes = {ledger._directory_authority_scope(components) for components, _receipt in receipts}
+    assert scopes <= set(files)
+
+
+def test_record_verifier_owned_file_refuses_replaced_writer_lock(tmp_path: Path, monkeypatch):
+    _bind_workspace(tmp_path)
+    receipt = tmp_path / ".brigade" / "scanners" / "runs" / "run-a" / "receipt.json"
+    receipt.parent.mkdir(parents=True)
+    receipt.write_bytes(b'{"run_id":"run-a"}')
+    original_write = ledger._write_external_directory_authority
+    writes: list[bool] = []
+
+    def boom(target: Path) -> None:
+        raise OSError("import inbox lock was replaced while held")
+
+    def wrapped(*args, **kwargs):
+        writes.append(True)
+        return original_write(*args, **kwargs)
+
+    monkeypatch.setattr(inbox_lock, "verify_inbox_writer_lock", boom)
+    monkeypatch.setattr(ledger, "_write_external_directory_authority", wrapped)
+    data = receipt.read_bytes()
+    descriptor = os.open(receipt, os.O_RDONLY | os.O_NOFOLLOW)
+    try:
+        with pytest.raises(OSError, match="replaced while held"):
+            ledger._record_verifier_owned_file(
+                tmp_path,
+                components=(".brigade", "scanners", "runs", "run-a", "receipt.json"),
+                descriptor=descriptor,
+                data=data,
+            )
+    finally:
+        os.close(descriptor)
+    assert writes == []
+
+
 def test_open_verifier_owned_directory_closes_child_on_exception(tmp_path: Path, monkeypatch):
     descriptor = ledger._open_verifier_owned_directory(
         tmp_path,
@@ -127,6 +214,53 @@ def test_open_verifier_owned_directory_closes_child_on_exception(tmp_path: Path,
     child_fds = [fd for name, fd in opened if name == "proofs"]
     assert child_fds
     assert child_fds[-1] in closed
+
+
+def test_open_verifier_owned_directory_parent_close_handoff_is_interrupt_safe(tmp_path: Path, monkeypatch):
+    """Closing parent must drop ownership first so a later handler cannot close a reused fd."""
+    descriptor = ledger._open_verifier_owned_directory(
+        tmp_path,
+        components=(".brigade", "work", "imports", "proofs"),
+        anchor_name=".proofs.authority.json",
+        create=True,
+    )
+    os.close(descriptor)
+
+    opened: dict[str, int] = {}
+    recycled: list[int] = []
+    real_open = ledger._dirfd_open_dir
+    real_close = os.close
+
+    def tracking_open(parent: int, name: str) -> int:
+        child = real_open(parent, name)
+        opened[name] = child
+        return child
+
+    def close_parent_then_recycle(fd: int) -> None:
+        real_close(fd)
+        if recycled or fd != opened.get("imports"):
+            return
+        dummy = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+        recycled.append(dummy)
+        raise RuntimeError("interrupt after parent close")
+
+    monkeypatch.setattr(ledger, "_dirfd_open_dir", tracking_open)
+    monkeypatch.setattr(os, "close", close_parent_then_recycle)
+
+    with pytest.raises(RuntimeError, match="interrupt after parent close"):
+        ledger._open_verifier_owned_directory(
+            tmp_path,
+            components=(".brigade", "work", "imports", "proofs"),
+            anchor_name=".proofs.authority.json",
+            create=True,
+        )
+
+    assert recycled
+    dummy = recycled[0]
+    # The number may have been closed earlier in the walk; the dummy
+    # opened after parent close must still be live.
+    os.fstat(dummy)
+    real_close(dummy)
 
 
 def test_read_verified_authority_snapshot_reads_past_one_chunk(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Closes #1233 - the six pre-existing findings CodeRabbit raised on the ledger package split (#1232), each a one-function change with a unit test:

1. `authority_store.py`: drop the unused pre-try `_directory_authority_store_path` call so `data_root()` failures surface as `error: ...` + exit 1, not a traceback
2. `descriptor_anchors.py`: serialize scanner receipt authority updates against concurrent writers
3. `descriptor_anchors.py`: close the dirfd child descriptor on every exceptional exit
4. `descriptor_anchors.py`: read authority records to EOF instead of one `os.read` chunk
5. `tasks_plans.py`: report `REASON_CORRUPT_PLAN_RECEIPT` and exit non-zero on a corrupt plan receipt instead of silently replacing it
6. `import_model.py`: bound `gh issue view` with a subprocess timeout so one hung `gh` cannot block doctor

Per the issue, findings 2 and 4 went through a Daybreak pass (read-only `brigade run` on the gpt-daybreak-blue seat). Round 1 confirmed the EOF fix safe and found two residuals in the first commit: the shared file lock is process-reentrant (same-process threads could interleave the read-modify-write) and an fd double-close/leak window in the ownership transfer. The follow-up commit adds same-process thread serialization + held-lock validation before publication and sentinel-before-close fd transfers. Daybreak round 2: both CONFIRMED FIXED (`descriptor_anchors.py:31-48,168-198,359-440`).

Implemented by `brigade run` cursor_grok worker seats; independently verified: `test_ledger_1233_findings.py` (305 lines new), `test_work_cmd_ledger.py`, `test_work_cmd_ledger_integrity.py`, `test_ledger_facade.py` all exit 0, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)