### PR TITLE
fix(work): thread-owned inbox lock reentrancy, locked canonical writers, bounded lock timeouts

### DIFF
--- a/src/brigade/handoff_cmd/issue_ops.py
+++ b/src/brigade/handoff_cmd/issue_ops.py
@@ -609,56 +609,58 @@ def _close_stale_local_issue_work(
     dry_run: bool,
 ) -> dict[str, list[dict[str, Any]]]:
     from .. import work_cmd
+    from ..work_cmd import ledger as ledger_mod
 
     wanted_categories = {category for category in categories or [] if category}
     now = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
     closed_imports: list[dict[str, Any]] = []
-    imports = work_cmd._read_imports(target)
-    for item in imports:
-        if not isinstance(item, dict) or item.get("status", "pending") != "pending":
-            continue
-        if item.get("source") != ISSUE_SOURCE:
-            continue
-        issue_id = _handoff_issue_id(item)
-        if not issue_id:
-            continue
-        if issue_id in current_ids and issue_id not in close_current_ids:
-            continue
-        if wanted_categories and _handoff_issue_category(item) not in wanted_categories:
-            continue
-        updated = dict(item)
-        updated["status"] = "dismissed"
-        updated["updated_at"] = now
-        updated["dismissed_at"] = now
-        updated["dismiss_reason"] = _stale_close_reason(issue_id, close_current_ids)
-        item.update(updated)
-        closed_imports.append(updated)
-    if closed_imports and not dry_run:
-        work_cmd._write_imports(target, imports)
-
     closed_tasks: list[dict[str, Any]] = []
