### PR TITLE
fix(hooks): never drop timeout-latch increments; bound overflow retries to the follow-up window

### DIFF
--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -3164,6 +3164,7 @@ def _run_best_effort_bounded(
     *,
     timeout: float,
     default: Any,
+    on_abandon: Callable[[], None] | None = None,
 ) -> Any:
     """Run ``fn`` in a daemon thread; return ``default`` if it exceeds ``timeout``.
 
@@ -3191,6 +3192,11 @@ def _run_best_effort_bounded(
     thread = threading.Thread(target=_run, name="brigade-hook-best-effort", daemon=True)
     thread.start()
     if not done.wait(timeout=max(timeout, 0.0)):
+        if on_abandon is not None:
+            try:
+                on_abandon()
+            except Exception:  # noqa: BLE001 - parent must still emit a valid envelope
+                pass
         return default
     return box[0]
 

--- a/src/brigade/claude_hooks/session_state.py
+++ b/src/brigade/claude_hooks/session_state.py
@@ -18,9 +18,10 @@ _SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
 _SESSION_STATE_PROCESS_LOCKS: dict[str, threading.Lock] = {}
 _TIMEOUT_JOURNAL_MAX_LINES = 16
 _TIMEOUT_JOURNAL_MAX_BYTES = 4096
-_TIMEOUT_LOCK_RETRIES = 3
+_PENDING_MAX_BYTES = 65536
 _ANNOUNCE_TOKEN = b"announced"
 _ANNOUNCE_CLAIMED_KEY = "hook_announce_claimed"
+_FOLLOWUP_ABANDON_PENDING_LOG = "timeout follow-up abandoned; pending increment will fold later"
 
 
 def _rt() -> Any:
@@ -28,6 +29,30 @@ def _rt() -> Any:
     from . import runtime
 
     return runtime
+
+
+def _timeout_lock_attempts() -> int:
+    """Return how many lock waits fit strictly inside the follow-up window."""
+    followup = float(_rt()._TIMEOUT_FOLLOWUP_SECONDS)
+    lock = float(_rt()._SESSION_STATE_LOCK_SECONDS)
+    if lock <= 0:
+        return 1
+    attempts = 0
+    while (attempts + 1) * lock < followup:
+        attempts += 1
+    return max(1, attempts)
+
+
+def _timeout_retry_wall_seconds() -> float:
+    """Worst-case lock-wait time for one overflow record attempt."""
+    return _timeout_lock_attempts() * float(_rt()._SESSION_STATE_LOCK_SECONDS)
+
+
+def __getattr__(name: str) -> Any:
+    """Expose the derived retry count so tests can assert on the live budget."""
+    if name == "_TIMEOUT_LOCK_RETRIES":
+        return _timeout_lock_attempts() - 1
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _reset_session_state_locks() -> None:
@@ -57,9 +82,19 @@ def _timeouts_path(state_path: Path) -> Path:
     return Path(f"{state_path}.timeouts")
 
 
+def _pending_path(state_path: Path) -> Path:
+    """Return the overflow pending-increment sidecar beside one session state file."""
+    return Path(f"{state_path}.timeouts.pending")
+
+
 def _journal_path(target: Path, session_id: str) -> Path:
     state_path = _rt()._state_path(target.expanduser().resolve(), session_id)
     return _timeouts_path(state_path)
+
+
+def _pending_increment_path(target: Path, session_id: str) -> Path:
+    state_path = _rt()._state_path(target.expanduser().resolve(), session_id)
+    return _pending_path(state_path)
 
 
 def _journal_path_is_safe_without_nofollow(path: Path) -> bool:
@@ -119,22 +154,25 @@ def _parse_timeout_journal(data: bytes) -> tuple[int, bool, str | None]:
     return count, announced, first_claim
 
 
-def _read_timeout_journal(target: Path, session_id: str) -> tuple[int, bool, str | None]:
-    """Read the timeout journal, or ``(0, False, None)`` on refusal or failure."""
-    path = _journal_path(target, session_id)
+def _read_sidecar_bytes(path: Path, max_bytes: int) -> bytes:
+    """Read one sidecar through the journal's O_NOFOLLOW / identity checks."""
     try:
         if not _journal_path_is_safe_without_nofollow(path):
-            return 0, False, None
+            return b""
         fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
         try:
             if not _journal_fd_is_safe(fd, path):
-                return 0, False, None
-            data = os.read(fd, _TIMEOUT_JOURNAL_MAX_BYTES)
+                return b""
+            return os.read(fd, max_bytes)
         finally:
             os.close(fd)
     except OSError:
-        return 0, False, None
-    return _parse_timeout_journal(data)
+        return b""
+
+
+def _read_timeout_journal(target: Path, session_id: str) -> tuple[int, bool, str | None]:
+    """Read the timeout journal, or ``(0, False, None)`` on refusal or failure."""
+    return _parse_timeout_journal(_read_sidecar_bytes(_journal_path(target, session_id), _TIMEOUT_JOURNAL_MAX_BYTES))
 
 
 def _journal_timeout_count(target: Path, session_id: str) -> int:
