### PR TITLE
test(fleet): isolate host node identity from claim-target discovery

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,15 +94,53 @@ def _no_live_fleet_hub(monkeypatch):
 def _isolate_user_brigade_dir(tmp_path_factory, monkeypatch):
     """Redirect user-level ``~/.brigade`` sticky state away from the real home.
 
-    Authority signed-markers default to ``$HOME/.brigade``. The redirected
-    path must end in ``.brigade`` so tests exercise the real default location
-    instead of a ``user_brigade`` temp that accidentally omits that component.
+    Authority signed-markers default to ``$HOME/.brigade`` (``BRIGADE_USER_DIR``).
+    Fleet identity uses ``fleet_client.brigade_home()``, which reads
+    ``BRIGADE_HOME`` and otherwise ``Path.home() / ".brigade"``. Cover both
+    so a host ``~/.brigade/node.toml`` cannot leak into claim-target lookup.
+    The redirected path must end in ``.brigade`` so tests exercise the real
+    default location instead of a ``user_brigade`` temp that accidentally
+    omits that component.
     """
     home = tmp_path_factory.mktemp("operator_home")
     user_dir = home / ".brigade"
     user_dir.mkdir(mode=PRIVATE_DIRECTORY_MODE)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("BRIGADE_USER_DIR", str(user_dir))
+    monkeypatch.setenv("BRIGADE_HOME", str(user_dir))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fleet_workspace_walk(tmp_path, monkeypatch, request):
+    """Stop fleet workspace discovery from climbing to a host node identity.
+
+    ``find_workspace_for_path`` walks ancestors looking for ``.brigade/node.toml``.
+    When pytest tmp lives under ``$HOME`` and the host has a home identity,
+    that walk resolves the home directory as the workspace (#1182). Redirecting
+    ``HOME`` / ``BRIGADE_HOME`` does not help: the real file is still on the
+    filesystem above ``tmp_path``. Bound discovery to the test sandbox.
+    """
+    if not request.module.__name__.rsplit(".", 1)[-1].startswith("test_fleet"):
+        return
+
+    from brigade import fleet_client
+
+    real = fleet_client.find_workspace_for_path
+    try:
+        bound = tmp_path.resolve()
+    except OSError:
+        bound = tmp_path
+
+    def find_workspace_for_path(start):
+        found = real(start)
+        if found is None:
+            return None
+        try:
+            return found if found.resolve().is_relative_to(bound) else None
+        except OSError:
+            return None
+
+    monkeypatch.setattr(fleet_client, "find_workspace_for_path", find_workspace_for_path)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -952,6 +952,32 @@ class TestClientClaims:
         bare.mkdir()
         assert fleet_client.resolve_claim_target(bare) == "just-a-dir"
 
+    def test_resolve_claim_target_ignores_redirected_home_identity(self, tmp_path):
+        """A planted home node.toml must not steal the claim key (#1182).
+
+        ``find_workspace_for_path`` walks ancestors. When pytest tmp lives
+        under ``$HOME`` and ``~/.brigade/node.toml`` exists, that walk
+        resolves the home directory name. Isolation must keep the workspace
+        name even when the redirected home carries a real identity file.
+        """
+        from brigade import node as node_mod
+
+        home = fleet_client.home_identity_target()
+        _plant_home_identity(home, NODE_A)
+        assert node_mod.node_path(home).is_file()
+
+        workspace = tmp_path / "ws"
+        nested = workspace / "src" / "deep"
+        nested.mkdir(parents=True)
+        node_mod.ensure_identity(workspace)
+        assert fleet_client.resolve_claim_target(nested) == "ws"
+        assert fleet_client.resolve_claim_target(nested) != home.name
+
+        bare = tmp_path / "just-a-dir"
+        bare.mkdir()
+        assert fleet_client.resolve_claim_target(bare) == "just-a-dir"
+        assert fleet_client.resolve_claim_target(bare) != home.name
+
 
 class TestFleetClaimsCli:
     def test_claims_table_and_json(self, hub, monkeypatch, capsys):

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -952,31 +952,51 @@ class TestClientClaims:
         bare.mkdir()
         assert fleet_client.resolve_claim_target(bare) == "just-a-dir"
 