-    ledger = work_cmd._read_task_ledger(target)
-    for task in ledger.get("tasks", []):
-        if not isinstance(task, dict) or task.get("status", "pending") != "pending":
-            continue
-        if task.get("source") != f"import:{ISSUE_SOURCE}":
-            continue
-        issue_id = _handoff_issue_id(task)
-        if not issue_id:
-            continue
-        if issue_id in current_ids and issue_id not in close_current_ids:
-            continue
-        if wanted_categories and _handoff_issue_category(task) not in wanted_categories:
-            continue
-        updated = dict(task)
-        updated["status"] = "done"
-        updated["updated_at"] = now
-        updated["completed_at"] = now
-        updated["completion_reason"] = _stale_close_reason(issue_id, close_current_ids)
-        task.update(updated)
-        closed_tasks.append(updated)
-    if closed_tasks and not dry_run:
-        work_cmd._write_task_ledger(target, ledger)
+    with work_cmd._task_ledger_lock(target), ledger_mod._canonical_inbox_write(target):
+        imports = work_cmd._read_imports(target)
+        for item in imports:
+            if not isinstance(item, dict) or item.get("status", "pending") != "pending":
+                continue
+            if item.get("source") != ISSUE_SOURCE:
+                continue
+            issue_id = _handoff_issue_id(item)
+            if not issue_id:
+                continue
+            if issue_id in current_ids and issue_id not in close_current_ids:
+                continue
+            if wanted_categories and _handoff_issue_category(item) not in wanted_categories:
+                continue
+            updated = dict(item)
+            updated["status"] = "dismissed"
+            updated["updated_at"] = now
+            updated["dismissed_at"] = now
+            updated["dismiss_reason"] = _stale_close_reason(issue_id, close_current_ids)
+            item.update(updated)
+            closed_imports.append(updated)
+        if closed_imports and not dry_run:
+            work_cmd._write_imports(target, imports)
+
+        ledger = work_cmd._read_task_ledger(target)
+        for task in ledger.get("tasks", []):
+            if not isinstance(task, dict) or task.get("status", "pending") != "pending":
+                continue
+            if task.get("source") != f"import:{ISSUE_SOURCE}":
+                continue
+            issue_id = _handoff_issue_id(task)
+            if not issue_id:
+                continue
+            if issue_id in current_ids and issue_id not in close_current_ids:
+                continue
+            if wanted_categories and _handoff_issue_category(task) not in wanted_categories:
+                continue
+            updated = dict(task)
+            updated["status"] = "done"
+            updated["updated_at"] = now
+            updated["completed_at"] = now
+            updated["completion_reason"] = _stale_close_reason(issue_id, close_current_ids)
+            task.update(updated)
+            closed_tasks.append(updated)
+        if closed_tasks and not dry_run:
+            work_cmd._write_task_ledger(target, ledger)
 
     return {
         "imports": closed_imports,

--- a/src/brigade/operator_cmd/migration.py
+++ b/src/brigade/operator_cmd/migration.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .. import work_cmd
+from ..work_cmd import ledger as ledger_mod
 from .adoption import adoption_plan_payload
 from .surfaces import (
     _read_latest_surfaces_capture,
@@ -209,43 +210,44 @@ def migration_consolidate(
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    imports = work_cmd._read_imports(target)
-    rollup_ids = [
-        str(item.get("id"))
-        for item in imports
-        if isinstance(item, dict)
-        and item.get("status", "pending") == "pending"
-        and item.get("source") == "operator-migration"
-        and ((item.get("metadata") or {}).get("gap_name") if isinstance(item.get("metadata"), dict) else None)
-        in {"surface_reviews_missing", "surface_records_need_owner"}
-    ]
-    candidates = []
-    now = datetime.now(timezone.utc).isoformat()
-    for item in imports:
-        if (
-            not isinstance(item, dict)
-            or item.get("status", "pending") != "pending"
-            or item.get("source") != "operator-surface-review"
-        ):
-            continue
-        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
-        if surface and metadata.get("surface") != surface:
-            continue
-        if review_status and metadata.get("review_status") != review_status:
-            continue
-        candidates.append(item)
-    if rollup_ids and not dry_run:
-        rollup_id = rollup_ids[0]
-        for item in candidates:
-            item["status"] = "dismissed"
-            item["dismissed_at"] = now
-            item["dismiss_reason"] = reason
+    with ledger_mod._canonical_inbox_write(target):
+        imports = work_cmd._read_imports(target)
+        rollup_ids = [
+            str(item.get("id"))
+            for item in imports
+            if isinstance(item, dict)
+            and item.get("status", "pending") == "pending"
+            and item.get("source") == "operator-migration"
+            and ((item.get("metadata") or {}).get("gap_name") if isinstance(item.get("metadata"), dict) else None)
+            in {"surface_reviews_missing", "surface_records_need_owner"}
+        ]
+        candidates = []
+        now = datetime.now(timezone.utc).isoformat()
+        for item in imports:
+            if (
+                not isinstance(item, dict)
+                or item.get("status", "pending") != "pending"
+                or item.get("source") != "operator-surface-review"
+            ):
+                continue
             metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
-            metadata["superseded_by_import_id"] = rollup_id
-            metadata["superseded_by_source"] = "operator-migration"
-            item["metadata"] = metadata
-        if candidates:
-            work_cmd._write_imports(target, imports)
+            if surface and metadata.get("surface") != surface:
+                continue
+            if review_status and metadata.get("review_status") != review_status:
+                continue
+            candidates.append(item)
+        if rollup_ids and not dry_run:
+            rollup_id = rollup_ids[0]
+            for item in candidates:
+                item["status"] = "dismissed"
+                item["dismissed_at"] = now
+                item["dismiss_reason"] = reason
+                metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+                metadata["superseded_by_import_id"] = rollup_id
+                metadata["superseded_by_source"] = "operator-migration"
+                item["metadata"] = metadata
+            if candidates:
+                work_cmd._write_imports(target, imports)
     result = {
         "target": str(target),
         "surface": surface,
@@ -496,37 +498,38 @@ def _supersede_stale_operator_migration_imports(
             current_by_identity[identity] = fingerprint
     if not current_by_identity:
         return []
-    imports = work_cmd._read_imports(target)
-    superseded: list[str] = []
-    now = datetime.now(timezone.utc).isoformat()
-    for item in imports:
-        if (
-            not isinstance(item, dict)
-            or item.get("status", "pending") != "pending"
-            or item.get("source") != "operator-migration"
-        ):
-            continue
-        identity = work_cmd._import_source_identity(item)
-        if identity not in current_by_identity:
-            continue
-        current = current_by_identity[identity]
-        existing = work_cmd._import_fingerprint(item)
-        if existing == current:
-            continue
-        item_id = str(item.get("id") or "")
-        if item_id:
-            superseded.append(item_id)
-        if not dry_run:
-            item["status"] = "dismissed"
-            item["dismissed_at"] = now
-            item["dismiss_reason"] = "superseded-by-current-migration-rollup"
-            metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
-            metadata["superseded_by_source"] = "operator-migration"
-            metadata["current_source_fingerprint"] = current
-            item["metadata"] = metadata
-    if superseded and not dry_run:
-        work_cmd._write_imports(target, imports)
-    return superseded
+    with ledger_mod._canonical_inbox_write(target):
+        imports = work_cmd._read_imports(target)
+        superseded: list[str] = []
+        now = datetime.now(timezone.utc).isoformat()
+        for item in imports:
+            if (
+                not isinstance(item, dict)
+                or item.get("status", "pending") != "pending"
+                or item.get("source") != "operator-migration"
+            ):
+                continue
+            identity = work_cmd._import_source_identity(item)
+            if identity not in current_by_identity:
+                continue
+            current = current_by_identity[identity]
+            existing = work_cmd._import_fingerprint(item)
+            if existing == current:
+                continue
+            item_id = str(item.get("id") or "")
+            if item_id:
+                superseded.append(item_id)
+            if not dry_run:
+                item["status"] = "dismissed"
+                item["dismissed_at"] = now
+                item["dismiss_reason"] = "superseded-by-current-migration-rollup"
+                metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+                metadata["superseded_by_source"] = "operator-migration"
+                metadata["current_source_fingerprint"] = current
+                item["metadata"] = metadata
+        if superseded and not dry_run:
+            work_cmd._write_imports(target, imports)
+        return superseded
 
 
 def _supersede_stale_operator_source_imports(
@@ -553,39 +556,40 @@ def _supersede_stale_operator_source_imports(
         gap.get("name") for gap in (payload.get("gaps") or {}).get("items") or [] if isinstance(gap, dict)
     }
     has_surface_rollup = "surface_records_need_owner" in migration_gap_names
-    imports = work_cmd._read_imports(target)
-    superseded: list[str] = []
-    now = datetime.now(timezone.utc).isoformat()
-    for item in imports:
-        if not isinstance(item, dict) or item.get("status", "pending") != "pending":
-            continue
-        source = item.get("source")
-        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
-        source_key = metadata.get("source_item_key")
-        should_supersede = False
-        reason = "superseded-by-current-migration-status"
-        if (
-            source == "operator-adoption"
-            and isinstance(source_key, str)
-            and source_key not in current_adoption_issue_keys
-        ):
-            should_supersede = True
-        elif source == "operator-surface" and has_surface_rollup:
-            surface = metadata.get("surface")
-            if isinstance(surface, str) and surface in reviewed_surfaces:
+    with ledger_mod._canonical_inbox_write(target):
+        imports = work_cmd._read_imports(target)
+        superseded: list[str] = []
+        now = datetime.now(timezone.utc).isoformat()
+        for item in imports:
+            if not isinstance(item, dict) or item.get("status", "pending") != "pending":
+                continue
+            source = item.get("source")
+            metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+            source_key = metadata.get("source_item_key")
+            should_supersede = False
+            reason = "superseded-by-current-migration-status"
+            if (
+                source == "operator-adoption"
+                and isinstance(source_key, str)
+                and source_key not in current_adoption_issue_keys
+            ):
                 should_supersede = True
-                reason = "superseded-by-reviewed-surface-rollup"
-        if not should_supersede:
-            continue
-        item_id = str(item.get("id") or "")
-        if item_id:
-            superseded.append(item_id)
-        if not dry_run:
-            item["status"] = "dismissed"
-            item["dismissed_at"] = now
-            item["dismiss_reason"] = reason
-            metadata["superseded_by_source"] = "operator-migration"
-            item["metadata"] = metadata
-    if superseded and not dry_run:
-        work_cmd._write_imports(target, imports)
-    return superseded
+            elif source == "operator-surface" and has_surface_rollup:
+                surface = metadata.get("surface")
+                if isinstance(surface, str) and surface in reviewed_surfaces:
+                    should_supersede = True
+                    reason = "superseded-by-reviewed-surface-rollup"
+            if not should_supersede:
+                continue
+            item_id = str(item.get("id") or "")
+            if item_id:
+                superseded.append(item_id)
+            if not dry_run:
+                item["status"] = "dismissed"
+                item["dismissed_at"] = now
+                item["dismiss_reason"] = reason
+                metadata["superseded_by_source"] = "operator-migration"
+                item["metadata"] = metadata
+        if superseded and not dry_run:
+            work_cmd._write_imports(target, imports)
+        return superseded

--- a/src/brigade/phases_cmd/session_ops.py
+++ b/src/brigade/phases_cmd/session_ops.py
@@ -1226,54 +1226,58 @@ def session_import_issues(*, target: Path, session_id: str, dry_run: bool = Fals
         print(f"error: {exc}", file=sys.stderr)
         return 2
     from .. import work_cmd
+    from ..work_cmd import ledger as ledger_mod
 
-    existing = work_cmd._read_imports(target)
-    existing_keys = {
-        (
-            item.get("source"),
-            (item.get("metadata") or {}).get("session_id") if isinstance(item.get("metadata"), dict) else None,
-            (item.get("metadata") or {}).get("phase_id") if isinstance(item.get("metadata"), dict) else None,
-            (item.get("metadata") or {}).get("issue_type") if isinstance(item.get("metadata"), dict) else None,
-            (item.get("metadata") or {}).get("source_fingerprint") if isinstance(item.get("metadata"), dict) else None,
-        ): item
-        for item in existing
-        if item.get("source") == "phase-session" and isinstance(item.get("metadata"), dict)
-    }
-    created: list[dict[str, Any]] = []
-    skipped: list[dict[str, Any]] = []
-    for candidate in candidates:
-        metadata = candidate["metadata"]
-        key = (
-            "phase-session",
-            metadata.get("session_id"),
-            metadata.get("phase_id"),
-            metadata.get("issue_type"),
-            metadata.get("source_fingerprint"),
-        )
-        if key in existing_keys:
-            skipped.append(
-                {
-                    "import_id": existing_keys[key].get("id"),
-                    "status": existing_keys[key].get("status"),
-                    "metadata": metadata,
-                }
+    with ledger_mod._canonical_inbox_write(target):
+        existing = work_cmd._read_imports(target)
+        existing_keys = {
+            (
+                item.get("source"),
+                (item.get("metadata") or {}).get("session_id") if isinstance(item.get("metadata"), dict) else None,
+                (item.get("metadata") or {}).get("phase_id") if isinstance(item.get("metadata"), dict) else None,
+                (item.get("metadata") or {}).get("issue_type") if isinstance(item.get("metadata"), dict) else None,
+                (item.get("metadata") or {}).get("source_fingerprint")
+                if isinstance(item.get("metadata"), dict)
+                else None,
+            ): item
+            for item in existing
+            if item.get("source") == "phase-session" and isinstance(item.get("metadata"), dict)
+        }
+        created: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        for candidate in candidates:
+            metadata = candidate["metadata"]
+            key = (
+                "phase-session",
+                metadata.get("session_id"),
+                metadata.get("phase_id"),
+                metadata.get("issue_type"),
+                metadata.get("source_fingerprint"),
             )
-            continue
-        item = work_cmd._make_import(
-            candidate["text"],
-            kind=candidate["kind"],
-            source=candidate["source"],
-            metadata=metadata,
-            task_type="task",
-            priority="high",
-            acceptance=candidate["acceptance"],
-            template="bugfix",
-        )
-        created.append(item)
-        if not dry_run:
-            existing.append(item)
-    if created and not dry_run:
-        work_cmd._write_imports(target, existing)
+            if key in existing_keys:
+                skipped.append(
+                    {
+                        "import_id": existing_keys[key].get("id"),
+                        "status": existing_keys[key].get("status"),
+                        "metadata": metadata,
+                    }
+                )
+                continue
+            item = work_cmd._make_import(
+                candidate["text"],
+                kind=candidate["kind"],
+                source=candidate["source"],
+                metadata=metadata,
+                task_type="task",
+                priority="high",
+                acceptance=candidate["acceptance"],
+                template="bugfix",
+            )
+            created.append(item)
+            if not dry_run:
+                existing.append(item)
+        if created and not dry_run:
+            work_cmd._write_imports(target, existing)
     payload = {
         "schema_version": constants.SCHEMA_VERSION,
         "schema": constants._schema("phase-ledger-session-import-issues"),

--- a/src/brigade/repos_cmd/actions_dispatch.py
+++ b/src/brigade/repos_cmd/actions_dispatch.py
@@ -18,6 +18,7 @@ from typing import Any
 from uuid import uuid4
 
 from .. import actionqueue, config as brigade_config, reportstore, toml_compat as tomllib, work_cmd
+from ..work_cmd import ledger as ledger_mod
 from ..budgets import HANDOFF_BACKLOG_STALE_DAYS
 from ..install import apply_gitignore
 from ..localio import (
@@ -151,29 +152,30 @@ def _supersede_prior_dispatch_imports(
     repo_path: Path, action: dict[str, Any], current_import_ids: set[str]
 ) -> list[str]:
     source_fingerprint = str(action.get("source_fingerprint") or fleet._fingerprint_payload(action))
-    imports = work_cmd._read_imports(repo_path)
-    superseded: list[str] = []
-    changed = False
-    now = _now().isoformat()
-    for item in imports:
-        metadata = _dict_or_empty(item.get("metadata"))
-        if metadata.get("fleet_action_id") != action.get("fleet_action_id"):
-            continue
-        if item.get("id") in current_import_ids:
-            continue
-        if metadata.get("source_fingerprint") == source_fingerprint:
-            continue
-        if item.get("status") == "superseded":
-            continue
-        item["status"] = "superseded"
-        item["updated_at"] = now
-        item["superseded_at"] = now
-        item["superseded_by"] = sorted(current_import_ids)[0] if current_import_ids else None
-        superseded.append(str(item.get("id")))
-        changed = True
-    if changed:
-        work_cmd._write_imports(repo_path, imports)
-    return superseded
+    with ledger_mod._canonical_inbox_write(repo_path):
+        imports = work_cmd._read_imports(repo_path)
+        superseded: list[str] = []
+        changed = False
+        now = _now().isoformat()
+        for item in imports:
+            metadata = _dict_or_empty(item.get("metadata"))
+            if metadata.get("fleet_action_id") != action.get("fleet_action_id"):
+                continue
+            if item.get("id") in current_import_ids:
+                continue
+            if metadata.get("source_fingerprint") == source_fingerprint:
+                continue
+            if item.get("status") == "superseded":
+                continue
+            item["status"] = "superseded"
+            item["updated_at"] = now
+            item["superseded_at"] = now
+            item["superseded_by"] = sorted(current_import_ids)[0] if current_import_ids else None
+            superseded.append(str(item.get("id")))
+            changed = True
+        if changed:
+            work_cmd._write_imports(repo_path, imports)
+        return superseded
 
 
 def _dispatch_state(action: dict[str, Any], repo_path: Path | None = None) -> dict[str, Any]:

--- a/src/brigade/trust_gate.py
+++ b/src/brigade/trust_gate.py
@@ -520,32 +520,33 @@ def review_work_import(
     from .work_cmd import ledger as ledger_mod
 
     expected = _require_digest(expected_hash)
-    item, imports = ledger_mod._find_import(target, import_id)
-    if item is None:
-        raise TrustReviewError(f"import not found: {import_id}")
-    env = envelope_from_record(item)
-    text = str(item.get("text") or "")
-    current = current_envelope_digest(env, text)
-    if current != expected:
-        raise TrustReviewError("content hash does not match the current envelope digest")
-    item_ref = f"{ITEM_REF_WORK_IMPORT}{item.get('id')}"
-    label = trust_label_of(env)
-    if label == "reviewed" and has_matching_transition(
-        target, item_ref=item_ref, to_label="reviewed", envelope_content_hash=current
-    ):
-        return {"status": "noop", "item_ref": item_ref, "to_label": "reviewed", "envelope_content_hash": current}
-    if label in {"unknown", "quarantined"}:
-        raise TrustReviewError(f"cannot review {label} content until classification or scan is resolved")
-    if label != "untrusted":
-        raise TrustReviewError(f"cannot review trust label {label}")
-    now = localio.utc_now_iso()
-    updated_env = apply_trust_label(env, to_label="reviewed", assigned_by=operator_command, assigned_at=now)
-    raw_metadata = item.get("metadata")
-    metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
-    metadata["provenance"] = updated_env
-    item["metadata"] = metadata
-    item["updated_at"] = now
-    ledger_mod._write_imports(target, imports)
+    with ledger_mod._canonical_inbox_write(target):
+        item, imports = ledger_mod._find_import(target, import_id)
+        if item is None:
+            raise TrustReviewError(f"import not found: {import_id}")
+        env = envelope_from_record(item)
+        text = str(item.get("text") or "")
+        current = current_envelope_digest(env, text)
+        if current != expected:
+            raise TrustReviewError("content hash does not match the current envelope digest")
+        item_ref = f"{ITEM_REF_WORK_IMPORT}{item.get('id')}"
+        label = trust_label_of(env)
+        if label == "reviewed" and has_matching_transition(
+            target, item_ref=item_ref, to_label="reviewed", envelope_content_hash=current
+        ):
+            return {"status": "noop", "item_ref": item_ref, "to_label": "reviewed", "envelope_content_hash": current}
+        if label in {"unknown", "quarantined"}:
+            raise TrustReviewError(f"cannot review {label} content until classification or scan is resolved")
+        if label != "untrusted":
+            raise TrustReviewError(f"cannot review trust label {label}")
+        now = localio.utc_now_iso()
+        updated_env = apply_trust_label(env, to_label="reviewed", assigned_by=operator_command, assigned_at=now)
+        raw_metadata = item.get("metadata")
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
+        metadata["provenance"] = updated_env
+        item["metadata"] = metadata
+        item["updated_at"] = now
+        ledger_mod._write_imports(target, imports)
     event = build_provenance_event(
         item_ref=item_ref,
         from_label=label,

--- a/src/brigade/work_cmd/imports.py
+++ b/src/brigade/work_cmd/imports.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 from .. import evidence_brief, scrub
 from ..untrusted import scan_untrusted, wrap_untrusted
-from . import constants, helpers, ledger as ledger_mod
+from . import constants, helpers, inbox_lock, ledger as ledger_mod
 from . import edges as edges_mod
 from . import scanners as scanners_mod
 from . import services as services_mod
@@ -128,11 +128,15 @@ def import_context(
         return 2
 
     # Round 6 (M2): read under the canonical locks like every other writer.
-    with ledger_mod._canonical_inbox_write(target):
-        imports = ledger_mod._read_imports(target)
-        item = ledger_mod._make_import(framed, kind="context", source=source_text, metadata=metadata)
-        imports.append(item)
-        ledger_mod._write_imports(target, imports)
+    try:
+        with ledger_mod._canonical_inbox_write(target):
+            imports = ledger_mod._read_imports(target)
+            item = ledger_mod._make_import(framed, kind="context", source=source_text, metadata=metadata)
+            imports.append(item)
+            ledger_mod._write_imports(target, imports)
+    except inbox_lock.InboxLockTimeout as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
     if json_output:
         print(json.dumps(item, indent=2, sort_keys=True))
@@ -854,62 +858,66 @@ def import_promote_handoff(
     # Round 6 (M2): hold the canonical writer locks from the initial read
     # through publication so a scanner commit in between survives.
     run_after_id: str | None = None
-    with ledger_mod._canonical_inbox_write(target):
-        item, _imports = ledger_mod._find_import(target, import_id)
-        if item is None:
-            print(f"error: import not found: {import_id}", file=sys.stderr)
-            return 1
-        if run_after:
-            if item.get("kind") != "task":
-                print(f"error: --run requires a task import: {item.get('id')}", file=sys.stderr)
+    try:
+        with ledger_mod._canonical_inbox_write(target):
+            item, _imports = ledger_mod._find_import(target, import_id)
+            if item is None:
+                print(f"error: import not found: {import_id}", file=sys.stderr)
+                return 1
+            if run_after:
+                if item.get("kind") != "task":
+                    print(f"error: --run requires a task import: {item.get('id')}", file=sys.stderr)
+                    return 2
+                # Delegate outside the inbox locks: promotion takes the task
+                # ledger first, and no lock holder may wait on it afterwards.
+                run_after_id = str(item.get("id"))
+        if run_after_id is not None:
+            return import_promote(target=target, import_id=run_after_id, run_after=True)
+        with ledger_mod._canonical_inbox_write(target):
+            item, imports = ledger_mod._find_import(target, import_id)
+            if item is None:
+                print(f"error: import not found: {import_id}", file=sys.stderr)
+                return 1
+            payload = ledger_mod._import_handoff_plan_payload(target, item)
+            if payload["blockers"]:
+                if json_output:
+                    print(json.dumps(payload, indent=2, sort_keys=True))
+                else:
+                    for blocker in payload["blockers"]:
+                        print(f"error: {blocker}", file=sys.stderr)
                 return 2
-            # Delegate outside the inbox locks: promotion takes the task
-            # ledger first, and no lock holder may wait on it afterwards.
-            run_after_id = str(item.get("id"))
-    if run_after_id is not None:
-        return import_promote(target=target, import_id=run_after_id, run_after=True)
-    with ledger_mod._canonical_inbox_write(target):
-        item, imports = ledger_mod._find_import(target, import_id)
-        if item is None:
-            print(f"error: import not found: {import_id}", file=sys.stderr)
-            return 1
-        payload = ledger_mod._import_handoff_plan_payload(target, item)
-        if payload["blockers"]:
-            if json_output:
-                print(json.dumps(payload, indent=2, sort_keys=True))
-            else:
-                for blocker in payload["blockers"]:
-                    print(f"error: {blocker}", file=sys.stderr)
-            return 2
-        target_document = str(payload["target_document"])
-        handoff_path = ledger_mod._write_import_handoff(target, item, target_document)
-        from .. import handoff_cmd
+            target_document = str(payload["target_document"])
+            handoff_path = ledger_mod._write_import_handoff(target, item, target_document)
+            from .. import handoff_cmd
 
-        lint_result = handoff_cmd.lint_file(handoff_path)
-        if not lint_result.valid:
-            try:
-                handoff_path.unlink()
-            except OSError:
-                pass
-            failure_payload = dict(payload)
-            failure_payload.update(
-                {
-                    "handoff_path": str(handoff_path),
-                    "lint": lint_result.as_dict(),
-                    "handoff_ready": False,
-                    "blockers": [*payload["blockers"], *lint_result.errors],
-                }
+            lint_result = handoff_cmd.lint_file(handoff_path)
+            if not lint_result.valid:
+                try:
+                    handoff_path.unlink()
+                except OSError:
+                    pass
+                failure_payload = dict(payload)
+                failure_payload.update(
+                    {
+                        "handoff_path": str(handoff_path),
+                        "lint": lint_result.as_dict(),
+                        "handoff_ready": False,
+                        "blockers": [*payload["blockers"], *lint_result.errors],
+                    }
+                )
+                if json_output:
+                    print(json.dumps(failure_payload, indent=2, sort_keys=True))
+                else:
+                    for error in lint_result.errors:
+                        print(f"error: handoff lint failed: {error}", file=sys.stderr)
+                return 2
+            ledger_mod._mark_import_handoff_promoted(
+                target, item, handoff_path=handoff_path, target_document=target_document
             )
-            if json_output:
-                print(json.dumps(failure_payload, indent=2, sort_keys=True))
-            else:
-                for error in lint_result.errors:
-                    print(f"error: handoff lint failed: {error}", file=sys.stderr)
-            return 2
-        ledger_mod._mark_import_handoff_promoted(
-            target, item, handoff_path=handoff_path, target_document=target_document
-        )
-        ledger_mod._write_imports(target, imports)
+            ledger_mod._write_imports(target, imports)
+    except inbox_lock.InboxLockTimeout as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     output = dict(payload)
     output.update(
         {
@@ -964,6 +972,9 @@ def import_promote(
                 source=source,
                 metadata_filters=metadata_filters,
             )
+        except inbox_lock.InboxLockTimeout as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
         except ledger_mod.TaskLedgerError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
@@ -1010,6 +1021,9 @@ def import_promote(
             if created:
                 ledger_mod._write_task_ledger(target, ledger)
             ledger_mod._write_imports(target, imports)
+    except inbox_lock.InboxLockTimeout as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     except edges_mod.EdgeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -1055,29 +1069,33 @@ def import_dismiss(
         return 2
     if all_matching:
         # Round 6 (M2): read and publish inside one canonical lock window.
-        with ledger_mod._canonical_inbox_write(target):
-            imports = ledger_mod._read_imports(target)
-            wanted_ids = {
-                item.get("id")
-                for item in ledger_mod._matching_pending_imports(
-                    target,
-                    kind=kind,
-                    source=source,
-                    metadata_filters=metadata_filters,
-                )
-            }
-            now = helpers._now().isoformat()
-            dismissed: list[dict[str, Any]] = []
-            for item in imports:
-                if item.get("id") not in wanted_ids:
-                    continue
-                item["status"] = "dismissed"
-                item["updated_at"] = now
-                item["dismissed_at"] = now
-                if reason and reason.strip():
-                    item["dismiss_reason"] = reason.strip()
-                dismissed.append(item)
-            ledger_mod._write_imports(target, imports)
+        try:
+            with ledger_mod._canonical_inbox_write(target):
+                imports = ledger_mod._read_imports(target)
+                wanted_ids = {
+                    item.get("id")
+                    for item in ledger_mod._matching_pending_imports(
+                        target,
+                        kind=kind,
+                        source=source,
+                        metadata_filters=metadata_filters,
+                    )
+                }
+                now = helpers._now().isoformat()
+                dismissed: list[dict[str, Any]] = []
+                for item in imports:
+                    if item.get("id") not in wanted_ids:
+                        continue
+                    item["status"] = "dismissed"
+                    item["updated_at"] = now
+                    item["dismissed_at"] = now
+                    if reason and reason.strip():
+                        item["dismiss_reason"] = reason.strip()
+                    dismissed.append(item)
+                ledger_mod._write_imports(target, imports)
+        except inbox_lock.InboxLockTimeout as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
         print(f"dismissed: {len(dismissed)}")
         if reason and reason.strip():
             print(f"reason: {reason.strip()}")
@@ -1088,21 +1106,25 @@ def import_dismiss(
         print("error: import id is required unless --all is passed", file=sys.stderr)
         return 2
     # Round 6 (M2): read and publish inside one canonical lock window.
-    with ledger_mod._canonical_inbox_write(target):
-        item, imports = ledger_mod._find_import(target, import_id)
-        if item is None:
-            print(f"error: import not found: {import_id}", file=sys.stderr)
-            return 1
-        if item.get("status", "pending") != "pending":
-            print(f"error: import is not pending: {item.get('id')} ({item.get('status')})", file=sys.stderr)
-            return 2
-        now = helpers._now().isoformat()
-        item["status"] = "dismissed"
-        item["updated_at"] = now
-        item["dismissed_at"] = now
-        if reason and reason.strip():
-            item["dismiss_reason"] = reason.strip()
-        ledger_mod._write_imports(target, imports)
+    try:
+        with ledger_mod._canonical_inbox_write(target):
+            item, imports = ledger_mod._find_import(target, import_id)
+            if item is None:
+                print(f"error: import not found: {import_id}", file=sys.stderr)
+                return 1
+            if item.get("status", "pending") != "pending":
+                print(f"error: import is not pending: {item.get('id')} ({item.get('status')})", file=sys.stderr)
+                return 2
+            now = helpers._now().isoformat()
+            item["status"] = "dismissed"
+            item["updated_at"] = now
+            item["dismissed_at"] = now
+            if reason and reason.strip():
+                item["dismiss_reason"] = reason.strip()
+            ledger_mod._write_imports(target, imports)
+    except inbox_lock.InboxLockTimeout as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     print(f"import: {item.get('id')}")
     print("status: dismissed")
     if item.get("dismiss_reason"):

--- a/src/brigade/work_cmd/inbox_lock.py
+++ b/src/brigade/work_cmd/inbox_lock.py
@@ -44,18 +44,15 @@ open-to-validation window remains a documented residual there. A same-UID
 attacker can additionally ignore the advisory locks entirely; launch-time
 inbox revalidation detects that case.
 
-Each lock is reentrant per process so nested writer paths inside one
-acquisition cannot self-deadlock; nested acquisitions share the outer
-cross-process acquisition.
+Each lock is reentrant for the owning thread so nested writer paths inside
+one acquisition cannot self-deadlock; other threads in the same process
+wait on a per-entry ``RLock`` until that owner fully releases, then take
+their own cross-process acquisition.
 
 Residuals tracked in escoffier-labs/brigade#1215: a descendant that calls
 ``setsid()`` or double-forks escapes process-group reaping (``descendants_reaped``
-records that the group was reaped, not that no descendant survives); reentrancy
-is process-wide rather than thread-owned; canonical writers outside ``work_cmd``
-(operator migration, trust gate, session ops, issue ops, actions dispatch) still
-read the inbox before taking the locks; ``InboxLockTimeout`` escapes a few CLI
-paths as a traceback instead of a bounded nonzero result; and the Windows
-``LK_NBLCK`` deadline path has no native contention test yet.
+records that the group was reaped, not that no descendant survives); and the
+Windows ``LK_NBLCK`` deadline path has no native contention test yet.
 """
 
 from __future__ import annotations
@@ -105,20 +102,21 @@ if hasattr(os, "register_at_fork"):
 
 
 class _ActiveInboxLock:
-    """One process-wide registry entry: ownership and depth together.
+    """One registry entry: thread-owned depth plus the cross-process hold.
 
-    Keeping the cross-process acquisition and the reentrancy count in a single
-    entry means an inner thread context can never lose the fd to an outer
-    context that exits first, the descriptor closes exactly once at outermost
-    exit, and concurrent first acquisitions serialize on ``ready`` instead of
-    observing a half-initialized entry.
+    Only the owning thread may increase ``depth``. Other threads serialize on
+    ``thread_lock`` until that owner fully releases, so two threads cannot
+    share the writer window. The descriptor still closes exactly once at the
+    owner's outermost exit.
     """
 
     def __init__(self) -> None:
         self.owner: _HeldInboxLock | None = None
         self.depth = 0
+        self.owner_ident: int | None = None
         self.ready = threading.Event()
         self.error: BaseException | None = None
+        self.thread_lock = threading.RLock()
 
 
 #: Default bounded window for one cross-process inbox lock acquisition. A
@@ -337,8 +335,8 @@ def scanner_inbox_run_lock(target: Path, *, deadline_seconds: float | None = Non
     """Hold the workspace's run-wide inbox exclusion for the block.
 
     Only a scanner launcher holds this across its run window; honest Brigade
-    writers in other processes serialize behind it (reentrant per process so
-    nested paths inside one holder cannot self-deadlock). Acquisition is
+    writers in other processes serialize behind it (reentrant for the owning
+    thread so nested paths inside one holder cannot self-deadlock). Acquisition is
     deadline-bounded: a lock held past ``deadline_seconds`` (default
     :data:`DEFAULT_LOCK_DEADLINE_SECONDS`) raises :class:`InboxLockTimeout`.
     """
@@ -353,7 +351,7 @@ def inbox_writer_lock(target: Path, *, deadline_seconds: float | None = None) ->
     Serializes one read-modify-write section across all writers: outside
     writers (run lock first), self-importing scanner children (this lock
     only), and the launcher's stamping/rollback sections (under its run lock).
-    Reentrant per process like the run lock, and deadline-bounded like it.
+    Reentrant for the owning thread like the run lock, and deadline-bounded like it.
     """
     with _held_inbox_lock(inbox_writer_lock_path(target), deadline_seconds=deadline_seconds) as held:
         yield held
@@ -362,24 +360,49 @@ def inbox_writer_lock(target: Path, *, deadline_seconds: float | None = None) ->
 @contextlib.contextmanager
 def _held_inbox_lock(key_path: Path, *, deadline_seconds: float | None = None) -> Iterator[_HeldInboxLock]:
     key = str(key_path)
-    with _PROCESS_LOCK:
-        entry = _ACTIVE_LOCKS.get(key)
-        fresh = entry is None
-        if fresh:
-            entry = _ActiveInboxLock()
-            _ACTIVE_LOCKS[key] = entry
+    ident = threading.get_ident()
+    requested_seconds, deadline = _resolve_deadline(deadline_seconds)
+    entry: _ActiveInboxLock | None = None
+    fresh = False
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise InboxLockTimeout(f"import inbox lock stayed busy for {requested_seconds:g}s: {key}")
+        with _PROCESS_LOCK:
+            entry = _ACTIVE_LOCKS.get(key)
+            if entry is None:
+                entry = _ActiveInboxLock()
+                _ACTIVE_LOCKS[key] = entry
         assert entry is not None
-        entry.depth += 1
+        if not entry.thread_lock.acquire(timeout=remaining):
+            raise InboxLockTimeout(f"import inbox lock stayed busy for {requested_seconds:g}s: {key}")
+        with _PROCESS_LOCK:
+            current = _ACTIVE_LOCKS.get(key)
+            if current is not entry:
+                entry.thread_lock.release()
+                continue
+            if entry.owner_ident is None:
+                entry.owner_ident = ident
+                fresh = True
+            elif entry.owner_ident == ident:
+                fresh = False
+            else:
+                entry.thread_lock.release()
+                continue
+            entry.depth += 1
+        break
+    assert entry is not None
     try:
-        if fresh and entry is not None:
+        if fresh:
             # Initialization runs outside the module lock (the cross-process
-            # acquisition blocks), but the entry exists and later joiners wait
-            # on ``ready``, so no one can observe a missing owner.
+            # acquisition blocks). Same-thread reentry waits on ``ready``;
+            # other threads are still queued on ``thread_lock``.
             try:
                 owned = _acquire_cross_process(key, deadline_seconds=deadline_seconds)
             except BaseException as exc:
                 with _PROCESS_LOCK:
                     entry.error = exc
+                    entry.owner_ident = None
                     if _ACTIVE_LOCKS.get(key) is entry:
                         _ACTIVE_LOCKS.pop(key, None)
                 entry.ready.set()
@@ -389,7 +412,6 @@ def _held_inbox_lock(key_path: Path, *, deadline_seconds: float | None = None) -
             entry.ready.set()
             yield owned
         else:
-            assert entry is not None
             entry.ready.wait()
             if entry.error is not None:
                 raise entry.error
@@ -406,9 +428,12 @@ def _held_inbox_lock(key_path: Path, *, deadline_seconds: float | None = None) -
                 # longer holds, and the entry must be gone before the fd closes.
                 drop = True
                 release_owned = entry.owner
+                entry.owner = None
+                entry.owner_ident = None
                 _ACTIVE_LOCKS.pop(key, None)
         if drop and release_owned is not None:
             release_owned.release()
+        entry.thread_lock.release()
 
 
 def _open_lock_parent_posix(lock_path: Path) -> tuple[int, str]:

--- a/src/brigade/work_cmd/services.py
+++ b/src/brigade/work_cmd/services.py
@@ -14,7 +14,7 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-from . import constants, helpers, ledger as ledger_mod, config as config_mod
+from . import constants, helpers, inbox_lock, ledger as ledger_mod, config as config_mod
 from . import scanners as scanners_mod
 from . import sweeps as sweeps_mod
 from ..card_identity import IdentityIndex, card_identity, valid_card_id
@@ -1080,24 +1080,31 @@ def inbox_archive(*, target: Path, json_output: bool = False) -> int:
     now = helpers._now()
     # Round 6 (M2): read and publish inside one canonical lock window so a
     # scanner commit landing before this writer excludes survives the archive.
-    with ledger_mod._canonical_inbox_write(target):
-        imports = [item for item in ledger_mod._read_imports(target) if isinstance(item, dict)]
-        archived: list[dict[str, Any]] = []
-        kept: list[dict[str, Any]] = []
-        for item in imports:
-            status = str(item.get("status", "pending"))
-            timestamp = _archive_import_cutoff(item)
-            age_hours = (now - timestamp).total_seconds() / 3600 if timestamp is not None else 0
-            if status in {"promoted", "dismissed", "superseded"} and age_hours >= constants.IMPORT_ARCHIVE_STALE_HOURS:
-                archived_item = dict(item)
-                archived_item["archived_at"] = now.isoformat()
-                archived_item["archive_reason"] = f"{status}_older_than_{constants.IMPORT_ARCHIVE_STALE_HOURS}h"
-                archived.append(archived_item)
-            else:
-                kept.append(item)
-        if archived:
-            ledger_mod._append_archived_imports(target, archived)
-            ledger_mod._write_imports(target, kept)
+    try:
+        with ledger_mod._canonical_inbox_write(target):
+            imports = [item for item in ledger_mod._read_imports(target) if isinstance(item, dict)]
+            archived: list[dict[str, Any]] = []
+            kept: list[dict[str, Any]] = []
+            for item in imports:
+                status = str(item.get("status", "pending"))
+                timestamp = _archive_import_cutoff(item)
+                age_hours = (now - timestamp).total_seconds() / 3600 if timestamp is not None else 0
+                if (
+                    status in {"promoted", "dismissed", "superseded"}
+                    and age_hours >= constants.IMPORT_ARCHIVE_STALE_HOURS
+                ):
+                    archived_item = dict(item)
+                    archived_item["archived_at"] = now.isoformat()
+                    archived_item["archive_reason"] = f"{status}_older_than_{constants.IMPORT_ARCHIVE_STALE_HOURS}h"
+                    archived.append(archived_item)
+                else:
+                    kept.append(item)
+            if archived:
+                ledger_mod._append_archived_imports(target, archived)
+                ledger_mod._write_imports(target, kept)
+    except inbox_lock.InboxLockTimeout as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     payload = {
         "target": str(target),
         "imports_path": str(helpers._imports_path(target)),

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1801,3 +1801,62 @@ def test_adopt_plan_counts_guidance_files_and_dirs_separately(tmp_path, capsys):
     assert cli.main(["operator", "adopt", "plan", "--target", str(tmp_path)]) == 0
     out = capsys.readouterr().out
     assert "guidance_files: 1 (+1 dirs)" in out
+
+
+def test_migration_consolidate_keeps_scanner_commit_landing_before_publication(tmp_path, monkeypatch, capsys):
+    """Finding 3: a canonical writer that locked before reading keeps a concurrent scanner row."""
+    import contextlib
+
+    from brigade.work_cmd import ledger as ledger_mod
+
+    inbox = work_cmd.helpers._imports_path(tmp_path)
+    inbox.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "id": "mig-rollup-1",
+            "kind": "task",
+            "source": "operator-migration",
+            "status": "pending",
+            "text": "rollup gap",
+            "metadata": {"gap_name": "surface_reviews_missing"},
+        },
+        {
+            "id": "surf-review-1",
+            "kind": "task",
+            "source": "operator-surface-review",
+            "status": "pending",
+            "text": "tiny surface review",
+            "metadata": {"surface": "shell_crontab", "review_status": "needs-owner"},
+        },
+    ]
+    inbox.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
+
+    real = ledger_mod._canonical_inbox_write
+
+    @contextlib.contextmanager
+    def patched(target):
+        with inbox.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "id": "scan-mig-1",
+                        "text": "scanner migrate row",
+                        "kind": "task",
+                        "source": "scanner",
+                        "status": "pending",
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+        with real(target):
+            yield
+
+    monkeypatch.setattr(ledger_mod, "_canonical_inbox_write", patched)
+
+    assert operator_cmd.migration_consolidate(target=tmp_path, json_output=True) == 0
+    capsys.readouterr()
+    final = {item["id"]: item for item in work_cmd._read_imports(tmp_path)}
+    assert final["surf-review-1"]["status"] == "dismissed"
+    assert "scan-mig-1" in final, f"scanner commit deleted by migration consolidate: {sorted(final)}"
+    assert final["scan-mig-1"]["status"] == "pending"

--- a/tests/test_work_cmd_imports.py
+++ b/tests/test_work_cmd_imports.py
@@ -4873,3 +4873,58 @@ def test_dismiss_single_keeps_scanner_commit_landing_before_publication(tmp_path
     assert final[seeded["id"]]["status"] == "dismissed"
     assert final["scan-one-1"]["status"] == "pending"
     assert "scan-one-1" in final, f"scanner commit deleted by dismiss: {sorted(final)}"
+
+
+def _raise_canonical_inbox_lock_timeout(monkeypatch):
+    import contextlib
+
+    from brigade.work_cmd import inbox_lock as inbox_lock_mod
+    from brigade.work_cmd import ledger as ledger_mod
+
+    @contextlib.contextmanager
+    def boom(_target):
+        raise inbox_lock_mod.InboxLockTimeout("import inbox lock stayed busy for 0.5s: test")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(ledger_mod, "_canonical_inbox_write", boom)
+
+
+def test_import_context_returns_bounded_error_on_inbox_lock_timeout(tmp_path, monkeypatch, capsys):
+    """Finding 4: context returns rc 1 with a bounded error instead of a traceback."""
+    _raise_canonical_inbox_lock_timeout(monkeypatch)
+    assert work_cmd.import_context(target=tmp_path, text="context under lock timeout") == 1
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+    assert "import inbox lock stayed busy" in captured.err
+    assert "Traceback" not in captured.err
+    assert "Traceback" not in captured.out
+
+
+def test_import_promote_handoff_returns_bounded_error_on_inbox_lock_timeout(tmp_path, monkeypatch, capsys):
+    """Finding 4: promote-handoff returns rc 1 with a bounded error instead of a traceback."""
+    _raise_canonical_inbox_lock_timeout(monkeypatch)
+    assert work_cmd.import_promote_handoff(target=tmp_path, import_id="imp-timeout") == 1
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+    assert "import inbox lock stayed busy" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_import_promote_returns_bounded_error_on_inbox_lock_timeout(tmp_path, monkeypatch, capsys):
+    """Finding 4: promote returns rc 1 with a bounded error instead of a traceback."""
+    _raise_canonical_inbox_lock_timeout(monkeypatch)
+    assert work_cmd.import_promote(target=tmp_path, import_id="imp-timeout") == 1
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+    assert "import inbox lock stayed busy" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_import_dismiss_returns_bounded_error_on_inbox_lock_timeout(tmp_path, monkeypatch, capsys):
+    """Finding 4: dismiss returns rc 1 with a bounded error instead of a traceback."""
+    _raise_canonical_inbox_lock_timeout(monkeypatch)
+    assert work_cmd.import_dismiss(target=tmp_path, import_id="imp-timeout") == 1
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+    assert "import inbox lock stayed busy" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_work_cmd_scanners.py
+++ b/tests/test_work_cmd_scanners.py
@@ -4781,14 +4781,26 @@ import_format = "jsonl"
     assert "writer lock" in str(receipt.get("error")), receipt
 
 
-def test_overlapping_thread_acquisitions_share_one_owner_close_once_and_stay_exclusive(tmp_path, monkeypatch):
-    """Round 6 (L1): depth and ownership live in one registry entry.
+def _writer_lock_probe_script(tmp_path, lock_path):
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "import errno, fcntl, os, sys\n"
+        f"lock = {str(lock_path)!r}\n"
+        "fd = os.open(lock, os.O_RDWR | os.O_CREAT, 0o600)\n"
+        "try:\n"
+        "    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+        "except OSError as exc:\n"
+        "    sys.exit(0 if exc.errno in (errno.EACCES, errno.EAGAIN) else 1)\n"
+        "sys.exit(2)\n"
+    )
+    return probe
 
-    An inner thread context must stay protected when the outer context exits
-    first, the fd closes exactly once at outermost exit, and concurrent first
-    acquisitions serialize instead of exposing a half-initialized entry.
-    """
+
+def test_overlapping_thread_acquisitions_are_thread_owned_and_close_once(tmp_path, monkeypatch):
+    """Finding 2: reentrancy is owned by one thread; others wait for full release."""
+    import subprocess
     import threading
+    import time
 
     from brigade.work_cmd import inbox_lock as inbox_lock_mod
 
@@ -4802,77 +4814,81 @@ def test_overlapping_thread_acquisitions_share_one_owner_close_once_and_stay_exc
 
     monkeypatch.setattr(inbox_lock_mod._HeldInboxLock, "release", spying_release)
 
-    outer_entered = threading.Event()
-    outer_exit = threading.Event()
-    inner_entered = threading.Event()
-    inner_exit = threading.Event()
+    owner_entered = threading.Event()
+    owner_exit = threading.Event()
+    waiter_entered = threading.Event()
+    waiter_exit = threading.Event()
+    owner_ident = {"value": None}
 
-    def outer():
+    def owner():
         with inbox_lock_mod.inbox_writer_lock(tmp_path):
-            outer_entered.set()
-            assert outer_exit.wait(timeout=30)
+            owner_ident["value"] = threading.get_ident()
+            with inbox_lock_mod.inbox_writer_lock(tmp_path):
+                owner_entered.set()
+                entry = inbox_lock_mod._ACTIVE_LOCKS[key]
+                assert entry.depth == 2
+                assert entry.owner_ident == threading.get_ident()
+                assert owner_exit.wait(timeout=30)
 
-    def inner():
+    def waiter():
         with inbox_lock_mod.inbox_writer_lock(tmp_path):
-            inner_entered.set()
-            assert inner_exit.wait(timeout=30)
+            waiter_entered.set()
+            assert waiter_exit.wait(timeout=30)
 
-    thread_outer = threading.Thread(target=outer)
-    thread_inner = threading.Thread(target=inner)
-    thread_outer.start()
-    assert outer_entered.wait(timeout=30)
+    thread_owner = threading.Thread(target=owner)
+    thread_waiter = threading.Thread(target=waiter)
+    thread_owner.start()
+    assert owner_entered.wait(timeout=30)
     held_fd = inbox_lock_mod._ACTIVE_LOCKS[key].owner.fd
-    thread_inner.start()
+    thread_waiter.start()
 
-    deadline = __import__("time").monotonic() + 30
-    while not inner_entered.is_set() and __import__("time").monotonic() < deadline:
-        __import__("time").sleep(0.01)
-    assert inner_entered.is_set(), "inner acquisition never entered"
+    deadline = time.monotonic() + 0.3
+    while time.monotonic() < deadline:
+        assert not waiter_entered.is_set(), "other thread entered the writer window while the owner still held it"
+        time.sleep(0.01)
+    assert inbox_lock_mod._ACTIVE_LOCKS[key].owner_ident == owner_ident["value"]
+    assert inbox_lock_mod._ACTIVE_LOCKS[key].depth == 2
 
-    # The outer context exits FIRST while the inner one is still inside.
-    outer_exit.set()
-    thread_outer.join(timeout=30)
-
-    assert key in inbox_lock_mod._ACTIVE_LOCKS, "outer exit dropped the entry while an inner context held it"
-    inbox_lock_mod.verify_inbox_writer_lock(tmp_path)
-    assert inner_entered.is_set()
-
-    # Cross-process exclusion must still hold while the inner context runs.
-    probe = tmp_path / "probe.py"
-    probe.write_text(
-        "import errno, fcntl, os, sys\n"
-        f"lock = {str(inbox_lock_mod.inbox_writer_lock_path(tmp_path))!r}\n"
-        "fd = os.open(lock, os.O_RDWR | os.O_CREAT, 0o600)\n"
-        "try:\n"
-        "    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
-        "except OSError as exc:\n"
-        "    sys.exit(0 if exc.errno in (errno.EACCES, errno.EAGAIN) else 1)\n"
-        "sys.exit(2)\n"
+    blocked = subprocess.run(
+        [sys.executable, str(_writer_lock_probe_script(tmp_path, inbox_lock_mod.inbox_writer_lock_path(tmp_path)))],
+        timeout=30,
     )
-    import subprocess
+    assert blocked.returncode == 0, "owner lost cross-process exclusion during nested hold"
 
-    blocked = subprocess.run([sys.executable, str(probe)], timeout=30)
-    assert blocked.returncode == 0, "inner context lost cross-process exclusion after outer exit"
+    owner_exit.set()
+    thread_owner.join(timeout=30)
+    assert not thread_owner.is_alive()
+    assert waiter_entered.wait(timeout=30), "waiter never entered after the owner fully released"
+    assert inbox_lock_mod._ACTIVE_LOCKS[key].owner_ident == thread_waiter.ident
+    assert inbox_lock_mod._ACTIVE_LOCKS[key].depth == 1
+    assert released_fds == [held_fd], f"owner nest closed the fd {len(released_fds)} times: {released_fds}"
 
-    inner_exit.set()
-    thread_inner.join(timeout=30)
+    blocked = subprocess.run(
+        [sys.executable, str(_writer_lock_probe_script(tmp_path, inbox_lock_mod.inbox_writer_lock_path(tmp_path)))],
+        timeout=30,
+    )
+    assert blocked.returncode == 0, "waiter lost cross-process exclusion"
+
+    waiter_exit.set()
+    thread_waiter.join(timeout=30)
     assert key not in inbox_lock_mod._ACTIVE_LOCKS
-    assert released_fds == [held_fd], f"fd closed {len(released_fds)} times: {released_fds}"
+    assert len(released_fds) == 2, released_fds
 
-    # Concurrent first acquisitions must serialize their initialization.
     errors: list[BaseException] = []
     barrier = threading.Barrier(6)
-    # All racers must be inside their acquisition before any is allowed to
-    # leave; otherwise a fast thread can fully release before a slow one
-    # enters, yielding multiple ownership cycles instead of one shared owner.
-    inside_barrier = threading.Barrier(6)
+    seen_idents: list[int] = []
+    seen_guard = threading.Lock()
 
     def racer():
         barrier.wait(timeout=30)
         try:
             with inbox_lock_mod.inbox_writer_lock(tmp_path):
                 inbox_lock_mod.verify_inbox_writer_lock(tmp_path)
-                inside_barrier.wait(timeout=30)
+                entry = inbox_lock_mod._ACTIVE_LOCKS[key]
+                assert entry.depth == 1
+                assert entry.owner_ident == threading.get_ident()
+                with seen_guard:
+                    seen_idents.append(threading.get_ident())
         except BaseException as exc:  # pragma: no cover - surfaced below
             errors.append(exc)
 
@@ -4883,8 +4899,32 @@ def test_overlapping_thread_acquisitions_share_one_owner_close_once_and_stay_exc
         thread.join(timeout=60)
     assert not errors, errors
     assert key not in inbox_lock_mod._ACTIVE_LOCKS
-    # Exactly one additional acquisition/release cycle came out of the race.
-    assert len(released_fds) == 2, released_fds
+    assert len(seen_idents) == 6, seen_idents
+    assert len(released_fds) == 8, released_fds
+
+
+def test_two_threads_do_not_lose_updates_under_writer_lock(tmp_path):
+    """Finding 2: two threads serialize their read-modify-write on one entry."""
+    import threading
+
+    from brigade.work_cmd import inbox_lock as inbox_lock_mod
+
+    counter = tmp_path / "counter.txt"
+    counter.write_text("0")
+
+    def bump():
+        with inbox_lock_mod.inbox_writer_lock(tmp_path):
+            value = int(counter.read_text())
+            __import__("time").sleep(0.05)
+            counter.write_text(str(value + 1))
+
+    threads = [threading.Thread(target=bump) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+    assert counter.read_text() == "2"
 
 
 def test_outside_canonical_writer_gets_typed_failure_when_writer_lock_busy(tmp_path, monkeypatch):

--- a/tests/test_work_cmd_services.py
+++ b/tests/test_work_cmd_services.py
@@ -3748,3 +3748,23 @@ def test_inbox_archive_keeps_scanner_commit_landing_before_publication(tmp_path,
     # ...and the scanner commit landing before publication survived.
     assert "scan-archive-1" in final, f"scanner commit deleted by archive: {sorted(final)}"
     assert final["scan-archive-1"]["status"] == "pending"
+
+
+def test_inbox_archive_returns_bounded_error_on_inbox_lock_timeout(tmp_path, monkeypatch, capsys):
+    """Finding 4: archive returns rc 1 with a bounded error instead of a traceback."""
+    import contextlib
+
+    from brigade.work_cmd import inbox_lock as inbox_lock_mod
+    from brigade.work_cmd import ledger as ledger_mod
+
+    @contextlib.contextmanager
+    def boom(_target):
+        raise inbox_lock_mod.InboxLockTimeout("import inbox lock stayed busy for 0.5s: test")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(ledger_mod, "_canonical_inbox_write", boom)
+    assert work_cmd.inbox_archive(target=tmp_path, json_output=True) == 1
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+    assert "import inbox lock stayed busy" in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
Closes findings 2, 3 and 4 of #1215 (Daybreak residuals from the #1207 inbox writer lock work). Findings 1 (scanner descendant containment via cgroup or PID namespace) and 5 (Windows contention test) stay open on the issue.

2. **Thread-owned reentrancy** (`work_cmd/inbox_lock.py`): only the acquiring thread may increase depth; other threads serialize on the per-entry lock until full release, so two threads can no longer share the writer window. The round-7 test that encoded the old process-wide semantics is rewritten, plus a two-thread lost-update regression.
3. **Canonical writers read under the lock**: `operator_cmd/migration.py`, `trust_gate.py`, `phases_cmd/session_ops.py`, `handoff_cmd/issue_ops.py`, `repos_cmd/actions_dispatch.py` now read the inbox inside `_canonical_inbox_write`, task-ledger lock first where both ledgers change, so a stale pre-lock read cannot publish over a scanner row and its evidence.
4. **`InboxLockTimeout` at the command surface** (`work_cmd/imports.py`, `services.py`): context, promotion, dismiss, and archive return rc 1 with a bounded error instead of a traceback; locks are already released, no partial write.

Implemented by a `brigade run` cursor_grok worker seat. Daybreak read-only pass (gpt-daybreak-blue): **(2), (3), (4) CONFIRMED FIXED** with line references (`inbox_lock.py:104-119,361-436`; the five writer sites; `imports.py:131-139,861-920,...`; `services.py:1083-1107`). Independently verified: scanners, imports, services, operator, phases, handoff, repos test suites exit 0; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)