@@ -142,9 +180,8 @@ def _journal_timeout_count(target: Path, session_id: str) -> int:
     return _read_timeout_journal(target, session_id)[0]
 
 
-def _append_journal_line(target: Path, session_id: str, payload: bytes) -> bool:
-    """Append one journal line with the existing path/byte hardening."""
-    path = _journal_path(target, session_id)
+def _append_sidecar_line(path: Path, payload: bytes, *, max_bytes: int | None) -> bool:
+    """Append one sidecar line with O_NOFOLLOW, 0600, and identity checks."""
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         if not _journal_path_is_safe_without_nofollow(path):
@@ -154,7 +191,7 @@ def _append_journal_line(target: Path, session_id: str, payload: bytes) -> bool:
         try:
             if not _journal_fd_is_safe(fd, path):
                 return False
-            if os.fstat(fd).st_size >= _TIMEOUT_JOURNAL_MAX_BYTES:
+            if max_bytes is not None and os.fstat(fd).st_size >= max_bytes:
                 return False
             os.write(fd, payload)
         finally:
@@ -162,6 +199,11 @@ def _append_journal_line(target: Path, session_id: str, payload: bytes) -> bool:
     except OSError:
         return False
     return True
+
+
+def _append_journal_line(target: Path, session_id: str, payload: bytes) -> bool:
+    """Append one journal line with the existing path/byte hardening."""
+    return _append_sidecar_line(_journal_path(target, session_id), payload, max_bytes=_TIMEOUT_JOURNAL_MAX_BYTES)
 
 
 def _append_timeout_journal(target: Path, session_id: str) -> tuple[int, bool]:
@@ -177,6 +219,21 @@ def _append_timeout_journal(target: Path, session_id: str) -> tuple[int, bool]:
 def _append_timeout_marker(target: Path, session_id: str) -> int:
     """Append one timeout marker without taking the session-state lock."""
     return _append_timeout_journal(target, session_id)[0]
+
+
+def _pending_timeout_count(target: Path, session_id: str) -> int:
+    """Return overflow pending-increment markers, or zero on read failure."""
+    data = _read_sidecar_bytes(_pending_increment_path(target, session_id), _PENDING_MAX_BYTES)
+    return sum(1 for raw in data.splitlines() if raw.strip())
+
+
+def _append_pending_increment(target: Path, session_id: str) -> bool:
+    """Persist one overflow increment before a lock retry that may be abandoned."""
+    return _append_sidecar_line(
+        _pending_increment_path(target, session_id),
+        f"{localio.utc_now_iso()}\n".encode(),
+        max_bytes=_PENDING_MAX_BYTES,
+    )
 
 
 def _persisted_announce_claimed(state: object) -> bool:
@@ -209,9 +266,18 @@ def _timeout_journal_folded(state: dict[str, Any]) -> int:
     return folded if isinstance(folded, int) and not isinstance(folded, bool) and folded >= 0 else 0
 
 
-def _effective_timeout_count(state: dict[str, Any], journal_lines: int) -> int:
-    """Return state count plus journal markers not yet folded into it."""
-    return _timeout_state_count(state) + max(journal_lines - _timeout_journal_folded(state), 0)
+def _timeout_pending_folded(state: dict[str, Any]) -> int:
+    folded = state.get("hook_timeout_pending_folded")
+    return folded if isinstance(folded, int) and not isinstance(folded, bool) and folded >= 0 else 0
+
+
+def _effective_timeout_count(state: dict[str, Any], journal_lines: int, pending_lines: int = 0) -> int:
+    """Return state count plus journal and pending markers not yet folded into it."""
+    return (
+        _timeout_state_count(state)
+        + max(journal_lines - _timeout_journal_folded(state), 0)
+        + max(pending_lines - _timeout_pending_folded(state), 0)
+    )
 
 
 @contextlib.contextmanager
@@ -246,11 +312,12 @@ def _session_state_lock(target: Path, session_id: str) -> Iterator[None]:
 
 def _read_hook_latch(target: Path, session_id: str) -> tuple[bool, bool]:
     journal_lines, journal_announced, _claim = _read_timeout_journal(target, session_id)
+    pending_lines = _pending_timeout_count(target, session_id)
     state = _rt().read_session_state(target, session_id)
     current_state = state if isinstance(state, dict) else {}
     latched = (
         current_state.get("hook_latched") is True
-        or _effective_timeout_count(current_state, journal_lines) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
+        or _effective_timeout_count(current_state, journal_lines, pending_lines) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
     )
     if not latched:
         return False, False