-    def test_resolve_claim_target_ignores_redirected_home_identity(self, tmp_path):
+    def test_resolve_claim_target_ignores_redirected_home_identity(self, tmp_path, monkeypatch, request):
         """A planted home node.toml must not steal the claim key (#1182).
 
         ``find_workspace_for_path`` walks ancestors. When pytest tmp lives
         under ``$HOME`` and ``~/.brigade/node.toml`` exists, that walk
         resolves the home directory name. Isolation must keep the workspace
-        name even when the redirected home carries a real identity file.
+        name even when an ancestor of the sandbox carries a real identity.
         """
         from brigade import node as node_mod
 
-        home = fleet_client.home_identity_target()
-        _plant_home_identity(home, NODE_A)
-        assert node_mod.node_path(home).is_file()
+        # Plant on a real ancestor of the pytest sandbox. The class fixture
+        # home (tmp_path / "brigade-home") is a sibling of these workspaces
+        # and would never be discovered by the walk.
+        ancestor = tmp_path.parent
+        monkeypatch.setenv("BRIGADE_HOME", str(ancestor / ".brigade"))
+        assert fleet_client.home_identity_target() == ancestor
+
+        planted = node_mod.node_path(ancestor)
+        brigade_dir = planted.parent
+        existed_dir = brigade_dir.is_dir()
+        previous = planted.read_text(encoding="utf-8") if planted.is_file() else None
+
+        def _cleanup_planted_ancestor_identity() -> None:
+            if previous is None:
+                planted.unlink(missing_ok=True)
+                if not existed_dir and brigade_dir.is_dir() and not any(brigade_dir.iterdir()):
+                    brigade_dir.rmdir()
+            else:
+                planted.write_text(previous, encoding="utf-8")
+
+        request.addfinalizer(_cleanup_planted_ancestor_identity)
+        _plant_home_identity(ancestor, NODE_A)
+        assert planted.is_file()
 
         workspace = tmp_path / "ws"
         nested = workspace / "src" / "deep"
         nested.mkdir(parents=True)
         node_mod.ensure_identity(workspace)
         assert fleet_client.resolve_claim_target(nested) == "ws"
-        assert fleet_client.resolve_claim_target(nested) != home.name
+        assert fleet_client.resolve_claim_target(nested) != ancestor.name
 
         bare = tmp_path / "just-a-dir"
         bare.mkdir()
         assert fleet_client.resolve_claim_target(bare) == "just-a-dir"
-        assert fleet_client.resolve_claim_target(bare) != home.name
+        assert fleet_client.resolve_claim_target(bare) != ancestor.name
 
 
 class TestFleetClaimsCli:


### PR DESCRIPTION
Fixes #1182. On an enrolled host with pytest tmp under `$HOME`, `find_workspace_for_path` walked ancestors up to the real `~/.brigade/node.toml` and resolved the workspace to the home directory, failing `test_resolve_claim_target_uses_workspace_name` and `test_release_path_proves_the_claim_belongs_to_that_workspace`. CI never saw it because runners carry no node identity.

Redirecting `HOME` was not enough (the real file is still on the filesystem above `tmp_path`). `tests/conftest.py` now also sets `BRIGADE_HOME` on the redirected home and, for `test_fleet*` modules only, bounds `find_workspace_for_path` to `tmp_path`. A new test plants a home `node.toml` and asserts the workspace name still wins; it failed first (`assert 'clawdbot' == 'just-a-dir'`) and passes after the fixture.

Implemented by a `brigade run` cursor_grok worker seat; independently verified on this enrolled host: `test_fleet_claims.py`, `test_fleet_claim_release.py`, `test_fleet_nodes.py`, `test_fleet_sync.py` exit 0, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure workspace claim resolution remains tied to the correct workspace.
  * Prevented redirected home-directory identity files from affecting fleet workspace detection during tests.
  * Improved test isolation for authority markers and fleet identity lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->