### PR TITLE
test(run): wait on durable phase state instead of fixed 5s polls in SIGTERM tests

### DIFF
--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -17,6 +17,7 @@ from brigade import proc
 from brigade import provenance
 from brigade import runguard
 from brigade.roster import Agent, Roster
+from tests import thread_sync
 from tests.run_test_helpers import HEALTHY_SEAT_HEALTH_CHILD_SETUP, run_aboyeur_guarded
 from tests.support import PRIVATE_FILE_MODE, assert_private_mode
 from tests.work_cmd_test_helpers import _init_git_repo
@@ -4697,19 +4698,28 @@ with runguard.run_lock(workspace, run_dir=run_dir):
     child_env = os.environ.copy()
     child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
     child = subprocess.Popen([sys.executable, "-c", script], env=child_env)
+
+    def handoff_phase_ready() -> bool:
+        if child.poll() is not None:
+            pytest.fail(f"run exited before reaching handoff (rc={child.returncode})")
+        try:
+            run_meta = json.loads((output_dir / "run.json").read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+        return run_meta.get("status") == "handoff" and "finished_at" not in run_meta
+
     try:
-        deadline = time.monotonic() + 5
-        while time.monotonic() < deadline:
-            try:
-                run_meta = json.loads((output_dir / "run.json").read_text())
-            except (OSError, json.JSONDecodeError):
-                time.sleep(0.02)
-                continue
-            if run_meta.get("status") == "handoff":
-                break
-            time.sleep(0.02)
-        else:
-            pytest.fail("run did not reach handoff before SIGTERM")
+        # run.json status=handoff is written before write_run_handoff. Poll that
+        # durable receipt field with a load-tolerant bound; a 5s window loses
+        # to child import + journaled phase writes on a saturated CI runner.
+        try:
+            thread_sync.wait_for_predicate(
+                handoff_phase_ready,
+                description="run receipt status=handoff",
+                poll_interval=0.02,
+            )
+        except AssertionError as exc:
+            pytest.fail(f"run did not reach handoff before SIGTERM: {exc}")
 
         child.send_signal(signal.SIGTERM)
         assert child.wait(timeout=3) == 128 + signal.SIGTERM

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -2919,19 +2919,29 @@ with runguard.run_lock(workspace, run_dir=run_dir):
     child_env = os.environ.copy()
     child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
     proc = subprocess.Popen([sys.executable, "-c", script], env=child_env)
+
+    def planning_phase_ready() -> bool:
+        if proc.poll() is not None:
+            pytest.fail(f"run exited before reaching planning (rc={proc.returncode})")
+        try:
+            run_meta = json.loads((output_dir / "run.json").read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+        return run_meta.get("status") == "planning"
+
     try:
-        deadline = time.monotonic() + 5
-        while time.monotonic() < deadline:
-            try:
-                run_meta = json.loads((output_dir / "run.json").read_text())
-            except (OSError, json.JSONDecodeError):
-                time.sleep(0.02)
-                continue
-            if run_meta.get("status") == "planning":
-                break
-            time.sleep(0.02)
-        else:
-            pytest.fail("direct run did not reach planning before SIGTERM")
+        # run.json status=planning is written before the blocked plan loop.
+        # Poll that durable receipt field with a load-tolerant bound; a 5s
+        # window loses to child import + journaled phase writes on a
+        # saturated CI runner.
+        try:
+            thread_sync.wait_for_predicate(
+                planning_phase_ready,
+                description="run receipt status=planning",
+                poll_interval=0.02,
+            )
+        except AssertionError as exc:
+            pytest.fail(f"direct run did not reach planning before SIGTERM: {exc}")
 
         proc.send_signal(signal.SIGTERM)
         assert proc.wait(timeout=5) == 128 + signal.SIGTERM

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -2107,20 +2107,31 @@ raise SystemExit(cli.main([
     child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
     child = subprocess.Popen([sys.executable, "-c", script], env=child_env, start_new_session=True)
     worker_pid = None
+
+    def blocked_dispatch_ready() -> bool:
+        nonlocal worker_pid
+        if child.poll() is not None:
+            pytest.fail(f"run exited before reaching blocked dispatch (rc={child.returncode})")
+        try:
+            run_meta = json.loads((output_dir / "run.json").read_text())
+            worker_pid = int(worker_pid_path.read_text())
+        except (OSError, ValueError, json.JSONDecodeError):
+            return False
+        return run_meta.get("status") == "dispatching"
+
     try:
-        deadline = time.monotonic() + 5
-        while time.monotonic() < deadline:
-            try:
-                run_meta = json.loads((output_dir / "run.json").read_text())
-                worker_pid = int(worker_pid_path.read_text())
-            except (OSError, ValueError, json.JSONDecodeError):
-                time.sleep(0.02)
-                continue
-            if run_meta.get("status") == "dispatching":
-                break
-            time.sleep(0.02)
-        else:
-            pytest.fail("run did not reach a blocked dispatch")
+        # run.json status=dispatching plus the worker pid file mark the
+        # blocked worker. Poll those durable markers with a load-tolerant
+        # bound; a 5s window loses to child import + journaled phase writes
+        # on a saturated CI runner.
+        try:
+            thread_sync.wait_for_predicate(
+                blocked_dispatch_ready,
+                description="run receipt status=dispatching with worker pid",
+                poll_interval=0.02,
+            )
+        except AssertionError as exc:
+            pytest.fail(f"run did not reach a blocked dispatch: {exc}")
 
         child.send_signal(sig)
         assert child.wait(timeout=3) == expected_code


### PR DESCRIPTION
Fixes #1212.

**Root cause**: `test_handoff_sigterm_terminalizes_nonterminal_receipt` polled `run.json` for `status=handoff` with a fixed 5s deadline. Under CI load the child's import plus the orchestrator's journaled phase writes overran it, the poll gave up with `run did not reach handoff before SIGTERM`, and the signal was never sent. The orchestrator already writes `status=handoff` durably (journal + checkpoint + fsync) before `write_run_handoff`, so there was a reliable marker; the test just did not wait for it.

**Fix** (test-only, two commits):
- `1599e334`: the handoff test waits on the receipt field through `tests.thread_sync.wait_for_predicate` (30s bound), failing fast if the child exits early.
- `a91b082d`: the two sibling tests with the same 5s pattern get the same treatment: `test_direct_run_terminalizes_sigterm_in_subprocess` waits on `status=planning`; `test_run_cli_cancels_blocked_worker_process_before_releasing_lock` waits on `status=dispatching` plus a readable `worker.pid`.

Terminalization and cancellation assertions are unchanged. Two further 5s waits in `tests/test_run_cli.py` (control-setup ~1984, GraphTrail baseline ~2193) were left alone; they can get the same treatment if they ever flake.

Implemented by `brigade run` cursor_grok worker seats; each named test passed 5/5 consecutive runs. Independently verified: `test_aboyeur.py` + `test_run_cli.py` (373 tests) exit 0, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)