### PR TITLE
chore(ci): bump checkout, setup-python, paths-filter, upload/download-artifact majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       evidence_ledger: ${{ steps.filter.outputs.evidence_ledger }}
       notify: ${{ steps.filter.outputs.notify }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -50,7 +50,7 @@ jobs:
       run:
         working-directory: engines/code-graph
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: 1.85.0
@@ -69,7 +69,7 @@ jobs:
       run:
         working-directory: engines/code-graph
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
@@ -111,7 +111,7 @@ jobs:
       run:
         working-directory: engines/code-graph
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
@@ -130,7 +130,7 @@ jobs:
       run:
         working-directory: engines/code-graph
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
@@ -148,7 +148,7 @@ jobs:
       run:
         working-directory: engines/evidence-ledger
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -176,7 +176,7 @@ jobs:
         # Override job default: checkout is gated, so stations/notify is absent.
         working-directory: ${{ github.workspace }}
         run: echo "stations/notify unchanged; required check satisfied without running Go tests."
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         if: ${{ needs.changes.outputs.notify == 'true' }}
         with:
           persist-credentials: false
@@ -225,7 +225,7 @@ jobs:
         # Override job default: checkout is gated, so stations/notify is absent.
         working-directory: ${{ github.workspace }}
         run: echo "stations/notify unchanged; required check satisfied without running Go tests."
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         if: ${{ needs.changes.outputs.notify == 'true' }}
         with:
           persist-credentials: false
@@ -247,8 +247,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -283,8 +283,8 @@ jobs:
         python: ["3.10", "3.11", "3.12"]
         shard: [0, 1, 2, 3]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -303,7 +303,7 @@ jobs:
         run: python scripts/ci_pytest_shard.py --shard-index "${{ matrix.shard }}" --shard-count 4 -- -q --cov=brigade --cov-report=
       - name: Upload coverage data
         if: matrix.python == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python }}-${{ matrix.shard }}
           path: .coverage.${{ matrix.python }}.${{ matrix.shard }}
@@ -314,8 +314,8 @@ jobs:
     needs: test-shards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -325,7 +325,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
       - name: Download coverage data
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
           path: .coverage-data
@@ -357,8 +357,8 @@ jobs:
   component-manifest-provenance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -373,15 +373,15 @@ jobs:
   content-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           path: brigade
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           repository: solomonneas/content-guard
           ref: v0.1.1
           path: content-guard
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Scan
@@ -393,8 +393,8 @@ jobs:
   repo-metadata:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -457,8 +457,8 @@ jobs:
           - name: "repo+claude+publisher"
             flags: "--depth repo --harnesses claude --include publisher"
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: pipx install
@@ -500,8 +500,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: pipx install
@@ -566,8 +566,8 @@ jobs:
     name: windows-native-acceptance
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Run Windows native acceptance (source install)

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -17,8 +17,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: Derive and stamp the development wheel version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Verify tag matches every declared version
         env:
           TAG: ${{ github.ref_name }}
@@ -80,7 +80,7 @@ jobs:
       run:
         working-directory: engines/code-graph
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
@@ -104,7 +104,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE/release-assets" | Out-Null
           Copy-Item target/release/graphtrail.exe "$env:GITHUB_WORKSPACE/release-assets/graphtrail-${{ matrix.platform }}.exe"
           Copy-Item target/release/graphtrail-mcp.exe "$env:GITHUB_WORKSPACE/release-assets/graphtrail-mcp-${{ matrix.platform }}.exe"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: rust-${{ matrix.platform }}
           path: release-assets/
@@ -138,7 +138,7 @@ jobs:
       run:
         working-directory: engines/evidence-ledger
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -154,7 +154,7 @@ jobs:
           if [ "$GOOS" = windows ]; then suffix=.exe; fi
           go build -trimpath -o "$GITHUB_WORKSPACE/release-assets/miseledger-${{ matrix.platform }}$suffix" ./cmd/miseledger
           go build -trimpath -o "$GITHUB_WORKSPACE/release-assets/sessionfind-${{ matrix.platform }}$suffix" ./cmd/sessionfind
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: go-${{ matrix.platform }}
           path: release-assets/
@@ -188,7 +188,7 @@ jobs:
       run:
         working-directory: stations/notify
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -212,7 +212,7 @@ jobs:
           VERSION="${AGENT_NOTIFY_TAG#v}"
           BUILD_DATE="$(date -u -d "@$(git show -s --format=%ct ${AGENT_NOTIFY_COMMIT})" +%Y-%m-%dT%H:%M:%SZ)"
           go build -trimpath -ldflags "-X main.version=${VERSION} -X main.commit=${AGENT_NOTIFY_COMMIT} -X main.buildDate=${BUILD_DATE} -s -w" -o "$GITHUB_WORKSPACE/release-assets/agent-notify-${{ matrix.platform }}$suffix" ./cmd/agent-notify
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: agent-notify-${{ matrix.platform }}
           path: release-assets/
