### PR TITLE
feat: add first-party Wazuh triage pack

### DIFF
--- a/docs/plans/2026-08-28-grokbot-findings-wazuh-remediation.md
+++ b/docs/plans/2026-08-28-grokbot-findings-wazuh-remediation.md
@@ -70,21 +70,21 @@ Fleet Hub receives only the persisted opaque `report_event` object: irreversible
 
 ## Slice 2 test-first recipe
 
-- [ ] Write `tests/test_grokbot_wazuh_contracts.py::test_ingest_rejects_unbounded_or_secret_fields`; assert unknown keys, oversized body, raw credentials, and caller-supplied command/path values are rejected.
-- [ ] Run `pytest -q tests/test_grokbot_wazuh_contracts.py::test_ingest_rejects_unbounded_or_secret_fields`; expect failure because the pack does not exist.
-- [ ] Implement the strict contracts and bounded normalizer. The normalized record must contain producer, finding ID, revision, observed time, severity, title, redacted body, source reference, source digest, and content digest.
-- [ ] Run the test; expect it to pass.
-- [ ] Write `tests/test_grokbot_wazuh_policy.py::test_known_noise_expires_to_watch_and_high_confidence_event_escalates`; assert SCA repeats and known installer events classify as suppress/watch with expiry, while a cataloged high-confidence event classifies as escalate.
-- [ ] Run that test; expect failure because classification is absent.
-- [ ] Implement deterministic classification precedence: malformed/unknown -> watch, expired suppression -> watch, explicit suppression -> suppress, matching high-confidence rule and scope -> escalate, otherwise watch.
-- [ ] Run `pytest -q tests/test_grokbot_wazuh_contracts.py tests/test_grokbot_wazuh_normalize.py tests/test_grokbot_wazuh_policy.py`; expect all tests to pass.
-- [ ] Write `tests/test_grokbot_wazuh_tools.py::test_ingest_dedupes_and_emits_one_review_finding`; assert repeated identical fingerprints produce one current finding, one sanitized relay event, and one review draft.
-- [ ] Run it; expect failure because storage/tools are absent.
-- [ ] Implement the private atomic store and six public tools. `wazuh_ingest` accepts only bounded normalized alert batches, `wazuh_alert_status` returns counts and last-seen timestamps, `wazuh_classify` returns category and reason, `wazuh_incident_bundle` returns grouped public findings, `wazuh_propose_remediation` creates a proposal only for `escalate`, and `wazuh_action_status` returns opaque lifecycle state.
-- [ ] Run `pytest -q tests/test_grokbot_wazuh_tools.py tests/test_grokbot_wazuh_store.py`; expect all tests to pass with no raw body in public results.
-- [ ] Write lifecycle tests for default bind collision, preview-only setup, mode-0600 state, canary read path, failed second-write rollback, and exact tool inventory; run `pytest -q tests/test_grokbot_wazuh_lifecycle.py tests/test_grokbot_packs.py tests/test_run_cloud.py` and expect all tests to pass.
-- [ ] Verify through Brigade: `brigade work verify run --target . --command "pytest -q tests/test_grokbot_wazuh_contracts.py tests/test_grokbot_wazuh_normalize.py tests/test_grokbot_wazuh_policy.py tests/test_grokbot_wazuh_store.py tests/test_grokbot_wazuh_tools.py tests/test_grokbot_wazuh_lifecycle.py tests/test_grokbot_packs.py tests/test_run_cloud.py" --capture grokbot-wazuh-triage-pack`; expect a successful receipt.
-- [ ] Commit only the Slice 2 files with `git add src/brigade/grokbot_wazuh src/brigade/grokbot_packs.py src/brigade/cli/run_cloud.py tests/test_grokbot_wazuh* tests/test_grokbot_packs.py tests/test_run_cloud.py && git commit -m "feat: add first-party Wazuh triage pack"`.
+- [x] Write `tests/test_grokbot_wazuh_contracts.py::test_ingest_rejects_unbounded_or_secret_fields`; assert unknown keys, oversized body, raw credentials, and caller-supplied command/path values are rejected.
+- [x] Run `pytest -q tests/test_grokbot_wazuh_contracts.py::test_ingest_rejects_unbounded_or_secret_fields`; expect failure because the pack does not exist.
+- [x] Implement the strict contracts and bounded normalizer. The normalized record must contain producer, finding ID, revision, observed time, severity, title, redacted body, source reference, source digest, and content digest.
+- [x] Run the test; expect it to pass.
+- [x] Write `tests/test_grokbot_wazuh_policy.py::test_known_noise_expires_to_watch_and_high_confidence_event_escalates`; assert SCA repeats and known installer events classify as suppress/watch with expiry, while a cataloged high-confidence event classifies as escalate.
+- [x] Run that test; expect failure because classification is absent.
+- [x] Implement deterministic classification precedence: malformed/unknown -> watch, expired suppression -> watch, explicit suppression -> suppress, matching high-confidence rule and scope -> escalate, otherwise watch.
+- [x] Run `pytest -q tests/test_grokbot_wazuh_contracts.py tests/test_grokbot_wazuh_normalize.py tests/test_grokbot_wazuh_policy.py`; expect all tests to pass.
+- [x] Write `tests/test_grokbot_wazuh_tools.py::test_ingest_dedupes_and_emits_one_review_finding`; assert repeated identical fingerprints produce one current finding, one sanitized relay event, and one review draft.
+- [x] Run it; expect failure because storage/tools are absent.
+- [x] Implement the private atomic store and six public tools. `wazuh_ingest` accepts only bounded normalized alert batches, `wazuh_alert_status` returns counts and last-seen timestamps, `wazuh_classify` returns category and reason, `wazuh_incident_bundle` returns grouped public findings, `wazuh_propose_remediation` creates a proposal only for `escalate`, and `wazuh_action_status` returns opaque lifecycle state.
+- [x] Run `pytest -q tests/test_grokbot_wazuh_tools.py tests/test_grokbot_wazuh_store.py`; expect all tests to pass with no raw body in public results.
+- [x] Write lifecycle tests for default bind collision, preview-only setup, mode-0600 state, canary read path, failed second-write rollback, and exact tool inventory; run `pytest -q tests/test_grokbot_wazuh_lifecycle.py tests/test_grokbot_packs.py` (no `tests/test_run_cloud.py` in this tree; CLI pack/serve coverage lives in the pack and lifecycle tests) and expect all tests to pass.
+- [x] Verify through Brigade: `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_grokbot_wazuh_contracts.py","tests/test_grokbot_wazuh_normalize.py","tests/test_grokbot_wazuh_policy.py","tests/test_grokbot_wazuh_store.py","tests/test_grokbot_wazuh_tools.py","tests/test_grokbot_wazuh_lifecycle.py","tests/test_grokbot_packs.py"]' --capture grokbot-wazuh-triage-pack`; receipt `20260828-224612-work-verify-9e7954` completed with 62 focused tests passing.
+- [x] Commit only the Slice 2 files with `git add src/brigade/grokbot_wazuh src/brigade/grokbot_packs.py src/brigade/cli/run_cloud.py tests/test_grokbot_wazuh* tests/test_grokbot_packs.py && git commit -m "feat: add first-party Wazuh triage pack"`.
 
 ## Slice 3 test-first recipe
 

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -267,7 +267,8 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
     serve_identity = p_grokbot_serve.add_mutually_exclusive_group(required=True)
     serve_identity.add_argument("--instance", choices=("operator", "repository-scout", "implementation-worker"))
     serve_identity.add_argument(
-        "--pack", choices=("cerebro-memory", "fleet-steward", "backup-steward", "obsidian-operator")
+        "--pack",
+        choices=("cerebro-memory", "fleet-steward", "backup-steward", "obsidian-operator", "wazuh-triage"),
     )
     p_grokbot_serve.add_argument(
         "--bind", default=None, help="Listener host:port. Defaults to the role or pack loopback."
@@ -365,25 +366,25 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
         "--runtime-path",
         type=Path,
         default=None,
-        help="Absolute runtime JSON path. Required for fleet-steward, backup-steward, and obsidian-operator.",
+        help="Absolute runtime JSON path. Required for fleet-steward, backup-steward, obsidian-operator, and wazuh-triage.",
     )
     p_pack_setup.add_argument(
         "--ledger-path",
         type=Path,
         default=None,
-        help="Absolute steward ledger path. Required for fleet-steward and backup-steward.",
+        help="Absolute steward ledger path. Required for fleet-steward, backup-steward, and wazuh-triage.",
     )
     p_pack_setup.add_argument(
         "--action-state-path",
         type=Path,
         default=None,
-        help="Absolute action-state directory. Required for fleet-steward, backup-steward, and obsidian-operator.",
+        help="Absolute action-state directory. Required for fleet-steward, backup-steward, obsidian-operator, and wazuh-triage.",
     )
     p_pack_setup.add_argument(
         "--approval-dir",
         type=Path,
         default=None,
-        help="Absolute approval directory. Required for fleet-steward, backup-steward, and obsidian-operator.",
+        help="Absolute approval directory. Required for fleet-steward, backup-steward, obsidian-operator, and wazuh-triage.",
     )
     p_pack_setup.add_argument(
         "--staging-dir",
@@ -906,6 +907,14 @@ def _dispatch_grokbot(args, target: Path) -> int:
                     listener_kwargs["upstream_key_env"] = args.upstream_key_env
                     obsidian_config, obsidian_tools = build_obsidian_listener(target, **listener_kwargs)
                     run_obsidian_listener(obsidian_config, obsidian_tools)
+                elif args.pack == "wazuh-triage":
+                    from ..grokbot_wazuh.lifecycle import (
+                        build_listener_from_target as build_wazuh_listener,
+                        run_listener as run_wazuh_listener,
+                    )
+
+                    wazuh_config, wazuh_tools = build_wazuh_listener(target, **listener_kwargs)
+                    run_wazuh_listener(wazuh_config, wazuh_tools)
                 else:
                     cerebro_config, cerebro_tools = grokbot_cerebro.build_listener_from_target(
                         target, **listener_kwargs
@@ -929,7 +938,14 @@ def _dispatch_grokbot(args, target: Path) -> int:
             print("error: Grok Bot listener configuration is invalid", file=sys.stderr)
             return 2
         except Exception as exc:
-            from .. import grokbot_backup, grokbot_cerebro, grokbot_fleet, grokbot_obsidian, grokbot_packs
+            from .. import (
+                grokbot_backup,
+                grokbot_cerebro,
+                grokbot_fleet,
+                grokbot_obsidian,
+                grokbot_packs,
+                grokbot_wazuh,
+            )
 
             if isinstance(
                 exc,
@@ -939,6 +955,7 @@ def _dispatch_grokbot(args, target: Path) -> int:
                     grokbot_fleet.FleetError,
                     grokbot_obsidian.ObsidianError,
                     grokbot_packs.PackError,
+                    grokbot_wazuh.WazuhError,
                 ),
             ):
                 print("error: Grok Bot listener configuration is invalid", file=sys.stderr)

--- a/src/brigade/grokbot_packs.py
+++ b/src/brigade/grokbot_packs.py
@@ -16,7 +16,15 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
-from . import grokbot_backup, grokbot_cerebro, grokbot_fleet, grokbot_mcp, grokbot_obsidian, grokbot_ops
+from . import (
+    grokbot_backup,
+    grokbot_cerebro,
+    grokbot_fleet,
+    grokbot_mcp,
+    grokbot_obsidian,
+    grokbot_ops,
+    grokbot_wazuh,
+)
 
 PACK_SCHEMA = "brigade.grokbot.connector-pack.v1"
 INSTANCE_SCHEMA = "brigade.grokbot.connector-instance.v1"
@@ -44,8 +52,9 @@ CONNECTOR_DEFAULT_BINDS = {
     "cerebro-memory": "127.0.0.1:8770",
     "fleet-steward": "127.0.0.1:8771",
     "obsidian-operator": "127.0.0.1:8773",
+    "wazuh-triage": "127.0.0.1:8774",
 }
-STEWARD_PACK_IDS = frozenset({"backup-steward", "fleet-steward"})
+STEWARD_PACK_IDS = frozenset({"backup-steward", "fleet-steward", "wazuh-triage"})
 OBSIDIAN_PACK_ID = "obsidian-operator"
 FLEET_INSTANCE_KEYS = INSTANCE_KEYS | frozenset(
     {
@@ -103,6 +112,8 @@ def _connector_tools(pack_id: str) -> frozenset[str]:
         return grokbot_fleet.TOOLS
     if pack_id == OBSIDIAN_PACK_ID:
         return grokbot_obsidian.TOOLS
+    if pack_id == "wazuh-triage":
+        return grokbot_wazuh.TOOLS
     return frozenset()
 
 
@@ -276,6 +287,8 @@ def doctor(target: Path, pack_id: str) -> list[dict[str, str]]:
         return grokbot_backup.doctor(target)
     if pack["id"] == OBSIDIAN_PACK_ID:
         return grokbot_obsidian.doctor(target)
+    if pack["id"] == "wazuh-triage":
+        return grokbot_wazuh.doctor(target)
     return grokbot_cerebro.doctor(target)
 
 
@@ -289,6 +302,8 @@ def canary(target: Path, pack_id: str) -> dict[str, Any]:
         return grokbot_backup.canary(target)
     if pack["id"] == OBSIDIAN_PACK_ID:
         return grokbot_obsidian.canary(target)
+    if pack["id"] == "wazuh-triage":
+        return grokbot_wazuh.canary(target)
     return grokbot_cerebro.canary(target)
 
 
@@ -304,6 +319,8 @@ def render_install_service(target: Path, pack_id: str) -> str:
             return grokbot_backup.render_unit(target, python=sys.executable)
         if pack["id"] == OBSIDIAN_PACK_ID:
             return grokbot_obsidian.render_unit(target, python=sys.executable)
+        if pack["id"] == "wazuh-triage":
+            return grokbot_wazuh.render_unit(target, python=sys.executable)
         return grokbot_cerebro.render_unit(target, python=sys.executable)
     except PackError:
         raise
@@ -317,6 +334,7 @@ def render_install_service(target: Path, pack_id: str) -> str:
                 grokbot_cerebro.CerebroError,
                 grokbot_fleet.FleetError,
                 grokbot_obsidian.ObsidianError,
+                grokbot_wazuh.WazuhError,
             ),
         ):
             raise PackError("unsafe-path") from exc
@@ -341,6 +359,8 @@ def apply_install_service(
             path = grokbot_backup.write_unit(target, out_dir, force=force)
         elif pack["id"] == OBSIDIAN_PACK_ID:
             path = grokbot_obsidian.write_unit(target, out_dir, force=force)
+        elif pack["id"] == "wazuh-triage":
+            path = grokbot_wazuh.write_unit(target, out_dir, force=force)
         else:
             path = grokbot_cerebro.write_unit(target, out_dir, force=force)
     except PackError:
@@ -355,6 +375,7 @@ def apply_install_service(
                 grokbot_cerebro.CerebroError,
                 grokbot_fleet.FleetError,
                 grokbot_obsidian.ObsidianError,
+                grokbot_wazuh.WazuhError,
             ),
         ):
             raise PackError("unsafe-path") from exc
@@ -966,13 +987,20 @@ def _steward_path_references(
                 str(action_state_path),
                 str(approval_dir),
             )
+        if pack_id == "wazuh-triage":
+            return grokbot_wazuh.validate_disjoint_state_paths(
+                str(runtime_path),
+                str(ledger_path),
+                str(action_state_path),
+                str(approval_dir),
+            )
         return grokbot_fleet.validate_disjoint_state_paths(
             str(runtime_path),
             str(ledger_path),
             str(action_state_path),
             str(approval_dir),
         )
-    except (grokbot_backup.BackupError, grokbot_fleet.FleetError) as exc:
+    except (grokbot_backup.BackupError, grokbot_fleet.FleetError, grokbot_wazuh.WazuhError) as exc:
         raise PackError("unsafe-path") from exc
 
 

--- a/src/brigade/grokbot_wazuh/__init__.py
+++ b/src/brigade/grokbot_wazuh/__init__.py
@@ -1,0 +1,65 @@
+"""First-party Grok Bot Wazuh triage connector pack."""
+
+from __future__ import annotations
+
+from .contracts import (
+    DEFAULT_BIND,
+    ERROR_MESSAGES,
+    PACK_ID,
+    TOOLS,
+    WazuhError,
+    parse_action_status_input,
+    parse_alert_status_input,
+    parse_classify_input,
+    parse_identifier,
+    parse_incident_input,
+    parse_ingest_input,
+    parse_opaque_id,
+    parse_propose_input,
+)
+
+__all__ = [
+    "DEFAULT_BIND",
+    "ERROR_MESSAGES",
+    "PACK_ID",
+    "TOOLS",
+    "WazuhError",
+    "parse_action_status_input",
+    "parse_alert_status_input",
+    "parse_classify_input",
+    "parse_identifier",
+    "parse_incident_input",
+    "parse_ingest_input",
+    "parse_opaque_id",
+    "parse_propose_input",
+]
+
+
+def doctor(target, *, timeout=None):
+    from .lifecycle import doctor as _doctor
+
+    return _doctor(target, timeout=timeout)
+
+
+def canary(target, *, timeout=None):
+    from .lifecycle import canary as _canary
+
+    return _canary(target, timeout=timeout)
+
+
+def render_unit(target, *, python=None):
+    from .lifecycle import render_unit as _render_unit
+
+    return _render_unit(target, python=python)
+
+
+def write_unit(target, out_dir, *, force=False, python=None):
+    from .lifecycle import write_unit as _write_unit
+
+    return _write_unit(target, out_dir, force=force, python=python)
+
+
+def validate_disjoint_state_paths(runtime_path, ledger_path, action_state_path, approval_dir):
+    from .lifecycle import validate_disjoint_state_paths as _validate
+
+    return _validate(runtime_path, ledger_path, action_state_path, approval_dir)

--- a/src/brigade/grokbot_wazuh/contracts.py
+++ b/src/brigade/grokbot_wazuh/contracts.py
@@ -1,0 +1,217 @@
+"""Closed Wazuh triage public contracts and stable errors."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+PACK_ID = "wazuh-triage"
+DEFAULT_BIND = "127.0.0.1:8774"
+PRODUCER = "wazuh"
+TOOLS = frozenset(
+    {
+        "wazuh_action_status",
+        "wazuh_alert_status",
+        "wazuh_classify",
+        "wazuh_incident_bundle",
+        "wazuh_ingest",
+        "wazuh_propose_remediation",
+    }
+)
+IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+OPAQUE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+FINGERPRINT_RE = re.compile(r"^[0-9a-f]{64}$")
+DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
+ERROR_MESSAGES = {
+    "invalid_request": "Tool input failed validation",
+    "denied": "Wazuh request was denied",
+    "not_found": "Wazuh resource was not found",
+    "unavailable": "Wazuh observation is unavailable",
+    "timeout": "Wazuh observation timed out",
+    "protocol_error": "Wazuh observation failed",
+}
+STATUSES = frozenset({"ok", "partial", "unavailable", "denied", "invalid"})
+CATEGORIES = frozenset({"suppress", "watch", "escalate"})
+SEVERITIES = frozenset({"info", "low", "medium", "warning", "high", "critical", "unknown"})
+PROPOSAL_STATES = frozenset({"proposed", "expired", "denied"})
+ALERT_KEYS = frozenset(
+    {
+        "agent_id",
+        "decoder",
+        "detail",
+        "rule_description",
+        "rule_groups",
+        "rule_id",
+        "rule_level",
+        "timestamp",
+    }
+)
+FORBIDDEN_ALERT_KEYS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "bearer",
+        "command",
+        "credential",
+        "password",
+        "path",
+        "private_key",
+        "secret",
+        "token",
+    }
+)
+INGEST_KEYS = frozenset({"alerts"})
+FINDING_KEYS = frozenset(
+    {
+        "body",
+        "content_digest",
+        "finding_id",
+        "observed_at",
+        "producer",
+        "revision",
+        "severity",
+        "source_digest",
+        "source_ref",
+        "title",
+    }
+)
+MAX_ALERTS = 50
+MAX_DETAIL_BYTES = 16_384
+MAX_DESCRIPTION_CHARS = 200
+MAX_GROUPS = 8
+MAX_GROUP_CHARS = 64
+MAX_IDENTIFIER = 64
+MAX_RULE_ID = 32
+MAX_FINDING_ID = 128
+PATH_VALUE_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)")
+COMMAND_VALUE_RE = re.compile(r"\b(?:curl|ssh|bash|wget|powershell|cmd)\b", re.IGNORECASE)
+
+
+class WazuhError(Exception):
+    """Stable public Wazuh failure. Messages never include paths or child output."""
+
+    def __init__(self, code: str, message: str | None = None):
+        self.code = code
+        self.message = message if message is not None else ERROR_MESSAGES[code]
+        super().__init__(self.message)
+
+    def public_error(self) -> dict[str, dict[str, str]]:
+        return {"error": {"code": self.code, "message": ERROR_MESSAGES[self.code]}}
+
+    def __repr__(self) -> str:
+        return f"WazuhError({self.code!r})"
+
+
+def parse_identifier(value: object, *, maximum: int = MAX_IDENTIFIER) -> str:
+    if not isinstance(value, str) or not 1 <= len(value) <= maximum or not IDENTIFIER_RE.fullmatch(value):
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return value
+
+
+def parse_finding_id(value: object) -> str:
+    return parse_identifier(value, maximum=MAX_FINDING_ID)
+
+
+def parse_opaque_id(value: object) -> str:
+    if not isinstance(value, str) or not OPAQUE_ID_RE.fullmatch(value):
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return value
+
+
+def parse_fingerprint(value: object) -> str:
+    if not isinstance(value, str) or not FINGERPRINT_RE.fullmatch(value):
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return value
+
+
+def is_offset_datetime(value: object) -> bool:
+    return isinstance(value, str) and DATETIME_RE.fullmatch(value) is not None
+
+
+def parse_ingest_input(raw: object) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(raw, dict) or set(raw) != INGEST_KEYS:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    alerts = raw.get("alerts")
+    if not isinstance(alerts, list) or not alerts or len(alerts) > MAX_ALERTS:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return {"alerts": [_parse_alert(item) for item in alerts]}
+
+
+def parse_alert_status_input(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, dict) or raw:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return {}
+
+
+def parse_classify_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) != {"fingerprint"}:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return {"fingerprint": parse_fingerprint(raw.get("fingerprint"))}
+
+
+def parse_incident_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) != {"scope"}:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return {"scope": parse_finding_id(raw.get("scope"))}
+
+
+def parse_propose_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) != {"finding_id"}:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return {"finding_id": parse_finding_id(raw.get("finding_id"))}
+
+
+def parse_action_status_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) != {"proposal_id"}:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return {"proposal_id": parse_opaque_id(raw.get("proposal_id"))}
+
+
+def omit_undefined(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: item for key, item in value.items() if item is not None}
+
+
+def _parse_alert(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    extra = set(raw) - ALERT_KEYS
+    if extra or ALERT_KEYS - set(raw) or extra & FORBIDDEN_ALERT_KEYS or set(raw) & FORBIDDEN_ALERT_KEYS:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    rule_id = parse_identifier(raw.get("rule_id"), maximum=MAX_RULE_ID)
+    level = raw.get("rule_level")
+    if type(level) is not int or not 0 <= level <= 15:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    description = _bounded_text(raw.get("rule_description"), maximum=MAX_DESCRIPTION_CHARS)
+    _reject_command_or_path(description)
+    groups = raw.get("rule_groups")
+    if not isinstance(groups, list) or len(groups) > MAX_GROUPS:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    parsed_groups = [parse_identifier(item, maximum=MAX_GROUP_CHARS) for item in groups]
+    agent_id = parse_identifier(raw.get("agent_id"))
+    decoder = parse_identifier(raw.get("decoder"))
+    if not is_offset_datetime(raw.get("timestamp")):
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    detail = raw.get("detail")
+    if not isinstance(detail, str) or "\x00" in detail or len(detail.encode("utf-8")) > MAX_DETAIL_BYTES:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return {
+        "rule_id": rule_id,
+        "rule_level": level,
+        "rule_description": description,
+        "rule_groups": parsed_groups,
+        "agent_id": agent_id,
+        "decoder": decoder,
+        "timestamp": raw["timestamp"],
+        "detail": detail,
+    }
+
+
+def _bounded_text(value: object, *, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > maximum or "\x00" in value:
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return value
+
+
+def _reject_command_or_path(value: str) -> None:
+    if PATH_VALUE_RE.search(value) or COMMAND_VALUE_RE.search(value):
+        raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])

--- a/src/brigade/grokbot_wazuh/lifecycle.py
+++ b/src/brigade/grokbot_wazuh/lifecycle.py
@@ -1,0 +1,643 @@
+"""Pack lifecycle, listener, doctor, canary, and unit rendering."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import stat
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, NoReturn
+
+from .. import grokbot_mcp, grokbot_ops
+from .contracts import PACK_ID, TOOLS, WazuhError
+from .store import WazuhStore, read_secure_text
+from .tools import WazuhTriageTools
+
+MAX_REQUEST_BYTES = 16_384
+SERVICE_NAME = "grokbot-wazuh-triage"
+WAZUH_PATH_KEYS = ("runtime_path", "ledger_path", "action_state_path", "approval_dir")
+RUNTIME_SCHEMA = "brigade.grokbot.wazuh-runtime.v1"
+_TOOL_DESCRIPTIONS = {
+    "wazuh_ingest": "Ingest a bounded Wazuh alert batch",
+    "wazuh_alert_status": "Read current Wazuh alert counts",
+    "wazuh_classify": "Read one alert classification",
+    "wazuh_incident_bundle": "Read grouped public Wazuh findings",
+    "wazuh_propose_remediation": "Propose remediation for an escalated finding",
+    "wazuh_action_status": "Read opaque remediation proposal state",
+}
+
+
+@dataclass(frozen=True)
+class WazuhListenerConfig:
+    target: Path
+    bind_host: str
+    bind_port: int
+    allowed_hosts: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
+    bearer: str
+    runtime_path: str
+    ledger_path: str
+    action_state_path: str
+    approval_dir: str
+
+    def __repr__(self) -> str:
+        return f"WazuhListenerConfig(bind_host={self.bind_host!r}, bind_port={self.bind_port})"
+
+
+def _environment_invalid() -> NoReturn:
+    raise WazuhError("invalid_request", "Wazuh environment is invalid")
+
+
+def normalize_absolute_path(path_value: str) -> str:
+    trimmed = os.path.normpath(path_value).rstrip("/")
+    return trimmed if trimmed else "/"
+
+
+def validate_absolute_reference(path_text: object) -> str:
+    if not isinstance(path_text, str) or not path_text or "\0" in path_text:
+        _environment_invalid()
+    if not path_text.startswith("/") or any(part in {".", ".."} for part in path_text.split("/")):
+        _environment_invalid()
+    return normalize_absolute_path(path_text)
+
+
+def validate_disjoint_state_paths(
+    runtime_path: str,
+    ledger_path: str,
+    action_state_path: str,
+    approval_dir: str,
+) -> dict[str, str]:
+    paths = {
+        "runtime_path": validate_absolute_reference(runtime_path),
+        "ledger_path": validate_absolute_reference(ledger_path),
+        "action_state_path": validate_absolute_reference(action_state_path),
+        "approval_dir": validate_absolute_reference(approval_dir),
+    }
+    values = list(paths.values())
+    for left_index, left in enumerate(values):
+        for right in values[left_index + 1 :]:
+            if left == right or left.startswith(f"{right}/") or right.startswith(f"{left}/"):
+                _environment_invalid()
+    return paths
+
+
+def _lstat_nofollow(path_text: str, *, directory: bool = False) -> os.stat_result:
+    path = Path(path_text)
+    parent = -1
+    descriptor = -1
+    try:
+        parent = grokbot_ops._open_parent_nofollow(path, create=False)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        if directory:
+            flags |= getattr(os, "O_DIRECTORY", 0)
+        if os.name == "posix":
+            descriptor = os.open(path.name, flags, dir_fd=parent)
+        else:
+            from ..work_cmd import nt_dirfd
+
+            if directory:
+                descriptor = nt_dirfd.open_child_directory(parent, path.name, writable=False)
+            else:
+                descriptor = nt_dirfd.open_file(parent, path.name, os.O_RDONLY)
+        info = os.fstat(descriptor)
+    except OSError as exc:
+        raise WazuhError("invalid_request", "Wazuh environment is invalid") from exc
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+        if parent != -1:
+            os.close(parent)
+    if stat.S_ISLNK(info.st_mode):
+        _environment_invalid()
+    return info
+
+
+def validate_runtime_file(path_text: str) -> str:
+    normalized = validate_absolute_reference(path_text)
+    try:
+        read_secure_text(normalized)
+    except (OSError, WazuhError) as exc:
+        raise WazuhError("invalid_request", "Wazuh environment is invalid") from exc
+    return normalized
+
+
+def validate_state_directory(path_text: str, *, must_exist: bool) -> str:
+    normalized = validate_absolute_reference(path_text)
+    path = Path(normalized)
+    if not path.exists():
+        if must_exist:
+            _environment_invalid()
+        return normalized
+    info = _lstat_nofollow(normalized, directory=True)
+    if not stat.S_ISDIR(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o700:
+        _environment_invalid()
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        _environment_invalid()
+    return normalized
+
+
+def _opaque_id() -> str:
+    return secrets.token_hex(16)
+
+
+def _load_validated_instance(target: Path) -> dict[str, Any]:
+    from .. import grokbot_packs
+
+    payload = grokbot_packs._load_instance_config(target, PACK_ID)
+    paths = validate_disjoint_state_paths(
+        str(payload["runtime_path"]),
+        str(payload["ledger_path"]),
+        str(payload["action_state_path"]),
+        str(payload["approval_dir"]),
+    )
+    grokbot_packs._parse_default_bind(str(payload["bind"]))
+    grokbot_packs._validate_bearer_reference(payload["bearer"])
+    validated = dict(payload)
+    validated.update(paths)
+    return validated
+
+
+def _resolve_bearer(reference: Mapping[str, str]) -> str:
+    bearer = grokbot_ops._resolve_bearer(dict(reference))
+    if len(bearer) < 32:
+        _environment_invalid()
+    return bearer
+
+
+def _load_runtime(target: Path) -> tuple[WazuhListenerConfig, str]:
+    from .. import grokbot_packs
+
+    payload = _load_validated_instance(target)
+    host, port = grokbot_packs._parse_default_bind(str(payload["bind"]))
+    bearer = _resolve_bearer(payload["bearer"])
+    config = WazuhListenerConfig(
+        target=target,
+        bind_host=host,
+        bind_port=port,
+        allowed_hosts=tuple(payload["allowed_hosts"]),
+        allowed_origins=tuple(payload["allowed_origins"]),
+        bearer=bearer,
+        runtime_path=payload["runtime_path"],
+        ledger_path=payload["ledger_path"],
+        action_state_path=payload["action_state_path"],
+        approval_dir=payload["approval_dir"],
+    )
+    return config, bearer
+
+
+def _owner_from_runtime(runtime_path: str, default: Path) -> Path:
+    try:
+        text = read_secure_text(validate_absolute_reference(runtime_path))
+    except (OSError, WazuhError) as exc:
+        raise WazuhError("invalid_request", "Wazuh environment is invalid") from exc
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise WazuhError("invalid_request", "Wazuh environment is invalid") from exc
+    if not isinstance(payload, dict):
+        _environment_invalid()
+    if not payload:
+        return default
+    if set(payload) != {"schema", "owner_path"} or payload.get("schema") != RUNTIME_SCHEMA:
+        _environment_invalid()
+    return Path(validate_absolute_reference(payload.get("owner_path")))
+
+
+def build_tools_from_config(
+    config: WazuhListenerConfig,
+    *,
+    env: Mapping[str, str] | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> WazuhTriageTools:
+    source = os.environ if env is None else env
+    dispatch_token = source.get("GROKBOT_DISPATCH_TOKEN")
+    if dispatch_token is not None and dispatch_token == config.bearer:
+        _environment_invalid()
+    runtime_path = validate_runtime_file(config.runtime_path)
+    validate_state_directory(config.action_state_path, must_exist=False)
+    validate_state_directory(config.approval_dir, must_exist=True)
+    owner = _owner_from_runtime(runtime_path, config.target)
+    store = WazuhStore(config.ledger_path)
+    store.ready()
+    secrets = [
+        config.bearer,
+        config.runtime_path,
+        config.ledger_path,
+        config.action_state_path,
+        config.approval_dir,
+        *([dispatch_token] if dispatch_token else []),
+    ]
+    return WazuhTriageTools(
+        store=store,
+        target=config.target,
+        owner=owner,
+        now=now or (lambda: datetime.now(timezone.utc)),
+        request_id=_opaque_id,
+        create_proposal_id=_opaque_id,
+        secrets=secrets,
+    )
+
+
+class WazuhAdapter:
+    def __init__(self, config: WazuhListenerConfig, tools: WazuhTriageTools):
+        self.config = config
+        self.tools = tools
+
+    def authorized(self, authorization: str | None) -> bool:
+        if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
+            return False
+        bearer = authorization[7:]
+        if not bearer.isascii():
+            return False
+        import hmac
+
+        return hmac.compare_digest(bearer, self.config.bearer)
+
+    def health_payload(self) -> dict[str, object]:
+        return {"ok": True, "service": SERVICE_NAME}
+
+    def tool_inventory(self) -> list[dict[str, str]]:
+        return [{"name": name, "description": _TOOL_DESCRIPTIONS[name]} for name in sorted(TOOLS)]
+
+    def call_tool(self, name: str, arguments: object) -> dict[str, Any]:
+        try:
+            return self.tools.call_tool(name, arguments)
+        except WazuhError as exc:
+            return exc.public_error()
+
+
+def doctor(target: Path, *, timeout: int | None = None) -> list[dict[str, str]]:
+    from .. import grokbot_packs
+
+    checks: list[dict[str, str]] = []
+
+    def record(name: str, ok: bool) -> None:
+        checks.append({"check": name, "status": "ok" if ok else "fail"})
+
+    try:
+        from mcp.server import MCPServer  # noqa: F401
+
+        record("dependency", True)
+    except ImportError:
+        record("dependency", False)
+    try:
+        config, bearer = _load_runtime(target)
+        record("config", True)
+    except (WazuhError, grokbot_packs.PackError, grokbot_mcp.ConfigurationError, OSError, ValueError, KeyError):
+        record("config", False)
+        return checks
+    parent = grokbot_packs.instance_config_path(target, PACK_ID).parent
+    record("permissions", os.access(parent, os.W_OK) if parent.is_dir() else False)
+    record("endpoint", _health_check(config, bearer, timeout or grokbot_ops.DEFAULT_TIMEOUT_SECONDS))
+    return checks
+
+
+def canary(target: Path, *, timeout: int | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"ok": False, "pack_id": PACK_ID}
+    try:
+        config, bearer = _load_runtime(target)
+    except Exception:
+        result["reason"] = "config"
+        return result
+    wait = timeout or grokbot_ops.DEFAULT_TIMEOUT_SECONDS
+    base = f"http://{grokbot_ops._connect_host(config.bind_host)}:{config.bind_port}"
+    health = grokbot_ops._request_json(f"{base}/health", bearer, wait, method="GET")
+    anonymous_status = grokbot_ops._anonymous_health_status(f"{base}/health", wait)
+    tools_response = grokbot_ops._tools_list(base, bearer, wait)
+    if health is None or health.get("ok") is not True or health.get("service") != SERVICE_NAME:
+        result["reason"] = "health"
+        return result
+    if anonymous_status not in {401, 403}:
+        result["reason"] = "auth"
+        return result
+    if tools_response is None:
+        result["reason"] = "inventory-unreachable"
+        return result
+    names = {tool.get("name") for tool in tools_response if isinstance(tool, dict)}
+    if names != set(TOOLS):
+        result["reason"] = "inventory-mismatch"
+        return result
+    result.update(
+        {
+            "ok": True,
+            "health": health,
+            "auth_rejected_without_bearer": True,
+            "tools": sorted(TOOLS),
+        }
+    )
+    return result
+
+
+def render_unit(target: Path, *, python: str | None = None) -> str:
+    instance = _load_validated_instance(target)
+    reference = instance["bearer"]
+    bind = instance["bind"]
+    args = [
+        python or sys.executable,
+        "-m",
+        "brigade",
+        "run",
+        "cloud",
+        "grokbot",
+        "serve",
+        "--pack",
+        PACK_ID,
+        "--target",
+        str(target),
+        "--bind",
+        bind,
+    ]
+    for host in instance.get("allowed_hosts", []):
+        args += ["--allow-host", host]
+    for origin in instance.get("allowed_origins", []):
+        args += ["--allow-origin", origin]
+    if reference["kind"] == "file":
+        args += ["--bearer-file", reference["path"]]
+    elif reference["kind"] == "env":
+        args += ["--bearer-env", reference["name"]]
+    exec_start = " ".join(grokbot_ops._systemd_quote(argument) for argument in args)
+    writable = " ".join(
+        grokbot_ops._systemd_quote(path)
+        for path in (
+            str(Path(instance["ledger_path"]).parent),
+            instance["action_state_path"],
+        )
+    )
+    return (
+        "# Generated by brigade run cloud grokbot pack install-service.\n"
+        f"# Unit: {grokbot_ops.unit_name(PACK_ID)}\n"
+        "[Unit]\n"
+        "Description=Brigade Grok Bot MCP listener (wazuh-triage)\n"
+        "After=network.target\n\n"
+        "[Service]\n"
+        "Type=simple\n"
+        f"ExecStart={exec_start}\n"
+        "Restart=on-failure\n"
+        "KillMode=mixed\n"
+        "TimeoutStopSec=20\n"
+        "StandardOutput=journal\n"
+        "StandardError=journal\n"
+        "NoNewPrivileges=yes\n"
+        "PrivateTmp=yes\n"
+        "ProtectSystem=strict\n"
+        "ProtectHome=read-only\n\n"
+        f"ReadWritePaths={writable}\n\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+def write_unit(target: Path, out_dir: Path, *, force: bool = False, python: str | None = None) -> Path:
+    rendered = render_unit(target, python=python)
+    path = out_dir / grokbot_ops.unit_name(PACK_ID)
+    try:
+        existing = grokbot_ops._read_regular_text(path)
+    except FileNotFoundError:
+        existing = None
+    except OSError as exc:
+        if not force or not grokbot_ops._path_is_symlink(path):
+            raise grokbot_ops.ServiceRenderError(f"refusing unsafe unit path: {path.name}") from exc
+        existing = None
+    if existing == rendered:
+        return path
+    if existing is not None and not force:
+        raise grokbot_ops.ServiceRenderError(f"refusing to overwrite existing unit: {path.name}")
+    try:
+        grokbot_ops._write_text_nofollow_atomic(
+            path,
+            rendered,
+            mode=0o644,
+            replace_symlink=force,
+            replace=force or existing is not None,
+        )
+    except OSError as exc:
+        raise grokbot_ops.ServiceRenderError(f"refusing unsafe unit path: {path.name}") from exc
+    return path
+
+
+def build_app(config: WazuhListenerConfig, tools: WazuhTriageTools) -> Callable[..., Any]:
+    MCPServer, JSONResponse, _, TransportSecuritySettings = grokbot_mcp._load_mcp()
+    adapter = WazuhAdapter(config, tools)
+    server = MCPServer(SERVICE_NAME, version="1")
+
+    @server.custom_route("/health", methods=["GET"])
+    async def health(_: Any) -> Any:
+        return JSONResponse(adapter.health_payload())
+
+    _register_tools(server, adapter)
+    allowed_hosts = list(dict.fromkeys((*grokbot_mcp.SDK_LOOPBACK_ALLOWED_HOSTS, *config.allowed_hosts)))
+    if not grokbot_mcp._is_loopback(config.bind_host):
+        allowed_hosts = list(config.allowed_hosts)
+    app = server.streamable_http_app(
+        json_response=True,
+        stateless_http=True,
+        max_request_body_size=MAX_REQUEST_BYTES,
+        host=config.bind_host,
+        transport_security=TransportSecuritySettings(
+            allowed_hosts=allowed_hosts,
+            allowed_origins=list(config.allowed_origins),
+        ),
+    )
+    return _WazuhGateASGI(app, _WazuhRequestGate(config), adapter)
+
+
+def run_listener(config: WazuhListenerConfig, tools: WazuhTriageTools) -> None:
+    grokbot_mcp._load_mcp()
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise grokbot_mcp.OptionalDependencyError() from exc
+    uvicorn.run(
+        build_app(config, tools), host=config.bind_host, port=config.bind_port, access_log=False, log_level="warning"
+    )
+
+
+def build_listener_from_target(
+    target: Path,
+    *,
+    bind: str | None,
+    allowed_hosts: list[str],
+    allowed_origins: list[str],
+    bearer_file: Path | None,
+    bearer_env: str | None,
+) -> tuple[WazuhListenerConfig, WazuhTriageTools]:
+    from .. import grokbot_packs
+
+    instance = grokbot_packs._load_instance_config(target, PACK_ID)
+    chosen_bind = bind or instance["bind"]
+    host, port = grokbot_packs._parse_default_bind(chosen_bind)
+    paths = validate_disjoint_state_paths(
+        str(instance["runtime_path"]),
+        str(instance["ledger_path"]),
+        str(instance["action_state_path"]),
+        str(instance["approval_dir"]),
+    )
+    bearer = grokbot_mcp.load_bearer(bearer_file=bearer_file, bearer_env=bearer_env)
+    if len(bearer) < 32:
+        _environment_invalid()
+    dispatch_token = os.environ.get("GROKBOT_DISPATCH_TOKEN")
+    if dispatch_token is not None and bearer == dispatch_token:
+        _environment_invalid()
+    config = WazuhListenerConfig(
+        target=target.expanduser().resolve(),
+        bind_host=host,
+        bind_port=port,
+        allowed_hosts=tuple(allowed_hosts),
+        allowed_origins=tuple(allowed_origins),
+        bearer=bearer,
+        **paths,
+    )
+    return config, build_tools_from_config(config)
+
+
+def _register_tools(server: Any, adapter: WazuhAdapter) -> None:
+    def wazuh_ingest(alerts: list[dict[str, Any]]) -> dict[str, Any]:
+        return adapter.call_tool("wazuh_ingest", {"alerts": alerts})
+
+    def wazuh_alert_status() -> dict[str, Any]:
+        return adapter.call_tool("wazuh_alert_status", {})
+
+    def wazuh_classify(fingerprint: str) -> dict[str, Any]:
+        return adapter.call_tool("wazuh_classify", {"fingerprint": fingerprint})
+
+    def wazuh_incident_bundle(scope: str) -> dict[str, Any]:
+        return adapter.call_tool("wazuh_incident_bundle", {"scope": scope})
+
+    def wazuh_propose_remediation(finding_id: str) -> dict[str, Any]:
+        return adapter.call_tool("wazuh_propose_remediation", {"finding_id": finding_id})
+
+    def wazuh_action_status(proposal_id: str) -> dict[str, Any]:
+        return adapter.call_tool("wazuh_action_status", {"proposal_id": proposal_id})
+
+    for name, handler in (
+        ("wazuh_ingest", wazuh_ingest),
+        ("wazuh_alert_status", wazuh_alert_status),
+        ("wazuh_classify", wazuh_classify),
+        ("wazuh_incident_bundle", wazuh_incident_bundle),
+        ("wazuh_propose_remediation", wazuh_propose_remediation),
+        ("wazuh_action_status", wazuh_action_status),
+    ):
+        handler.__name__ = name
+        handler.__doc__ = _TOOL_DESCRIPTIONS[name]
+        server.tool(name=name, description=_TOOL_DESCRIPTIONS[name])(handler)
+
+
+class _WazuhRequestGate:
+    def __init__(self, config: WazuhListenerConfig, *, max_request_bytes: int = MAX_REQUEST_BYTES):
+        self.config = config
+        self.max_request_bytes = max_request_bytes
+        self._adapter = WazuhAdapter(config, config_tools_placeholder(config))
+
+    def reject_reason(self, headers: Mapping[str, str], body_size: int) -> str | None:
+        if body_size < 0 or body_size > self.max_request_bytes:
+            return "too-large"
+        host = headers.get("host", "").split(":", 1)[0].casefold()
+        if grokbot_mcp._is_loopback(self.config.bind_host) and host in {"localhost", "127.0.0.1", "::1", ""}:
+            pass
+        elif host not in {entry.casefold().split(":", 1)[0] for entry in self.config.allowed_hosts}:
+            return "forbidden"
+        origin = headers.get("origin")
+        if origin is not None and origin not in self.config.allowed_origins:
+            return "forbidden"
+        if not self._adapter.authorized(headers.get("authorization")):
+            return "unauthorized"
+        return None
+
+
+def config_tools_placeholder(config: WazuhListenerConfig) -> WazuhTriageTools:
+    return WazuhTriageTools(  # pragma: no cover - constructed for auth only
+        store=None,  # type: ignore[arg-type]
+        target=config.target,
+        owner=config.target,
+        now=lambda: datetime.now(timezone.utc),
+        request_id=_opaque_id,
+        create_proposal_id=_opaque_id,
+        secrets=[],
+    )
+
+
+class _WazuhGateASGI:
+    def __init__(self, app: Callable[..., Any], gate: _WazuhRequestGate, adapter: WazuhAdapter):
+        self.app = app
+        self.gate = gate
+        self.adapter = adapter
+
+    async def __call__(self, scope: dict[str, Any], receive: Callable[..., Any], send: Callable[..., Any]) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = {key.decode("latin-1").casefold(): value.decode("latin-1") for key, value in scope.get("headers", [])}
+        content_length = headers.get("content-length")
+        if content_length is not None and (
+            not content_length.isdecimal() or int(content_length) > self.gate.max_request_bytes
+        ):
+            await grokbot_mcp._reject_http(send, 413, "Request body is too large")
+            return
+        reason = self.gate.reject_reason(headers, 0)
+        if reason is not None:
+            await grokbot_mcp._reject_http(
+                send,
+                401 if reason == "unauthorized" else 403,
+                "Unauthorized" if reason == "unauthorized" else "Forbidden",
+            )
+            return
+        body, messages, too_large = await grokbot_mcp._read_bounded_body(receive, self.gate.max_request_bytes)
+        if too_large:
+            await grokbot_mcp._reject_http(send, 413, "Request body is too large")
+            return
+        if scope.get("path") == "/mcp" and _invalid_wazuh_tool_request(body):
+            await grokbot_mcp._reject_tool(send, body)
+            return
+        await self.app(scope, grokbot_mcp._replay_messages(messages, receive), send)
+
+
+def _invalid_wazuh_tool_request(body: bytes) -> bool:
+    from .contracts import (
+        parse_action_status_input,
+        parse_alert_status_input,
+        parse_classify_input,
+        parse_incident_input,
+        parse_ingest_input,
+        parse_propose_input,
+    )
+
+    try:
+        request = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(request, dict) or request.get("method") != "tools/call":
+        return False
+    params = request.get("params")
+    if not isinstance(params, dict):
+        return True
+    name = params.get("name")
+    if name not in TOOLS:
+        return True
+    arguments = params.get("arguments")
+    parser = {
+        "wazuh_ingest": parse_ingest_input,
+        "wazuh_alert_status": parse_alert_status_input,
+        "wazuh_classify": parse_classify_input,
+        "wazuh_incident_bundle": parse_incident_input,
+        "wazuh_propose_remediation": parse_propose_input,
+        "wazuh_action_status": parse_action_status_input,
+    }[name]
+    try:
+        parser(arguments if arguments is not None else {})
+    except WazuhError:
+        return True
+    return False
+
+
+def _health_check(config: WazuhListenerConfig, bearer: str, timeout: int) -> bool:
+    payload = grokbot_ops._request_json(
+        f"http://{grokbot_ops._connect_host(config.bind_host)}:{config.bind_port}/health",
+        bearer,
+        timeout,
+        method="GET",
+    )
+    return payload is not None and payload.get("ok") is True and payload.get("service") == SERVICE_NAME

--- a/src/brigade/grokbot_wazuh/normalize.py
+++ b/src/brigade/grokbot_wazuh/normalize.py
@@ -1,0 +1,236 @@
+"""Bounded Wazuh alert normalization, redaction, and fingerprints."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+from .. import grokbot_findings
+from .contracts import MAX_RULE_ID, PRODUCER, SEVERITIES, omit_undefined, parse_identifier
+
+MAX_REDACTED_BYTES = 4_096
+_PID_RE = re.compile(r"\bpid=\d+\b", re.IGNORECASE)
+_URL_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.-]*://[^\s]+")
+_CREDENTIAL_URI_RE = re.compile(r"([A-Za-z][A-Za-z0-9+.-]*://)([^/\s@]+)@")
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_IPV6_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:\[(?:[0-9A-Fa-f]{0,4}:){2,}[0-9A-Fa-f:]{0,4}(?:%[A-Za-z0-9._-]+)?\]|"
+    r"(?:[0-9A-Fa-f]{0,4}:){2,}[0-9A-Fa-f:]{0,4}(?:%[A-Za-z0-9._-]+)?)(?![A-Za-z0-9])"
+)
+_HOSTNAME_RE = re.compile(r"\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+\b")
+_QUOTED_PATH_RE = re.compile(r"(['\"])(?:[A-Za-z]:[\\/]|/)[^\"'\r\n]*\1")
+_BARE_PATH_RE = re.compile(r"(?<![A-Za-z0-9])(?:[A-Za-z]:[\\/]|/)[^|;\r\n]*")
+_TOKEN_RE = re.compile(r"\b(?:ghp|gho|github_pat|sk|Bearer)[_-][A-Za-z0-9._-]{8,}\b", re.IGNORECASE)
+_AUTHORIZATION_BEARER_RE = re.compile(r"(?i)\bAuthorization\s*:\s*Bearer\s+\S+")
+_BEARER_VALUE_RE = re.compile(r"(?i)\bBearer\s+\S+")
+_SENSITIVE_KEY = r"api[_-]?key|secret|credential|private[_-]?key|password|token"
+_SENSITIVE_EQUALS_RE = re.compile(rf"(?i)\b({_SENSITIVE_KEY})\s*=\s*\S+")
+_SENSITIVE_COLON_RE = re.compile(rf"(?i)\b({_SENSITIVE_KEY})\s*:\s*\S+")
+_SENSITIVE_JSON_RE = re.compile(
+    rf'(?i)(?P<q>["\'])(?P<key>{_SENSITIVE_KEY})(?P=q)\s*:\s*(?P<vq>["\'])(?:(?!(?P=vq)).)*(?P=vq)'
+)
+RULE_ID_CLASSES = {
+    "501": "agent-disconnected",
+    "503": "agent-disconnected",
+    "504": "agent-disconnected",
+    "510": "fim-change",
+    "530": "critical-storage",
+    "533": "service-failure",
+    "550": "port-change",
+    "5501": "windows-logon",
+    "5502": "windows-logon",
+    "5503": "auth-failure",
+    "5710": "auth-brute-force",
+    "5712": "auth-brute-force",
+    "18104": "windows-installer",
+    "18107": "windows-installer",
+    "19001": "sca-repeat",
+    "19002": "sca-repeat",
+    "80790": "sca-repeat",
+}
+GROUP_CLASSES = {
+    "agent_disconnected": "agent-disconnected",
+    "authentication_failed": "auth-failure",
+    "authentication_success": "windows-logon",
+    "sca": "sca-repeat",
+    "service_availability": "service-failure",
+    "syslog_sshd": "auth-brute-force",
+    "syscheck": "fim-change",
+}
+ESCALATE_CLASSES = frozenset(
+    {
+        "agent-disconnected",
+        "auth-brute-force",
+        "critical-storage",
+        "service-failure",
+    }
+)
+NOISE_CLASSES = frozenset(
+    {
+        "lxc-pseudo-file",
+        "sca-repeat",
+        "windows-installer",
+        "windows-logon",
+    }
+)
+WATCH_CLASSES = frozenset({"fim-change", "port-change", "unknown"})
+
+
+def utf8_byte_length(value: str) -> int:
+    return len(value.encode("utf-8"))
+
+
+def truncate_utf8(text: str, max_bytes: int) -> str:
+    result: list[str] = []
+    used = 0
+    for char in text:
+        next_size = utf8_byte_length(char)
+        if used + next_size > max_bytes:
+            break
+        result.append(char)
+        used += next_size
+    return "".join(result)
+
+
+def sanitize_detail(value: str, secrets: Sequence[str] = ()) -> str:
+    try:
+        sanitized = value
+        ordered = sorted({secret for secret in secrets if secret}, key=len, reverse=True)
+        for secret in ordered:
+            bounded = re.compile(rf"(?<![A-Za-z0-9]){re.escape(secret)}(?![A-Za-z0-9])")
+            sanitized = bounded.sub("[redacted]", sanitized)
+        sanitized = _AUTHORIZATION_BEARER_RE.sub("[redacted]", sanitized)
+        sanitized = _BEARER_VALUE_RE.sub("[redacted]", sanitized)
+        sanitized = _SENSITIVE_JSON_RE.sub(r"\g<q>\g<key>\g<q>: \g<vq>[redacted]\g<vq>", sanitized)
+        sanitized = _SENSITIVE_EQUALS_RE.sub(r"\1=[redacted]", sanitized)
+        sanitized = _SENSITIVE_COLON_RE.sub(r"\1:[redacted]", sanitized)
+        sanitized = _TOKEN_RE.sub("[redacted]", sanitized)
+        sanitized = _PID_RE.sub("pid=[redacted]", sanitized)
+        sanitized = _URL_RE.sub("[redacted]", sanitized)
+        sanitized = _CREDENTIAL_URI_RE.sub(r"\1[redacted]@", sanitized)
+        sanitized = _IPV4_RE.sub("[redacted]", sanitized)
+        sanitized = _IPV6_RE.sub("[redacted]", sanitized)
+        sanitized = _HOSTNAME_RE.sub("[redacted]", sanitized)
+        sanitized = _QUOTED_PATH_RE.sub(r"\1[redacted]\1", sanitized)
+        sanitized = _BARE_PATH_RE.sub("[redacted]", sanitized)
+        return truncate_utf8(sanitized, MAX_REDACTED_BYTES)
+    except Exception:
+        return "[redacted]"
+
+
+def rule_class_for(alert: Mapping[str, Any]) -> str:
+    mapped = RULE_ID_CLASSES.get(str(alert.get("rule_id")))
+    if mapped == "fim-change" and _is_lxc_pseudo_file(alert):
+        return "lxc-pseudo-file"
+    if mapped is not None:
+        return mapped
+    for group in alert.get("rule_groups") or ():
+        if group in GROUP_CLASSES:
+            if GROUP_CLASSES[group] == "fim-change" and _is_lxc_pseudo_file(alert):
+                return "lxc-pseudo-file"
+            return GROUP_CLASSES[group]
+    return "unknown"
+
+
+def severity_for_level(level: int) -> str:
+    if level >= 15:
+        return "critical"
+    if level >= 12:
+        return "high"
+    if level >= 8:
+        return "warning"
+    if level >= 4:
+        return "medium"
+    if level >= 1:
+        return "info"
+    return "unknown"
+
+
+def fingerprint_for(alert: Mapping[str, Any], rule_class: str) -> str:
+    payload = {
+        "agent_id": alert["agent_id"],
+        "producer": PRODUCER,
+        "rule_class": rule_class,
+        "rule_id": alert["rule_id"],
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def semantic_revision(
+    *,
+    severity: str,
+    title: str,
+    body: str,
+    source_digest: str,
+    content_digest: str,
+) -> str:
+    payload = {
+        "body": body,
+        "content_digest": content_digest,
+        "severity": severity,
+        "source_digest": source_digest,
+        "title": title,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def normalize_alert(alert: Mapping[str, Any], secrets: Sequence[str] = ()) -> dict[str, Any]:
+    rule_class = rule_class_for(alert)
+    try:
+        agent_id = parse_identifier(alert["agent_id"])
+    except Exception:
+        agent_id = "unknown"
+        rule_class = "unknown"
+    raw_title = str(alert.get("rule_description") or rule_class).strip() or rule_class
+    title = sanitize_detail(raw_title, secrets)[: grokbot_findings.MAX_TITLE_CHARS].strip() or rule_class
+    body = sanitize_detail(str(alert.get("detail") or "[redacted]"), secrets)
+    if not body.strip():
+        body = "[redacted]"
+    try:
+        rule_id = parse_identifier(alert.get("rule_id") or "unknown", maximum=MAX_RULE_ID)
+    except Exception:
+        rule_id = "unknown"
+        rule_class = "unknown"
+    finding_id = f"{agent_id}:{rule_class}:{rule_id}"
+    observed_at = str(alert.get("timestamp") or "")
+    severity = severity_for_level(int(alert["rule_level"])) if type(alert.get("rule_level")) is int else "unknown"
+    if severity not in SEVERITIES:
+        severity = "unknown"
+    source_ref = f"{PRODUCER}:{rule_class}"
+    digest = fingerprint_for(alert, rule_class)
+    source_digest = f"sha256:{digest}"
+    digest_title = title[: grokbot_findings.MAX_TITLE_CHARS]
+    content = grokbot_findings.content_digest(digest_title, body)
+    record = {
+        "producer": PRODUCER,
+        "finding_id": finding_id,
+        "revision": semantic_revision(
+            severity=severity,
+            title=digest_title,
+            body=body,
+            source_digest=source_digest,
+            content_digest=content,
+        ),
+        "observed_at": observed_at,
+        "severity": severity,
+        "title": digest_title,
+        "body": body,
+        "source_ref": source_ref,
+        "source_digest": source_digest,
+        "content_digest": content,
+        "fingerprint": digest,
+        "rule_class": rule_class,
+        "agent_id": agent_id,
+        "rule_id": rule_id,
+    }
+    return omit_undefined(record)
+
+
+def _is_lxc_pseudo_file(alert: Mapping[str, Any]) -> bool:
+    decoder = str(alert.get("decoder") or "")
+    groups = {str(item) for item in (alert.get("rule_groups") or ())}
+    return decoder == "lxc-syscheck" or "lxc" in groups or "container" in groups

--- a/src/brigade/grokbot_wazuh/policy.py
+++ b/src/brigade/grokbot_wazuh/policy.py
@@ -1,0 +1,100 @@
+"""Explicit suppress/watch/escalate rules, expiry, and action eligibility."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from .normalize import ESCALATE_CLASSES, NOISE_CLASSES
+
+DEFAULT_SUPPRESSION_TTL = timedelta(days=7)
+SUPPRESSION_KEYS = frozenset({"created_at", "expires_at", "fingerprint", "reason", "scope"})
+
+
+def classify(
+    record: Mapping[str, Any],
+    *,
+    suppressions: Sequence[Mapping[str, Any]] = (),
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    stamp = _aware(now)
+    rule_class = str(record.get("rule_class") or "unknown")
+    fingerprint = str(record.get("fingerprint") or "")
+    matching = _matching_suppression(fingerprint, suppressions)
+    if matching is not None and _is_expired(matching, stamp):
+        return _result("watch", "expired-suppression", None)
+    if matching is not None:
+        return _result("suppress", str(matching["reason"]), str(matching["expires_at"]))
+    if rule_class == "unknown" or not fingerprint:
+        return _result("watch", "unknown-or-malformed", None)
+    if rule_class in ESCALATE_CLASSES:
+        return _result("escalate", f"high-confidence:{rule_class}", None)
+    if rule_class in NOISE_CLASSES:
+        expires = (stamp + DEFAULT_SUPPRESSION_TTL).isoformat().replace("+00:00", "Z")
+        return _result("suppress", f"known-noise:{rule_class}", expires)
+    return _result("watch", f"review-only:{rule_class}", None)
+
+
+def is_action_eligible(classification: Mapping[str, Any]) -> bool:
+    return classification.get("category") == "escalate"
+
+
+def suppression_entry(
+    *,
+    reason: str,
+    fingerprint: str,
+    scope: str,
+    created_at: str,
+    expires_at: str,
+) -> dict[str, str]:
+    return {
+        "reason": reason,
+        "fingerprint": fingerprint,
+        "scope": scope,
+        "created_at": created_at,
+        "expires_at": expires_at,
+    }
+
+
+def _result(category: str, reason: str, expires_at: str | None) -> dict[str, Any]:
+    return {"category": category, "reason": reason, "expires_at": expires_at}
+
+
+def _matching_suppression(
+    fingerprint: str,
+    suppressions: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    if not fingerprint:
+        return None
+    for item in suppressions:
+        if not isinstance(item, Mapping) or set(item) != SUPPRESSION_KEYS:
+            continue
+        if item.get("fingerprint") != fingerprint:
+            continue
+        if not all(isinstance(item.get(key), str) and item[key] for key in SUPPRESSION_KEYS):
+            continue
+        return item
+    return None
+
+
+def _is_expired(item: Mapping[str, Any], now: datetime) -> bool:
+    try:
+        expires = _parse_time(str(item["expires_at"]))
+    except ValueError:
+        return True
+    return expires <= now
+
+
+def _parse_time(value: str) -> datetime:
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise ValueError("naive")
+    return parsed
+
+
+def _aware(value: datetime | None) -> datetime:
+    stamp = value if value is not None else datetime.now(timezone.utc)
+    if stamp.tzinfo is None:
+        return stamp.replace(tzinfo=timezone.utc)
+    return stamp

--- a/src/brigade/grokbot_wazuh/store.py
+++ b/src/brigade/grokbot_wazuh/store.py
@@ -1,0 +1,438 @@
+"""Private bounded Wazuh dedupe and classification state."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .. import grokbot_ops
+from .contracts import (
+    CATEGORIES,
+    ERROR_MESSAGES,
+    FINDING_KEYS,
+    MAX_RULE_ID,
+    PRODUCER,
+    PROPOSAL_STATES,
+    WazuhError,
+    is_offset_datetime,
+    parse_finding_id,
+    parse_fingerprint,
+    parse_identifier,
+    parse_opaque_id,
+)
+
+STATE_SCHEMA = "brigade.grokbot.wazuh-state.v1"
+STATE_KEYS = frozenset({"alerts", "proposals", "schema", "suppressions"})
+MAX_ALERTS = 2_048
+MAX_SUPPRESSIONS = 256
+MAX_PROPOSALS = 64
+RELAY_STATUSES = frozenset({"pending", "reported"})
+PUBLIC_ALERT_KEYS = frozenset(
+    {
+        "agent_id",
+        "category",
+        "count",
+        "finding_id",
+        "fingerprint",
+        "first_seen",
+        "last_seen",
+        "reason",
+        "rule_class",
+        "rule_id",
+        "severity",
+    }
+)
+_SEMANTIC_KEYS = ("revision", "severity", "title", "body", "source_digest", "content_digest")
+
+
+def _unavailable() -> None:
+    raise WazuhError("unavailable", ERROR_MESSAGES["unavailable"])
+
+
+def _invalid() -> None:
+    raise WazuhError("protocol_error", ERROR_MESSAGES["protocol_error"])
+
+
+def _assert_secure_stat(info: os.stat_result, *, directory: bool) -> None:
+    if directory:
+        if not stat.S_ISDIR(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o700:
+            _invalid()
+    elif not stat.S_ISREG(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o600:
+        _invalid()
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        _invalid()
+
+
+def read_secure_text(path: Path | str, *, expected_mode: int = 0o600) -> str:
+    """Read one current-UID-owned regular file through a no-follow descriptor."""
+    target = Path(path)
+    parent = -1
+    descriptor = -1
+    try:
+        parent = grokbot_ops._open_parent_nofollow(target, create=False)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        if os.name == "posix":
+            descriptor = os.open(target.name, flags, dir_fd=parent)
+        else:
+            from ..work_cmd import nt_dirfd
+
+            descriptor = nt_dirfd.open_file(parent, target.name, os.O_RDONLY)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode) or stat.S_IMODE(info.st_mode) != expected_mode:
+            _invalid()
+        if hasattr(os, "getuid") and info.st_uid != os.getuid():
+            _invalid()
+        with os.fdopen(os.dup(descriptor), "r", encoding="utf-8") as handle:
+            return handle.read()
+    except WazuhError:
+        raise
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        raise WazuhError("protocol_error", ERROR_MESSAGES["protocol_error"]) from exc
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+        if parent != -1:
+            os.close(parent)
+
+
+class WazuhStore:
+    """Owner-only JSON state with atomic mode-0600 replacement."""
+
+    def __init__(self, state_path: str):
+        if not isinstance(state_path, str) or not state_path:
+            _invalid()
+        self._path = Path(state_path)
+        self._lock = threading.Lock()
+
+    def ready(self) -> None:
+        with self._lock:
+            self._ensure_state_dir()
+            self._load()
+
+    def upsert_alert(
+        self,
+        record: Mapping[str, Any],
+        decision: Mapping[str, Any],
+        *,
+        now: datetime,
+    ) -> dict[str, Any]:
+        return self.upsert_alerts(((record, decision),), now=now)[0]
+
+    def upsert_alerts(
+        self,
+        items: Sequence[tuple[Mapping[str, Any], Mapping[str, Any]]],
+        *,
+        now: datetime,
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            state = self._load()
+            incoming = [parse_fingerprint(record["fingerprint"]) for record, _decision in items]
+            new_count = len({fingerprint for fingerprint in incoming if fingerprint not in state["alerts"]})
+            if len(state["alerts"]) + new_count > MAX_ALERTS:
+                _unavailable()
+            results: list[dict[str, Any]] = []
+            for record, decision in items:
+                results.append(self._apply_alert(state, record, decision, now=now))
+            self._persist(state)
+            return results
+
+    def preflight_capacity(self, records: Sequence[Mapping[str, Any]]) -> None:
+        with self._lock:
+            state = self._load()
+            incoming = {parse_fingerprint(record["fingerprint"]) for record in records}
+            new_count = len(incoming - set(state["alerts"]))
+            if len(state["alerts"]) + new_count > MAX_ALERTS:
+                _unavailable()
+
+    def mark_relay_status(self, fingerprints: Sequence[str], status: str) -> None:
+        if status not in RELAY_STATUSES:
+            _invalid()
+        with self._lock:
+            state = self._load()
+            changed = False
+            for fingerprint in fingerprints:
+                key = parse_fingerprint(fingerprint)
+                item = state["alerts"].get(key)
+                if item is None or item.get("relay_status") == status:
+                    continue
+                item["relay_status"] = status
+                changed = True
+            if changed:
+                self._persist(state)
+
+    def current_count(self) -> int:
+        with self._lock:
+            return len(self._load()["alerts"])
+
+    def get_alert(self, fingerprint: str) -> dict[str, Any] | None:
+        with self._lock:
+            item = self._load()["alerts"].get(parse_fingerprint(fingerprint))
+            return dict(item) if item is not None else None
+
+    def public_alert(self, fingerprint: str) -> dict[str, Any] | None:
+        stored = self.get_alert(fingerprint)
+        if stored is None:
+            return None
+        return {key: stored[key] for key in sorted(PUBLIC_ALERT_KEYS) if key in stored}
+
+    def alerts(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [dict(item) for item in self._load()["alerts"].values()]
+
+    def public_alerts(self) -> list[dict[str, Any]]:
+        return [{key: item[key] for key in sorted(PUBLIC_ALERT_KEYS) if key in item} for item in self.alerts()]
+
+    def suppressions(self) -> list[dict[str, str]]:
+        with self._lock:
+            return [dict(item) for item in self._load()["suppressions"].values()]
+
+    def get_finding(self, finding_id: str) -> dict[str, Any] | None:
+        key = parse_finding_id(finding_id)
+        for item in self.alerts():
+            if item["finding_id"] == key:
+                return item
+        return None
+
+    def put_proposal(self, proposal: Mapping[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            state = self._load()
+            proposal_id = parse_opaque_id(proposal["proposal_id"])
+            recorded = {
+                "proposal_id": proposal_id,
+                "finding_id": parse_finding_id(proposal["finding_id"]),
+                "fingerprint": parse_fingerprint(proposal["fingerprint"]),
+                "state": _proposal_state(proposal["state"]),
+                "created_at": _require_time(proposal["created_at"]),
+                "expires_at": _require_time(proposal["expires_at"]),
+            }
+            if len(state["proposals"]) >= MAX_PROPOSALS and proposal_id not in state["proposals"]:
+                _unavailable()
+            state["proposals"][proposal_id] = recorded
+            self._persist(state)
+            return dict(recorded)
+
+    def get_proposal(self, proposal_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            item = self._load()["proposals"].get(parse_opaque_id(proposal_id))
+            return dict(item) if item is not None else None
+
+    def expire_proposal_if_needed(self, proposal_id: str, now: datetime) -> dict[str, Any] | None:
+        with self._lock:
+            state = self._load()
+            item = state["proposals"].get(parse_opaque_id(proposal_id))
+            if item is None:
+                return None
+            recorded = dict(item)
+            if recorded["state"] == "proposed" and _is_expired(recorded["expires_at"], now):
+                recorded["state"] = "expired"
+                state["proposals"][recorded["proposal_id"]] = recorded
+                self._persist(state)
+            return recorded
+
+    def counts(self) -> dict[str, int]:
+        alerts = self.public_alerts()
+        counts = {"current": len(alerts), "suppressed": 0, "watched": 0, "escalated": 0}
+        for item in alerts:
+            category = item.get("category")
+            if category == "suppress":
+                counts["suppressed"] += 1
+            elif category == "escalate":
+                counts["escalated"] += 1
+            else:
+                counts["watched"] += 1
+        return counts
+
+    def last_seen(self) -> str | None:
+        stamps = [item["last_seen"] for item in self.public_alerts() if item.get("last_seen")]
+        return max(stamps) if stamps else None
+
+    def finding_entry(self, stored: Mapping[str, Any]) -> dict[str, str]:
+        return {key: str(stored[key]) for key in sorted(FINDING_KEYS)}
+
+    def _apply_alert(
+        self,
+        state: dict[str, Any],
+        record: Mapping[str, Any],
+        decision: Mapping[str, Any],
+        *,
+        now: datetime,
+    ) -> dict[str, Any]:
+        fingerprint = parse_fingerprint(record["fingerprint"])
+        existing = state["alerts"].get(fingerprint)
+        stamp = _iso(now)
+        observed = str(record["observed_at"] or stamp)
+        if existing is None:
+            stored = _stored_alert(record, decision, first_seen=observed, last_seen=observed, count=1)
+            stored["relay_status"] = "pending"
+            created = True
+            needs_relay = True
+        else:
+            stored = dict(existing)
+            stored["count"] = int(existing["count"]) + 1
+            stored["last_seen"] = observed
+            stored["category"] = decision["category"]
+            stored["reason"] = decision["reason"]
+            semantic_changed = any(stored.get(key) != record.get(key) for key in _SEMANTIC_KEYS)
+            if semantic_changed:
+                stored["revision"] = parse_identifier(record["revision"])
+                stored["severity"] = str(record["severity"])
+                stored["title"] = str(record["title"])
+                stored["body"] = str(record["body"])
+                stored["source_digest"] = str(record["source_digest"])
+                stored["content_digest"] = str(record["content_digest"])
+                stored["observed_at"] = str(record["observed_at"])
+                stored["relay_status"] = "pending"
+            created = False
+            needs_relay = semantic_changed or stored.get("relay_status") != "reported"
+        state["alerts"][fingerprint] = stored
+        if decision["category"] == "suppress" and decision.get("expires_at"):
+            state["suppressions"][fingerprint] = {
+                "reason": str(decision["reason"]),
+                "fingerprint": fingerprint,
+                "scope": str(record.get("rule_class") or "unknown"),
+                "created_at": existing["first_seen"] if existing is not None else observed,
+                "expires_at": str(decision["expires_at"]),
+            }
+        return {
+            "created": created,
+            "fingerprint": fingerprint,
+            "count": stored["count"],
+            "needs_relay": needs_relay,
+        }
+
+    def _ensure_state_dir(self) -> None:
+        parent = -1
+        try:
+            parent = grokbot_ops._open_parent_nofollow(self._path, create=True)
+            info = os.fstat(parent)
+            if not stat.S_ISDIR(info.st_mode):
+                _invalid()
+            if hasattr(os, "fchmod"):
+                os.fchmod(parent, 0o700)
+                info = os.fstat(parent)
+            _assert_secure_stat(info, directory=True)
+        except WazuhError:
+            raise
+        except OSError as exc:
+            raise WazuhError("unavailable", ERROR_MESSAGES["unavailable"]) from exc
+        finally:
+            if parent != -1:
+                os.close(parent)
+
+    def _empty(self) -> dict[str, Any]:
+        return {"schema": STATE_SCHEMA, "alerts": {}, "suppressions": {}, "proposals": {}}
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            payload = json.loads(read_secure_text(self._path))
+        except FileNotFoundError:
+            return self._empty()
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise WazuhError("protocol_error", ERROR_MESSAGES["protocol_error"]) from exc
+        if not isinstance(payload, dict) or payload.get("schema") != STATE_SCHEMA or set(payload) != STATE_KEYS:
+            _invalid()
+        alerts = payload.get("alerts")
+        suppressions = payload.get("suppressions")
+        proposals = payload.get("proposals")
+        if not isinstance(alerts, dict) or not isinstance(suppressions, dict) or not isinstance(proposals, dict):
+            _invalid()
+        if len(alerts) > MAX_ALERTS or len(suppressions) > MAX_SUPPRESSIONS or len(proposals) > MAX_PROPOSALS:
+            _invalid()
+        return {
+            "schema": STATE_SCHEMA,
+            "alerts": {key: dict(value) for key, value in alerts.items()},
+            "suppressions": {key: dict(value) for key, value in suppressions.items()},
+            "proposals": {key: dict(value) for key, value in proposals.items()},
+        }
+
+    def _persist(self, state: Mapping[str, Any]) -> None:
+        if len(state["alerts"]) > MAX_ALERTS or len(state["suppressions"]) > MAX_SUPPRESSIONS:
+            _unavailable()
+        if len(state["proposals"]) > MAX_PROPOSALS:
+            _unavailable()
+        self._ensure_state_dir()
+        body = json.dumps(
+            {
+                "schema": STATE_SCHEMA,
+                "alerts": state["alerts"],
+                "suppressions": state["suppressions"],
+                "proposals": state["proposals"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        try:
+            grokbot_ops._write_text_nofollow_atomic(self._path, body, mode=0o600)
+        except OSError as exc:
+            raise WazuhError("unavailable", ERROR_MESSAGES["unavailable"]) from exc
+
+
+def _stored_alert(
+    record: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    *,
+    first_seen: str,
+    last_seen: str,
+    count: int,
+) -> dict[str, Any]:
+    if decision.get("category") not in CATEGORIES:
+        _invalid()
+    stored = {
+        "producer": PRODUCER,
+        "finding_id": parse_finding_id(record["finding_id"]),
+        "revision": parse_identifier(record["revision"]),
+        "observed_at": str(record["observed_at"]),
+        "severity": str(record["severity"]),
+        "title": str(record["title"]),
+        "body": str(record["body"]),
+        "source_ref": str(record["source_ref"]),
+        "source_digest": str(record["source_digest"]),
+        "content_digest": str(record["content_digest"]),
+        "fingerprint": parse_fingerprint(record["fingerprint"]),
+        "rule_class": parse_identifier(record["rule_class"]),
+        "agent_id": parse_identifier(record["agent_id"]),
+        "rule_id": parse_identifier(record["rule_id"], maximum=MAX_RULE_ID),
+        "category": decision["category"],
+        "reason": str(decision["reason"]),
+        "first_seen": first_seen,
+        "last_seen": last_seen,
+        "count": count,
+        "relay_status": "pending",
+    }
+    return stored
+
+
+def _proposal_state(value: object) -> str:
+    if value not in PROPOSAL_STATES:
+        _invalid()
+    return str(value)
+
+
+def _require_time(value: object) -> str:
+    if not is_offset_datetime(value):
+        _invalid()
+    return str(value)
+
+
+def _is_expired(value: str, now: datetime) -> bool:
+    try:
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return True
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    stamp = now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
+    return parsed <= stamp
+
+
+def _iso(now: datetime) -> str:
+    stamp = now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
+    return stamp.isoformat().replace("+00:00", "Z")

--- a/src/brigade/grokbot_wazuh/tools.py
+++ b/src/brigade/grokbot_wazuh/tools.py
@@ -1,0 +1,275 @@
+"""Public Wazuh triage tool handlers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .. import grokbot_findings, grokbot_findings_relay
+from .contracts import (
+    ERROR_MESSAGES,
+    TOOLS,
+    WazuhError,
+    parse_action_status_input,
+    parse_alert_status_input,
+    parse_classify_input,
+    parse_incident_input,
+    parse_ingest_input,
+    parse_propose_input,
+)
+from .normalize import normalize_alert
+from .policy import classify, is_action_eligible
+from .store import PUBLIC_ALERT_KEYS, WazuhStore
+
+PROPOSAL_TTL = timedelta(hours=1)
+PUBLIC_RESULT_LIMIT = 131_072
+
+
+def _iso(now: Callable[[], datetime]) -> str:
+    stamp = now()
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp.isoformat().replace("+00:00", "Z")
+
+
+def _envelope(*, request_id: str, observed_at: str, status: str, data: Any) -> dict[str, Any]:
+    return {
+        "request_id": request_id,
+        "observed_at": observed_at,
+        "status": status,
+        "data": data,
+    }
+
+
+class WazuhTriageTools:
+    """Closed public Wazuh triage tool surface."""
+
+    def __init__(
+        self,
+        *,
+        store: WazuhStore,
+        target: Path,
+        owner: Path,
+        now: Callable[[], datetime],
+        request_id: Callable[[], str],
+        create_proposal_id: Callable[[], str],
+        secrets: list[str] | None = None,
+    ):
+        self.store = store
+        self.target = Path(target)
+        self.owner = Path(owner)
+        self.now = now
+        self.request_id = request_id
+        self.create_proposal_id = create_proposal_id
+        self.secrets = list(secrets or [])
+
+    def inventory(self) -> list[str]:
+        return sorted(TOOLS)
+
+    def call_tool(self, name: str, arguments: object) -> dict[str, Any]:
+        handlers = {
+            "wazuh_ingest": self.wazuh_ingest,
+            "wazuh_alert_status": self.wazuh_alert_status,
+            "wazuh_classify": self.wazuh_classify,
+            "wazuh_incident_bundle": self.wazuh_incident_bundle,
+            "wazuh_propose_remediation": self.wazuh_propose_remediation,
+            "wazuh_action_status": self.wazuh_action_status,
+        }
+        if name not in handlers:
+            raise WazuhError("invalid_request", ERROR_MESSAGES["invalid_request"])
+        result = handlers[name](arguments)
+        encoded = __import__("json").dumps(result, separators=(",", ":"))
+        if len(encoded.encode("utf-8")) > PUBLIC_RESULT_LIMIT:
+            raise WazuhError("protocol_error", ERROR_MESSAGES["protocol_error"])
+        return result
+
+    def wazuh_ingest(self, raw: object) -> dict[str, Any]:
+        parsed = parse_ingest_input(raw)
+        stamp = self.now()
+        records = [normalize_alert(alert, self.secrets) for alert in parsed["alerts"]]
+        self.store.preflight_capacity(records)
+        suppressions = self.store.suppressions()
+        items = [(record, classify(record, suppressions=suppressions, now=stamp)) for record in records]
+        results = self.store.upsert_alerts(items, now=stamp)
+        created = 0
+        fingerprints: list[str] = []
+        entries: dict[str, dict[str, str]] = {}
+        for result in results:
+            fingerprints.append(result["fingerprint"])
+            if result["created"]:
+                created += 1
+            if result["needs_relay"]:
+                stored = self.store.get_alert(result["fingerprint"])
+                if stored is not None:
+                    entries[result["fingerprint"]] = self.store.finding_entry(stored)
+        if entries:
+            grokbot_findings_relay.relay_apply(
+                list(entries.values()),
+                self.target,
+                self.owner,
+                limit=min(len(entries), grokbot_findings.MAX_ENTRIES),
+                now=stamp,
+            )
+            confirmed = _confirmed_reported_fingerprints(self.target, entries)
+            if confirmed:
+                self.store.mark_relay_status(confirmed, "reported")
+        counts = self.store.counts()
+        return _envelope(
+            request_id=self.request_id(),
+            observed_at=_iso(self.now),
+            status="ok",
+            data={
+                "current": counts["current"],
+                "created": created,
+                "ingested": len(parsed["alerts"]),
+                "fingerprints": fingerprints,
+                "last_seen": self.store.last_seen(),
+            },
+        )
+
+    def wazuh_alert_status(self, raw: object) -> dict[str, Any]:
+        parse_alert_status_input(raw)
+        counts = _count_projected(self._projected_public_alerts())
+        return _envelope(
+            request_id=self.request_id(),
+            observed_at=_iso(self.now),
+            status="ok",
+            data={
+                "current": counts["current"],
+                "suppressed": counts["suppressed"],
+                "watched": counts["watched"],
+                "escalated": counts["escalated"],
+                "last_seen": self.store.last_seen(),
+            },
+        )
+
+    def wazuh_classify(self, raw: object) -> dict[str, Any]:
+        parsed = parse_classify_input(raw)
+        stored = self.store.get_alert(parsed["fingerprint"])
+        if stored is None:
+            raise WazuhError("not_found", ERROR_MESSAGES["not_found"])
+        decision = classify(stored, suppressions=self.store.suppressions(), now=self.now())
+        return _envelope(
+            request_id=self.request_id(),
+            observed_at=_iso(self.now),
+            status="ok",
+            data={
+                "category": decision["category"],
+                "reason": decision["reason"],
+                "expires_at": decision["expires_at"],
+                "fingerprint": parsed["fingerprint"],
+            },
+        )
+
+    def wazuh_incident_bundle(self, raw: object) -> dict[str, Any]:
+        parsed = parse_incident_input(raw)
+        scope = parsed["scope"]
+        findings = [
+            item
+            for item in self._projected_public_alerts()
+            if item["rule_class"] == scope or item["finding_id"] == scope or item["finding_id"].endswith(f":{scope}")
+        ]
+        return _envelope(
+            request_id=self.request_id(),
+            observed_at=_iso(self.now),
+            status="ok",
+            data={"scope": scope, "findings": findings},
+        )
+
+    def wazuh_propose_remediation(self, raw: object) -> dict[str, Any]:
+        parsed = parse_propose_input(raw)
+        stored = self.store.get_finding(parsed["finding_id"])
+        if stored is None:
+            raise WazuhError("not_found", ERROR_MESSAGES["not_found"])
+        decision = classify(stored, suppressions=self.store.suppressions(), now=self.now())
+        if not is_action_eligible(decision):
+            raise WazuhError("denied", ERROR_MESSAGES["denied"])
+        created = _iso(self.now)
+        expires = (self.now() + PROPOSAL_TTL).isoformat().replace("+00:00", "Z")
+        proposal = self.store.put_proposal(
+            {
+                "proposal_id": self.create_proposal_id(),
+                "finding_id": stored["finding_id"],
+                "fingerprint": stored["fingerprint"],
+                "state": "proposed",
+                "created_at": created,
+                "expires_at": expires,
+            }
+        )
+        return _envelope(
+            request_id=self.request_id(),
+            observed_at=created,
+            status="ok",
+            data={
+                "proposal_id": proposal["proposal_id"],
+                "state": proposal["state"],
+                "finding_id": proposal["finding_id"],
+            },
+        )
+
+    def wazuh_action_status(self, raw: object) -> dict[str, Any]:
+        parsed = parse_action_status_input(raw)
+        proposal = self.store.expire_proposal_if_needed(parsed["proposal_id"], self.now())
+        if proposal is None:
+            raise WazuhError("not_found", ERROR_MESSAGES["not_found"])
+        return _envelope(
+            request_id=self.request_id(),
+            observed_at=_iso(self.now),
+            status="ok",
+            data={
+                "proposal_id": proposal["proposal_id"],
+                "state": proposal["state"],
+                "created_at": proposal["created_at"],
+                "expires_at": proposal["expires_at"],
+            },
+        )
+
+    def _projected_public_alerts(self) -> list[dict[str, Any]]:
+        stamp = self.now()
+        suppressions = self.store.suppressions()
+        return [
+            _project_public_alert(item, classify(item, suppressions=suppressions, now=stamp))
+            for item in self.store.alerts()
+        ]
+
+
+def _project_public_alert(stored: Mapping[str, Any], decision: Mapping[str, Any]) -> dict[str, Any]:
+    public = {key: stored[key] for key in sorted(PUBLIC_ALERT_KEYS) if key in stored}
+    public["category"] = decision["category"]
+    public["reason"] = decision["reason"]
+    return public
+
+
+def _count_projected(alerts: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts = {"current": len(alerts), "suppressed": 0, "watched": 0, "escalated": 0}
+    for item in alerts:
+        category = item.get("category")
+        if category == "suppress":
+            counts["suppressed"] += 1
+        elif category == "escalate":
+            counts["escalated"] += 1
+        else:
+            counts["watched"] += 1
+    return counts
+
+
+def _confirmed_reported_fingerprints(
+    target: Path,
+    entries: Mapping[str, Mapping[str, str]],
+) -> list[str]:
+    reported = {
+        record["relay_id"]
+        for record in grokbot_findings_relay._read_outbox_records(target)
+        if record.get("status") == "reported"
+    }
+    confirmed: list[str] = []
+    for fingerprint, entry in entries.items():
+        relay_id = grokbot_findings.identity_digest(
+            entry["producer"],
+            entry["finding_id"],
+            entry["revision"],
+        )
+        if relay_id in reported:
+            confirmed.append(fingerprint)
+    return confirmed

--- a/tests/test_grokbot_packs.py
+++ b/tests/test_grokbot_packs.py
@@ -20,6 +20,7 @@ PACK_IDS = (
     "obsidian-operator",
     "operator",
     "repository-scout",
+    "wazuh-triage",
 )
 CEREBRO_TOOLS = (
     "cerebro_health",
@@ -51,6 +52,14 @@ OBSIDIAN_TOOLS = (
     "obsidian_propose_action",
     "obsidian_read",
     "obsidian_search",
+)
+WAZUH_TOOLS = (
+    "wazuh_action_status",
+    "wazuh_alert_status",
+    "wazuh_classify",
+    "wazuh_incident_bundle",
+    "wazuh_ingest",
+    "wazuh_propose_remediation",
 )
 
 
@@ -116,6 +125,11 @@ def test_registry_is_closed_deterministic_and_exact_key_validated():
             assert shown["tools"] == list(OBSIDIAN_TOOLS)
             assert shown["default_bind"] == "127.0.0.1:8773"
             assert shown["public_route"] == "/mcp"
+        elif pack["id"] == "wazuh-triage":
+            assert pack["kind"] == "connector"
+            assert shown["tools"] == list(WAZUH_TOOLS)
+            assert shown["default_bind"] == "127.0.0.1:8774"
+            assert shown["public_route"] == ""
         else:
             assert pack["kind"] == "connector"
             assert pack["id"] == "fleet-steward"
@@ -198,6 +212,7 @@ def test_first_party_queue_packs_keep_isolated_ports_tools_and_credentials():
     assert grokbot_mcp.parse_bind(packs["fleet-steward"]["default_bind"])[1] == 8771
     assert grokbot_mcp.parse_bind(packs["backup-steward"]["default_bind"])[1] == 8772
     assert grokbot_mcp.parse_bind(packs["obsidian-operator"]["default_bind"])[1] == 8773
+    assert grokbot_mcp.parse_bind(packs["wazuh-triage"]["default_bind"])[1] == 8774
     assert packs["operator"]["tools"] == _queue_tools("operator")
     assert packs["repository-scout"]["tools"] == _queue_tools("repository-scout")
     assert packs["implementation-worker"]["tools"] == _queue_tools("implementation-worker")
@@ -1013,6 +1028,14 @@ def test_fleet_setup_refuses_queue_and_cerebro_default_ports(tmp_path: Path, mon
             bearer_env="TEST_GROKBOT_BEARER",
             **paths,
         )
+    with _reject("duplicate-port"):
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "fleet-steward",
+            bind="127.0.0.1:8774",
+            bearer_env="TEST_GROKBOT_BEARER",
+            **paths,
+        )
     assert grokbot_ops.load_config(tmp_path, "operator")["bind"] == "127.0.0.1:8766"
 
 
@@ -1068,7 +1091,7 @@ def test_backup_setup_preview_apply_and_rejects_foreign_keys(tmp_path: Path, mon
 def test_backup_setup_refuses_existing_default_ports(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
     paths = _fleet_paths(tmp_path)
-    for bind in ("127.0.0.1:8766", "127.0.0.1:8770", "127.0.0.1:8771", "127.0.0.1:8773"):
+    for bind in ("127.0.0.1:8766", "127.0.0.1:8770", "127.0.0.1:8771", "127.0.0.1:8773", "127.0.0.1:8774"):
         with _reject("duplicate-port"):
             grokbot_packs.apply_setup(
                 tmp_path,

--- a/tests/test_grokbot_wazuh_contracts.py
+++ b/tests/test_grokbot_wazuh_contracts.py
@@ -1,0 +1,97 @@
+"""Closed Wazuh triage contracts: exact-key ingest and public result bounds."""
+
+from __future__ import annotations
+
+import pytest
+
+from brigade.grokbot_wazuh.contracts import (
+    ERROR_MESSAGES,
+    FORBIDDEN_ALERT_KEYS,
+    MAX_DETAIL_BYTES,
+    MAX_FINDING_ID,
+    MAX_RULE_ID,
+    TOOLS,
+    WazuhError,
+    parse_action_status_input,
+    parse_alert_status_input,
+    parse_classify_input,
+    parse_identifier,
+    parse_incident_input,
+    parse_ingest_input,
+    parse_opaque_id,
+    parse_propose_input,
+)
+
+
+def _alert(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "rule_id": "504",
+        "rule_level": 12,
+        "rule_description": "Agent disconnected",
+        "rule_groups": ["agent_disconnected"],
+        "agent_id": "001",
+        "decoder": "agent-buffer",
+        "timestamp": "2026-08-28T16:00:00Z",
+        "detail": "Wazuh agent stopped sending keepalive",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_public_tool_inventory_is_exact():
+    assert TOOLS == {
+        "wazuh_action_status",
+        "wazuh_alert_status",
+        "wazuh_classify",
+        "wazuh_incident_bundle",
+        "wazuh_ingest",
+        "wazuh_propose_remediation",
+    }
+
+
+def test_ingest_rejects_unbounded_or_secret_fields():
+    assert parse_ingest_input({"alerts": [_alert()]})["alerts"][0]["rule_id"] == "504"
+    with pytest.raises(WazuhError) as unknown:
+        parse_ingest_input({"alerts": [_alert(note="extra")]})
+    assert unknown.value.code == "invalid_request"
+    with pytest.raises(WazuhError) as oversized:
+        parse_ingest_input({"alerts": [_alert(detail="x" * (MAX_DETAIL_BYTES + 1))]})
+    assert oversized.value.code == "invalid_request"
+    for key in sorted(FORBIDDEN_ALERT_KEYS):
+        raw = _alert()
+        raw[key] = "not-a-real-token"
+        with pytest.raises(WazuhError) as forbidden:
+            parse_ingest_input({"alerts": [raw]})
+        assert forbidden.value.code == "invalid_request"
+        assert key not in str(forbidden.value)
+        assert "not-a-real-token" not in str(forbidden.value)
+    for value in ("/etc/shadow", "C:\\Windows\\Temp", "curl http://example.invalid", "ssh root@192.0.2.10"):
+        with pytest.raises(WazuhError) as supplied:
+            parse_ingest_input({"alerts": [_alert(rule_description=value)]})
+        assert supplied.value.code == "invalid_request"
+        assert value not in str(supplied.value)
+
+
+def test_identifiers_and_tool_inputs_are_strict():
+    assert parse_identifier("agent-disconnected") == "agent-disconnected"
+    assert parse_opaque_id("a" * 32) == "a" * 32
+    assert parse_alert_status_input({}) == {}
+    assert parse_classify_input({"fingerprint": "a" * 64}) == {"fingerprint": "a" * 64}
+    assert parse_incident_input({"scope": "agent-disconnected"}) == {"scope": "agent-disconnected"}
+    assert parse_propose_input({"finding_id": "agent-disconnected"}) == {"finding_id": "agent-disconnected"}
+    assert parse_action_status_input({"proposal_id": "a" * 32}) == {"proposal_id": "a" * 32}
+    with pytest.raises(WazuhError) as caught:
+        parse_ingest_input({"alerts": [_alert()], "extra": True})
+    assert caught.value.public_error() == {
+        "error": {"code": "invalid_request", "message": ERROR_MESSAGES["invalid_request"]}
+    }
+    for value in ("", "a" * 65, "../host", "host/sub", "host;id"):
+        with pytest.raises(WazuhError):
+            parse_identifier(value)
+    finding_id = f"{'a' * 64}:agent-disconnected:{'r' * MAX_RULE_ID}"
+    assert len(finding_id) <= MAX_FINDING_ID
+    assert parse_propose_input({"finding_id": finding_id})["finding_id"] == finding_id
+    assert parse_incident_input({"scope": finding_id})["scope"] == finding_id
+    with pytest.raises(WazuhError) as oversized_rule:
+        parse_ingest_input({"alerts": [_alert(rule_id="r" * (MAX_RULE_ID + 1))]})
+    assert oversized_rule.value.code == "invalid_request"

--- a/tests/test_grokbot_wazuh_lifecycle.py
+++ b/tests/test_grokbot_wazuh_lifecycle.py
@@ -1,0 +1,261 @@
+"""Wazuh triage lifecycle: preview, bind collision, canary, and inventory."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, grokbot_ops, grokbot_packs
+from brigade.grokbot_wazuh.contracts import TOOLS, WazuhError
+from brigade.grokbot_wazuh.lifecycle import (
+    render_unit,
+    validate_disjoint_state_paths,
+)
+
+SECRET = "not-a-real-token-value-32chars!!"
+
+
+def _wazuh_paths(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime.json"
+    ledger = tmp_path / "state" / "wazuh.json"
+    actions = tmp_path / "actions"
+    approvals = tmp_path / "approvals"
+    runtime.write_text("{}", encoding="utf-8")
+    os.chmod(runtime, 0o600)
+    ledger.parent.mkdir(mode=0o700)
+    actions.mkdir(mode=0o700)
+    approvals.mkdir(mode=0o700)
+    os.chmod(ledger.parent, 0o700)
+    os.chmod(actions, 0o700)
+    os.chmod(approvals, 0o700)
+    return {
+        "runtime_path": runtime,
+        "ledger_path": ledger,
+        "action_state_path": actions,
+        "approval_dir": approvals,
+    }
+
+
+def test_disjoint_paths_reject_overlap_dots_and_relative():
+    with pytest.raises(WazuhError) as caught:
+        validate_disjoint_state_paths("/var/lib/a", "/var/lib/a/state.json", "/var/lib/b", "/var/lib/c")
+    assert caught.value.code == "invalid_request"
+    assert "/var/lib/a" not in str(caught.value)
+    with pytest.raises(WazuhError):
+        validate_disjoint_state_paths("/var/lib/../a", "/var/lib/b", "/var/lib/c", "/var/lib/d")
+    with pytest.raises(WazuhError):
+        validate_disjoint_state_paths("var/lib/a", "/var/lib/b", "/var/lib/c", "/var/lib/d")
+
+
+def test_pack_setup_doctor_canary_and_unit_hide_secrets(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    paths = _wazuh_paths(tmp_path)
+    preview = grokbot_packs.preview_setup(
+        tmp_path,
+        "wazuh-triage",
+        bearer_env="TEST_GROKBOT_BEARER",
+        **paths,
+    )
+    assert preview["apply"] is False
+    assert preview["bind"] == "127.0.0.1:8774"
+    assert not grokbot_packs.instance_config_path(tmp_path, "wazuh-triage").exists()
+    assert str(paths["runtime_path"]) not in json.dumps(preview)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "wazuh-triage",
+        bearer_env="TEST_GROKBOT_BEARER",
+        **paths,
+    )
+    checks = grokbot_packs.doctor(tmp_path, "wazuh-triage")
+    canary = grokbot_packs.canary(tmp_path, "wazuh-triage")
+    unit = grokbot_packs.render_install_service(tmp_path, "wazuh-triage")
+    sanitized = json.dumps({"checks": checks, "canary": canary})
+    assert SECRET not in sanitized
+    assert str(paths["runtime_path"]) not in sanitized
+    assert SECRET not in unit
+    assert str(paths["runtime_path"]) not in unit
+    assert "--pack" in unit
+    assert "wazuh-triage" in unit
+    assert "127.0.0.1:8774" in unit
+    assert "NoNewPrivileges=yes" in unit
+    assert "KillMode=mixed" in unit
+    assert "StandardOutput=journal" in unit
+    assert "ProtectSystem=strict" in unit
+    assert canary["ok"] is False
+    assert all(set(check) == {"check", "status"} for check in checks)
+    assert set(TOOLS) == {
+        "wazuh_action_status",
+        "wazuh_alert_status",
+        "wazuh_classify",
+        "wazuh_incident_bundle",
+        "wazuh_ingest",
+        "wazuh_propose_remediation",
+    }
+    unit_dir = tmp_path / "units"
+    installed = grokbot_packs.apply_install_service(tmp_path, "wazuh-triage", out_dir=unit_dir)
+    assert installed["unit"] == grokbot_ops.unit_name("wazuh-triage")
+    grokbot_packs.apply_remove(tmp_path, "wazuh-triage", unit_dir=unit_dir)
+    assert not grokbot_packs.instance_config_path(tmp_path, "wazuh-triage").exists()
+
+
+def test_default_bind_collision_and_failed_rewrite_rollback(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    paths = _wazuh_paths(tmp_path)
+    for bind in ("127.0.0.1:8766", "127.0.0.1:8770", "127.0.0.1:8771", "127.0.0.1:8772", "127.0.0.1:8773"):
+        with pytest.raises(grokbot_packs.PackError) as caught:
+            grokbot_packs.apply_setup(
+                tmp_path,
+                "wazuh-triage",
+                bind=bind,
+                bearer_env="TEST_GROKBOT_BEARER",
+                **paths,
+            )
+        assert caught.value.reason == "duplicate-port"
+        assert not grokbot_packs.instance_config_path(tmp_path, "wazuh-triage").exists()
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "wazuh-triage",
+        bearer_env="TEST_GROKBOT_BEARER",
+        **paths,
+    )
+    pack_path = grokbot_packs.instance_config_path(tmp_path, "wazuh-triage")
+    prior = pack_path.read_bytes()
+    real_write = grokbot_ops._write_text_nofollow_atomic
+
+    def fail_updated_bind(path: Path, data: str, **kwargs: object) -> None:
+        if Path(path) == pack_path and "8794" in data:
+            raise OSError("disk full")
+        real_write(path, data, **kwargs)
+
+    monkeypatch.setattr(grokbot_ops, "_write_text_nofollow_atomic", fail_updated_bind)
+    with pytest.raises(grokbot_packs.PackError) as caught:
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "wazuh-triage",
+            bind="127.0.0.1:8794",
+            bearer_env="TEST_GROKBOT_BEARER",
+            **paths,
+        )
+    assert caught.value.reason == "unsafe-path"
+    assert pack_path.read_bytes() == prior
+
+
+def test_unit_rendering_does_not_resolve_secret_values(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    paths = _wazuh_paths(tmp_path)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "wazuh-triage",
+        bearer_env="TEST_GROKBOT_BEARER",
+        **paths,
+    )
+    unit = render_unit(tmp_path)
+    assert SECRET not in unit
+    assert "--bearer-env" in unit
+    assert str(paths["runtime_path"]) not in unit
+
+
+def test_successful_canary_is_read_only_and_does_not_mutate_state(tmp_path: Path, monkeypatch):
+    from brigade.grokbot_wazuh import lifecycle as lifecycle_mod
+    from brigade.grokbot_wazuh.contracts import parse_ingest_input
+    from brigade.grokbot_wazuh.normalize import normalize_alert
+    from brigade.grokbot_wazuh.policy import classify
+    from brigade.grokbot_wazuh.store import WazuhStore
+
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    paths = _wazuh_paths(tmp_path)
+    grokbot_packs.apply_setup(
+        tmp_path,
+        "wazuh-triage",
+        bearer_env="TEST_GROKBOT_BEARER",
+        **paths,
+    )
+    store = WazuhStore(str(paths["ledger_path"]))
+    store.ready()
+    alert = parse_ingest_input(
+        {
+            "alerts": [
+                {
+                    "rule_id": "504",
+                    "rule_level": 12,
+                    "rule_description": "Agent disconnected",
+                    "rule_groups": ["agent_disconnected"],
+                    "agent_id": "001",
+                    "decoder": "agent-buffer",
+                    "timestamp": "2026-08-28T16:00:00Z",
+                    "detail": "keepalive stopped",
+                }
+            ]
+        }
+    )["alerts"][0]
+    record = normalize_alert(alert)
+    store.upsert_alert(record, classify(record), now=datetime(2026, 8, 28, 16, tzinfo=timezone.utc))
+    before = paths["ledger_path"].read_bytes() if paths["ledger_path"].exists() else b""
+    monkeypatch.setattr(
+        grokbot_ops,
+        "_request_json",
+        lambda *_args, **_kwargs: {"ok": True, "service": "grokbot-wazuh-triage"},
+    )
+    monkeypatch.setattr(grokbot_ops, "_anonymous_health_status", lambda *_args, **_kwargs: 401)
+    monkeypatch.setattr(grokbot_ops, "_tools_list", lambda *_args, **_kwargs: [{"name": name} for name in TOOLS])
+    result = lifecycle_mod.canary(tmp_path)
+    assert result["ok"] is True
+    assert result["auth_rejected_without_bearer"] is True
+    assert set(result["tools"]) == set(TOOLS)
+    after = paths["ledger_path"].read_bytes() if paths["ledger_path"].exists() else b""
+    assert after == before
+
+
+def test_runtime_owner_read_uses_nofollow_descriptor_not_path_read_text(tmp_path: Path, monkeypatch):
+    from brigade.grokbot_wazuh.lifecycle import RUNTIME_SCHEMA, _owner_from_runtime
+
+    runtime = tmp_path / "runtime.json"
+    owner = tmp_path / "owner-dir"
+    owner.mkdir()
+    runtime.write_text(
+        json.dumps({"schema": RUNTIME_SCHEMA, "owner_path": str(owner.resolve())}),
+        encoding="utf-8",
+    )
+    os.chmod(runtime, 0o600)
+    original = Path.read_text
+
+    def boom(self: Path, *args: object, **kwargs: object) -> str:
+        if self.name == "runtime.json":
+            raise AssertionError("TOCTOU Path.read_text")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    resolved = _owner_from_runtime(str(runtime.resolve()), tmp_path)
+    assert resolved == owner.resolve()
+    real = tmp_path / "real-runtime.json"
+    real.write_text("{}", encoding="utf-8")
+    os.chmod(real, 0o600)
+    linked = tmp_path / "linked-runtime.json"
+    linked.symlink_to(real)
+    with pytest.raises(WazuhError):
+        _owner_from_runtime(str(linked), tmp_path)
+
+
+def test_cli_pack_and_serve_choices_include_wazuh_triage():
+    parser = cli._build_parser()
+    shown = parser.parse_args(["run", "cloud", "grokbot", "pack", "show", "--id", "wazuh-triage", "--json"])
+    assert shown.pack_id == "wazuh-triage"
+    served = parser.parse_args(
+        [
+            "run",
+            "cloud",
+            "grokbot",
+            "serve",
+            "--pack",
+            "wazuh-triage",
+            "--bearer-env",
+            "TEST_GROKBOT_BEARER",
+        ]
+    )
+    assert served.pack == "wazuh-triage"
+    assert not hasattr(served, "wazuh_token")
+    assert "wazuh-triage" in grokbot_packs.STEWARD_PACK_IDS

--- a/tests/test_grokbot_wazuh_normalize.py
+++ b/tests/test_grokbot_wazuh_normalize.py
@@ -1,0 +1,147 @@
+# content-guard: allow bearer-token file
+# content-guard: allow api-key-assignment file
+"""Normalization, redaction, and deterministic fingerprint tests."""
+
+from __future__ import annotations
+
+from brigade.grokbot_wazuh.contracts import FINDING_KEYS, parse_ingest_input
+from brigade.grokbot_wazuh.normalize import fingerprint_for, normalize_alert, rule_class_for, sanitize_detail
+
+
+def _alert(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "rule_id": "504",
+        "rule_level": 12,
+        "rule_description": "Agent disconnected",
+        "rule_groups": ["agent_disconnected"],
+        "agent_id": "001",
+        "decoder": "agent-buffer",
+        "timestamp": "2026-08-28T16:00:00Z",
+        "detail": "Wazuh agent stopped sending keepalive",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_normalized_record_has_required_finding_fields_and_redacted_body():
+    secret = "ghp_exampleNotARealToken0000000000000001"
+    alert = parse_ingest_input(
+        {
+            "alerts": [
+                _alert(
+                    detail=(
+                        f"Bearer {secret} ssh root@192.0.2.10 "
+                        "command: curl http://example.invalid/secret "
+                        "path=/var/ossec/logs/alerts/alerts.json"
+                    )
+                )
+            ]
+        }
+    )["alerts"][0]
+    record = normalize_alert(alert, secrets=(secret,))
+    assert FINDING_KEYS <= set(record)
+    assert record["producer"] == "wazuh"
+    assert record["finding_id"] == "001:agent-disconnected:504"
+    assert record["revision"] != "1"
+    assert len(record["revision"]) == 64
+    assert record["observed_at"] == "2026-08-28T16:00:00Z"
+    assert record["severity"] == "high"
+    assert record["title"] == "Agent disconnected"
+    assert record["source_ref"] == "wazuh:agent-disconnected"
+    assert secret not in record["body"]
+    assert "192.0.2.10" not in record["body"]
+    assert "http://example.invalid/secret" not in record["body"]
+    assert "/var/ossec/logs/alerts/alerts.json" not in record["body"]
+    assert "[redacted]" in record["body"]
+    assert record["content_digest"].startswith("sha256:")
+    assert record["source_digest"].startswith("sha256:")
+
+
+def test_fingerprints_are_deterministic_and_ignore_volatile_detail():
+    left = parse_ingest_input({"alerts": [_alert(detail="first seen")]})["alerts"][0]
+    right = parse_ingest_input({"alerts": [_alert(detail="later seen")]})["alerts"][0]
+    assert fingerprint_for(left, rule_class_for(left)) == fingerprint_for(right, rule_class_for(right))
+    assert normalize_alert(left)["fingerprint"] == normalize_alert(right)["fingerprint"]
+
+
+def test_sanitize_detail_never_raises_and_truncates():
+    assert sanitize_detail("ok") == "ok"
+    assert len(sanitize_detail("x" * 20_000).encode("utf-8")) <= 4_096
+    assert sanitize_detail("token=not-a-real-token", secrets=("not-a-real-token",)) == "token=[redacted]"
+
+
+def test_title_and_common_secret_forms_are_sanitized_before_storage():
+    alert = parse_ingest_input(
+        {
+            "alerts": [
+                _alert(
+                    rule_description="Authorization: Bearer not-a-real-bearer-token",
+                    detail=(
+                        "Authorization: Bearer not-a-real-bearer-token "
+                        "password=not-a-real-password token=not-a-real-token "
+                        "host=web.internal.example src=192.0.2.10 path=/var/ossec/logs/alerts.json"
+                    ),
+                )
+            ]
+        }
+    )["alerts"][0]
+    record = normalize_alert(alert)
+    assert "Authorization" not in record["title"]
+    assert "Bearer" not in record["title"]
+    assert "not-a-real-bearer-token" not in record["title"]
+    assert "not-a-real-bearer-token" not in record["body"]
+    assert "not-a-real-password" not in record["body"]
+    assert "not-a-real-token" not in record["body"]
+    assert "web.internal.example" not in record["body"]
+    assert "192.0.2.10" not in record["body"]
+    assert "/var/ossec/logs/alerts.json" not in record["body"]
+    assert "[redacted]" in record["title"]
+    assert "[redacted]" in record["body"]
+
+
+def test_semantic_revision_is_deterministic_and_changes_with_sanitized_content():
+    first = normalize_alert(parse_ingest_input({"alerts": [_alert(rule_level=8)]})["alerts"][0])
+    same = normalize_alert(parse_ingest_input({"alerts": [_alert(rule_level=8)]})["alerts"][0])
+    escalated = normalize_alert(
+        parse_ingest_input({"alerts": [_alert(rule_level=15, detail="later body")]})["alerts"][0]
+    )
+    assert first["fingerprint"] == same["fingerprint"] == escalated["fingerprint"]
+    assert first["revision"] == same["revision"]
+    assert first["revision"] != "1"
+    assert first["revision"] != escalated["revision"]
+    assert first["severity"] == "warning"
+    assert escalated["severity"] == "critical"
+
+
+def test_composed_finding_id_accepts_maximum_agent_id():
+    agent_id = "a" * 64
+    rule_id = "r" * 32
+    alert = parse_ingest_input({"alerts": [_alert(agent_id=agent_id, rule_id=rule_id)]})["alerts"][0]
+    record = normalize_alert(alert)
+    assert record["finding_id"] == f"{agent_id}:agent-disconnected:{rule_id}"
+    assert record["agent_id"] == agent_id
+    assert record["rule_id"] == rule_id
+    assert len(record["finding_id"]) <= 128
+
+
+def test_sensitive_assignments_are_redacted_in_equals_colon_and_json_forms():
+    alert = parse_ingest_input(
+        {
+            "alerts": [
+                _alert(
+                    detail=(
+                        "api_key=not-a-real-api-key-value-01 "
+                        "secret: not-a-real-secret-value-01 "
+                        '"credential": "not-a-real-credential-value-01" '
+                        "private_key = not-a-real-private-key-01"
+                    )
+                )
+            ]
+        }
+    )["alerts"][0]
+    record = normalize_alert(alert)
+    assert "not-a-real-api-key-value-01" not in record["body"]
+    assert "not-a-real-secret-value-01" not in record["body"]
+    assert "not-a-real-credential-value-01" not in record["body"]
+    assert "not-a-real-private-key-01" not in record["body"]
+    assert record["body"].count("[redacted]") >= 4

--- a/tests/test_grokbot_wazuh_policy.py
+++ b/tests/test_grokbot_wazuh_policy.py
@@ -1,0 +1,116 @@
+"""Classification precedence, expiry, and action eligibility."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from brigade.grokbot_wazuh.contracts import parse_ingest_input
+from brigade.grokbot_wazuh.normalize import normalize_alert
+from brigade.grokbot_wazuh.policy import classify, is_action_eligible
+
+NOW = datetime(2026, 8, 28, 16, 0, tzinfo=timezone.utc)
+
+
+def _record(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "rule_id": "504",
+        "rule_level": 12,
+        "rule_description": "Agent disconnected",
+        "rule_groups": ["agent_disconnected"],
+        "agent_id": "001",
+        "decoder": "agent-buffer",
+        "timestamp": "2026-08-28T16:00:00Z",
+        "detail": "Wazuh agent stopped sending keepalive",
+    }
+    payload.update(overrides)
+    alert = parse_ingest_input({"alerts": [payload]})["alerts"][0]
+    return normalize_alert(alert)
+
+
+def test_known_noise_expires_to_watch_and_high_confidence_event_escalates():
+    sca = _record(
+        rule_id="80790",
+        rule_level=3,
+        rule_description="SCA check failed",
+        rule_groups=["sca"],
+        decoder="sca",
+        detail="Repeated SCA compliance finding",
+    )
+    installer = _record(
+        rule_id="18107",
+        rule_level=5,
+        rule_description="Windows installer event",
+        rule_groups=["windows"],
+        decoder="windows_eventchannel",
+        detail="Expected installer noise",
+    )
+    disconnected = _record()
+    sca_now = classify(sca, suppressions=(), now=NOW)
+    assert sca_now["category"] == "suppress"
+    assert sca_now["expires_at"]
+    assert not is_action_eligible(sca_now)
+    expired = classify(
+        sca,
+        suppressions=(
+            {
+                "reason": "sca-repeat",
+                "fingerprint": sca["fingerprint"],
+                "scope": "sca-repeat",
+                "created_at": (NOW - timedelta(days=8)).isoformat().replace("+00:00", "Z"),
+                "expires_at": (NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+            },
+        ),
+        now=NOW,
+    )
+    assert expired["category"] == "watch"
+    assert not is_action_eligible(expired)
+    installer_now = classify(installer, suppressions=(), now=NOW)
+    assert installer_now["category"] in {"suppress", "watch"}
+    assert installer_now["expires_at"] or installer_now["category"] == "watch"
+    assert not is_action_eligible(installer_now)
+    escalated = classify(disconnected, suppressions=(), now=NOW)
+    assert escalated["category"] == "escalate"
+    assert escalated["reason"]
+    assert is_action_eligible(escalated)
+
+
+def test_malformed_unknown_and_explicit_suppression_follow_precedence():
+    unknown = _record(
+        rule_id="99999",
+        rule_level=7,
+        rule_description="Unrecognized decoder event",
+        rule_groups=["local"],
+        decoder="unknown-decoder",
+        detail="No catalog match",
+    )
+    classified = classify(unknown, suppressions=(), now=NOW)
+    assert classified["category"] == "watch"
+    assert not is_action_eligible(classified)
+    fingerprint = unknown["fingerprint"]
+    suppressed = classify(
+        unknown,
+        suppressions=(
+            {
+                "reason": "operator-noise",
+                "fingerprint": fingerprint,
+                "scope": "unknown",
+                "created_at": NOW.isoformat().replace("+00:00", "Z"),
+                "expires_at": (NOW + timedelta(days=1)).isoformat().replace("+00:00", "Z"),
+            },
+        ),
+        now=NOW,
+    )
+    assert suppressed["category"] == "suppress"
+    assert suppressed["reason"] == "operator-noise"
+    assert not is_action_eligible(suppressed)
+    port_change = _record(
+        rule_id="550",
+        rule_level=7,
+        rule_description="Port change observed",
+        rule_groups=["syslog"],
+        decoder="netstat",
+        detail="Listening port set changed",
+    )
+    watched = classify(port_change, suppressions=(), now=NOW)
+    assert watched["category"] == "watch"
+    assert not is_action_eligible(watched)

--- a/tests/test_grokbot_wazuh_store.py
+++ b/tests/test_grokbot_wazuh_store.py
@@ -1,0 +1,125 @@
+# content-guard: allow bearer-token file
+"""Private atomic Wazuh triage state: mode, bounds, and public projections."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from brigade.grokbot_wazuh.contracts import WazuhError, parse_ingest_input
+from brigade.grokbot_wazuh.normalize import normalize_alert
+from brigade.grokbot_wazuh.policy import classify
+from brigade.grokbot_wazuh.store import WazuhStore
+
+NOW = datetime(2026, 8, 28, 16, 0, tzinfo=timezone.utc)
+SECRET_DETAIL = "Bearer ghp_exampleNotARealToken0000000000000001 path=/etc/shadow"
+
+
+def _record(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "rule_id": "504",
+        "rule_level": 12,
+        "rule_description": "Agent disconnected",
+        "rule_groups": ["agent_disconnected"],
+        "agent_id": "001",
+        "decoder": "agent-buffer",
+        "timestamp": "2026-08-28T16:00:00Z",
+        "detail": SECRET_DETAIL,
+    }
+    payload.update(overrides)
+    return normalize_alert(parse_ingest_input({"alerts": [payload]})["alerts"][0])
+
+
+def test_store_upserts_one_current_alert_and_writes_mode_0600(tmp_path: Path):
+    path = tmp_path / "state" / "wazuh.json"
+    store = WazuhStore(str(path))
+    store.ready()
+    record = _record()
+    decision = classify(record, now=NOW)
+    first = store.upsert_alert(record, decision, now=NOW)
+    second = store.upsert_alert(record, decision, now=NOW)
+    assert first["created"] is True
+    assert second["created"] is False
+    assert store.current_count() == 1
+    stored = store.get_alert(record["fingerprint"])
+    assert stored is not None
+    assert stored["count"] == 2
+    assert stored["fingerprint"] == record["fingerprint"]
+    public = store.public_alert(record["fingerprint"])
+    assert public is not None
+    assert "body" not in public
+    assert "title" not in public
+    assert "source_ref" not in public
+    leaked = json.dumps(public)
+    assert "ghp_exampleNotARealToken0000000000000001" not in leaked
+    assert "/etc/shadow" not in leaked
+    assert path.is_file()
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_store_rejects_insecure_mode_and_keeps_suppressions_bounded(tmp_path: Path):
+    path = tmp_path / "state" / "wazuh.json"
+    path.parent.mkdir(mode=0o700)
+    os.chmod(path.parent, 0o700)
+    path.write_text("{}", encoding="utf-8")
+    os.chmod(path, 0o644)
+    store = WazuhStore(str(path))
+    with pytest.raises(WazuhError) as caught:
+        store.ready()
+    assert caught.value.code in {"unavailable", "protocol_error"}
+    assert str(path) not in str(caught.value)
+
+
+def test_store_reads_through_nofollow_descriptor_not_path_read_text(tmp_path: Path, monkeypatch):
+    path = tmp_path / "state" / "wazuh.json"
+    store = WazuhStore(str(path))
+    store.ready()
+    record = _record()
+    store.upsert_alert(record, classify(record, now=NOW), now=NOW)
+    original = Path.read_text
+
+    def boom(self: Path, *args: object, **kwargs: object) -> str:
+        if self.name == "wazuh.json":
+            raise AssertionError("TOCTOU Path.read_text")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    loaded = store.get_alert(record["fingerprint"])
+    assert loaded is not None
+    assert loaded["finding_id"] == record["finding_id"]
+    linked = tmp_path / "linked-state" / "wazuh.json"
+    linked.parent.mkdir(mode=0o700)
+    os.chmod(linked.parent, 0o700)
+    real = tmp_path / "linked-state" / "real.json"
+    real.write_bytes(path.read_bytes())
+    os.chmod(real, 0o600)
+    linked.symlink_to(real)
+    with pytest.raises(WazuhError) as caught:
+        WazuhStore(str(linked)).ready()
+    assert caught.value.code in {"unavailable", "protocol_error"}
+    assert str(linked) not in str(caught.value)
+
+
+def test_store_updates_semantic_fields_on_same_fingerprint(tmp_path: Path):
+    path = tmp_path / "state" / "wazuh.json"
+    store = WazuhStore(str(path))
+    store.ready()
+    first = _record(rule_level=8, rule_description="Agent disconnected", detail="first body")
+    second = _record(rule_level=15, rule_description="Agent disconnected critical", detail="escalated body")
+    assert first["fingerprint"] == second["fingerprint"]
+    store.upsert_alert(first, classify(first, now=NOW), now=NOW)
+    store.upsert_alert(second, classify(second, now=NOW), now=NOW)
+    stored = store.get_alert(first["fingerprint"])
+    assert stored is not None
+    assert stored["count"] == 2
+    assert stored["severity"] == "critical"
+    assert stored["title"] == second["title"]
+    assert stored["body"] == second["body"]
+    assert stored["revision"] == second["revision"]
+    assert stored["content_digest"] == second["content_digest"]
+    assert stored["source_digest"] == second["source_digest"]

--- a/tests/test_grokbot_wazuh_tools.py
+++ b/tests/test_grokbot_wazuh_tools.py
@@ -1,0 +1,491 @@
+# content-guard: allow bearer-token file
+"""Public Wazuh triage tools: ingest, classify, propose, and opaque status."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from brigade import fleet_client
+from brigade.grokbot_wazuh.contracts import TOOLS, WazuhError
+from brigade.grokbot_wazuh.store import WazuhStore
+from brigade.grokbot_wazuh.tools import WazuhTriageTools
+
+NOW = datetime(2026, 8, 28, 16, 0, tzinfo=timezone.utc)
+SECRET = "ghp_exampleNotARealToken0000000000000001"
+FORBIDDEN_PUBLIC = {
+    "body",
+    "title",
+    "source_ref",
+    "source_digest",
+    "command",
+    "credential",
+    "password",
+    "token",
+    "secret",
+    "path",
+}
+
+
+def _alert(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "rule_id": "504",
+        "rule_level": 12,
+        "rule_description": "Agent disconnected",
+        "rule_groups": ["agent_disconnected"],
+        "agent_id": "001",
+        "decoder": "agent-buffer",
+        "timestamp": "2026-08-28T16:00:00Z",
+        "detail": f"Bearer {SECRET} agent keepalive stopped",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _tools(tmp_path: Path, monkeypatch) -> tuple[WazuhTriageTools, Path, Path]:
+    home = tmp_path / "home"
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    monkeypatch.delenv("BRIGADE_FLEET_HUB_URL", raising=False)
+    monkeypatch.delenv("BRIGADE_FLEET_TOKEN", raising=False)
+    monkeypatch.setattr(fleet_client, "report_event", lambda *_args, **_kwargs: True)
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    store_path = tmp_path / "state" / "wazuh.json"
+    store = WazuhStore(str(store_path))
+    store.ready()
+    tools = WazuhTriageTools(
+        store=store,
+        target=queue,
+        owner=owner,
+        now=lambda: NOW,
+        request_id=lambda: "req-wazuh-1",
+        create_proposal_id=lambda: "a" * 32,
+    )
+    return tools, queue, owner
+
+
+def _public_keys(value: object) -> set[str]:
+    keys: set[str] = set()
+    if isinstance(value, dict):
+        keys.update(value)
+        for item in value.values():
+            keys.update(_public_keys(item))
+    elif isinstance(value, list):
+        for item in value:
+            keys.update(_public_keys(item))
+    return keys
+
+
+def test_ingest_dedupes_and_emits_one_review_finding(tmp_path: Path, monkeypatch):
+    tools, queue, owner = _tools(tmp_path, monkeypatch)
+    first = tools.call_tool("wazuh_ingest", {"alerts": [_alert()]})
+    second = tools.call_tool("wazuh_ingest", {"alerts": [_alert()]})
+    assert first["data"]["current"] == 1
+    assert first["data"]["created"] == 1
+    assert second["data"]["current"] == 1
+    assert second["data"]["created"] == 0
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 1
+    assert "untrusted" in drafts[0].read_text(encoding="utf-8").casefold()
+    assert SECRET not in drafts[0].read_text(encoding="utf-8")
+    outbox = list((queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert len(outbox) == 1
+    event = json.loads(outbox[0].read_text(encoding="utf-8"))["event"]
+    assert set(event) == {"run_id", "seat", "harness", "state", "ts", "sequence", "digest"}
+    assert SECRET not in json.dumps(event)
+    assert SECRET not in json.dumps(first)
+    assert SECRET not in json.dumps(second)
+    assert FORBIDDEN_PUBLIC.isdisjoint(_public_keys(first))
+    assert FORBIDDEN_PUBLIC.isdisjoint(_public_keys(second))
+
+
+def test_status_classify_bundle_and_propose_stay_public_and_gated(tmp_path: Path, monkeypatch):
+    tools, _queue, _owner = _tools(tmp_path, monkeypatch)
+    ingested = tools.call_tool("wazuh_ingest", {"alerts": [_alert()]})
+    fingerprint = ingested["data"]["fingerprints"][0]
+    status = tools.call_tool("wazuh_alert_status", {})
+    assert status["data"]["current"] == 1
+    assert status["data"]["escalated"] == 1
+    assert status["data"]["last_seen"] == "2026-08-28T16:00:00Z"
+    classified = tools.call_tool("wazuh_classify", {"fingerprint": fingerprint})
+    assert classified["data"]["category"] == "escalate"
+    assert classified["data"]["reason"]
+    bundle = tools.call_tool("wazuh_incident_bundle", {"scope": "agent-disconnected"})
+    assert bundle["data"]["findings"]
+    assert FORBIDDEN_PUBLIC.isdisjoint(_public_keys(bundle))
+    proposed = tools.call_tool("wazuh_propose_remediation", {"finding_id": "001:agent-disconnected:504"})
+    assert proposed["data"]["state"] == "proposed"
+    assert proposed["data"]["proposal_id"] == "a" * 32
+    action = tools.call_tool("wazuh_action_status", {"proposal_id": "a" * 32})
+    assert action["data"]["state"] == "proposed"
+    assert set(TOOLS) == set(tools.inventory())
+    noise = tools.call_tool(
+        "wazuh_ingest",
+        {
+            "alerts": [
+                _alert(
+                    rule_id="80790",
+                    rule_level=3,
+                    rule_description="SCA check failed",
+                    rule_groups=["sca"],
+                    decoder="sca",
+                    detail="Repeated SCA compliance finding",
+                    agent_id="002",
+                )
+            ]
+        },
+    )
+    noise_id = "002:sca-repeat:80790"
+    try:
+        tools.call_tool("wazuh_propose_remediation", {"finding_id": noise_id})
+        raised = False
+    except WazuhError as exc:
+        raised = True
+        assert exc.code == "denied"
+    assert raised
+    assert "created" in noise["data"]
+
+
+def test_identical_ingest_retries_after_relay_failure_and_pending_or_ready_outbox(tmp_path: Path, monkeypatch):
+    from brigade.grokbot_findings import FindingsError
+    from brigade.grokbot_wazuh import tools as tools_mod
+
+    tools, queue, owner = _tools(tmp_path, monkeypatch)
+    real_relay = tools_mod.grokbot_findings_relay.relay_apply
+
+    def fail_relay(*_args, **_kwargs):
+        raise FindingsError("unsafe-storage")
+
+    monkeypatch.setattr(tools_mod.grokbot_findings_relay, "relay_apply", fail_relay)
+    try:
+        tools.call_tool("wazuh_ingest", {"alerts": [_alert()]})
+        raised = False
+    except FindingsError:
+        raised = True
+    assert raised
+    assert tools.store.current_count() == 1
+    monkeypatch.setattr(tools_mod.grokbot_findings_relay, "relay_apply", real_relay)
+    recovered = tools.call_tool("wazuh_ingest", {"alerts": [_alert()]})
+    assert recovered["data"]["current"] == 1
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 1
+    outbox_dir = queue / ".brigade" / "cloud" / "grokbot" / "outbox"
+    outbox = list(outbox_dir.glob("*.json"))
+    assert len(outbox) == 1
+    assert json.loads(outbox[0].read_text(encoding="utf-8"))["status"] == "reported"
+
+    pending_clock = {"now": datetime(2026, 8, 28, 17, 0, tzinfo=timezone.utc)}
+    pending_tools = WazuhTriageTools(
+        store=WazuhStore(str(tmp_path / "pending-state" / "wazuh.json")),
+        target=tmp_path / "pending-queue",
+        owner=tmp_path / "pending-owner",
+        now=lambda: pending_clock["now"],
+        request_id=lambda: "req-wazuh-pending",
+        create_proposal_id=lambda: "b" * 32,
+    )
+    (tmp_path / "pending-queue").mkdir()
+    (tmp_path / "pending-owner").mkdir()
+    pending_tools.store.ready()
+    from brigade import grokbot_findings
+
+    real_deliver = grokbot_findings._deliver_one
+
+    def fail_after_pending(*args, **kwargs):
+        raise FindingsError("interrupted-draft")
+
+    monkeypatch.setattr(grokbot_findings, "_deliver_one", fail_after_pending)
+    try:
+        pending_tools.call_tool("wazuh_ingest", {"alerts": [_alert(agent_id="003")]})
+        pending_raised = False
+    except FindingsError:
+        pending_raised = True
+    assert pending_raised
+    monkeypatch.setattr(grokbot_findings, "_deliver_one", real_deliver)
+    pending_recovered = pending_tools.call_tool("wazuh_ingest", {"alerts": [_alert(agent_id="003")]})
+    assert pending_recovered["data"]["current"] == 1
+    pending_outbox = list((tmp_path / "pending-queue" / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert pending_outbox
+    assert json.loads(pending_outbox[0].read_text(encoding="utf-8"))["status"] == "reported"
+
+    ready_calls = {"count": 0}
+
+    def report_ready_then_true(*_args, **_kwargs):
+        ready_calls["count"] += 1
+        return ready_calls["count"] > 1
+
+    (tmp_path / "ready").mkdir()
+    ready_tools, ready_queue, _ready_owner = _tools(tmp_path / "ready", monkeypatch)
+    monkeypatch.setattr(fleet_client, "report_event", report_ready_then_true)
+    first_ready = ready_tools.call_tool("wazuh_ingest", {"alerts": [_alert(agent_id="004")]})
+    assert first_ready["data"]["current"] == 1
+    ready_outbox = list((ready_queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert json.loads(ready_outbox[0].read_text(encoding="utf-8"))["status"] == "ready"
+    second_ready = ready_tools.call_tool("wazuh_ingest", {"alerts": [_alert(agent_id="004")]})
+    assert second_ready["data"]["created"] == 0
+    ready_outbox = list((ready_queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert json.loads(ready_outbox[0].read_text(encoding="utf-8"))["status"] == "reported"
+
+
+def test_ingest_batch_preflights_capacity_and_does_not_persist_a_prefix(tmp_path: Path, monkeypatch):
+    from brigade.grokbot_wazuh import store as store_mod
+
+    monkeypatch.setattr(store_mod, "MAX_ALERTS", 2)
+    tools, _queue, _owner = _tools(tmp_path, monkeypatch)
+    tools.call_tool("wazuh_ingest", {"alerts": [_alert(agent_id="001")]})
+    assert tools.store.current_count() == 1
+    try:
+        tools.call_tool(
+            "wazuh_ingest",
+            {"alerts": [_alert(agent_id="002"), _alert(agent_id="003")]},
+        )
+        raised = False
+        code = ""
+    except WazuhError as exc:
+        raised = True
+        code = exc.code
+    assert raised
+    assert code == "unavailable"
+    assert tools.store.current_count() == 1
+    assert tools.store.get_finding("002:agent-disconnected:504") is None
+    assert tools.store.get_finding("003:agent-disconnected:504") is None
+
+
+def test_semantic_change_updates_stored_fields_and_relays_severity_escalation(tmp_path: Path, monkeypatch):
+    tools, queue, owner = _tools(tmp_path, monkeypatch)
+    first = tools.call_tool(
+        "wazuh_ingest",
+        {"alerts": [_alert(rule_level=8, rule_description="Agent disconnected", detail="first body")]},
+    )
+    fingerprint = first["data"]["fingerprints"][0]
+    stored = tools.store.get_alert(fingerprint)
+    assert stored is not None
+    first_revision = stored["revision"]
+    assert stored["severity"] == "warning"
+    assert stored["fingerprint"] == fingerprint
+    second = tools.call_tool(
+        "wazuh_ingest",
+        {
+            "alerts": [
+                _alert(
+                    rule_level=15,
+                    rule_description="Agent disconnected critical",
+                    detail="escalated body",
+                )
+            ]
+        },
+    )
+    assert second["data"]["current"] == 1
+    assert second["data"]["created"] == 0
+    updated = tools.store.get_alert(fingerprint)
+    assert updated is not None
+    assert updated["fingerprint"] == fingerprint
+    assert updated["severity"] == "critical"
+    assert updated["title"] == "Agent disconnected critical"
+    assert updated["body"] == "escalated body"
+    assert updated["revision"] != first_revision
+    assert updated["content_digest"] != stored["content_digest"]
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 2
+    events = list((queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert len(events) == 2
+    states = {json.loads(path.read_text(encoding="utf-8"))["event"]["state"] for path in events}
+    assert "finding.warning" in states
+    assert "finding.critical" in states
+
+
+def test_action_status_reports_and_persists_expired_after_clock_passes(tmp_path: Path, monkeypatch):
+    clock = {"now": NOW}
+    home = tmp_path / "home"
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    monkeypatch.delenv("BRIGADE_FLEET_HUB_URL", raising=False)
+    monkeypatch.delenv("BRIGADE_FLEET_TOKEN", raising=False)
+    monkeypatch.setattr(fleet_client, "report_event", lambda *_args, **_kwargs: True)
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    store = WazuhStore(str(tmp_path / "state" / "wazuh.json"))
+    store.ready()
+    tools = WazuhTriageTools(
+        store=store,
+        target=queue,
+        owner=owner,
+        now=lambda: clock["now"],
+        request_id=lambda: "req-wazuh-expire",
+        create_proposal_id=lambda: "c" * 32,
+    )
+    tools.call_tool("wazuh_ingest", {"alerts": [_alert()]})
+    proposed = tools.call_tool("wazuh_propose_remediation", {"finding_id": "001:agent-disconnected:504"})
+    assert proposed["data"]["state"] == "proposed"
+    from datetime import timedelta
+
+    clock["now"] = NOW + timedelta(hours=2)
+    action = tools.call_tool("wazuh_action_status", {"proposal_id": "c" * 32})
+    assert action["data"]["state"] == "expired"
+    persisted = store.get_proposal("c" * 32)
+    assert persisted is not None
+    assert persisted["state"] == "expired"
+    later = tools.call_tool("wazuh_action_status", {"proposal_id": "c" * 32})
+    assert later["data"]["state"] == "expired"
+
+
+def test_multi_alert_ingest_relays_every_pending_entry_and_retries_safely(tmp_path: Path, monkeypatch):
+    from brigade.grokbot_findings import FindingsError
+    from brigade.grokbot_wazuh import tools as tools_mod
+
+    tools, queue, owner = _tools(tmp_path, monkeypatch)
+    first = tools.call_tool(
+        "wazuh_ingest",
+        {"alerts": [_alert(agent_id="001"), _alert(agent_id="002")]},
+    )
+    assert first["data"]["created"] == 2
+    assert first["data"]["current"] == 2
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 2
+    outbox = list((queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert len(outbox) == 2
+    assert {json.loads(path.read_text(encoding="utf-8"))["status"] for path in outbox} == {"reported"}
+    for fingerprint in first["data"]["fingerprints"]:
+        stored = tools.store.get_alert(fingerprint)
+        assert stored is not None
+        assert stored["relay_status"] == "reported"
+
+    real_relay = tools_mod.grokbot_findings_relay.relay_apply
+
+    def fail_relay(*_args, **_kwargs):
+        raise FindingsError("unsafe-storage")
+
+    monkeypatch.setattr(tools_mod.grokbot_findings_relay, "relay_apply", fail_relay)
+    try:
+        tools.call_tool(
+            "wazuh_ingest",
+            {"alerts": [_alert(agent_id="003"), _alert(agent_id="004")]},
+        )
+        raised = False
+    except FindingsError:
+        raised = True
+    assert raised
+    failed = [
+        tools.store.get_finding("003:agent-disconnected:504"),
+        tools.store.get_finding("004:agent-disconnected:504"),
+    ]
+    assert all(item is not None and item["relay_status"] == "pending" for item in failed)
+    monkeypatch.setattr(tools_mod.grokbot_findings_relay, "relay_apply", real_relay)
+    recovered = tools.call_tool(
+        "wazuh_ingest",
+        {"alerts": [_alert(agent_id="003"), _alert(agent_id="004")]},
+    )
+    assert recovered["data"]["created"] == 0
+    assert recovered["data"]["current"] == 4
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 4
+    outbox = list((queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert len(outbox) == 4
+    assert {json.loads(path.read_text(encoding="utf-8"))["status"] for path in outbox} == {"reported"}
+    for finding_id in ("003:agent-disconnected:504", "004:agent-disconnected:504"):
+        stored = tools.store.get_finding(finding_id)
+        assert stored is not None
+        assert stored["relay_status"] == "reported"
+
+
+def test_same_agent_same_class_different_rule_ids_keep_distinct_identities(tmp_path: Path, monkeypatch):
+    tools, queue, owner = _tools(tmp_path, monkeypatch)
+    first = tools.call_tool(
+        "wazuh_ingest",
+        {
+            "alerts": [
+                _alert(rule_id="501", rule_description="Agent disconnected"),
+                _alert(rule_id="504", rule_description="Agent disconnected"),
+            ]
+        },
+    )
+    assert first["data"]["created"] == 2
+    assert first["data"]["current"] == 2
+    assert first["data"]["fingerprints"][0] != first["data"]["fingerprints"][1]
+    stored = [
+        tools.store.get_finding("001:agent-disconnected:501"),
+        tools.store.get_finding("001:agent-disconnected:504"),
+    ]
+    assert all(item is not None for item in stored)
+    assert stored[0]["finding_id"] != stored[1]["finding_id"]
+    assert stored[0]["rule_class"] == stored[1]["rule_class"] == "agent-disconnected"
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 2
+    outbox = list((queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert len(outbox) == 2
+    assert {json.loads(path.read_text(encoding="utf-8"))["status"] for path in outbox} == {"reported"}
+    replay = tools.call_tool(
+        "wazuh_ingest",
+        {
+            "alerts": [
+                _alert(rule_id="501", rule_description="Agent disconnected"),
+                _alert(rule_id="504", rule_description="Agent disconnected"),
+            ]
+        },
+    )
+    assert replay["data"]["created"] == 0
+    assert replay["data"]["current"] == 2
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 2
+    outbox = list((queue / ".brigade" / "cloud" / "grokbot" / "outbox").glob("*.json"))
+    assert len(outbox) == 2
+    assert {json.loads(path.read_text(encoding="utf-8"))["status"] for path in outbox} == {"reported"}
+    for finding_id in ("001:agent-disconnected:501", "001:agent-disconnected:504"):
+        item = tools.store.get_finding(finding_id)
+        assert item is not None
+        assert item["relay_status"] == "reported"
+
+
+def test_expired_suppression_is_not_reported_as_suppressed_by_status_or_bundle(tmp_path: Path, monkeypatch):
+    from datetime import timedelta
+
+    clock = {"now": NOW}
+    home = tmp_path / "home"
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    monkeypatch.delenv("BRIGADE_FLEET_HUB_URL", raising=False)
+    monkeypatch.delenv("BRIGADE_FLEET_TOKEN", raising=False)
+    monkeypatch.setattr(fleet_client, "report_event", lambda *_args, **_kwargs: True)
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    store = WazuhStore(str(tmp_path / "state" / "wazuh.json"))
+    store.ready()
+    tools = WazuhTriageTools(
+        store=store,
+        target=queue,
+        owner=owner,
+        now=lambda: clock["now"],
+        request_id=lambda: "req-wazuh-suppression",
+        create_proposal_id=lambda: "d" * 32,
+    )
+    ingested = tools.call_tool(
+        "wazuh_ingest",
+        {
+            "alerts": [
+                _alert(
+                    rule_id="80790",
+                    rule_level=3,
+                    rule_description="SCA check failed",
+                    rule_groups=["sca"],
+                    decoder="sca",
+                    detail="Repeated SCA compliance finding",
+                    agent_id="002",
+                )
+            ]
+        },
+    )
+    assert ingested["data"]["created"] == 1
+    active = tools.call_tool("wazuh_alert_status", {})
+    assert active["data"]["suppressed"] == 1
+    assert active["data"]["watched"] == 0
+    clock["now"] = NOW + timedelta(days=8)
+    expired = tools.call_tool("wazuh_alert_status", {})
+    assert expired["data"]["suppressed"] == 0
+    assert expired["data"]["watched"] == 1
+    bundle = tools.call_tool("wazuh_incident_bundle", {"scope": "sca-repeat"})
+    assert bundle["data"]["findings"]
+    assert {item["category"] for item in bundle["data"]["findings"]} == {"watch"}


### PR DESCRIPTION
## Summary

- Add the bundled `wazuh-triage` MCP pack with six closed tools for bounded ingest, status, classification, incident bundles, remediation proposals, and proposal status.
- Normalize, redact, deduplicate, and version Wazuh alerts before relaying sanitized coordination to Fleet Hub and full untrusted findings to Rocinante review handoffs.
- Persist owner-only bounded state with atomic batch ingest, descriptor-safe reads, per-finding delivery acknowledgement, suppression expiry, and proposal expiry.

## Safety boundary

- Loopback-only default listener with an isolated bearer.
- No generic shell, live Wazuh credential, direct Fleet Hub API call, or remediation executor.
- Only high-confidence escalations can create non-executable proposals. Mutation remains a later approval-gated slice.

## Verification

- `brigade work verify run --target . --argv-json ... --capture brigade-work`
- Receipt `20260828-232446-work-verify-1676d6`: 76 passed, formatting clean across 943 files, mypy clean across 526 source files, managed snapshots matched.
- `brigade guard git --history --range origin/main..HEAD`: `blocked=false`.

Refs #1255