@@ -290,6 +357,17 @@ def _write_session_state_preserving_latch(
                 updated["hook_timeout_journal_folded"] = max(folded_counts)
             else:
                 updated.pop("hook_timeout_journal_folded", None)
+            current_pending = current_state.get("hook_timeout_pending_folded")
+            next_pending = updated.get("hook_timeout_pending_folded")
+            pending_counts = [
+                pending
+                for pending in (current_pending, next_pending)
+                if isinstance(pending, int) and not isinstance(pending, bool)
+            ]
+            if pending_counts:
+                updated["hook_timeout_pending_folded"] = max(pending_counts)
+            else:
+                updated.pop("hook_timeout_pending_folded", None)
             updated["hook_latched"] = current_state.get("hook_latched") is True or updated.get("hook_latched") is True
             updated["hook_latch_announced"] = (
                 current_state.get("hook_latch_announced") is True or updated.get("hook_latch_announced") is True
@@ -322,16 +400,22 @@ def _with_announce_claim(state: dict[str, Any], claimed: bool) -> dict[str, Any]
 def _record_hook_timeout(target: Path, session_id: str, *, announce: bool = False) -> dict[str, Any]:
     state = _rt().read_session_state(target, session_id)
     fallback: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
+    overflowed = False
+    if _journal_timeout_count(target, session_id) >= _TIMEOUT_JOURNAL_MAX_LINES:
+        overflowed = _append_pending_increment(target, session_id)
     last_timeout: inbox_lock.InboxLockTimeout | None = None
-    for _attempt in range(_TIMEOUT_LOCK_RETRIES + 1):
+    for _attempt in range(_timeout_lock_attempts()):
         try:
             with _rt()._session_state_lock(target, session_id):
                 journal_lines = _journal_timeout_count(target, session_id)
+                pending_lines = _pending_timeout_count(target, session_id)
                 state = _rt().read_session_state(target, session_id)
                 updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
-                next_count = _effective_timeout_count(updated, journal_lines) + 1
+                extra = 0 if overflowed else 1
+                next_count = _effective_timeout_count(updated, journal_lines, pending_lines) + extra
                 updated["hook_timeout_count"] = next_count
                 updated["hook_timeout_journal_folded"] = journal_lines
+                updated["hook_timeout_pending_folded"] = pending_lines
                 already_announced = _persisted_announce_claimed(updated)
                 _apply_timeout_latch(updated, next_count)
                 _rt().write_session_state(target, session_id, updated)
@@ -343,11 +427,14 @@ def _record_hook_timeout(target: Path, session_id: str, *, announce: bool = Fals
             last_timeout = exc
             _, persisted = _append_timeout_journal(target, session_id)
             if not persisted:
+                if not overflowed:
+                    overflowed = _append_pending_increment(target, session_id)
                 continue
             fresh = _rt().read_session_state(target, session_id)
             current: dict[str, Any] = dict(fresh) if isinstance(fresh, dict) else dict(fallback)
             journal_lines, journal_announced, _claim = _read_timeout_journal(target, session_id)
-            next_count = _effective_timeout_count(current, journal_lines)
+            pending_lines = _pending_timeout_count(target, session_id)
+            next_count = _effective_timeout_count(current, journal_lines, pending_lines)
             current["hook_timeout_count"] = next_count
             _apply_timeout_latch(current, next_count)
             already = journal_announced or _persisted_announce_claimed(current)
@@ -364,16 +451,19 @@ def _clear_hook_timeouts(target: Path, session_id: str) -> None:
     try:
         with _rt()._session_state_lock(target, session_id):
             journal_lines = _journal_timeout_count(target, session_id)
+            pending_lines = _pending_timeout_count(target, session_id)
             state = _rt().read_session_state(target, session_id)
             current_state = state if isinstance(state, dict) else {}
             if (
                 current_state.get("hook_latched") is True
-                or _effective_timeout_count(current_state, journal_lines) >= _rt().HOOK_TIMEOUT_LATCH_AFTER
+                or _effective_timeout_count(current_state, journal_lines, pending_lines)
+                >= _rt().HOOK_TIMEOUT_LATCH_AFTER
             ):
                 return
             updated = dict(current_state) if current_state else {"session_id": session_id}
             updated["hook_timeout_count"] = 0
             updated["hook_timeout_journal_folded"] = journal_lines
+            updated["hook_timeout_pending_folded"] = pending_lines
             _rt().write_session_state(target, session_id, updated)
     except inbox_lock.InboxLockTimeout:
         return
@@ -390,7 +480,18 @@ def _apply_timeout_followup_inprocess(
     try:
         state = _rt()._record_hook_timeout(target, session_id, announce=True)
     except OSError:
-        return "degraded"
+        journal_lines, journal_announced, _claim = _read_timeout_journal(target, session_id)
+        pending_lines = _pending_timeout_count(target, session_id)
+        fresh = _rt().read_session_state(target, session_id)
+        recovered: dict[str, Any] = dict(fresh) if isinstance(fresh, dict) else {"session_id": session_id}
+        next_count = _effective_timeout_count(recovered, journal_lines, pending_lines)
+        recovered["hook_timeout_count"] = next_count
+        _apply_timeout_latch(recovered, next_count)
+        already = journal_announced or _persisted_announce_claimed(recovered)
+        claimed = False
+        if recovered.get("hook_latched") is True and not already:
+            claimed = _claim_timeout_announce(target, session_id)
+        state = _with_announce_claim(recovered, claimed)
     if state.get(_ANNOUNCE_CLAIMED_KEY) is True:
         outcome = "latched"
     elif state.get("hook_latched") is True:
@@ -424,9 +525,21 @@ def _bounded_timeout_followup(event: str, log_target: Path, session_id: str, exc
     def publish(outcome: str) -> None:
         published[0] = outcome
 
+    def mark_abandon() -> None:
+        try:
+            state = _rt().read_session_state(log_target, session_id)
+            current = state if isinstance(state, dict) else {}
+            pending = _pending_timeout_count(log_target, session_id)
+            if max(pending - _timeout_pending_folded(current), 0) <= 0:
+                return
+            envelope.append_log(log_target, f"{event}: {_FOLLOWUP_ABANDON_PENDING_LOG}")
+        except OSError:
+            return
+
     _rt()._run_best_effort_bounded(
         lambda: _rt()._apply_timeout_followup_inprocess(event, log_target, session_id, detail, publish=publish),
         timeout=_rt()._TIMEOUT_FOLLOWUP_SECONDS,
         default="degraded",
+        on_abandon=mark_abandon,
     )
     return published[0]

--- a/src/brigade/claude_hooks/session_state.py
+++ b/src/brigade/claude_hooks/session_state.py
@@ -18,6 +18,7 @@ _SESSION_STATE_PROCESS_LOCKS_GUARD = threading.Lock()
 _SESSION_STATE_PROCESS_LOCKS: dict[str, threading.Lock] = {}
 _TIMEOUT_JOURNAL_MAX_LINES = 16
 _TIMEOUT_JOURNAL_MAX_BYTES = 4096
+_TIMEOUT_LOCK_RETRIES = 3
 _ANNOUNCE_TOKEN = b"announced"
 _ANNOUNCE_CLAIMED_KEY = "hook_announce_claimed"
 
@@ -163,19 +164,19 @@ def _append_journal_line(target: Path, session_id: str, payload: bytes) -> bool:
     return True
 
 
-def _append_timeout_journal(target: Path, session_id: str) -> int:
+def _append_timeout_journal(target: Path, session_id: str) -> tuple[int, bool]:
     """Append one timeout occurrence without taking the session-state lock."""
     journal_lines, _already_announced, _first = _read_timeout_journal(target, session_id)
     if journal_lines >= _TIMEOUT_JOURNAL_MAX_LINES:
-        return journal_lines
+        return journal_lines, False
     if not _append_journal_line(target, session_id, f"{localio.utc_now_iso()}\n".encode()):
-        return journal_lines
-    return _read_timeout_journal(target, session_id)[0]
+        return journal_lines, False
+    return _read_timeout_journal(target, session_id)[0], True
 
 
 def _append_timeout_marker(target: Path, session_id: str) -> int:
     """Append one timeout marker without taking the session-state lock."""
-    return _append_timeout_journal(target, session_id)
+    return _append_timeout_journal(target, session_id)[0]
 
 
 def _persisted_announce_claimed(state: object) -> bool:
@@ -321,36 +322,42 @@ def _with_announce_claim(state: dict[str, Any], claimed: bool) -> dict[str, Any]
 def _record_hook_timeout(target: Path, session_id: str, *, announce: bool = False) -> dict[str, Any]:
     state = _rt().read_session_state(target, session_id)
     fallback: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
-    try:
-        with _rt()._session_state_lock(target, session_id):
-            journal_lines = _journal_timeout_count(target, session_id)
-            state = _rt().read_session_state(target, session_id)
-            updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
-            next_count = _effective_timeout_count(updated, journal_lines) + 1
-            updated["hook_timeout_count"] = next_count
-            updated["hook_timeout_journal_folded"] = journal_lines
-            already_announced = _persisted_announce_claimed(updated)
-            _apply_timeout_latch(updated, next_count)
-            _rt().write_session_state(target, session_id, updated)
-        claimed = False
-        if announce and updated.get("hook_latched") is True and not already_announced:
-            claimed = _claim_timeout_announce(target, session_id)
-        return _with_announce_claim(updated, claimed)
-    except inbox_lock.InboxLockTimeout:
-        journal_count = _append_timeout_marker(target, session_id)
-        fresh = _rt().read_session_state(target, session_id)
-        current: dict[str, Any] = dict(fresh) if isinstance(fresh, dict) else dict(fallback)
-        journal_lines, journal_announced, _claim = _read_timeout_journal(target, session_id)
-        next_count = (
-            _effective_timeout_count(current, journal_lines) if journal_count else _timeout_state_count(current) + 1
-        )
-        current["hook_timeout_count"] = next_count
-        _apply_timeout_latch(current, next_count)
-        already = journal_announced or _persisted_announce_claimed(current)
-        claimed = False
-        if announce and current.get("hook_latched") is True and not already:
-            claimed = _claim_timeout_announce(target, session_id)
-        return _with_announce_claim(current, claimed)
+    last_timeout: inbox_lock.InboxLockTimeout | None = None
+    for _attempt in range(_TIMEOUT_LOCK_RETRIES + 1):
+        try:
+            with _rt()._session_state_lock(target, session_id):
+                journal_lines = _journal_timeout_count(target, session_id)
+                state = _rt().read_session_state(target, session_id)
+                updated: dict[str, Any] = dict(state) if isinstance(state, dict) else {"session_id": session_id}
+                next_count = _effective_timeout_count(updated, journal_lines) + 1
+                updated["hook_timeout_count"] = next_count
+                updated["hook_timeout_journal_folded"] = journal_lines
+                already_announced = _persisted_announce_claimed(updated)
+                _apply_timeout_latch(updated, next_count)
+                _rt().write_session_state(target, session_id, updated)
+            claimed = False
+            if announce and updated.get("hook_latched") is True and not already_announced:
+                claimed = _claim_timeout_announce(target, session_id)
+            return _with_announce_claim(updated, claimed)
+        except inbox_lock.InboxLockTimeout as exc:
+            last_timeout = exc
+            _, persisted = _append_timeout_journal(target, session_id)
+            if not persisted:
+                continue
+            fresh = _rt().read_session_state(target, session_id)
+            current: dict[str, Any] = dict(fresh) if isinstance(fresh, dict) else dict(fallback)
+            journal_lines, journal_announced, _claim = _read_timeout_journal(target, session_id)
+            next_count = _effective_timeout_count(current, journal_lines)
+            current["hook_timeout_count"] = next_count
+            _apply_timeout_latch(current, next_count)
+            already = journal_announced or _persisted_announce_claimed(current)
+            claimed = False
+            if announce and current.get("hook_latched") is True and not already:
+                claimed = _claim_timeout_announce(target, session_id)
+            return _with_announce_claim(current, claimed)
+    if last_timeout is None:
+        raise RuntimeError("timeout retry loop exited without InboxLockTimeout")
+    raise last_timeout
 
 
 def _clear_hook_timeouts(target: Path, session_id: str) -> None:

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -21,6 +21,7 @@ import pytest
 
 from brigade.claude_hooks import envelope, runtime
 from brigade.work_cmd import inbox_lock
+from tests import thread_sync
 from tests.test_claude_hooks_user_target import PACKAGE_REF, _payload, _wired_claude
 
 
@@ -598,20 +599,25 @@ def test_abandoned_overflow_increment_is_recovered_by_next_fold(tmp_path: Path, 
     holder = threading.Thread(target=hold_session_lock)
     holder.start()
     assert acquired.wait(timeout=2)
+    pending_path = session_state._pending_increment_path(target, "s")
     process = mp.get_context("fork").Process(target=_record_hook_timeout_in_fork, args=(target, "s"))
     try:
         process.start()
-        deadline = time.monotonic() + 2
-        pending = 0
-        while time.monotonic() < deadline:
-            pending = session_state._pending_timeout_count(target, "s")
-            if pending >= 1:
-                break
-            time.sleep(0.01)
+        # Sidecar is written immediately before the overflow lock wait. Combined
+        # with a still-live child, this proves we are killing mid-wait rather
+        # than reaping a child that already exhausted its retry and exited.
+        thread_sync.wait_for_predicate(
+            lambda: pending_path.is_file() and process.is_alive(),
+            description="overflow child wrote *.json.timeouts.pending and is still in the lock wait",
+        )
+        assert process.is_alive()
+        assert process.exitcode is None
+        pending = session_state._pending_timeout_count(target, "s")
         assert pending >= 1, "overflow writer must persist a pending increment before the retry wait"
-        os.kill(process.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        assert process.pid is not None
+        os.kill(process.pid, signal.SIGKILL)
         process.join(timeout=2)
-        assert not process.is_alive()
+        assert process.exitcode == -signal.SIGKILL
     finally:
         release.set()
         holder.join(timeout=2)

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -12,6 +12,7 @@ import contextlib
 import json
 import multiprocessing as mp
 import os
+import signal
 import threading
 import time
 from pathlib import Path
@@ -35,12 +36,16 @@ def _record_hook_timeout_in_fork(target: Path, session_id: str) -> None:
 
 
 def _persisted_timeout_count(target: Path, session_id: str) -> int:
-    """Return state count plus journal markers not yet folded into it."""
+    """Return state count plus journal and pending markers not yet folded into it."""
     from brigade.claude_hooks import session_state
 
     state = runtime.read_session_state(target, session_id)
     current = state if isinstance(state, dict) else {}
-    return session_state._effective_timeout_count(current, session_state._journal_timeout_count(target, session_id))
+    return session_state._effective_timeout_count(
+        current,
+        session_state._journal_timeout_count(target, session_id),
+        session_state._pending_timeout_count(target, session_id),
+    )
 
 
 def test_session_state_helpers_resolve_runtime_primitives_at_call_time(tmp_path: Path, monkeypatch) -> None:
@@ -293,7 +298,10 @@ def test_concurrent_timeout_increments_are_not_lost(tmp_path: Path) -> None:
 
     def record() -> None:
         for _ in range(25):
-            runtime._record_hook_timeout(target, "s")
+            try:
+                runtime._record_hook_timeout(target, "s")
+            except inbox_lock.InboxLockTimeout:
+                continue
 
     threads = [threading.Thread(target=record) for _ in range(8)]
     for thread in threads:
@@ -308,33 +316,28 @@ def test_concurrent_timeout_increments_are_not_lost(tmp_path: Path) -> None:
 
 
 def test_journal_overflow_retries_lock_instead_of_dropping(tmp_path: Path, monkeypatch) -> None:
-    """A lock-timeout increment past the journal cap must retry the locked write."""
+    """A lock-timeout increment past the journal cap must persist and fold later."""
     from brigade.claude_hooks import session_state
 
     target = _wired_claude(tmp_path)
     overflow = session_state._TIMEOUT_JOURNAL_MAX_LINES + 4
-    overflow_timeouts = 1
-    real_lock = runtime._session_state_lock
 
     @contextlib.contextmanager
-    def gated_lock(lock_target: Path, session_id: str):
-        nonlocal overflow_timeouts
-        journal = session_state._journal_timeout_count(lock_target, session_id)
-        if journal < session_state._TIMEOUT_JOURNAL_MAX_LINES:
-            raise inbox_lock.InboxLockTimeout("busy")
-            yield
-        if overflow_timeouts > 0:
-            overflow_timeouts -= 1
-            raise inbox_lock.InboxLockTimeout("busy")
-            yield
-        with real_lock(lock_target, session_id):
-            yield
+    def timeout_lock(_target: Path, _session_id: str):
+        raise inbox_lock.InboxLockTimeout("busy")
+        yield
 
-    monkeypatch.setattr(runtime, "_session_state_lock", gated_lock)
-    for _ in range(overflow):
-        runtime._record_hook_timeout(target, "s")
+    with monkeypatch.context() as patch:
+        patch.setattr(runtime, "_session_state_lock", timeout_lock)
+        for _ in range(session_state._TIMEOUT_JOURNAL_MAX_LINES):
+            runtime._record_hook_timeout(target, "s")
+        for _ in range(overflow - session_state._TIMEOUT_JOURNAL_MAX_LINES):
+            with pytest.raises(inbox_lock.InboxLockTimeout, match="busy"):
+                runtime._record_hook_timeout(target, "s")
 
     assert _persisted_timeout_count(target, "s") == overflow
+    folded = runtime._record_hook_timeout(target, "s")
+    assert folded["hook_timeout_count"] == overflow + 1
     assert session_state._journal_timeout_count(target, "s") == session_state._TIMEOUT_JOURNAL_MAX_LINES
 
 
@@ -355,7 +358,7 @@ def test_journal_full_and_lock_exhausted_raises(tmp_path: Path, monkeypatch) -> 
 
     with pytest.raises(inbox_lock.InboxLockTimeout, match="busy"):
         runtime._record_hook_timeout(target, "s")
-    assert _persisted_timeout_count(target, "s") == session_state._TIMEOUT_JOURNAL_MAX_LINES
+    assert _persisted_timeout_count(target, "s") == session_state._TIMEOUT_JOURNAL_MAX_LINES + 1
 
 
 def test_held_lock_past_budget_does_not_lose_increments(tmp_path: Path) -> None:
@@ -396,7 +399,7 @@ def test_held_lock_past_budget_does_not_lose_increments(tmp_path: Path) -> None:
     for thread in threads:
         thread.join(timeout=5)
     assert not any(thread.is_alive() for thread in threads)
-    assert errors == []
+    assert all(isinstance(error, inbox_lock.InboxLockTimeout) for error in errors)
     assert _persisted_timeout_count(target, "s") == workers
 
 
@@ -553,6 +556,74 @@ def test_timeout_followup_budget_keeps_handler_headroom() -> None:
     worst = worker + terminate + followup + followup
     assert worst <= DEFAULT_HOOK_TIMEOUT_SECONDS - 0.5
     assert not hasattr(runtime, "_TIMEOUT_FOLLOWUP_OBSERVE_SLACK_SECONDS")
+
+
+def test_timeout_retry_budget_fits_inside_followup() -> None:
+    """Overflow lock retries must finish before the daemon follow-up is abandoned."""
+    from brigade.claude_hooks import session_state
+
+    followup = runtime._TIMEOUT_FOLLOWUP_SECONDS
+    lock = runtime._SESSION_STATE_LOCK_SECONDS
+    wall = session_state._timeout_retry_wall_seconds()
+    assert wall == session_state._timeout_lock_attempts() * lock
+    assert wall < followup
+    assert (session_state._TIMEOUT_LOCK_RETRIES + 1) * lock == wall
+
+
+@pytest.mark.skipif(os.name != "posix", reason="fork/kill abandon simulation is POSIX-only")
+def test_abandoned_overflow_increment_is_recovered_by_next_fold(tmp_path: Path, monkeypatch) -> None:
+    """A killed overflow writer leaves a pending increment that the next fold consumes."""
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+
+    @contextlib.contextmanager
+    def timeout_lock(_target: Path, _session_id: str):
+        raise inbox_lock.InboxLockTimeout("busy")
+        yield
+
+    with monkeypatch.context() as patch:
+        patch.setattr(runtime, "_session_state_lock", timeout_lock)
+        for _ in range(session_state._TIMEOUT_JOURNAL_MAX_LINES):
+            runtime._record_hook_timeout(target, "s")
+
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_session_lock() -> None:
+        with runtime._session_state_lock(target, "s"):
+            acquired.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_session_lock)
+    holder.start()
+    assert acquired.wait(timeout=2)
+    process = mp.get_context("fork").Process(target=_record_hook_timeout_in_fork, args=(target, "s"))
+    try:
+        process.start()
+        deadline = time.monotonic() + 2
+        pending = 0
+        while time.monotonic() < deadline:
+            pending = session_state._pending_timeout_count(target, "s")
+            if pending >= 1:
+                break
+            time.sleep(0.01)
+        assert pending >= 1, "overflow writer must persist a pending increment before the retry wait"
+        os.kill(process.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        process.join(timeout=2)
+        assert not process.is_alive()
+    finally:
+        release.set()
+        holder.join(timeout=2)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=2)
+
+    journaled = session_state._TIMEOUT_JOURNAL_MAX_LINES
+    assert _persisted_timeout_count(target, "s") == journaled + pending
+    recovered = runtime._record_hook_timeout(target, "s")
+    assert recovered["hook_timeout_count"] == journaled + pending + 1
+    assert _persisted_timeout_count(target, "s") == journaled + pending + 1
 
 
 def test_bounded_followup_latches_when_session_lock_times_out(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_claude_hooks_latch_race.py
+++ b/tests/test_claude_hooks_latch_race.py
@@ -34,6 +34,15 @@ def _record_hook_timeout_in_fork(target: Path, session_id: str) -> None:
     runtime._record_hook_timeout(target, session_id)
 
 
+def _persisted_timeout_count(target: Path, session_id: str) -> int:
+    """Return state count plus journal markers not yet folded into it."""
+    from brigade.claude_hooks import session_state
+
+    state = runtime.read_session_state(target, session_id)
+    current = state if isinstance(state, dict) else {}
+    return session_state._effective_timeout_count(current, session_state._journal_timeout_count(target, session_id))
+
+
 def test_session_state_helpers_resolve_runtime_primitives_at_call_time(tmp_path: Path, monkeypatch) -> None:
     from brigade.claude_hooks import session_state
 
@@ -272,6 +281,14 @@ def test_slow_timeout_writes_eventually_latch_and_hold(tmp_path: Path, monkeypat
 
 
 def test_concurrent_timeout_increments_are_not_lost(tmp_path: Path) -> None:
+    """Every increment is persisted in state and/or the timeout journal.
+
+    The per-session lock budget is 0.25s so a contended hook follow-up can
+    fail open to the journal. Under CI load some of the 200 calls take that
+    path; ``hook_timeout_count`` then lags until a later locked write folds
+    the journal. The production latch reads the effective total, so that is
+    the property this test guards.
+    """
     target = _wired_claude(tmp_path)
 
     def record() -> None:
@@ -284,10 +301,103 @@ def test_concurrent_timeout_increments_are_not_lost(tmp_path: Path) -> None:
     for thread in threads:
         thread.join()
 
+    assert _persisted_timeout_count(target, "s") == 200
     state = runtime.read_session_state(target, "s")
     assert state is not None
-    assert state["hook_timeout_count"] == 200
     assert state["hook_latched"] is True
+
+
+def test_journal_overflow_retries_lock_instead_of_dropping(tmp_path: Path, monkeypatch) -> None:
+    """A lock-timeout increment past the journal cap must retry the locked write."""
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    overflow = session_state._TIMEOUT_JOURNAL_MAX_LINES + 4
+    overflow_timeouts = 1
+    real_lock = runtime._session_state_lock
+
+    @contextlib.contextmanager
+    def gated_lock(lock_target: Path, session_id: str):
+        nonlocal overflow_timeouts
+        journal = session_state._journal_timeout_count(lock_target, session_id)
+        if journal < session_state._TIMEOUT_JOURNAL_MAX_LINES:
+            raise inbox_lock.InboxLockTimeout("busy")
+            yield
+        if overflow_timeouts > 0:
+            overflow_timeouts -= 1
+            raise inbox_lock.InboxLockTimeout("busy")
+            yield
+        with real_lock(lock_target, session_id):
+            yield
+
+    monkeypatch.setattr(runtime, "_session_state_lock", gated_lock)
+    for _ in range(overflow):
+        runtime._record_hook_timeout(target, "s")
+
+    assert _persisted_timeout_count(target, "s") == overflow
+    assert session_state._journal_timeout_count(target, "s") == session_state._TIMEOUT_JOURNAL_MAX_LINES
+
+
+def test_journal_full_and_lock_exhausted_raises(tmp_path: Path, monkeypatch) -> None:
+    """When the journal cannot accept another marker, lock timeout is not silent."""
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+
+    @contextlib.contextmanager
+    def timeout_lock(_target: Path, _session_id: str):
+        raise inbox_lock.InboxLockTimeout("busy")
+        yield
+
+    monkeypatch.setattr(runtime, "_session_state_lock", timeout_lock)
+    for _ in range(session_state._TIMEOUT_JOURNAL_MAX_LINES):
+        runtime._record_hook_timeout(target, "s")
+
+    with pytest.raises(inbox_lock.InboxLockTimeout, match="busy"):
+        runtime._record_hook_timeout(target, "s")
+    assert _persisted_timeout_count(target, "s") == session_state._TIMEOUT_JOURNAL_MAX_LINES
+
+
+def test_held_lock_past_budget_does_not_lose_increments(tmp_path: Path) -> None:
+    """Real lock contention past the 0.25s budget still persists every increment."""
+    from brigade.claude_hooks import session_state
+
+    target = _wired_claude(tmp_path)
+    workers = session_state._TIMEOUT_JOURNAL_MAX_LINES + 4
+    acquired = threading.Event()
+    release = threading.Event()
+    errors: list[BaseException] = []
+
+    def hold_session_lock() -> None:
+        with runtime._session_state_lock(target, "s"):
+            acquired.set()
+            release.wait(timeout=10)
+
+    def record() -> None:
+        try:
+            runtime._record_hook_timeout(target, "s")
+        except BaseException as exc:
+            errors.append(exc)
+
+    holder = threading.Thread(target=hold_session_lock)
+    holder.start()
+    assert acquired.wait(timeout=2)
+    threads = [threading.Thread(target=record) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        if session_state._journal_timeout_count(target, "s") >= session_state._TIMEOUT_JOURNAL_MAX_LINES:
+            break
+        time.sleep(0.01)
+    release.set()
+    holder.join(timeout=2)
+    assert not holder.is_alive()
+    for thread in threads:
+        thread.join(timeout=5)
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    assert _persisted_timeout_count(target, "s") == workers
 
 
 def test_preserving_writer_keeps_latch_from_a_stale_state(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #1295 (seen twice today on unrelated PRs: 193/200 and 189/200).

**Root cause** (production, not the test): when the per-session lock (`_SESSION_STATE_LOCK_SECONDS` = 0.25s) times out, the increment goes to a `*.json.timeouts` journal; past its 16-line cap increments were silently dropped for the rest of the session. The test asserted the raw `hook_timeout_count` field while the effective count also includes the unfolded journal.

**Fix** (three commits, each Daybreak-reviewed):
- `dd2727a0`: when the journal is full, `_record_hook_timeout` retries the locked write and raises `InboxLockTimeout` instead of dropping; the race test asserts the effective persisted total.
- `581ee558`: Daybreak found the retry budget (4 x 0.25s) could outlive the hook's 0.5s daemon follow-up. `_timeout_lock_attempts()` now derives the budget so it stays strictly below `_TIMEOUT_FOLLOWUP_SECONDS` (one attempt, 0.25s today), and a `*.json.timeouts.pending` sidecar (O_NOFOLLOW, 0600, same identity checks) is written *before* the lock wait so an abandoned process leaves a durable increment the next fold consumes (`hook_timeout_pending_folded`). An abandoned follow-up with pending unfolded logs it.
- final: the SIGKILL recovery test requires a live child and a `-SIGKILL` exit so it cannot pass vacuously.

Daybreak (gpt-daybreak-blue, read-only): final pass found no remaining security blocker; confirmed the 14.2s hook wall-time bound is unchanged, `InboxLockTimeout` degrades the hook to exit 0 with a doctor pointer rather than blocking later hooks, and no new symlink/TOCTOU window on the journal or sidecar.

Implemented by `brigade run` cursor_grok worker seats. Independently verified: all nine `tests/test_claude_hooks_*.py` files exit 0, ruff, mypy on `src/brigade/claude_hooks`, and the module-size ratchet clean; the latch-race file passed 5/5 consecutive runs after each round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)