@@ -227,16 +227,16 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: rust-*
           path: downloaded/rust
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: go-*
           path: downloaded/go
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: agent-notify-*
           path: downloaded/agent-notify
@@ -282,7 +282,7 @@ jobs:
             release-assets/agent-notify-darwin-arm64
             release-assets/agent-notify-windows-amd64.exe
             release-assets/component-manifest-v1.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: unified-release-assets
           path: release-assets/
@@ -294,7 +294,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: unified-release-assets
           path: release-assets
@@ -364,7 +364,7 @@ jobs:
       attestations: read
       artifact-metadata: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Redownload, checksum, provenance, and attestation gate
         env:
           GH_TOKEN: ${{ github.token }}
@@ -388,12 +388,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: unified-release-assets
           path: release-assets
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: Replace the packaged manifest with the release manifest
@@ -439,8 +439,8 @@ jobs:
             kind: windows
             extra: ''
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: Ensure Rosetta for darwin-amd64 smoke

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -20,7 +20,7 @@ def test_ci_workflow_path_filter_has_valid_structure_and_engine_paths():
 
     assert "jobs:\n  changes:" in text
     assert "runs-on: ubuntu-latest" in changes
-    assert "uses: dorny/paths-filter@v3" in changes
+    assert "uses: dorny/paths-filter@v4" in changes
     assert "code_graph: ${{ steps.filter.outputs.code_graph }}" in changes
     assert "evidence_ledger: ${{ steps.filter.outputs.evidence_ledger }}" in changes
     assert "notify: ${{ steps.filter.outputs.notify }}" in changes
@@ -125,7 +125,7 @@ def test_ci_workflow_notify_jobs_run_go_steps_only_when_notify_paths_change():
         ),
     ):
         section = _workflow_job_section(text, job_name)
-        for uses in ("actions/checkout@v5", "actions/setup-go@v5"):
+        for uses in ("actions/checkout@v7", "actions/setup-go@v5"):
             uses_at = 0
             while True:
                 try:
@@ -320,9 +320,9 @@ def test_ci_workflow_combines_python312_coverage_and_preserves_required_checks()
     assert "COVERAGE_FILE: .coverage.${{ matrix.python }}.${{ matrix.shard }}" in shards
     assert "--cov=brigade --cov-report=\n" in shards
     assert "--cov-report=term" not in shards
-    assert "uses: actions/upload-artifact@v4" in shards
+    assert "uses: actions/upload-artifact@v7" in shards
     assert "include-hidden-files: true" in shards
-    assert "uses: actions/download-artifact@v5" in coverage
+    assert "uses: actions/download-artifact@v8" in coverage
     assert "pattern: coverage-*" in coverage
     assert "python -m coverage combine .coverage-data" in coverage
     assert "python -m coverage report --fail-under=78" in coverage

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -208,7 +208,7 @@ def test_publish_workflow_builds_five_agent_notify_binaries_with_release_metadat
     # The wall-clock form must be absent so a re-run cannot drift the build date.
     assert 'BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"' not in section
     assert "date -u +%Y-%m-%dT%H:%M:%SZ" not in section
-    assert "actions/upload-artifact@v4" in section
+    assert "actions/upload-artifact@v7" in section
     assert "if-no-files-found: error" in section
 
 


### PR DESCRIPTION
Consolidates Dependabot's four GitHub Actions major bumps (#1287 setup-python v7, #1288 checkout v7, #1289 paths-filter v4, #1290 upload-artifact v7) into one PR, plus the paired `actions/download-artifact` v4/v5 -> v8 that Dependabot did not propose.

| action | from -> to | uses |
|---|---|---|
| actions/checkout | v5 -> v7 | 27 |
| actions/setup-python | v6 -> v7 | 12 |
| dorny/paths-filter | v3 -> v4 | 1 |
| actions/upload-artifact | v4 -> v7 | 5 |
| actions/download-artifact | v4/v5 -> v8 | 6 |

Why one PR: `tests/test_ci_workflow.py` and `tests/test_publish_workflow.py` assert these exact version strings (the reason #1290 failed CI), so the workflows and the tests have to move in the same commit. The `setup-python@v5` and `upload-artifact@v3` strings in `test_security_cmd.py` and `test_release_ci_health_cmd.py` are scanner fixtures and are untouched.

Verified: the four workflow test files (197 tests) exit 0, ruff clean, all three workflow YAMLs parse with no stale pins remaining. The CI run on this PR is the real proof for the runtime behaviour of the new majors.

Note: the `dependencies` label referenced by `.github/dependabot.yml` does not exist in the repo yet, so Dependabot PRs arrive unlabelled; creating it is a one-click repo setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)