### PR TITLE
chore(ci): add Dependabot config for pip, cargo, gomod, and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,110 @@
+# Dependabot version updates. Major bumps stay ungrouped so they can be reviewed alone.
+# Cargo is scoped to /engines/code-graph only; the benchmark fixture Cargo.toml under
+# engines/code-graph/benchmarks is not a workspace member and is not listed.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: /engines/code-graph
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: gomod
+    directory: /stations/notify
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: gomod
+    directory: /engines/evidence-ledger
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # npm: pre-wired for the npm wrapper package (#1273). Dependabot reports a
+  # config error on every run when an npm entry has no package.json, so this
+  # stays commented out. Uncomment and set `directory` in the same PR that adds
+  # the manifest.
+  # - package-ecosystem: npm
+  #   directory: /
+  #   schedule:
+  #     interval: weekly
+  #   open-pull-requests-limit: 5
+  #   labels:
+  #     - dependencies
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #   groups:
+  #     minor-and-patch:
+  #       patterns:
+  #         - "*"
+  #       update-types:
+  #         - minor
+  #         - patch


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering every dependency surface the repo has today:

| ecosystem | directory |
|---|---|
| pip | `/` (pyproject extras: dev, grokbot, research) |
| cargo | `/engines/code-graph` (benchmark fixture Cargo.toml excluded) |
| gomod | `/stations/notify`, `/engines/evidence-ledger` |
| github-actions | `/` |

Weekly, `open-pull-requests-limit: 5`, minor+patch grouped per ecosystem (one PR per ecosystem per week), major bumps ungrouped, conventional prefixes `chore(deps)` / `chore(ci)`, `dependencies` label.

The npm block is pre-wired but commented out for the npm wrapper (#1273): a live npm entry with no `package.json` makes Dependabot report a config error on every run. Uncomment it in the same PR that adds the manifest.

Verified through Brigade: YAML parses, 5 entries, every non-root directory exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)