### PR TITLE
fix(run): terminalize orphaned fleet runs

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -571,8 +571,8 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runs interrupt`
 - `brigade runs latest`
 - `brigade runs list`
-- `brigade runs recover`
 - `brigade runs reap`
+- `brigade runs recover`
 - `brigade runs redact`
 - `brigade runs resume`
 - `brigade runs serve`

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -61,7 +61,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade run`: 40 command path(s)
 - `brigade run-cloud`: 39 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
-- `brigade runs`: 18 command path(s)
+- `brigade runs`: 19 command path(s)
 - `brigade scrub`: 1 command path(s)
 - `brigade search`: 6 command path(s)
 - `brigade security`: 16 command path(s)
@@ -572,6 +572,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runs latest`
 - `brigade runs list`
 - `brigade runs recover`
+- `brigade runs reap`
 - `brigade runs redact`
 - `brigade runs resume`
 - `brigade runs serve`

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -435,7 +435,7 @@ The examples above all drive the same `brigade run` command to show its main fla
 Common `brigade run` flags:
 
 - `--dry-run` prints planned assignments as JSON and stops before worker dispatch.
-- `--detach` starts the run in a child process, writes child output to `detached.log`, and returns after `run.json` appears.
+- `--detach` starts the run in a child process, writes child output to `detached.log`, and returns after `run.json` appears. The child takes over a new session (`start_new_session` on POSIX, job-breakaway on Windows) and does not depend on the launching session staying alive.
 - `--wait[=SECONDS]` waits for the target's active run lock instead of failing immediately. A bare `--wait` waits up to 600 seconds. Without this flag, lock conflicts remain fail-fast.
 - `--no-fleet-claim` skips the fleet hub repo claim and relies on the local run lock alone (logged once). The escape hatch when a claim left by a crashed run blocks the repo; `brigade fleet claims --release <target>` frees such a claim (`--force` for another node's).
 - `--allow-dirty` bypasses the default dirty-git-worktree guard.
@@ -485,6 +485,18 @@ verified journal checkpoint. Recovery validates the bounded event chain and
 checkpoint before replacing `run.json`. If rollback leaves an older Brigade
 unable to interpret a journal event or projector version, stop that writer and
 roll forward. The append-only journal format is a one-way storage boundary.
+
+Use `brigade runs reap --cwd /path/to/repo` to terminalize local runs whose
+recorded owner process is gone. Reap writes `status: orphaned` and a dirty-file
+count (filenames stay off the receipt) through the same run.json writer every
+other status transition uses, under the run lock it claims from the dead owner.
+A run enrolled in lifecycle journaling therefore also gets a recovery
+checkpoint paired with a `run.orphaned` event, so the Hub row can close and
+`brigade doctor` stays clean; a legacy snapshot-only run is left snapshot-only
+rather than migrated. It does not rewrite Hub history: `brigade fleet
+status --all` ages silent nonterminal rows to display-only `run.stale` after
+24h, separate from the 30-minute live-status window. `brigade work brief`
+lists orphaned runs and the recorded dirty count.
 
 `brigade runs resume <run>` also handles an app-server run whose owner exited
 after dispatch began but before `worker-results.json` was aggregated. After it

--- a/src/brigade/aboyeur/run_io.py
+++ b/src/brigade/aboyeur/run_io.py
@@ -33,6 +33,7 @@ from .. import proc, receipt_schema, runguard
 from .. import run_control
 from .. import run_checkpoint
 from .. import run_budget
+from .. import run_dirfd
 from .. import run_events
 from .. import run_journal
 from .. import run_lifecycle
@@ -72,6 +73,15 @@ from . import orchestrator as _orchestrator_mod
 _AUTHORITY_REQUEST_FIELD = "run_journal_authority_requested"
 
 
+def _read_run_json_bytes(path: Path) -> bytes:
+    """Read run.json; descriptor-relative when a binding authorizes the path.
+
+    No active binding keeps Path.read_bytes. An authorized binding never
+    re-opens, stats, or resolves the lexical name after that check.
+    """
+    return run_dirfd.read_bytes(path, max_bytes=run_dirfd.MAX_READ_BYTES)
+
+
 def make_run_dir(base: Path, now: datetime | None = None, *, workspace: Path | None = None) -> Path:
     stamp = (now or datetime.now(timezone.utc)).strftime("%Y%m%d-%H%M%S")
     local_id = f"{stamp}-{uuid4().hex[:8]}"
@@ -108,7 +118,7 @@ def _resolve_authority_state(run_dir: Path) -> str:
     """
     run_json = run_dir / "run.json"
     try:
-        raw = run_json.read_bytes()
+        raw = _read_run_json_bytes(run_json)
     except FileNotFoundError:
         return "legacy"
     try:
@@ -318,18 +328,17 @@ def _write_json_inner(path: Path, payload: object) -> None:
             transition_status = status
             prior_status: str | None = None
             prior_kind: str | None = None
-            if path.is_file():
-                try:
-                    prior_snapshot = json.loads(path.read_bytes())
-                except (OSError, ValueError, UnicodeDecodeError, RecursionError):
-                    prior_snapshot = None
-                if isinstance(prior_snapshot, dict):
-                    raw_prior_status = prior_snapshot.get("status")
-                    if isinstance(raw_prior_status, str) and raw_prior_status:
-                        prior_status = raw_prior_status
-                    raw_prior_kind = prior_snapshot.get("kind")
-                    if isinstance(raw_prior_kind, str) and raw_prior_kind:
-                        prior_kind = raw_prior_kind
+            try:
+                prior_snapshot = json.loads(_read_run_json_bytes(path))
+            except (OSError, ValueError, UnicodeDecodeError, RecursionError):
+                prior_snapshot = None
+            if isinstance(prior_snapshot, dict):
+                raw_prior_status = prior_snapshot.get("status")
+                if isinstance(raw_prior_status, str) and raw_prior_status:
+                    prior_status = raw_prior_status
+                raw_prior_kind = prior_snapshot.get("kind")
+                if isinstance(raw_prior_kind, str) and raw_prior_kind:
+                    prior_kind = raw_prior_kind
             kind = payload.get("kind") if isinstance(payload.get("kind"), str) else prior_kind
             approval_reference = payload.get("approval_reference")
             if status == "running" and isinstance(approval_reference, Mapping):
@@ -408,7 +417,7 @@ def _write_json_inner(path: Path, payload: object) -> None:
             # runs skip this gate.
             if authority_state == "authoritative":
                 try:
-                    prior_snapshot = json.loads(path.read_bytes())
+                    prior_snapshot = json.loads(_read_run_json_bytes(path))
                 except (OSError, ValueError, UnicodeDecodeError) as exc:
                     raise run_lifecycle.LifecycleJournalError(
                         run_events._bound("authoritative prior snapshot is unreadable")

--- a/src/brigade/aboyeur/run_io.py
+++ b/src/brigade/aboyeur/run_io.py
@@ -229,7 +229,7 @@ def _genuine_journal_ahead(run_dir: Path) -> bool:
     """
     artifact_path = run_shadow.shadow_artifact_path(run_dir)
     try:
-        data = json.loads(artifact_path.read_text())
+        data = json.loads(run_journal.bound_read_text(artifact_path))
     except (OSError, ValueError):
         return False
     if not isinstance(data, dict):
@@ -272,7 +272,7 @@ def _authoritative_prior_decision(run_dir: Path, prior_snapshot: dict[str, objec
         if caught_up.ready:
             artifact_path = run_shadow.shadow_artifact_path(run_dir)
             try:
-                artifact = json.loads(artifact_path.read_text())
+                artifact = json.loads(run_journal.bound_read_text(artifact_path))
             except (OSError, ValueError) as exc:
                 raise run_lifecycle.LifecycleJournalError(
                     run_events._bound("authoritative run prior catch-up evidence is unreadable")

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -409,6 +409,32 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Replace an existing destination run directory with the same run id.",
     )
     p_runs_import.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    p_runs_reap = runs_sub.add_parser(
+        "reap",
+        help="Terminalize local runs whose recorded owner process is gone.",
+    )
+    p_runs_reap.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose default .brigade/runs directory should be scanned.",
+    )
+    p_runs_reap.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help="Explicit runs directory. Defaults to .brigade/runs under --cwd.",
+    )
+    p_runs_reap.add_argument(
+        "--older-than",
+        default="2h",
+        help="Only consider nonterminal runs older than this duration (default 2h).",
+    )
+    p_runs_reap.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the versioned brigade.runs-reap.v1 JSON contract.",
+    )
     p_runs_validate_archive = runs_sub.add_parser(
         "validate-archive",
         help="Validate a brigade.work-run archive manifest, digests, and export privacy rules.",
@@ -539,6 +565,15 @@ def dispatch(args) -> int:
             cwd=args.cwd,
             runs_dir=args.runs_dir,
             force=args.force,
+            json_output=args.json,
+        )
+    if args.runs_command == "reap":
+        from .. import run_reap
+
+        return run_reap.reap(
+            cwd=args.cwd,
+            runs_dir=args.runs_dir,
+            older_than=args.older_than,
             json_output=args.json,
         )
     if args.runs_command == "validate-archive":

--- a/src/brigade/dirfd.py
+++ b/src/brigade/dirfd.py
@@ -1,0 +1,221 @@
+"""Cross-platform descriptor-relative no-follow primitives.
+
+POSIX uses ``dir_fd`` plus ``O_NOFOLLOW``. Windows delegates to
+``work_cmd.nt_dirfd``. Callers that already monkeypatch
+``authority_store`` availability helpers keep those seams: this module is
+the implementation, and ``authority_store`` re-branches on its own names.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _nt_dirfd() -> Any:
+    """Load the Windows helper without importing the work_cmd package facade."""
+    return importlib.import_module("brigade.work_cmd.nt_dirfd")
+
+
+def posix_available() -> bool:
+    """Return whether POSIX openat/O_NOFOLLOW primitives can hold a parent."""
+    return (
+        os.name == "posix"
+        and bool(getattr(os, "O_NOFOLLOW", 0))
+        and bool(getattr(os, "O_DIRECTORY", 0))
+        and os.open in os.supports_dir_fd
+        and os.mkdir in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.unlink in os.supports_dir_fd
+        and os.rename in os.supports_dir_fd
+    )
+
+
+def nt_available() -> bool:
+    """Return whether Windows handle-relative no-follow operations can be used."""
+    if sys.platform != "win32":
+        return False
+    return bool(_nt_dirfd().available())
+
+
+def available() -> bool:
+    return posix_available() or nt_available()
+
+
+def unavailable(kind: str) -> OSError:
+    return OSError(f"descriptor-relative {kind} are unavailable")
+
+
+def validate_component(name: str) -> str:
+    """Reject empty, dotted, separator-bearing, or NUL names so walks stay contained."""
+    if not isinstance(name, str) or not name:
+        raise OSError("path component is empty")
+    if name in {".", ".."}:
+        raise OSError("path component is not contained")
+    if "/" in name or "\\" in name or ":" in name or "\x00" in name:
+        raise OSError("path component is not a single contained name")
+    return name
+
+
+def _posix_open_directory(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    return os.open(path, flags)
+
+
+def _nt_open_directory(path: Path) -> int:
+    return _nt_dirfd().open_root_directory(path)
+
+
+def _posix_open_file(path: Path, flags: int, mode: int) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if flags & os.O_CREAT:
+        return os.open(path, flags | nofollow | getattr(os, "O_CLOEXEC", 0), mode)
+    return os.open(path, flags | nofollow | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_CLOEXEC", 0))
+
+
+def _nt_open_file(path: Path, flags: int, mode: int) -> int:
+    return _nt_dirfd().open_path_file(path, flags, mode)
+
+
+def _posix_open_child_directory(parent: int, name: str) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    return os.open(name, flags, dir_fd=parent)
+
+
+def _nt_open_child_directory(parent: int, name: str) -> int:
+    return _nt_dirfd().open_child_directory(parent, name)
+
+
+def _posix_mkdir_child(parent: int, name: str) -> None:
+    os.mkdir(name, 0o700, dir_fd=parent)
+
+
+def _nt_mkdir_child(parent: int, name: str) -> None:
+    _nt_dirfd().mkdir_child(parent, name)
+
+
+def _posix_open_child_file(parent: int, name: str, flags: int, mode: int) -> int:
+    if flags & os.O_CREAT:
+        return os.open(name, flags, mode, dir_fd=parent)
+    return os.open(name, flags, dir_fd=parent)
+
+
+def _nt_open_child_file(parent: int, name: str, flags: int, mode: int) -> int:
+    return _nt_dirfd().open_file(parent, name, flags, mode)
+
+
+def _posix_replace_children(parent: int, source: str, destination: str) -> None:
+    os.replace(source, destination, src_dir_fd=parent, dst_dir_fd=parent)
+
+
+def _nt_replace_children(parent: int, source: str, destination: str) -> None:
+    _nt_dirfd().replace_children(parent, source, destination)
+
+
+def _posix_unlink_child(parent: int, name: str) -> None:
+    os.unlink(name, dir_fd=parent)
+
+
+def _nt_unlink_child(parent: int, name: str) -> None:
+    _nt_dirfd().unlink_child(parent, name)
+
+
+def _posix_stat_child(parent: int, name: str) -> os.stat_result:
+    return os.stat(name, dir_fd=parent, follow_symlinks=False)
+
+
+def _nt_stat_child(parent: int, name: str) -> os.stat_result:
+    return _nt_dirfd().stat_child(parent, name)
+
+
+def open_directory_nofollow(path: Path) -> int:
+    """Open a directory without following a final symlink or reparse point."""
+    if posix_available():
+        return _posix_open_directory(path)
+    if nt_available():
+        return _nt_open_directory(path)
+    raise unavailable("directory operations")
+
+
+def open_file_nofollow(path: Path, flags: int, mode: int = 0o600) -> int:
+    """Open a file path without following a final symlink or reparse point."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        return _posix_open_file(path, flags, mode)
+    if nt_available():
+        return _nt_open_file(path, flags, mode)
+    raise OSError("no-follow file open is unavailable")
+
+
+def open_child_directory(parent: int, name: str) -> int:
+    validate_component(name)
+    if posix_available():
+        return _posix_open_child_directory(parent, name)
+    if nt_available():
+        return _nt_open_child_directory(parent, name)
+    raise unavailable("directory operations")
+
+
+def mkdir_child(parent: int, name: str) -> None:
+    validate_component(name)
+    if posix_available():
+        _posix_mkdir_child(parent, name)
+        return
+    if nt_available():
+        _nt_mkdir_child(parent, name)
+        return
+    raise unavailable("directory operations")
+
+
+def open_child_file(parent: int, name: str, flags: int, mode: int = 0o600) -> int:
+    validate_component(name)
+    if posix_available():
+        return _posix_open_child_file(parent, name, flags, mode)
+    if nt_available():
+        return _nt_open_child_file(parent, name, flags, mode)
+    raise unavailable("import inbox operations")
+
+
+def replace_children(parent: int, source: str, destination: str) -> None:
+    validate_component(source)
+    validate_component(destination)
+    if posix_available():
+        _posix_replace_children(parent, source, destination)
+        return
+    if nt_available():
+        _nt_replace_children(parent, source, destination)
+        return
+    raise unavailable("import inbox operations")
+
+
+def unlink_child(parent: int, name: str) -> None:
+    validate_component(name)
+    if posix_available():
+        _posix_unlink_child(parent, name)
+        return
+    if nt_available():
+        _nt_unlink_child(parent, name)
+        return
+    raise unavailable("import inbox operations")
+
+
+def stat_child(parent: int, name: str) -> os.stat_result:
+    validate_component(name)
+    if posix_available():
+        return _posix_stat_child(parent, name)
+    if nt_available():
+        return _nt_stat_child(parent, name)
+    raise unavailable("import inbox validation")
+
+
+def fsync_directory(descriptor: int) -> None:
+    """Flush a held descriptor; directory fsync is best-effort on Windows."""
+    try:
+        os.fsync(descriptor)
+    except OSError as exc:
+        if sys.platform == "win32" and getattr(exc, "winerror", None) in {1, 5}:
+            return
+        raise

--- a/src/brigade/fleet_command_deck.py
+++ b/src/brigade/fleet_command_deck.py
@@ -18,7 +18,7 @@ from typing import Mapping, Sequence
 CLAIM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
-TERMINAL_STATES = frozenset({"run.completed", "run.failed", "run.interrupted"})
+TERMINAL_STATES = frozenset({"run.completed", "run.failed", "run.interrupted", "run.orphaned"})
 AWAITING_STATES = frozenset({"run.paused", "approval.requested", "approval.held"})
 TERMINAL_STATE_SUFFIXES = (
     ".completed",
@@ -28,6 +28,7 @@ TERMINAL_STATE_SUFFIXES = (
     ".canceled",
     ".timed_out",
     ".timeout",
+    ".orphaned",
 )
 FAILURE_STATE_SUFFIXES = (
     ".failed",
@@ -93,6 +94,7 @@ def default_cloud_config() -> CloudConfig:
 class DeckConfig:
     stations: Sequence[StationConfig] = ()
     stale_after_seconds: int = 1800
+    stale_history_after_seconds: int = 86400
     outcome_window: int = 20
     failed_lookback_seconds: int = 86400
     cloud: CloudConfig = field(default_factory=default_cloud_config)
@@ -203,6 +205,7 @@ def load_config(path: Path) -> DeckConfig:
     return DeckConfig(
         stations=stations,
         stale_after_seconds=_bounded_int(raw, "stale_after_seconds", 1800, 300, 21600),
+        stale_history_after_seconds=_bounded_int(raw, "stale_history_after_seconds", 86400, 3600, 604800),
         outcome_window=_bounded_int(raw, "outcome_window", 20, 1, 100),
         failed_lookback_seconds=_bounded_int(raw, "failed_lookback_seconds", 86400, 1, 2_592_000),
         cloud=_cloud_config(raw.get("cloud")),
@@ -274,6 +277,10 @@ def is_terminal_state(state: str) -> bool:
 
 
 def bucket_for(state: str, *, age_seconds: int | None, stale_after_seconds: int) -> str:
+    # The Hub's synthetic history state is already an age verdict; bucket it
+    # the same way ``fleet_dashboard.bucket_for`` does regardless of age.
+    if state == "run.stale":
+        return "stale"
     if state in AWAITING_STATES:
         return "awaiting approval"
     if state.endswith(FAILURE_STATE_SUFFIXES):

--- a/src/brigade/fleet_dashboard.py
+++ b/src/brigade/fleet_dashboard.py
@@ -151,6 +151,10 @@ def _parse_stamp(value: object) -> datetime | None:
 
 def bucket_for(state: str, *, age_seconds: float | None, exit_status: int | None = None) -> str:
     """Map a run_event type plus its age to an attention bucket."""
+    if state == "run.stale":
+        return "stale"
+    if state == "run.orphaned":
+        return "interrupted"
     if state == "verify.completed":
         if exit_status == 130:
             return "interrupted"

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -112,12 +112,15 @@ from pathlib import Path
 from typing import Any
 
 from . import fleet_command_deck, fleet_hub_preference
+from .fleet_hub_status import (
+    ACTIVE_EVENT_TTL_SECONDS as ACTIVE_EVENT_TTL_SECONDS,
+    STALE_HISTORY_AFTER_SECONDS as STALE_HISTORY_AFTER_SECONDS,
+    latest_status as latest_status,
+)
 
 SCHEMA_VERSION = 13
 DEFAULT_PORT = 3774
 MAX_BODY_BYTES = 8 * 1024 * 1024
-ACTIVE_EVENT_TTL_SECONDS = 30 * 60
-STALE_HISTORY_AFTER_SECONDS = 24 * 60 * 60
 
 # Dashboard cookie (issue #1124): a derived, read-only capability, not the token.
 DASHBOARD_COOKIE = "brigade_fleet_view"
@@ -711,100 +714,6 @@ def store_events(conn: sqlite3.Connection, raw_events: Any, *, caller_node: str 
             accepted += 1
     conn.commit()
     return {"accepted": accepted, "duplicate": duplicate}
-
-
-def _received_at_is_active(value: object, *, now: datetime, ttl_seconds: int) -> bool:
-    if not isinstance(value, str):
-        return False
-    try:
-        received = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return False
-    if received.tzinfo is None:
-        received = received.replace(tzinfo=timezone.utc)
-    return (now - received.astimezone(timezone.utc)).total_seconds() <= ttl_seconds
-
-
-def _received_at_age_seconds(value: object, *, now: datetime) -> float | None:
-    if not isinstance(value, str) or not value.strip():
-        return None
-    try:
-        received = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if received.tzinfo is None:
-        received = received.replace(tzinfo=timezone.utc)
-    return (now - received.astimezone(timezone.utc)).total_seconds()
-
-
-def latest_status(
-    conn: sqlite3.Connection,
-    *,
-    include_all: bool = False,
-    now: datetime | None = None,
-    active_ttl_seconds: int = ACTIVE_EVENT_TTL_SECONDS,
-    stale_history_after_seconds: int = STALE_HISTORY_AFTER_SECONDS,
-) -> list[dict[str, Any]]:
-    """Latest event per (node_id, run_id); non-terminal runs unless include_all.
-
-    Exactly one row per (node_id, run_id): ties on sequence (same sequence
-    seen with two digests) resolve to the most recently received, then the
-    larger digest, so the view never shows a run twice.
-
-    History views (``include_all``) age old nonterminal rows to synthetic
-    ``run.stale`` from Hub ``received_at``, keeping the recorded state in
-    ``original_state``. Event history itself is not rewritten.
-    """
-    rows = conn.execute(
-        "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, capability_fingerprint, received_at FROM ("
-        "  SELECT e.*, ROW_NUMBER() OVER ("
-        "    PARTITION BY node_id, run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
-        "  ) AS rn FROM events e"
-        ") WHERE rn = 1 ORDER BY node_id, run_id"
-    ).fetchall()
-    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
-    result = []
-    for row in rows:
-        state = row[5]
-        if not include_all and (
-            fleet_command_deck.is_terminal_state(state)
-            or not _received_at_is_active(row[11], now=current, ttl_seconds=active_ttl_seconds)
-        ):
-            continue
-        entry = {
-            "node_id": row[0],
-            "run_id": row[1],
-            "repo": row[2],
-            "seat": _last_known_seat(conn, row[0], row[1], row[3]),
-            "harness": row[4],
-            "state": state,
-            "ts": row[6],
-            "sequence": row[7],
-            "digest": row[8],
-            "exit_status": row[9],
-            "capability_fingerprint": row[10],
-            "received_at": row[11],
-        }
-        if include_all and not fleet_command_deck.is_terminal_state(state):
-            age = _received_at_age_seconds(row[11], now=current)
-            if age is not None and age > stale_history_after_seconds:
-                entry["original_state"] = state
-                entry["state"] = "run.stale"
-        result.append(entry)
-    return result
-
-
-def _last_known_seat(conn: sqlite3.Connection, node_id: str, run_id: str, latest: Any) -> Any:
-    """Keep the last non-empty seat when a terminal event drops it."""
-    if isinstance(latest, str) and latest.strip() and latest.strip() != "-":
-        return latest
-    row = conn.execute(
-        "SELECT seat FROM events WHERE node_id = ? AND run_id = ? "
-        "AND seat IS NOT NULL AND trim(seat) != '' AND seat != '-' "
-        "ORDER BY sequence DESC, received_at DESC, digest DESC LIMIT 1",
-        (node_id, run_id),
-    ).fetchone()
-    return row[0] if row else latest
 
 
 def get_run_preference(conn: sqlite3.Connection) -> dict[str, Any]:

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -117,6 +117,7 @@ SCHEMA_VERSION = 13
 DEFAULT_PORT = 3774
 MAX_BODY_BYTES = 8 * 1024 * 1024
 ACTIVE_EVENT_TTL_SECONDS = 30 * 60
+STALE_HISTORY_AFTER_SECONDS = 24 * 60 * 60
 
 # Dashboard cookie (issue #1124): a derived, read-only capability, not the token.
 DASHBOARD_COOKIE = "brigade_fleet_view"
@@ -193,6 +194,7 @@ TERMINAL_STATES = frozenset(
         "run.completed",
         "run.failed",
         "run.interrupted",
+        "run.orphaned",
         "verify.completed",
         "external.completed",
         "external.failed",
@@ -723,18 +725,35 @@ def _received_at_is_active(value: object, *, now: datetime, ttl_seconds: int) ->
     return (now - received.astimezone(timezone.utc)).total_seconds() <= ttl_seconds
 
 
+def _received_at_age_seconds(value: object, *, now: datetime) -> float | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        received = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if received.tzinfo is None:
+        received = received.replace(tzinfo=timezone.utc)
+    return (now - received.astimezone(timezone.utc)).total_seconds()
+
+
 def latest_status(
     conn: sqlite3.Connection,
     *,
     include_all: bool = False,
     now: datetime | None = None,
     active_ttl_seconds: int = ACTIVE_EVENT_TTL_SECONDS,
+    stale_history_after_seconds: int = STALE_HISTORY_AFTER_SECONDS,
 ) -> list[dict[str, Any]]:
     """Latest event per (node_id, run_id); non-terminal runs unless include_all.
 
     Exactly one row per (node_id, run_id): ties on sequence (same sequence
     seen with two digests) resolve to the most recently received, then the
     larger digest, so the view never shows a run twice.
+
+    History views (``include_all``) age old nonterminal rows to synthetic
+    ``run.stale`` from Hub ``received_at``, keeping the recorded state in
+    ``original_state``. Event history itself is not rewritten.
     """
     rows = conn.execute(
         "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, capability_fingerprint, received_at FROM ("
@@ -746,27 +765,32 @@ def latest_status(
     current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     result = []
     for row in rows:
+        state = row[5]
         if not include_all and (
-            fleet_command_deck.is_terminal_state(row[5])
+            fleet_command_deck.is_terminal_state(state)
             or not _received_at_is_active(row[11], now=current, ttl_seconds=active_ttl_seconds)
         ):
             continue
-        result.append(
-            {
-                "node_id": row[0],
-                "run_id": row[1],
-                "repo": row[2],
-                "seat": _last_known_seat(conn, row[0], row[1], row[3]),
-                "harness": row[4],
-                "state": row[5],
-                "ts": row[6],
-                "sequence": row[7],
-                "digest": row[8],
-                "exit_status": row[9],
-                "capability_fingerprint": row[10],
-                "received_at": row[11],
-            }
-        )
+        entry = {
+            "node_id": row[0],
+            "run_id": row[1],
+            "repo": row[2],
+            "seat": _last_known_seat(conn, row[0], row[1], row[3]),
+            "harness": row[4],
+            "state": state,
+            "ts": row[6],
+            "sequence": row[7],
+            "digest": row[8],
+            "exit_status": row[9],
+            "capability_fingerprint": row[10],
+            "received_at": row[11],
+        }
+        if include_all and not fleet_command_deck.is_terminal_state(state):
+            age = _received_at_age_seconds(row[11], now=current)
+            if age is not None and age > stale_history_after_seconds:
+                entry["original_state"] = state
+                entry["state"] = "run.stale"
+        result.append(entry)
     return result
 
 

--- a/src/brigade/fleet_hub_http.py
+++ b/src/brigade/fleet_hub_http.py
@@ -314,7 +314,11 @@ def make_handler(
                 self._send_html(500, f"hub database error: {exc}\n", content_type=plain)
                 return
             try:
-                runs = latest_status(conn, include_all=True)
+                runs = latest_status(
+                    conn,
+                    include_all=True,
+                    stale_history_after_seconds=frozen_deck.stale_history_after_seconds,
+                )
                 claims = list_claims(conn)
                 started_at = run_started_at(conn)
                 nodes = node_summary(conn)
@@ -469,7 +473,13 @@ def make_handler(
                             return
                         payload = {"nodes": list_nodes(conn)}
                     elif path == "/status":
-                        payload = {"runs": latest_status(conn, include_all=include_all)}
+                        payload = {
+                            "runs": latest_status(
+                                conn,
+                                include_all=include_all,
+                                stale_history_after_seconds=frozen_deck.stale_history_after_seconds,
+                            )
+                        }
                     elif path == "/cloud":
                         payload = cloud_snapshot(conn, frozen_deck, include_all=include_all, include_grokbot=is_admin)
                     elif path == "/models":

--- a/src/brigade/fleet_hub_status.py
+++ b/src/brigade/fleet_hub_status.py
@@ -1,0 +1,111 @@
+"""Latest-status projection for Fleet Hub events.
+
+Split from ``fleet_hub`` to keep that module under the size ratchet. The
+projection is one row per (node_id, run_id); Hub ``received_at`` is the
+authority for active TTL and stale-history aging.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+from . import fleet_command_deck
+
+ACTIVE_EVENT_TTL_SECONDS = 30 * 60
+STALE_HISTORY_AFTER_SECONDS = 24 * 60 * 60
+
+
+def _received_at_is_active(value: object, *, now: datetime, ttl_seconds: int) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        received = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if received.tzinfo is None:
+        received = received.replace(tzinfo=timezone.utc)
+    return (now - received.astimezone(timezone.utc)).total_seconds() <= ttl_seconds
+
+
+def _received_at_age_seconds(value: object, *, now: datetime) -> float | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        received = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if received.tzinfo is None:
+        received = received.replace(tzinfo=timezone.utc)
+    return (now - received.astimezone(timezone.utc)).total_seconds()
+
+
+def latest_status(
+    conn: sqlite3.Connection,
+    *,
+    include_all: bool = False,
+    now: datetime | None = None,
+    active_ttl_seconds: int = ACTIVE_EVENT_TTL_SECONDS,
+    stale_history_after_seconds: int = STALE_HISTORY_AFTER_SECONDS,
+) -> list[dict[str, Any]]:
+    """Latest event per (node_id, run_id); non-terminal runs unless include_all.
+
+    Exactly one row per (node_id, run_id): ties on sequence (same sequence
+    seen with two digests) resolve to the most recently received, then the
+    larger digest, so the view never shows a run twice.
+
+    History views (``include_all``) age old nonterminal rows to synthetic
+    ``run.stale`` from Hub ``received_at``, keeping the recorded state in
+    ``original_state``. Event history itself is not rewritten.
+    """
+    rows = conn.execute(
+        "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, capability_fingerprint, received_at FROM ("
+        "  SELECT e.*, ROW_NUMBER() OVER ("
+        "    PARTITION BY node_id, run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
+        "  ) AS rn FROM events e"
+        ") WHERE rn = 1 ORDER BY node_id, run_id"
+    ).fetchall()
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    result = []
+    for row in rows:
+        state = row[5]
+        if not include_all and (
+            fleet_command_deck.is_terminal_state(state)
+            or not _received_at_is_active(row[11], now=current, ttl_seconds=active_ttl_seconds)
+        ):
+            continue
+        entry = {
+            "node_id": row[0],
+            "run_id": row[1],
+            "repo": row[2],
+            "seat": _last_known_seat(conn, row[0], row[1], row[3]),
+            "harness": row[4],
+            "state": state,
+            "ts": row[6],
+            "sequence": row[7],
+            "digest": row[8],
+            "exit_status": row[9],
+            "capability_fingerprint": row[10],
+            "received_at": row[11],
+        }
+        if include_all and not fleet_command_deck.is_terminal_state(state):
+            age = _received_at_age_seconds(row[11], now=current)
+            if age is not None and age > stale_history_after_seconds:
+                entry["original_state"] = state
+                entry["state"] = "run.stale"
+        result.append(entry)
+    return result
+
+
+def _last_known_seat(conn: sqlite3.Connection, node_id: str, run_id: str, latest: Any) -> Any:
+    """Keep the last non-empty seat when a terminal event drops it."""
+    if isinstance(latest, str) and latest.strip() and latest.strip() != "-":
+        return latest
+    row = conn.execute(
+        "SELECT seat FROM events WHERE node_id = ? AND run_id = ? "
+        "AND seat IS NOT NULL AND trim(seat) != '' AND seat != '-' "
+        "ORDER BY sequence DESC, received_at DESC, digest DESC LIMIT 1",
+        (node_id, run_id),
+    ).fetchone()
+    return row[0] if row else latest

--- a/src/brigade/localio.py
+++ b/src/brigade/localio.py
@@ -43,6 +43,12 @@ def read_json_dict(path: Path) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _active_bound_target(path: Path) -> tuple[Any, tuple[str, ...], str] | None:
+    from . import run_dirfd
+
+    return run_dirfd.active_binding_for(path)
+
+
 def write_text_atomic(path: Path, data: str) -> None:
     """Write data to path atomically, creating parents.
 
@@ -52,7 +58,16 @@ def write_text_atomic(path: Path, data: str) -> None:
     replacement the temp file is removed and the existing file is left untouched.
     A directory-fsync failure occurs after replacement and means durable
     publication is unconfirmed, although the new bytes are already present.
+
+    When a ``run_dirfd`` binding is active and ``path`` is a lexical descendant
+    of that bound run directory, the write is authorized only through held
+    no-follow dirfds. Without a binding the pathname writer is unchanged.
     """
+    bound = _active_bound_target(path)
+    if bound is not None:
+        run_dir, components, name = bound
+        run_dir.write_text_atomic(components, name, data)
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_name)
@@ -95,7 +110,17 @@ def _supports_directory_fsync() -> bool:
 
 
 def write_bytes_atomic(path: Path, data: bytes) -> None:
-    """Write bytes to path atomically, creating parents."""
+    """Write bytes to path atomically, creating parents.
+
+    When a ``run_dirfd`` binding is active and ``path`` is a lexical descendant
+    of that bound run directory, the write is authorized only through held
+    no-follow dirfds. Without a binding the pathname writer is unchanged.
+    """
+    bound = _active_bound_target(path)
+    if bound is not None:
+        run_dir, components, name = bound
+        run_dir.write_bytes_atomic(components, name, data)
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_name)

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -30,6 +30,8 @@ CHECKPOINT_EVENT_TYPE = "run.snapshot.checkpointed"
 CHECKPOINT_MEDIA_TYPE = "application/vnd.brigade.run+json"
 CHECKPOINT_PRIVACY_CLASS = "private"
 CHECKPOINT_DIR_NAME = "recovery-checkpoints"
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_O_CLOEXEC = getattr(os, "O_CLOEXEC", 0)
 MAX_CHECKPOINT_BYTES = 16 * 1024 * 1024
 MAX_JOURNAL_BYTES = 8 * 1024 * 1024
 MAX_JOURNAL_EVENTS = 2048
@@ -482,7 +484,13 @@ def _fsync_directory(path: Path) -> None:
             raise close_err
 
 
-def _cleanup_temp(tmp_path: Path, cp_dir: Path, primary: CheckpointError | None) -> CheckpointError | None:
+def _cleanup_temp(
+    tmp_path: Path,
+    cp_dir: Path,
+    primary: CheckpointError | None,
+    *,
+    parent_fd: int | None = None,
+) -> CheckpointError | None:
     """Unlink the temp and fsync the checkpoint directory after a temp deletion.
 
     Used on the success, collision, and error paths so every successful temp
@@ -493,11 +501,18 @@ def _cleanup_temp(tmp_path: Path, cp_dir: Path, primary: CheckpointError | None)
     suppressed (the directory fsync still runs best-effort so the unlink is
     durable). When ``primary`` is ``None``, a cleanup-only failure returns a
     new bounded ``CheckpointError`` (``unlink`` or ``dir-fsync``).
+
+    ``parent_fd`` is the held checkpoint-directory descriptor of an active run
+    binding. When present the unlink is descriptor-relative, so cleanup can
+    only remove this transaction's own temp inside the bound run directory.
     """
     cleanup_err: CheckpointError | None = None
     unlinked = False
     try:
-        os.unlink(tmp_path)
+        if parent_fd is None:
+            os.unlink(tmp_path)
+        else:
+            os.unlink(tmp_path.name, dir_fd=parent_fd)
     except FileNotFoundError:
         # Preserve Path.unlink(missing_ok=True) semantics while using the
         # same os.unlink boundary on every supported Python version.
@@ -517,15 +532,46 @@ def _cleanup_temp(tmp_path: Path, cp_dir: Path, primary: CheckpointError | None)
 
 
 def _abort_with_cleanup(
-    tmp_path: Path, cp_dir: Path, primary: CheckpointError, *, cause: BaseException | None = None
+    tmp_path: Path,
+    cp_dir: Path,
+    primary: CheckpointError,
+    *,
+    cause: BaseException | None = None,
+    parent_fd: int | None = None,
 ) -> None:
     """Run temp cleanup, then raise ``primary`` (or a cleanup-only error)."""
-    cleanup_err = _cleanup_temp(tmp_path, cp_dir, primary)
+    cleanup_err = _cleanup_temp(tmp_path, cp_dir, primary, parent_fd=parent_fd)
     if cleanup_err is not None and primary is None:
         raise cleanup_err from None
     if cause is not None:
         raise primary from cause
     raise primary
+
+
+def _descriptor_relative_publish_available() -> bool:
+    """Whether link/unlink can be issued relative to a held directory descriptor."""
+    supports: frozenset[Any] = frozenset(getattr(os, "supports_dir_fd", ()))
+    return os.link in supports and os.unlink in supports
+
+
+def _bound_checkpoint_dir_fd(cp_dir: Path) -> int | None:
+    """Held descriptor for the checkpoint directory of an active run binding.
+
+    Returns None when no binding authorizes ``cp_dir``. Raises a bounded
+    ``CheckpointError`` when a binding is active but this platform cannot
+    publish descriptor-relative: a bound transaction never falls back to a
+    pathname link that a swapped directory entry could redirect.
+    """
+    if run_journal._bound_target(cp_dir) is None:
+        return None
+    if not _descriptor_relative_publish_available():
+        raise CheckpointError(_bound("descriptor-relative checkpoint publish is unavailable"), category="link")
+    try:
+        return run_journal.bound_dir_fd(cp_dir)
+    except run_journal.RunJournalError as exc:
+        raise CheckpointError(_bound(f"cannot open checkpoint directory: {exc.diagnostic}"), category="mkdir") from exc
+    except OSError as exc:
+        raise CheckpointError(_bound("cannot open checkpoint directory"), category="mkdir") from exc
 
 
 def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
@@ -563,12 +609,22 @@ def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
     except OSError as exc:
         raise CheckpointError(_bound("cannot create checkpoint directory"), category="mkdir") from exc
     final_path = checkpoint_path(run_dir, sha)
+    parent_fd = _bound_checkpoint_dir_fd(cp_dir)
 
     try:
-        fd, tmp_name = tempfile.mkstemp(dir=cp_dir, prefix=".checkpoint.", suffix=".tmp")
+        if parent_fd is None:
+            fd, tmp_name = tempfile.mkstemp(dir=cp_dir, prefix=".checkpoint.", suffix=".tmp")
+            tmp_path = Path(tmp_name)
+        else:
+            tmp_path = cp_dir / f".checkpoint.{uuid4().hex}.tmp"
+            fd = os.open(
+                tmp_path.name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW | _O_CLOEXEC,
+                run_journal._FILE_MODE,
+                dir_fd=parent_fd,
+            )
     except OSError as exc:
         raise CheckpointError(_bound("cannot create checkpoint temp"), category="temp-create") from exc
-    tmp_path = Path(tmp_name)
     primary: CheckpointError | None = None
     try:
         try:
@@ -594,29 +650,37 @@ def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
             primary = close_err
 
     if primary is not None:
-        _abort_with_cleanup(tmp_path, cp_dir, primary)
+        _abort_with_cleanup(tmp_path, cp_dir, primary, parent_fd=parent_fd)
 
     try:
-        os.link(tmp_path, final_path)
+        if parent_fd is None:
+            os.link(tmp_path, final_path)
+        else:
+            os.link(
+                tmp_path.name,
+                final_path.name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
     except FileExistsError:
         try:
             _verify_collision(final_path, run_json_bytes, sha)
         except CheckpointError as exc:
-            _abort_with_cleanup(tmp_path, cp_dir, exc)
-        cleanup_err = _cleanup_temp(tmp_path, cp_dir, None)
+            _abort_with_cleanup(tmp_path, cp_dir, exc, parent_fd=parent_fd)
+        cleanup_err = _cleanup_temp(tmp_path, cp_dir, None, parent_fd=parent_fd)
         if cleanup_err is not None:
             raise cleanup_err from None
         return final_path
     except OSError as exc:
         primary = CheckpointError(_bound("checkpoint link failed"), category="link")
-        _abort_with_cleanup(tmp_path, cp_dir, primary, cause=exc)
+        _abort_with_cleanup(tmp_path, cp_dir, primary, cause=exc, parent_fd=parent_fd)
 
     try:
         _fsync_directory(cp_dir)
     except CheckpointError as exc:
-        _abort_with_cleanup(tmp_path, cp_dir, exc)
+        _abort_with_cleanup(tmp_path, cp_dir, exc, parent_fd=parent_fd)
 
-    cleanup_err = _cleanup_temp(tmp_path, cp_dir, None)
+    cleanup_err = _cleanup_temp(tmp_path, cp_dir, None, parent_fd=parent_fd)
     if cleanup_err is not None:
         raise cleanup_err from None
 
@@ -751,7 +815,7 @@ def write_checkpoint(
     """
     from brigade import run_lifecycle  # lazy: avoid circular import
 
-    run_dir = Path(run_dir).expanduser().resolve()
+    run_dir = run_journal.normalize_run_dir(run_dir)
     run_json_bytes = bytes(run_json_bytes)
     if pairing_key is not None and (not isinstance(pairing_key, str) or not _HEX64.match(pairing_key)):
         raise CheckpointError(_bound("pairing_key must be 64-char lowercase hex"), category="pairing-key")
@@ -804,7 +868,7 @@ def write_checkpoint(
         publish_bytes = run_json_bytes
     run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
     journal_path = run_lifecycle._journal_path(run_dir)
-    if not journal_path.is_file():
+    if not run_journal.bound_is_file(journal_path):
         return None
     # Journal active: every publish/append must come from the process holding
     # the matching active run lock. A lock-less writer fails closed before any
@@ -900,12 +964,12 @@ def _restore_run_json_from_checkpoint(
     if run_meta is not None:
         return repaired
     run_json = run_dir / "run.json"
-    if run_json.is_file():
+    if run_journal.bound_is_file(run_json):
         # Preserve the corrupt original before replacing it.
         backup = run_json.with_name(f"run.json.corrupt-{uuid4().hex}")
         try:
-            run_json.rename(backup)
-        except OSError as exc:
+            run_journal.bound_rename(run_json, backup)
+        except (OSError, run_journal.RunJournalError) as exc:
             raise CheckpointError(_bound("could not preserve corrupt run.json"), category="preserve-corrupt") from exc
     try:
         localio.write_text_atomic(run_json, checkpoint_bytes.decode("utf-8"))
@@ -1090,12 +1154,12 @@ def recover_from_checkpoint(
     from brigade import run_lifecycle  # lazy: avoid circular import
 
     try:
-        run_dir = Path(run_dir).expanduser().resolve()
+        run_dir = run_journal.normalize_run_dir(run_dir)
     except (OSError, RuntimeError) as exc:
         raise CheckpointError(_bound("could not resolve run directory"), category="path-resolve") from exc
     run_id = run_dir.name
     journal_path = run_lifecycle._journal_path(run_dir)
-    if not journal_path.is_file():
+    if not run_journal.bound_is_file(journal_path):
         raise CheckpointError(_bound("lifecycle journal not found"), category="no-journal")
 
     try:

--- a/src/brigade/run_dirfd.py
+++ b/src/brigade/run_dirfd.py
@@ -1,0 +1,253 @@
+"""Descriptor-bound run directory walks and atomic writes.
+
+Phase 1 is dormant: no production caller activates a binding. ``localio``
+consults ``active_binding_for`` first; without a binding it keeps today's
+pathname writes. Authorization is lexical against the exact bound path, then
+resolution walks held no-follow dirfds. Pathname re-resolution never
+authorizes an operation.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Iterator
+from uuid import uuid4
+
+from . import dirfd
+
+MAX_READ_BYTES = 8 * 1024 * 1024
+
+_active: ContextVar[BoundRunDir | None] = ContextVar("brigade_bound_run_dir", default=None)
+
+
+def _close_descriptor(descriptor: int) -> None:
+    if descriptor < 0:
+        return
+    try:
+        os.close(descriptor)
+    except OSError:
+        pass
+
+
+def _lexical_relative(path: Path, root: Path) -> tuple[str, ...] | None:
+    path_parts = Path(os.fspath(path)).parts
+    root_parts = Path(os.fspath(root)).parts
+    if not path_parts or not root_parts:
+        return None
+    if len(path_parts) <= len(root_parts):
+        return None
+    if path_parts[: len(root_parts)] != root_parts:
+        return None
+    return path_parts[len(root_parts) :]
+
+
+class BoundRunDir:
+    """A no-follow handle on a run directory plus its (dev, ino) identity."""
+
+    def __init__(self, path: Path, root_fd: int, identity: tuple[int, int]) -> None:
+        self.path = path
+        self.identity = identity
+        self._root_fd = root_fd
+        self._dirs: dict[tuple[str, ...], int] = {(): root_fd}
+
+    def _require_open(self) -> int:
+        root = self._dirs.get(())
+        if root is None or root < 0:
+            raise OSError("bound run directory is closed")
+        return root
+
+    def dir_fd(self, *components: str, create: bool = False) -> int:
+        fd = self._require_open()
+        current: tuple[str, ...] = ()
+        for component in components:
+            dirfd.validate_component(component)
+            current = (*current, component)
+            cached = self._dirs.get(current)
+            if cached is not None:
+                fd = cached
+                continue
+            try:
+                child = dirfd.open_child_directory(fd, component)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    dirfd.mkdir_child(fd, component)
+                except FileExistsError:
+                    pass
+                child = dirfd.open_child_directory(fd, component)
+            self._dirs[current] = child
+            fd = child
+        return fd
+
+    def read_bytes(self, *parts: str, max_bytes: int = MAX_READ_BYTES) -> bytes | None:
+        if not parts:
+            raise OSError("path component is empty")
+        *directories, name = parts
+        for component in directories:
+            dirfd.validate_component(component)
+        dirfd.validate_component(name)
+        parent = self.dir_fd(*directories)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        try:
+            descriptor = dirfd.open_child_file(parent, name, flags)
+        except FileNotFoundError:
+            return None
+        try:
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_bytes:
+                    raise OSError("bound read exceeds byte limit")
+                chunks.append(chunk)
+            return b"".join(chunks)
+        finally:
+            _close_descriptor(descriptor)
+
+    def write_text_atomic(self, components: tuple[str, ...], name: str, data: str) -> None:
+        self.write_bytes_atomic(components, name, data.encode("utf-8"))
+
+    def write_bytes_atomic(self, components: tuple[str, ...], name: str, data: bytes) -> None:
+        for component in components:
+            dirfd.validate_component(component)
+        dirfd.validate_component(name)
+        parent = self.dir_fd(*components, create=True)
+        temporary = f".{name}.{uuid4().hex}.tmp"
+        descriptor = -1
+        try:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+            descriptor = dirfd.open_child_file(parent, temporary, flags, 0o600)
+            with os.fdopen(os.dup(descriptor), "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.close(descriptor)
+            descriptor = -1
+            dirfd.replace_children(parent, temporary, name)
+            dirfd.fsync_directory(parent)
+        except BaseException:
+            if descriptor != -1:
+                _close_descriptor(descriptor)
+                descriptor = -1
+            try:
+                dirfd.unlink_child(parent, temporary)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def open_file(self, components: tuple[str, ...], name: str, flags: int, mode: int = 0o600) -> int:
+        for component in components:
+            dirfd.validate_component(component)
+        dirfd.validate_component(name)
+        parent = self.dir_fd(*components)
+        extra = getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        return dirfd.open_child_file(parent, name, flags | extra, mode)
+
+    def replace(self, components: tuple[str, ...], source: str, destination: str) -> None:
+        parent = self.dir_fd(*components)
+        dirfd.replace_children(parent, source, destination)
+
+    def stat(self, components: tuple[str, ...], name: str) -> os.stat_result:
+        parent = self.dir_fd(*components)
+        return dirfd.stat_child(parent, name)
+
+    def still_bound(self) -> bool:
+        try:
+            held = os.fstat(self._require_open())
+        except OSError:
+            return False
+        if (held.st_dev, held.st_ino) != self.identity:
+            return False
+        try:
+            named = self.path.lstat()
+        except OSError:
+            return False
+        if stat.S_ISLNK(named.st_mode):
+            return False
+        return (named.st_dev, named.st_ino) == self.identity
+
+    def close(self) -> None:
+        descriptors = list(self._dirs.values())
+        self._dirs.clear()
+        self._root_fd = -1
+        for descriptor in descriptors:
+            _close_descriptor(descriptor)
+
+
+def bind_run_dir(run_dir: Path) -> BoundRunDir | None:
+    """Hold a no-follow directory handle bound to the contained identity.
+
+    Returns None when the identity cannot be established. That includes
+    platforms without an equivalent no-follow primitive.
+    """
+    if not dirfd.available():
+        return None
+    path = Path(run_dir)
+    try:
+        descriptor = dirfd.open_directory_nofollow(path)
+    except OSError:
+        return None
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISDIR(metadata.st_mode):
+            _close_descriptor(descriptor)
+            return None
+        try:
+            named = path.lstat()
+        except OSError:
+            _close_descriptor(descriptor)
+            return None
+        if stat.S_ISLNK(named.st_mode) or (named.st_dev, named.st_ino) != (metadata.st_dev, metadata.st_ino):
+            _close_descriptor(descriptor)
+            return None
+    except OSError:
+        _close_descriptor(descriptor)
+        return None
+    return BoundRunDir(path, descriptor, (metadata.st_dev, metadata.st_ino))
+
+
+@contextmanager
+def bound_run_dir(run_dir: Path) -> Iterator[BoundRunDir]:
+    bound = bind_run_dir(run_dir)
+    if bound is None:
+        raise OSError("run directory could not be bound")
+    token = _active.set(bound)
+    try:
+        yield bound
+    finally:
+        _active.reset(token)
+        bound.close()
+
+
+def active_binding_for(path: Path) -> tuple[BoundRunDir, tuple[str, ...], str] | None:
+    """Authorize only lexical descendants of the exact bound run path."""
+    bound = _active.get()
+    if bound is None:
+        return None
+    rest = _lexical_relative(Path(path), bound.path)
+    if rest is None:
+        return None
+    *directories, name = rest
+    for component in directories:
+        dirfd.validate_component(component)
+    dirfd.validate_component(name)
+    return bound, tuple(directories), name
+
+
+def read_bytes(path: Path, *, max_bytes: int = MAX_READ_BYTES) -> bytes:
+    found = active_binding_for(path)
+    if found is None:
+        return Path(path).read_bytes()
+    bound, components, name = found
+    payload = bound.read_bytes(*components, name, max_bytes=max_bytes)
+    if payload is None:
+        raise FileNotFoundError(path)
+    return payload

--- a/src/brigade/run_events.py
+++ b/src/brigade/run_events.py
@@ -94,6 +94,7 @@ EVENT_TYPES: dict[str, frozenset[str]] = {
     "run.completed": frozenset({"status", "detail"}),
     "run.failed": frozenset({"status", "detail"}),
     "run.interrupted": frozenset({"status", "detail"}),
+    "run.orphaned": frozenset({"status", "last_observed_status", "uncommitted_change_count"}),
     "run.snapshot.checkpointed": frozenset(
         {
             "path",

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -47,7 +47,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
 
-from brigade import run_events
+from brigade import run_dirfd, run_events
 from brigade.run_events import CanonicalizationError, canonical_bytes
 
 _DIR_MODE = 0o700
@@ -299,6 +299,190 @@ class RecoveryReport:
     quarantine_path: Path | None
 
 
+def _bound_target(path: Path) -> tuple[run_dirfd.BoundRunDir, tuple[str, ...], str] | None:
+    """Return the active run-directory binding that authorizes ``path``, or None.
+
+    Authorization is lexical against the exact bound run path. Ordinary
+    callers run with no binding and keep today's pathname behavior.
+    """
+    return run_dirfd.active_binding_for(Path(path))
+
+
+def bound_dir_fd(path: Path, *, create: bool = False) -> int | None:
+    """Held directory descriptor for a bound directory path, else None.
+
+    The descriptor is owned by the binding and cached for its lifetime: a
+    caller must never close it.
+    """
+    target = _bound_target(path)
+    if target is None:
+        return None
+    bound, components, name = target
+    return bound.dir_fd(*components, name, create=create)
+
+
+def normalize_run_dir(run_dir: Path) -> Path:
+    """Normalize a run directory without resolving out of an active binding.
+
+    Every writer module normalizes its ``run_dir`` argument before opening
+    anything under it. ``Path.resolve()`` follows symlinks, so a directory
+    entry swapped for a symlink after bind would resolve the whole transaction
+    into an outside directory and silently drop the binding. When the given
+    path is lexically the bound run directory, the bound path is returned
+    unchanged; otherwise the existing ``expanduser().resolve()`` normalization
+    applies.
+    """
+    path = Path(run_dir).expanduser()
+    target = run_dirfd.active_binding_for(path / "run.json")
+    if target is not None:
+        bound, components, _ = target
+        if not components:
+            return bound.path
+    return path.resolve()
+
+
+def _symlink_refusal(path: Path, exc: OSError, *, wants_directory: bool) -> RunJournalError | None:
+    """Translate the no-follow rejection errnos into the shared bounded error."""
+    if exc.errno == errno.ELOOP:
+        return RunJournalError(_bound(f"refusing symlinked path: {path.name}"))
+    if exc.errno == errno.ENOTDIR and wants_directory:
+        # Linux reports ENOTDIR (not ELOOP) for O_DIRECTORY|O_NOFOLLOW on a
+        # symlinked directory; it is the same rejection.
+        return RunJournalError(_bound(f"refusing symlinked path: {path.name}"))
+    return None
+
+
+def _open_bound(
+    target: tuple[run_dirfd.BoundRunDir, tuple[str, ...], str],
+    path: Path,
+    flags: int,
+    mode: int,
+) -> int:
+    """Open a bound path descriptor-relative through the held run handles."""
+    bound, components, name = target
+    wants_directory = bool(flags & _O_DIRECTORY)
+    open_flags = flags
+    if wants_directory and not _HAS_O_DIRECTORY:
+        open_flags &= ~_O_DIRECTORY
+    try:
+        fd = bound.open_file(components, name, open_flags, mode)
+    except OSError as exc:
+        refusal = _symlink_refusal(path, exc, wants_directory=wants_directory)
+        if refusal is not None:
+            raise refusal from exc
+        raise
+    if not wants_directory or _HAS_O_DIRECTORY:
+        return fd
+    try:
+        if not stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise RunJournalError(_bound(f"path is not a directory: {path.name}"))
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def bound_lstat(path: Path) -> os.stat_result | None:
+    """No-follow stat of a final component; None when it does not exist.
+
+    Under a binding the walk runs through held directory descriptors, so a
+    directory entry swapped after bind cannot redirect the stat outside the
+    bound run inode. Any other resolution failure under a binding is reported
+    as absent so callers fail closed instead of trusting a re-resolved path.
+    """
+    target = _bound_target(path)
+    if target is None:
+        try:
+            return os.lstat(path)
+        except (FileNotFoundError, NotADirectoryError):
+            return None
+    bound, components, name = target
+    try:
+        return bound.stat(components, name)
+    except OSError:
+        return None
+
+
+def bound_lexists(path: Path) -> bool:
+    """``os.path.lexists`` parity, resolved through the binding when active."""
+    if _bound_target(path) is None:
+        return os.path.lexists(path)
+    return bound_lstat(path) is not None
+
+
+def bound_exists(path: Path) -> bool:
+    """``Path.exists`` parity; under a binding a symlinked entry is not an entry.
+
+    A bound run never follows a final symlink, so a symlinked component is
+    reported as absent and the caller's existing no-follow open then fails
+    closed with the shared bounded refusal.
+    """
+    if _bound_target(path) is None:
+        return Path(path).exists()
+    info = bound_lstat(path)
+    return info is not None and not stat.S_ISLNK(info.st_mode)
+
+
+def bound_is_file(path: Path) -> bool:
+    """``Path.is_file`` parity; under a binding only a bound regular file counts."""
+    if _bound_target(path) is None:
+        return Path(path).is_file()
+    info = bound_lstat(path)
+    return info is not None and stat.S_ISREG(info.st_mode)
+
+
+def bound_is_dir(path: Path) -> bool:
+    """``Path.is_dir`` parity; under a binding only a bound directory counts."""
+    if _bound_target(path) is None:
+        return Path(path).is_dir()
+    info = bound_lstat(path)
+    return info is not None and stat.S_ISDIR(info.st_mode)
+
+
+def bound_read_bytes(path: Path) -> bytes:
+    """Read a file's bytes, descriptor-relative when a binding authorizes it.
+
+    Raises ``FileNotFoundError`` when absent and ``OSError`` when the bound
+    entry is a symlink, matching the fail-closed contract of the writers.
+    """
+    return run_dirfd.read_bytes(Path(path))
+
+
+def bound_read_text(path: Path) -> str:
+    """UTF-8 text read, descriptor-relative when a binding authorizes it."""
+    return bound_read_bytes(path).decode("utf-8")
+
+
+def _bound_rename(path: Path, target_path: Path) -> bool:
+    """Rename descriptor-relative through the binding; False when unbound.
+
+    A bound rename must stay inside one directory of the bound run: a
+    cross-directory move is refused rather than re-resolved by pathname.
+    """
+    source = _bound_target(path)
+    destination = _bound_target(target_path)
+    if source is None or destination is None:
+        return False
+    bound, components, name = source
+    _, target_components, target_name = destination
+    if target_components != components:
+        raise RunJournalError(_bound(f"refusing cross-directory rename: {Path(path).name}"))
+    bound.replace(components, name, target_name)
+    return True
+
+
+def bound_rename(path: Path, target_path: Path) -> None:
+    """``Path.rename`` parity, resolved descriptor-relative when bound."""
+    if not _bound_rename(path, target_path):
+        Path(path).rename(target_path)
+
+
+def bound_replace(path: Path, target_path: Path) -> None:
+    """``Path.replace`` parity, resolved descriptor-relative when bound."""
+    if not _bound_rename(path, target_path):
+        Path(path).replace(target_path)
+
+
 def _reject_symlink_final_component(path: Path) -> None:
     """Reject a symlinked final path component via lstat (fallback no-follow guard)."""
     try:
@@ -400,7 +584,15 @@ def _open_nofollow(path: Path, flags: int, mode: int = 0o666) -> int:
     Otherwise the final component is rejected via ``lstat`` before open and
     inode identity is verified with ``lstat``/``fstat`` before the descriptor
     is returned.
+
+    When a run-directory binding authorizes ``path``, the open resolves
+    descriptor-relative through the held handles instead: a directory entry
+    swapped after bind can only reach the original bound inode, or the open
+    fails closed. There is no pathname fallback for a bound path.
     """
+    target = _bound_target(path)
+    if target is not None:
+        return _open_bound(target, path, flags, mode)
     wants_directory = bool(flags & _O_DIRECTORY)
     open_flags = flags
     if wants_directory and not _HAS_O_DIRECTORY:
@@ -444,7 +636,22 @@ def _enforce_dir_mode(path: Path) -> None:
     With ``O_NOFOLLOW`` and ``fchmod``, mode is corrected on the opened
     directory descriptor. Without those APIs, the symlink guard and inode
     identity check run first, then ``chmod`` is applied on the verified path.
+
+    Under a binding the pathname ``lstat`` pre-checks are skipped: the
+    no-follow directory open below already resolves through held descriptors,
+    and re-resolving the name would reintroduce the swap it closes.
     """
+    if _bound_target(path) is not None:
+        fd = _open_nofollow(path, os.O_RDONLY | _O_DIRECTORY)
+        try:
+            info = os.fstat(fd)
+            if not stat.S_ISDIR(info.st_mode):
+                raise RunJournalError(_bound(f"path is not a directory: {path.name}"))
+            if stat.S_IMODE(info.st_mode) != _DIR_MODE:
+                _chmod_fd_or_path(fd, path, _DIR_MODE)
+        finally:
+            os.close(fd)
+        return
     _reject_symlink_final_component(path)
     try:
         st = os.lstat(path)
@@ -484,7 +691,24 @@ def _enforce_file_mode(path: Path) -> None:
 
 
 def _mkdir_private(path: Path) -> None:
-    """Create a directory with mode 0o700 at mkdir time, then enforce it."""
+    """Create a directory with mode 0o700 at mkdir time, then enforce it.
+
+    Under a binding the directory is created and opened descriptor-relative
+    through the held run handles, so a symlinked or swapped entry fails closed
+    with the shared refusal instead of creating anything outside the run.
+    """
+    target = _bound_target(path)
+    if target is not None:
+        bound, components, name = target
+        try:
+            bound.dir_fd(*components, name, create=True)
+        except OSError as exc:
+            refusal = _symlink_refusal(path, exc, wants_directory=True)
+            if refusal is not None:
+                raise refusal from exc
+            raise RunJournalError(_bound(f"cannot create directory: {path.name}")) from exc
+        _enforce_dir_mode(path)
+        return
     path.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
     _enforce_dir_mode(path)
 
@@ -521,7 +745,7 @@ def ensure_journal(journal_path: Path) -> None:
     events_dir = journal_path.parent
     _mkdir_private(events_dir)
     created = False
-    if not journal_path.exists():
+    if not bound_exists(journal_path):
         fd = _open_nofollow(journal_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_MODE)
         os.close(fd)
         created = True
@@ -615,9 +839,9 @@ def _read_tail_state(
     index: dict[str, dict[str, Any]] = {}
     partial_tail: bytes | None = None
     journal_bytes = 0
-    if os.path.lexists(journal_path) and not journal_path.exists():
+    if bound_lexists(journal_path) and not bound_exists(journal_path):
         raise RunJournalError(_bound(f"journal path is a dangling symlink: {journal_path.name}"))
-    if not journal_path.exists():
+    if not bound_exists(journal_path):
         return last_sequence, last_digest, index, partial_tail, journal_bytes
 
     fd = _open_nofollow(journal_path, os.O_RDONLY)
@@ -870,9 +1094,9 @@ def read_journal(journal_path: Path) -> JournalReport:
     """
     journal_path = Path(journal_path)
     report = JournalReport()
-    if os.path.lexists(journal_path) and not journal_path.exists():
+    if bound_lexists(journal_path) and not bound_exists(journal_path):
         raise RunJournalError(_bound(f"journal path is a dangling symlink: {journal_path.name}"))
-    if not journal_path.exists():
+    if not bound_exists(journal_path):
         return report
     raw = _read_bytes_nofollow(journal_path)
 
@@ -922,9 +1146,9 @@ def read_journal_bounded(journal_path: Path) -> JournalReport:
 
     journal_path = Path(journal_path)
     report = JournalReport()
-    if os.path.lexists(journal_path) and not journal_path.exists():
+    if bound_lexists(journal_path) and not bound_exists(journal_path):
         raise RunJournalError(_bound(f"journal path is a dangling symlink: {journal_path.name}"))
-    if not journal_path.exists():
+    if not bound_exists(journal_path):
         return report
 
     fd = _open_nofollow(journal_path, os.O_RDONLY)
@@ -998,7 +1222,7 @@ def recover_partial_tail(journal_path: Path, quarantine_dir: Path) -> RecoveryRe
     is the only API that mutates the journal body.
     """
     journal_path = Path(journal_path)
-    if not journal_path.exists():
+    if not bound_exists(journal_path):
         raise RunJournalError(_bound(f"journal path does not exist: {journal_path.name}"))
     with _append_critical_section(journal_path):
         return _recover_partial_tail_locked(journal_path, Path(quarantine_dir))
@@ -1006,9 +1230,9 @@ def recover_partial_tail(journal_path: Path, quarantine_dir: Path) -> RecoveryRe
 
 def _recover_partial_tail_locked(journal_path: Path, quarantine_dir: Path) -> RecoveryReport:
     """Perform recovery while the append critical section is held."""
-    if os.path.lexists(journal_path) and not journal_path.exists():
+    if bound_lexists(journal_path) and not bound_exists(journal_path):
         raise RunJournalError(_bound(f"journal path is a dangling symlink: {journal_path.name}"))
-    if not journal_path.exists():
+    if not bound_exists(journal_path):
         raise RunJournalError(_bound(f"journal path does not exist: {journal_path.name}"))
     _mkdir_private(quarantine_dir)
 

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -213,7 +213,7 @@ def is_lifecycle_journaling_enabled() -> bool:
 
 
 def _run_id_from_dir(run_dir: Path) -> str:
-    return run_dir.expanduser().resolve().name
+    return run_journal.normalize_run_dir(run_dir).name
 
 
 def _journal_path(run_dir: Path) -> Path:
@@ -231,11 +231,10 @@ def _dispatch_journal_path(run_dir: Path) -> Path | None:
     """
     journal_path = _journal_path(run_dir)
     try:
-        journal_mode = journal_path.lstat().st_mode
-    except FileNotFoundError:
-        journal_mode = None
+        journal_info = run_journal.bound_lstat(journal_path)
     except OSError as exc:
         raise LifecycleJournalError(run_events._bound("lifecycle journal enrollment check failed")) from exc
+    journal_mode = journal_info.st_mode if journal_info is not None else None
     if journal_mode is not None:
         if not stat.S_ISREG(journal_mode):
             raise LifecycleJournalError(run_events._bound("enrolled lifecycle journal is not a regular file"))
@@ -243,15 +242,15 @@ def _dispatch_journal_path(run_dir: Path) -> Path | None:
 
     run_json = run_dir / "run.json"
     try:
-        run_mode = run_json.lstat().st_mode
-    except FileNotFoundError as exc:
-        raise LifecycleJournalError(run_events._bound("dispatch run receipt is missing")) from exc
+        run_info = run_journal.bound_lstat(run_json)
     except OSError as exc:
         raise LifecycleJournalError(run_events._bound("dispatch run receipt enrollment check failed")) from exc
-    if not stat.S_ISREG(run_mode):
+    if run_info is None:
+        raise LifecycleJournalError(run_events._bound("dispatch run receipt is missing"))
+    if not stat.S_ISREG(run_info.st_mode):
         raise LifecycleJournalError(run_events._bound("dispatch run receipt is not a regular file"))
     try:
-        meta = json.loads(run_json.read_bytes())
+        meta = json.loads(run_journal.bound_read_bytes(run_json))
     except (OSError, ValueError, UnicodeDecodeError) as exc:
         raise LifecycleJournalError(run_events._bound("dispatch run receipt enrollment is unreadable")) from exc
     if not isinstance(meta, dict):
@@ -276,9 +275,9 @@ def _journal_requested(
 ) -> bool:
     """True when this run has durably requested lifecycle journaling."""
     run_json = run_dir / "run.json"
-    if run_json.is_file():
+    if run_journal.bound_is_file(run_json):
         try:
-            meta = json.loads(run_json.read_bytes())
+            meta = json.loads(run_journal.bound_read_bytes(run_json))
         except (OSError, ValueError, UnicodeDecodeError):
             return False
         return isinstance(meta, dict) and meta.get(_REQUEST_FIELD) is True
@@ -297,7 +296,7 @@ def _run_snapshot_state(run_dir: Path) -> tuple[str | None, str | None]:
     closed with a bounded category.
     """
     try:
-        raw = (run_dir / "run.json").read_bytes()
+        raw = run_journal.bound_read_bytes(run_dir / "run.json")
     except FileNotFoundError:
         return None, None
     digest = hashlib.sha256(raw).hexdigest()
@@ -362,7 +361,7 @@ def next_dispatch_attempt(run_dir: Path, seat: str) -> int:
     """
     if not isinstance(seat, str) or not seat:
         raise LifecycleJournalError(run_events._bound("dispatch fact seat must be non-empty"))
-    run_dir = Path(run_dir).expanduser().resolve()
+    run_dir = run_journal.normalize_run_dir(run_dir)
     journal_path = _dispatch_journal_path(run_dir)
     if journal_path is None:
         return 1
@@ -387,7 +386,7 @@ def allocate_next_dispatch_attempt(run_dir: Path, seat: str) -> int:
     """
     if not isinstance(seat, str) or not seat:
         raise LifecycleJournalError(run_events._bound("dispatch fact seat must be non-empty"))
-    run_dir = Path(run_dir).expanduser().resolve()
+    run_dir = run_journal.normalize_run_dir(run_dir)
     journal_path = _dispatch_journal_path(run_dir)
     if journal_path is None:
         return 1
@@ -431,7 +430,7 @@ def record_dispatch_fact(
     if attempt is not None and (isinstance(attempt, bool) or not isinstance(attempt, int) or attempt < 1):
         raise LifecycleJournalError(run_events._bound("dispatch fact attempt must be a positive integer"))
 
-    run_dir = Path(run_dir).expanduser().resolve()
+    run_dir = run_journal.normalize_run_dir(run_dir)
     with checkpoint_event_pair():
         journal_path = _dispatch_journal_path(run_dir)
         if journal_path is None:
@@ -444,7 +443,7 @@ def record_dispatch_fact(
             # writers, now applied before every dispatch pair.
             from brigade import aboyeur, run_shadow
 
-            snapshot = (run_dir / "run.json").read_bytes()
+            snapshot = run_journal.bound_read_bytes(run_dir / "run.json")
             try:
                 snapshot_obj = json.loads(snapshot)
             except (ValueError, UnicodeDecodeError) as exc:
@@ -558,7 +557,7 @@ def _recover_authoritative_dispatch_checkpoint(
     checkpoint = journal_report.events[-1]
     artifact_path = run_shadow.shadow_artifact_path(run_dir)
     try:
-        artifact = json.loads(artifact_path.read_text())
+        artifact = json.loads(run_journal.bound_read_text(artifact_path))
     except (OSError, ValueError) as exc:
         raise LifecycleJournalError(
             run_events._bound("authoritative dispatch checkpoint recovery evidence is unreadable")
@@ -762,9 +761,9 @@ def prepare_lifecycle_journal(
     ``LifecycleJournalError`` (generic category; the raw ``OSError`` text can
     carry a path or private value) on any ``ensure_journal`` failure.
     """
-    run_dir = Path(run_dir).expanduser().resolve()
+    run_dir = run_journal.normalize_run_dir(run_dir)
     journal_path = _journal_path(run_dir)
-    if journal_path.is_file():
+    if run_journal.bound_is_file(journal_path):
         return
     if not _journal_requested(run_dir, incoming=incoming_snapshot):
         return
@@ -789,7 +788,7 @@ def record_lifecycle_event(
     workspace: Path | None,
 ) -> run_journal.RunEvent:
     """Append or replay one checkpoint-paired fact under the active run lock."""
-    run_dir = Path(run_dir).expanduser().resolve()
+    run_dir = run_journal.normalize_run_dir(run_dir)
     run_id = _run_id_from_dir(run_dir)
     if not run_events._RUN_ID_RE.match(run_id):
         raise LifecycleJournalError(run_events._bound(f"invalid run_id from run_dir: {run_id!r}"))
@@ -812,7 +811,7 @@ def record_lifecycle_event(
         pairing_key = run_checkpoint.dispatch_pairing_key(event_type, seat, attempt)
     with checkpoint_event_pair():
         journal_path = _journal_path(run_dir)
-        if not journal_path.is_file():
+        if not run_journal.bound_is_file(journal_path):
             raise LifecycleJournalError("lifecycle journal is not active for this run")
         if workspace is None or not runguard.is_active_run_owner(workspace, run_dir):
             raise LifecycleJournalError("lifecycle journal append requires the active run lock for this run")
@@ -829,7 +828,7 @@ def record_lifecycle_event(
             # prior gate used by status and per-worker dispatch pairs.
             from brigade import aboyeur, run_shadow
 
-            snapshot = (run_dir / "run.json").read_bytes()
+            snapshot = run_journal.bound_read_bytes(run_dir / "run.json")
             try:
                 snapshot_obj = json.loads(snapshot)
             except (ValueError, UnicodeDecodeError) as exc:
@@ -921,7 +920,7 @@ def record_lifecycle_transition(
     the workspace from the run receipt payload (``lock_workspace`` or
     ``cwd``), as resolved by ``runguard.resolve_run_lock_workspace``.
     """
-    run_dir = Path(run_dir).expanduser().resolve()
+    run_dir = run_journal.normalize_run_dir(run_dir)
     event_type = STATUS_EVENT_TYPE.get(status)
     if event_type is None:
         # Unmapped statuses are not lifecycle transitions: no event, no
@@ -931,7 +930,7 @@ def record_lifecycle_transition(
     if not run_events._RUN_ID_RE.match(run_id):
         raise LifecycleJournalError(run_events._bound(f"invalid run_id from run_dir: {run_id!r}"))
     journal_path = _journal_path(run_dir)
-    if not journal_path.is_file():
+    if not run_journal.bound_is_file(journal_path):
         # Journal absent. Two legitimate skip paths remain: a legacy/no-request
         # run that never opted in, and a requested run whose activation could
         # not yet happen because the matching lock is not held (the pre-lock

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -117,6 +117,7 @@ STATUS_EVENT_TYPE: dict[str, str] = {
     "timeout": "run.failed",
     "dry-run": "run.completed",
     "incomplete": "run.failed",
+    "orphaned": "run.orphaned",
     "artifact-collection": "run.artifact_collection.started",
     "paused": "run.paused",
     "running": "run.resumed",
@@ -680,6 +681,15 @@ def _allowlisted_payload(
         if len(text) > run_events.MAX_PAYLOAD_STR_LEN:
             text = text[: run_events.MAX_PAYLOAD_STR_LEN]
         payload["detail"] = text
+    incoming = incoming_snapshot or {}
+    if "last_observed_status" in allowed:
+        last_status = incoming.get("last_observed_status")
+        if isinstance(last_status, str) and last_status:
+            payload["last_observed_status"] = last_status[: run_events.MAX_PAYLOAD_STR_LEN]
+    if "uncommitted_change_count" in allowed:
+        dirty = incoming.get("uncommitted_change_count")
+        if isinstance(dirty, int) and not isinstance(dirty, bool) and 0 <= dirty <= run_events.MAX_CANONICAL_INT:
+            payload["uncommitted_change_count"] = dirty
     if event_type in {"run.paused", "run.resumed"}:
         reference = _approval_reference(incoming_snapshot)
         if reference is None:

--- a/src/brigade/run_projector.py
+++ b/src/brigade/run_projector.py
@@ -113,6 +113,9 @@ PRESERVED_FIELDS: frozenset[str] = frozenset(
         # Artifact references
         "artifacts",
         "handoff",
+        "orphaned_at",
+        "last_observed_status",
+        "uncommitted_change_count",
     }
 )
 
@@ -187,6 +190,7 @@ _PAYLOAD_STATUS_RULES: dict[str, tuple[frozenset[str], str | None]] = {
     # Payload status is preserved so canceled (brigade run) and cancelled
     # (research) both project correctly without rewriting each other.
     "run.interrupted": (frozenset({"canceled", "cancelled"}), None),
+    "run.orphaned": (frozenset({"orphaned"}), "orphaned"),
 }
 
 

--- a/src/brigade/run_reap.py
+++ b/src/brigade/run_reap.py
@@ -40,7 +40,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
-from . import dirfd, proc, run_checkpoint, run_dirfd, run_journal, run_lifecycle, runguard, runs_cmd
+from . import dirfd, proc, run_checkpoint, run_dirfd, run_journal, run_lifecycle, run_redaction, runguard, runs_cmd
 
 SCHEMA = "brigade.runs-reap.v1"
 DEFAULT_OLDER_THAN = "2h"
@@ -91,6 +91,48 @@ class _BoundRunDir:
         if (held.st_dev, held.st_ino) != self.identity:
             return False
         return _directory_identity(self.path) == self.identity
+
+    def read_regular_file(self, name: str, *, max_bytes: int) -> bytes | None:
+        """Read a direct child that must be a regular file, without hanging on a FIFO.
+
+        Stats through the already-held directory descriptor, refuses anything
+        that is not a regular file or that exceeds ``max_bytes``, then opens
+        no-follow and non-blocking so a raced FIFO cannot block the reaper.
+        """
+        try:
+            info = dirfd.stat_child(self._fd, name)
+        except OSError:
+            return None
+        if not stat.S_ISREG(info.st_mode) or info.st_size < 0 or info.st_size > max_bytes:
+            return None
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NONBLOCK", 0)
+        try:
+            descriptor = dirfd.open_child_file(self._fd, name, flags)
+        except OSError:
+            return None
+        try:
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or opened.st_size < 0 or opened.st_size > max_bytes:
+                return None
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = os.read(descriptor, min(65536, max_bytes + 1 - total))
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_bytes:
+                    return None
+                chunks.append(chunk)
+            return b"".join(chunks)
+        except OSError:
+            return None
+        finally:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
 
     def close(self) -> None:
         fd = self._fd
@@ -260,6 +302,25 @@ def _read_run_bytes(run_dir: Path) -> tuple[bytes | None, dict[str, Any] | None]
     path = run_dir / "run.json"
     try:
         raw = run_journal.bound_read_bytes(path)
+        payload = json.loads(raw.decode("utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError, RecursionError):
+        return None, None
+    if not isinstance(payload, dict):
+        return None, None
+    return raw, payload
+
+
+def _read_bound_run_bytes(bound: _BoundRunDir) -> tuple[bytes | None, dict[str, Any] | None]:
+    """Initial snapshot through the already-held run directory descriptor.
+
+    The later CAS read stays on :func:`_read_run_bytes` under
+    :func:`_bound_transaction`. This path must not follow or block on a
+    FIFO, and it must not ingest an oversized receipt.
+    """
+    try:
+        raw = bound.read_regular_file("run.json", max_bytes=run_redaction.MAX_RUN_JSON_BYTES)
+        if raw is None:
+            return None, None
         payload = json.loads(raw.decode("utf-8"))
     except (OSError, ValueError, UnicodeDecodeError, RecursionError):
         return None, None
@@ -568,7 +629,7 @@ def reap(
             if not bound.still_bound():
                 skipped.append(_skip(child.name, "malformed"))
                 continue
-            raw, meta = _read_run_bytes(child)
+            raw, meta = _read_bound_run_bytes(bound)
             if raw is None or meta is None:
                 skipped.append(_skip(child.name, "malformed"))
                 continue

--- a/src/brigade/run_reap.py
+++ b/src/brigade/run_reap.py
@@ -307,7 +307,7 @@ def _revalidate_metadata(
     started = _parse_timestamp(meta.get("started_at"))
     if started is None:
         return "malformed"
-    if now - started < older_than:
+    if now - started <= older_than:
         return "too-young"
     return None
 
@@ -440,19 +440,20 @@ def _reap_one(
                     return None, _skip(run_dir.name, reason)
                 try:
                     return _terminalize(run_dir, current, workspace=workspace, now=now), None
-                except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
+                except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError, OSError) as exc:
                     # The sanctioned writer refused this run's transaction (an
-                    # unready authority gate, a broken chain), possibly after
-                    # activating the journal or publishing a checkpoint. Claim
-                    # mode already deleted the original dead owner's lock, so
-                    # releasing here would leave the run with no lock and no
-                    # matching ``.stale`` claim for ``brigade runs recover``.
-                    # ``RetainRunLockError`` keeps this claimed lock in place:
-                    # it records this run_dir, so once the reaper process exits
-                    # the lock reads back as a dead-owner stale lock that
-                    # recovery matches. The reason string stays bounded; the
-                    # writer's diagnostic may name a path, so it stays out of
-                    # the contract.
+                    # unready authority gate, a broken chain, or a raw
+                    # write-path OSError from the final run.json replace),
+                    # possibly after activating the journal or publishing a
+                    # checkpoint. Claim mode already deleted the original dead
+                    # owner's lock, so releasing here would leave the run with
+                    # no lock and no matching ``.stale`` claim for
+                    # ``brigade runs recover``. ``RetainRunLockError`` keeps
+                    # this claimed lock in place: it records this run_dir, so
+                    # once the reaper process exits the lock reads back as a
+                    # dead-owner stale lock that recovery matches. The reason
+                    # string stays bounded; the writer's diagnostic may name a
+                    # path, so it stays out of the contract.
                     raise runguard.RetainRunLockError("orphan reap write refused") from exc
     except ReapBindingError:
         # The run directory entry stopped resolving to the inode the reaper
@@ -525,14 +526,14 @@ def reap(
         return 2
     cwd = cwd.expanduser().resolve()
     if not cwd.is_dir():
-        print(f"error: --cwd is not a directory: {cwd}", file=sys.stderr)
+        print("error: --cwd is not a directory", file=sys.stderr)
         return 2
     # Resolve the root so a candidate's path already equals what every writer
     # module normalizes to. A binding is authorized lexically against the exact
     # bound path, so an unresolved root would silently skip the binding.
     root = runs_dir.expanduser().resolve() if runs_dir is not None else cwd / ".brigade" / "runs"
     if not root.is_dir():
-        print(f"error: runs directory not found: {root}", file=sys.stderr)
+        print("error: runs directory not found", file=sys.stderr)
         return 2
 
     clock = _utc_now(now)

--- a/src/brigade/run_reap.py
+++ b/src/brigade/run_reap.py
@@ -1,10 +1,34 @@
-"""Explicit local reaper for runs whose recorded owner process is gone."""
+"""Explicit local reaper for runs whose recorded owner process is gone.
+
+Containment status. The reaper binds each candidate run directory with a
+no-follow open and refuses to proceed when that identity cannot be established
+(:func:`_bind_contained_run_dir`), which fails closed on a symlinked or
+reparse-pointed run directory and on any platform without a no-follow
+directory primitive. It re-checks the bound identity at the last seam before
+handing the run to the sanctioned writer.
+
+That is a narrowed check, not a descriptor-bound transaction. The sanctioned
+``run.json`` transaction is path-based end to end: ``run_lifecycle``,
+``run_checkpoint``, ``run_journal``, ``run_shadow``, ``aboyeur.run_io``, and
+``localio`` each normalize with ``Path(run_dir).expanduser().resolve()`` and
+open by pathname, and their atomicity comes from same-directory
+``mkstemp``/``os.replace``. A swap of the run directory entry that lands after
+the final check, or between two writers inside the transaction, still
+redirects those opens. Binding the whole transaction means threading a
+directory descriptor through all six writer modules and rewriting each one's
+I/O to ``dir_fd``-relative calls, which is outside this change's blast radius;
+staging the transaction elsewhere and republishing descriptor-relative would
+trade the race for a non-atomic republish that can tear the lifecycle chain.
+Until that refactor lands, do not read the checks below as containment.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import stat
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -22,10 +46,143 @@ ORPHAN_SCAN_LIMIT = 50
 _OLDER_THAN_RE = re.compile(r"^(\d+)([smhd])$", re.IGNORECASE)
 _UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
 _REAPABLE_STATUSES = runs_cmd._NONTERMINAL_STATUSES
+_MALFORMED_PUBLIC_RUN_ID = "malformed"
+_UNKNOWN_STATUS = "unknown"
 
 
 class ReapError(ValueError):
     """Bounded CLI / contract error for the local reaper."""
+
+
+class _BoundRunDir:
+    """A no-follow handle on a run directory plus its (dev, ino) identity.
+
+    ``still_bound`` compares the held handle and a fresh no-follow open of the
+    same name against the identity recorded at bind time. That rejects a
+    symlinked or reparse-pointed run directory outright and narrows the window
+    for a directory swap, but it is a check, not containment: the sanctioned
+    ``run.json`` transaction that follows re-resolves ``run_dir`` by pathname
+    in every writer module, so a swap landing between the last check and a
+    writer's own open is still able to redirect that writer. See the module
+    docstring for the residual and why closing it is a cross-cutting change.
+    """
+
+    def __init__(self, path: Path, fd: int, identity: tuple[int, int]) -> None:
+        self.path = path
+        self._fd = fd
+        self.identity = identity
+
+    def still_bound(self) -> bool:
+        try:
+            held = os.fstat(self._fd)
+        except OSError:
+            return False
+        if (held.st_dev, held.st_ino) != self.identity:
+            return False
+        return _directory_identity(self.path) == self.identity
+
+    def close(self) -> None:
+        fd = self._fd
+        self._fd = -1
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _public_run_id(name: str) -> str:
+    if runs_cmd._is_bare_run_id(name):
+        return name
+    return _MALFORMED_PUBLIC_RUN_ID
+
+
+def _public_status(value: object) -> str:
+    if isinstance(value, str) and value in _REAPABLE_STATUSES:
+        return value
+    return _UNKNOWN_STATUS
+
+
+def _dirfd_identity_available() -> bool:
+    if bool(getattr(os, "O_NOFOLLOW", 0)) and bool(getattr(os, "O_DIRECTORY", 0)):
+        return True
+    if sys.platform == "win32":
+        try:
+            from .work_cmd import nt_dirfd
+        except ImportError:
+            return False
+        return nt_dirfd.available()
+    return False
+
+
+def _open_dir_nofollow(path: Path) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    directory = getattr(os, "O_DIRECTORY", 0)
+    if nofollow and directory:
+        flags = os.O_RDONLY | directory | nofollow | getattr(os, "O_CLOEXEC", 0)
+        return os.open(path, flags)
+    if sys.platform == "win32":
+        from .work_cmd import nt_dirfd
+
+        if nt_dirfd.available():
+            return nt_dirfd.open_root_directory(path, writable=False)
+    raise OSError("no-follow directory open is unavailable")
+
+
+def _directory_identity(path: Path) -> tuple[int, int] | None:
+    """Return (dev, ino) of a real directory without following a final symlink."""
+    if not _dirfd_identity_available():
+        return None
+    try:
+        fd = _open_dir_nofollow(path)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+    finally:
+        os.close(fd)
+    if not stat.S_ISDIR(st.st_mode):
+        return None
+    try:
+        named = path.lstat()
+    except OSError:
+        return None
+    if stat.S_ISLNK(named.st_mode):
+        return None
+    if (named.st_dev, named.st_ino) != (st.st_dev, st.st_ino):
+        return None
+    return (st.st_dev, st.st_ino)
+
+
+def _bind_contained_run_dir(path: Path) -> _BoundRunDir | None:
+    """Hold a no-follow directory handle bound to the contained identity.
+
+    Returns None when the identity cannot be established. That includes
+    platforms without an equivalent no-follow primitive: reap fails closed
+    rather than following a symlink or reparse point.
+    """
+    if not _dirfd_identity_available():
+        return None
+    try:
+        fd = _open_dir_nofollow(path)
+    except OSError:
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISDIR(st.st_mode):
+            os.close(fd)
+            return None
+        named = path.lstat()
+        if stat.S_ISLNK(named.st_mode) or (named.st_dev, named.st_ino) != (st.st_dev, st.st_ino):
+            os.close(fd)
+            return None
+    except OSError:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return None
+    return _BoundRunDir(path, fd, (st.st_dev, st.st_ino))
 
 
 def parse_older_than(value: str) -> timedelta:
@@ -105,10 +262,12 @@ def _read_run_bytes(run_dir: Path) -> tuple[bytes | None, dict[str, Any] | None]
 
 
 def _skip(run_id: str, reason: str) -> dict[str, str]:
-    return {"run_id": run_id, "reason": reason}
+    return {"run_id": _public_run_id(run_id), "reason": reason}
 
 
 def _classify_child(child: Path, resolved_root: Path) -> str | None:
+    if not runs_cmd._is_bare_run_id(child.name):
+        return "malformed"
     try:
         if child.is_symlink():
             return "symlink"
@@ -179,9 +338,7 @@ def _terminalize(run_dir: Path, meta: dict[str, Any], *, workspace: Path, now: d
     """
     from . import aboyeur, receipt_schema
 
-    last_status = meta.get("status")
-    if not isinstance(last_status, str) or not last_status:
-        last_status = "unknown"
+    last_status = _public_status(meta.get("status"))
     dirty = _count_uncommitted_changes(workspace)
     orphaned_at = now.isoformat()
     updated = dict(meta)
@@ -196,7 +353,7 @@ def _terminalize(run_dir: Path, meta: dict[str, Any], *, workspace: Path, now: d
     )
     aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(updated))
     return {
-        "run_id": run_dir.name,
+        "run_id": _public_run_id(run_dir.name),
         "last_observed_status": last_status,
         "uncommitted_change_count": dirty,
         "orphaned_at": orphaned_at,
@@ -210,6 +367,7 @@ def _reap_one(
     fingerprint: str,
     older_than: timedelta,
     now: datetime,
+    bound: _BoundRunDir,
 ) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
     reason = _preflight(run_dir, meta, older_than=older_than, now=now)
     if reason is not None:
@@ -218,6 +376,8 @@ def _reap_one(
     assert workspace is not None
     try:
         with runguard.run_lock(workspace, run_dir=run_dir, wait_seconds=0, stale_action="claim"):
+            if not bound.still_bound():
+                return None, _skip(run_dir.name, "concurrently-changed")
             raw, current = _read_run_bytes(run_dir)
             if raw is None or current is None:
                 return None, _skip(run_dir.name, "concurrently-changed")
@@ -228,14 +388,28 @@ def _reap_one(
             reason = _revalidate_metadata(current, older_than=older_than, now=now)
             if reason is not None:
                 return None, _skip(run_dir.name, reason)
+            if not bound.still_bound():
+                return None, _skip(run_dir.name, "concurrently-changed")
             try:
                 return _terminalize(run_dir, current, workspace=workspace, now=now), None
-            except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError):
+            except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
                 # The sanctioned writer refused this run's transaction (an
-                # unready authority gate, a broken chain). Skip it rather than
-                # abandoning the rest of the scan; the diagnostic is bounded
-                # but may name a path, so it stays out of the contract.
-                return None, _skip(run_dir.name, "write-refused")
+                # unready authority gate, a broken chain), possibly after
+                # activating the journal or publishing a checkpoint. Claim
+                # mode already deleted the original dead owner's lock, so
+                # releasing here would leave the run with no lock and no
+                # matching ``.stale`` claim for ``brigade runs recover``.
+                # ``RetainRunLockError`` keeps this claimed lock in place: it
+                # records this run_dir, so once the reaper process exits the
+                # lock reads back as a dead-owner stale lock that recovery
+                # matches. The reason string stays bounded; the writer's
+                # diagnostic may name a path, so it stays out of the contract.
+                raise runguard.RetainRunLockError("orphan reap write refused") from exc
+    except runguard.RetainRunLockError:
+        # Caught outside the context so ``run_lock`` has already skipped the
+        # release. The rest of the scan still runs; other runs in this
+        # workspace now see the retained live lock and skip.
+        return None, _skip(run_dir.name, "write-refused")
     except runguard.RunLockError:
         return None, _skip(run_dir.name, "concurrently-changed")
 
@@ -269,12 +443,13 @@ def list_orphaned_runs(
             continue
         dirty = meta.get("uncommitted_change_count")
         count = dirty if isinstance(dirty, int) and not isinstance(dirty, bool) and dirty >= 0 else 0
+        run_id = _public_run_id(child.name)
         rows.append(
             {
-                "run_id": child.name,
-                "last_observed_status": meta.get("last_observed_status"),
+                "run_id": run_id,
+                "last_observed_status": _public_status(meta.get("last_observed_status")),
                 "uncommitted_change_count": min(count, MAX_UNCOMMITTED_CHANGE_COUNT),
-                "suggested_command": f"brigade runs show {child.name}",
+                "suggested_command": f"brigade runs show {run_id}",
             }
         )
         if len(rows) >= limit:
@@ -318,21 +493,36 @@ def reap(
             continue
         if classified is not None or not child.is_dir():
             continue
-        raw, meta = _read_run_bytes(child)
-        if raw is None or meta is None:
-            skipped.append(_skip(child.name, "malformed"))
+        bound = _bind_contained_run_dir(child)
+        if bound is None:
+            # Fail closed before any mutation. A platform with no no-follow
+            # directory primitive can never bind, so it reports ``unbindable``
+            # for every candidate rather than reusing the bad-run-id reason.
+            reason = "malformed" if _dirfd_identity_available() else "unbindable"
+            skipped.append(_skip(child.name, reason))
             continue
-        won, lost = _reap_one(
-            child,
-            meta,
-            fingerprint=_run_fingerprint(raw),
-            older_than=threshold,
-            now=clock,
-        )
-        if won is not None:
-            reaped.append(won)
-        elif lost is not None:
-            skipped.append(lost)
+        try:
+            if not bound.still_bound():
+                skipped.append(_skip(child.name, "malformed"))
+                continue
+            raw, meta = _read_run_bytes(child)
+            if raw is None or meta is None:
+                skipped.append(_skip(child.name, "malformed"))
+                continue
+            won, lost = _reap_one(
+                child,
+                meta,
+                fingerprint=_run_fingerprint(raw),
+                older_than=threshold,
+                now=clock,
+                bound=bound,
+            )
+            if won is not None:
+                reaped.append(won)
+            elif lost is not None:
+                skipped.append(lost)
+        finally:
+            bound.close()
 
     if json_output:
         print(

--- a/src/brigade/run_reap.py
+++ b/src/brigade/run_reap.py
@@ -22,15 +22,6 @@ reach the original held run inode, or the operation fails closed with a
 bounded error. No write in this transaction can reach a directory outside the
 bound run.
 
-One read residual remains, and it is a read only: ``aboyeur.run_io`` still
-opens ``run.json`` by pathname for its prior-snapshot and authority-state
-gates (``_write_json_inner`` and ``_resolve_authority_state``). A swap landing
-between the reaper's CAS read and those gates can feed them outside bytes.
-Closing it needs the same treatment inside ``aboyeur.run_io``, which is
-outside this module set. The consequence is bounded: the gates can only
-refuse, or record a transition on the bound run itself, and every resulting
-write still lands on the held inode.
-
 Ordinary callers run with no binding and keep the existing pathname behavior;
 the binding is authorized lexically against the exact bound run path, so it
 never widens to a sibling run.
@@ -49,7 +40,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
-from . import proc, run_checkpoint, run_dirfd, run_journal, run_lifecycle, runguard, runs_cmd
+from . import dirfd, proc, run_checkpoint, run_dirfd, run_journal, run_lifecycle, runguard, runs_cmd
 
 SCHEMA = "brigade.runs-reap.v1"
 DEFAULT_OLDER_THAN = "2h"
@@ -67,6 +58,14 @@ _UNKNOWN_STATUS = "unknown"
 
 class ReapError(ValueError):
     """Bounded CLI / contract error for the local reaper."""
+
+
+class RetainRunLockError(runguard.RetainRunLockError):
+    """Keep the claimed lock and carry the bounded public skip reason."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 class _BoundRunDir:
@@ -116,15 +115,11 @@ def _public_status(value: object) -> str:
 
 
 def _dirfd_identity_available() -> bool:
-    if bool(getattr(os, "O_NOFOLLOW", 0)) and bool(getattr(os, "O_DIRECTORY", 0)):
-        return True
-    if sys.platform == "win32":
-        try:
-            from .work_cmd import nt_dirfd
-        except ImportError:
-            return False
-        return nt_dirfd.available()
-    return False
+    # Same predicate as ``run_dirfd`` / ``dirfd.available()`` so identity
+    # cannot be claimed on a platform that cannot bind the transaction.
+    # Windows stays fail-closed unless ``dirfd.nt_available()`` is true.
+    # Tests keep monkeypatching this name.
+    return dirfd.available()
 
 
 def _open_dir_nofollow(path: Path) -> int:
@@ -423,38 +418,48 @@ def _reap_one(
     try:
         with runguard.run_lock(workspace, run_dir=run_dir, wait_seconds=0, stale_action="claim"):
             if not bound.still_bound():
-                return None, _skip(run_dir.name, "concurrently-changed")
+                raise RetainRunLockError("concurrently-changed")
             # Everything below runs inside the transaction binding: the CAS
             # read, the revalidation it gates, and the sanctioned writer all
             # resolve descriptor-relative through the same held run inode.
-            with _bound_transaction(bound):
-                raw, current = _read_run_bytes(run_dir)
-                if raw is None or current is None:
-                    return None, _skip(run_dir.name, "concurrently-changed")
-                if _run_fingerprint(raw) != fingerprint:
-                    return None, _skip(run_dir.name, "concurrently-changed")
-                # Under the reaper's newly claimed live lock, re-check run.json
-                # only. Original-owner liveness was already proven before acquire.
-                reason = _revalidate_metadata(current, older_than=older_than, now=now)
-                if reason is not None:
-                    return None, _skip(run_dir.name, reason)
-                try:
-                    return _terminalize(run_dir, current, workspace=workspace, now=now), None
-                except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError, OSError) as exc:
-                    # The sanctioned writer refused this run's transaction (an
-                    # unready authority gate, a broken chain, or a raw
-                    # write-path OSError from the final run.json replace),
-                    # possibly after activating the journal or publishing a
-                    # checkpoint. Claim mode already deleted the original dead
-                    # owner's lock, so releasing here would leave the run with
-                    # no lock and no matching ``.stale`` claim for
-                    # ``brigade runs recover``. ``RetainRunLockError`` keeps
-                    # this claimed lock in place: it records this run_dir, so
-                    # once the reaper process exits the lock reads back as a
-                    # dead-owner stale lock that recovery matches. The reason
-                    # string stays bounded; the writer's diagnostic may name a
-                    # path, so it stays out of the contract.
-                    raise runguard.RetainRunLockError("orphan reap write refused") from exc
+            try:
+                with _bound_transaction(bound):
+                    raw, current = _read_run_bytes(run_dir)
+                    if raw is None or current is None:
+                        raise RetainRunLockError("concurrently-changed")
+                    if _run_fingerprint(raw) != fingerprint:
+                        stale_reason = _revalidate_metadata(current, older_than=older_than, now=now)
+                        if stale_reason in {"terminal", "already-orphaned"}:
+                            return None, _skip(run_dir.name, "concurrently-changed")
+                        raise RetainRunLockError("concurrently-changed")
+                    # Under the reaper's newly claimed live lock, re-check run.json
+                    # only. Original-owner liveness was already proven before acquire.
+                    reason = _revalidate_metadata(current, older_than=older_than, now=now)
+                    if reason is not None:
+                        return None, _skip(run_dir.name, reason)
+                    try:
+                        return _terminalize(run_dir, current, workspace=workspace, now=now), None
+                    except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError, OSError) as exc:
+                        # The sanctioned writer refused this run's transaction (an
+                        # unready authority gate, a broken chain, or a raw
+                        # write-path OSError from the final run.json replace),
+                        # possibly after activating the journal or publishing a
+                        # checkpoint. Claim mode already deleted the original dead
+                        # owner's lock, so releasing here would leave the run with
+                        # no lock and no matching ``.stale`` claim for
+                        # ``brigade runs recover``. ``RetainRunLockError`` keeps
+                        # this claimed lock in place: it records this run_dir, so
+                        # once the reaper process exits the lock reads back as a
+                        # dead-owner stale lock that recovery matches. The reason
+                        # string stays bounded; the writer's diagnostic may name a
+                        # path, so it stays out of the contract.
+                        raise runguard.RetainRunLockError("orphan reap write refused") from exc
+            except ReapBindingError:
+                raise RetainRunLockError("concurrently-changed") from None
+    except RetainRunLockError as exc:
+        # Caught outside the context so ``run_lock`` has already skipped the
+        # release. Public skip reason stays the bounded value on the error.
+        return None, _skip(run_dir.name, exc.reason)
     except ReapBindingError:
         # The run directory entry stopped resolving to the inode the reaper
         # validated. Nothing was written; report it like any other CAS loss.
@@ -528,11 +533,12 @@ def reap(
     if not cwd.is_dir():
         print("error: --cwd is not a directory", file=sys.stderr)
         return 2
-    # Resolve the root so a candidate's path already equals what every writer
-    # module normalizes to. A binding is authorized lexically against the exact
-    # bound path, so an unresolved root would silently skip the binding.
+    # Explicit --runs-dir is canonicalized so writer-normalized candidate
+    # paths match the binding. The default workspace root must already be
+    # canonical: do not follow or resolve a workspace-controlled
+    # ``.brigade/runs`` symlink.
     root = runs_dir.expanduser().resolve() if runs_dir is not None else cwd / ".brigade" / "runs"
-    if not root.is_dir():
+    if (runs_dir is None and root.is_symlink()) or not root.is_dir():
         print("error: runs directory not found", file=sys.stderr)
         return 2
 

--- a/src/brigade/run_reap.py
+++ b/src/brigade/run_reap.py
@@ -1,25 +1,39 @@
 """Explicit local reaper for runs whose recorded owner process is gone.
 
-Containment status. The reaper binds each candidate run directory with a
-no-follow open and refuses to proceed when that identity cannot be established
+Containment. The reaper binds each candidate run directory with a no-follow
+open and refuses to proceed when that identity cannot be established
 (:func:`_bind_contained_run_dir`), which fails closed on a symlinked or
 reparse-pointed run directory and on any platform without a no-follow
-directory primitive. It re-checks the bound identity at the last seam before
-handing the run to the sanctioned writer.
+directory primitive.
 
-That is a narrowed check, not a descriptor-bound transaction. The sanctioned
-``run.json`` transaction is path-based end to end: ``run_lifecycle``,
-``run_checkpoint``, ``run_journal``, ``run_shadow``, ``aboyeur.run_io``, and
-``localio`` each normalize with ``Path(run_dir).expanduser().resolve()`` and
-open by pathname, and their atomicity comes from same-directory
-``mkstemp``/``os.replace``. A swap of the run directory entry that lands after
-the final check, or between two writers inside the transaction, still
-redirects those opens. Binding the whole transaction means threading a
-directory descriptor through all six writer modules and rewriting each one's
-I/O to ``dir_fd``-relative calls, which is outside this change's blast radius;
-staging the transaction elsewhere and republishing descriptor-relative would
-trade the race for a non-atomic republish that can tear the lifecycle chain.
-Until that refactor lands, do not read the checks below as containment.
+The whole terminalization transaction then runs under a descriptor binding
+(:func:`run_dirfd.bound_run_dir`) whose identity is proven equal to that
+already-held handle, so the transaction is pinned to the exact inode the
+reaper validated. Inside the binding every write, and every read owned by the
+five run modules, resolves descriptor-relative through held directory
+handles: ``run_journal``'s no-follow opens, stats, reads, and renames; the
+``run_checkpoint`` temp/link/unlink publish; ``run_lifecycle``'s snapshot and
+enrollment reads; ``run_shadow``'s evidence reads and quarantine renames; and
+``localio``'s atomic writers. Those modules also stop normalizing ``run_dir``
+with ``Path.resolve()`` under a binding (``run_journal.normalize_run_dir``),
+which is what previously let a swapped symlink relocate a whole transaction.
+A directory-entry swap or a symlink planted after bind can therefore only
+reach the original held run inode, or the operation fails closed with a
+bounded error. No write in this transaction can reach a directory outside the
+bound run.
+
+One read residual remains, and it is a read only: ``aboyeur.run_io`` still
+opens ``run.json`` by pathname for its prior-snapshot and authority-state
+gates (``_write_json_inner`` and ``_resolve_authority_state``). A swap landing
+between the reaper's CAS read and those gates can feed them outside bytes.
+Closing it needs the same treatment inside ``aboyeur.run_io``, which is
+outside this module set. The consequence is bounded: the gates can only
+refuse, or record a transition on the bound run itself, and every resulting
+write still lands on the held inode.
+
+Ordinary callers run with no binding and keep the existing pathname behavior;
+the binding is authorized lexically against the exact bound run path, so it
+never widens to a sibling run.
 """
 
 from __future__ import annotations
@@ -30,11 +44,12 @@ import os
 import re
 import stat
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
-from . import proc, run_checkpoint, run_lifecycle, runguard, runs_cmd
+from . import proc, run_checkpoint, run_dirfd, run_journal, run_lifecycle, runguard, runs_cmd
 
 SCHEMA = "brigade.runs-reap.v1"
 DEFAULT_OLDER_THAN = "2h"
@@ -58,13 +73,10 @@ class _BoundRunDir:
     """A no-follow handle on a run directory plus its (dev, ino) identity.
 
     ``still_bound`` compares the held handle and a fresh no-follow open of the
-    same name against the identity recorded at bind time. That rejects a
-    symlinked or reparse-pointed run directory outright and narrows the window
-    for a directory swap, but it is a check, not containment: the sanctioned
-    ``run.json`` transaction that follows re-resolves ``run_dir`` by pathname
-    in every writer module, so a swap landing between the last check and a
-    writer's own open is still able to redirect that writer. See the module
-    docstring for the residual and why closing it is a cross-cutting change.
+    same name against the identity recorded at bind time. This handle stays
+    open for the whole candidate, so its inode cannot be recycled: the
+    transaction binding taken in :func:`_terminalize` proves it is the same
+    inode by comparing identities, and only then does any writer run.
     """
 
     def __init__(self, path: Path, fd: int, identity: tuple[int, int]) -> None:
@@ -252,7 +264,7 @@ def _utc_now(now: datetime | None) -> datetime:
 def _read_run_bytes(run_dir: Path) -> tuple[bytes | None, dict[str, Any] | None]:
     path = run_dir / "run.json"
     try:
-        raw = path.read_bytes()
+        raw = run_journal.bound_read_bytes(path)
         payload = json.loads(raw.decode("utf-8"))
     except (OSError, ValueError, UnicodeDecodeError, RecursionError):
         return None, None
@@ -321,6 +333,40 @@ def _preflight(
     return None
 
 
+class ReapBindingError(RuntimeError):
+    """The transaction binding could not be pinned to the validated run inode."""
+
+
+@contextmanager
+def _bound_transaction(bound: _BoundRunDir) -> Iterator[run_dirfd.BoundRunDir]:
+    """Bind the whole terminalization transaction to the already-held run inode.
+
+    ``bound`` has held a no-follow descriptor on this run directory since
+    before any check ran, so that inode cannot be recycled while we hold it.
+    The transaction binding re-opens the name no-follow and is accepted only
+    when its identity equals the held one; a swap or symlink landing in
+    between yields a different identity (or no binding at all) and raises
+    ``ReapBindingError`` before any writer runs.
+    """
+    # A bound path is authorized lexically. If a writer would normalize this
+    # run directory to a different path, the binding would silently not apply,
+    # so refuse instead of running the transaction unbound.
+    try:
+        if Path(bound.path).expanduser().resolve() != bound.path:
+            raise ReapBindingError("run directory path is not writer-normalized")
+    except OSError as exc:
+        raise ReapBindingError("run directory path could not be normalized") from exc
+    try:
+        with run_dirfd.bound_run_dir(bound.path) as transaction:
+            if transaction.identity != bound.identity or not transaction.still_bound():
+                raise ReapBindingError("run directory identity changed before the transaction")
+            if not bound.still_bound():
+                raise ReapBindingError("run directory identity changed before the transaction")
+            yield transaction
+    except OSError as exc:
+        raise ReapBindingError("run directory could not be bound") from exc
+
+
 def _terminalize(run_dir: Path, meta: dict[str, Any], *, workspace: Path, now: datetime) -> dict[str, Any]:
     """Write the orphaned snapshot through the sanctioned run.json writer.
 
@@ -378,33 +424,40 @@ def _reap_one(
         with runguard.run_lock(workspace, run_dir=run_dir, wait_seconds=0, stale_action="claim"):
             if not bound.still_bound():
                 return None, _skip(run_dir.name, "concurrently-changed")
-            raw, current = _read_run_bytes(run_dir)
-            if raw is None or current is None:
-                return None, _skip(run_dir.name, "concurrently-changed")
-            if _run_fingerprint(raw) != fingerprint:
-                return None, _skip(run_dir.name, "concurrently-changed")
-            # Under the reaper's newly claimed live lock, re-check run.json
-            # only. Original-owner liveness was already proven before acquire.
-            reason = _revalidate_metadata(current, older_than=older_than, now=now)
-            if reason is not None:
-                return None, _skip(run_dir.name, reason)
-            if not bound.still_bound():
-                return None, _skip(run_dir.name, "concurrently-changed")
-            try:
-                return _terminalize(run_dir, current, workspace=workspace, now=now), None
-            except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
-                # The sanctioned writer refused this run's transaction (an
-                # unready authority gate, a broken chain), possibly after
-                # activating the journal or publishing a checkpoint. Claim
-                # mode already deleted the original dead owner's lock, so
-                # releasing here would leave the run with no lock and no
-                # matching ``.stale`` claim for ``brigade runs recover``.
-                # ``RetainRunLockError`` keeps this claimed lock in place: it
-                # records this run_dir, so once the reaper process exits the
-                # lock reads back as a dead-owner stale lock that recovery
-                # matches. The reason string stays bounded; the writer's
-                # diagnostic may name a path, so it stays out of the contract.
-                raise runguard.RetainRunLockError("orphan reap write refused") from exc
+            # Everything below runs inside the transaction binding: the CAS
+            # read, the revalidation it gates, and the sanctioned writer all
+            # resolve descriptor-relative through the same held run inode.
+            with _bound_transaction(bound):
+                raw, current = _read_run_bytes(run_dir)
+                if raw is None or current is None:
+                    return None, _skip(run_dir.name, "concurrently-changed")
+                if _run_fingerprint(raw) != fingerprint:
+                    return None, _skip(run_dir.name, "concurrently-changed")
+                # Under the reaper's newly claimed live lock, re-check run.json
+                # only. Original-owner liveness was already proven before acquire.
+                reason = _revalidate_metadata(current, older_than=older_than, now=now)
+                if reason is not None:
+                    return None, _skip(run_dir.name, reason)
+                try:
+                    return _terminalize(run_dir, current, workspace=workspace, now=now), None
+                except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
+                    # The sanctioned writer refused this run's transaction (an
+                    # unready authority gate, a broken chain), possibly after
+                    # activating the journal or publishing a checkpoint. Claim
+                    # mode already deleted the original dead owner's lock, so
+                    # releasing here would leave the run with no lock and no
+                    # matching ``.stale`` claim for ``brigade runs recover``.
+                    # ``RetainRunLockError`` keeps this claimed lock in place:
+                    # it records this run_dir, so once the reaper process exits
+                    # the lock reads back as a dead-owner stale lock that
+                    # recovery matches. The reason string stays bounded; the
+                    # writer's diagnostic may name a path, so it stays out of
+                    # the contract.
+                    raise runguard.RetainRunLockError("orphan reap write refused") from exc
+    except ReapBindingError:
+        # The run directory entry stopped resolving to the inode the reaper
+        # validated. Nothing was written; report it like any other CAS loss.
+        return None, _skip(run_dir.name, "concurrently-changed")
     except runguard.RetainRunLockError:
         # Caught outside the context so ``run_lock`` has already skipped the
         # release. The rest of the scan still runs; other runs in this
@@ -474,7 +527,10 @@ def reap(
     if not cwd.is_dir():
         print(f"error: --cwd is not a directory: {cwd}", file=sys.stderr)
         return 2
-    root = runs_dir.expanduser() if runs_dir is not None else cwd / ".brigade" / "runs"
+    # Resolve the root so a candidate's path already equals what every writer
+    # module normalizes to. A binding is authorized lexically against the exact
+    # bound path, so an unresolved root would silently skip the binding.
+    root = runs_dir.expanduser().resolve() if runs_dir is not None else cwd / ".brigade" / "runs"
     if not root.is_dir():
         print(f"error: runs directory not found: {root}", file=sys.stderr)
         return 2

--- a/src/brigade/run_reap.py
+++ b/src/brigade/run_reap.py
@@ -1,0 +1,358 @@
+"""Explicit local reaper for runs whose recorded owner process is gone."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from . import proc, run_checkpoint, run_lifecycle, runguard, runs_cmd
+
+SCHEMA = "brigade.runs-reap.v1"
+DEFAULT_OLDER_THAN = "2h"
+MAX_UNCOMMITTED_CHANGE_COUNT = 10_000
+# Bounded scan for the work-brief surface, matched to doctor's
+# ``_RECOVERY_CHECKPOINTS_SCAN_LIMIT`` so a brief on a repo with no orphan
+# never parses unbounded run history.
+ORPHAN_SCAN_LIMIT = 50
+_OLDER_THAN_RE = re.compile(r"^(\d+)([smhd])$", re.IGNORECASE)
+_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+_REAPABLE_STATUSES = runs_cmd._NONTERMINAL_STATUSES
+
+
+class ReapError(ValueError):
+    """Bounded CLI / contract error for the local reaper."""
+
+
+def parse_older_than(value: str) -> timedelta:
+    raw = value.strip()
+    match = _OLDER_THAN_RE.fullmatch(raw)
+    if match is None:
+        raise ValueError("older-than must look like 2h, 30m, 90s, or 1d")
+    amount = int(match.group(1))
+    seconds = amount * _UNITS[match.group(2).lower()]
+    if seconds <= 0:
+        raise ValueError("older-than must be a positive duration")
+    return timedelta(seconds=seconds)
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _run_fingerprint(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _porcelain_path(line: str) -> str:
+    if len(line) < 4:
+        return ""
+    path = line[3:]
+    if " -> " in path:
+        path = path.split(" -> ", 1)[1]
+    if len(path) >= 2 and path[0] == path[-1] == '"':
+        path = path[1:-1]
+    return path
+
+
+def _is_brigade_runtime_path(path: str) -> bool:
+    return path == ".brigade" or path.startswith(".brigade/")
+
+
+def _count_uncommitted_changes(workspace: Path) -> int:
+    result = proc.run(["git", "status", "--porcelain=v1"], cwd=workspace)
+    if result.code != 0:
+        return 0
+    count = 0
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        if _is_brigade_runtime_path(_porcelain_path(line)):
+            continue
+        count += 1
+    return min(count, MAX_UNCOMMITTED_CHANGE_COUNT)
+
+
+def _utc_now(now: datetime | None) -> datetime:
+    clock = now if now is not None else datetime.now(timezone.utc)
+    if clock.tzinfo is None:
+        clock = clock.replace(tzinfo=timezone.utc)
+    return clock.astimezone(timezone.utc)
+
+
+def _read_run_bytes(run_dir: Path) -> tuple[bytes | None, dict[str, Any] | None]:
+    path = run_dir / "run.json"
+    try:
+        raw = path.read_bytes()
+        payload = json.loads(raw.decode("utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError, RecursionError):
+        return None, None
+    if not isinstance(payload, dict):
+        return None, None
+    return raw, payload
+
+
+def _skip(run_id: str, reason: str) -> dict[str, str]:
+    return {"run_id": run_id, "reason": reason}
+
+
+def _classify_child(child: Path, resolved_root: Path) -> str | None:
+    try:
+        if child.is_symlink():
+            return "symlink"
+        if not child.is_dir():
+            return None
+        if not runs_cmd._run_dir_is_contained(child, resolved_root):
+            return "malformed"
+    except OSError:
+        return "malformed"
+    return None
+
+
+def _revalidate_metadata(
+    meta: dict[str, Any],
+    *,
+    older_than: timedelta,
+    now: datetime,
+) -> str | None:
+    """CAS-time run.json checks. Does not inspect lock ownership or liveness."""
+    status = meta.get("status")
+    if status == "orphaned":
+        return "already-orphaned"
+    if not isinstance(status, str) or status not in _REAPABLE_STATUSES or meta.get("finished_at"):
+        return "terminal"
+    started = _parse_timestamp(meta.get("started_at"))
+    if started is None:
+        return "malformed"
+    if now - started < older_than:
+        return "too-young"
+    return None
+
+
+def _preflight(
+    run_dir: Path,
+    meta: dict[str, Any],
+    *,
+    older_than: timedelta,
+    now: datetime,
+) -> str | None:
+    reason = _revalidate_metadata(meta, older_than=older_than, now=now)
+    if reason is not None:
+        return reason
+    workspace = runguard.resolve_run_lock_workspace(meta, run_dir)
+    if workspace is None:
+        return "ambiguous"
+    state = runguard.run_lock_state(workspace, run_dir)
+    if state == "live":
+        return "live"
+    if state != "stale":
+        return "ambiguous"
+    return None
+
+
+def _terminalize(run_dir: Path, meta: dict[str, Any], *, workspace: Path, now: datetime) -> dict[str, Any]:
+    """Write the orphaned snapshot through the sanctioned run.json writer.
+
+    ``aboyeur._write_json`` owns the whole transaction: it activates the
+    lifecycle journal only when this run durably requested it, publishes the
+    recovery checkpoint paired with the ``run.orphaned`` event, appends the
+    lifecycle transition, records shadow parity, and atomically replaces
+    ``run.json`` (projecting it for authority-requested and authoritative
+    runs). The reaper holds the matching run lock for ``run_dir``, which is
+    what every one of those steps verifies ownership against.
+
+    A legacy snapshot-only run is never migrated: no journal is manufactured
+    here, so ``brigade doctor``'s recovery-checkpoint check keeps omitting it
+    as ``no-journal`` instead of failing on a journal with no checkpoint.
+    """
+    from . import aboyeur, receipt_schema
+
+    last_status = meta.get("status")
+    if not isinstance(last_status, str) or not last_status:
+        last_status = "unknown"
+    dirty = _count_uncommitted_changes(workspace)
+    orphaned_at = now.isoformat()
+    updated = dict(meta)
+    updated.update(
+        {
+            "status": "orphaned",
+            "orphaned_at": orphaned_at,
+            "last_observed_status": last_status,
+            "uncommitted_change_count": dirty,
+            "finished_at": orphaned_at,
+        }
+    )
+    aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(updated))
+    return {
+        "run_id": run_dir.name,
+        "last_observed_status": last_status,
+        "uncommitted_change_count": dirty,
+        "orphaned_at": orphaned_at,
+    }
+
+
+def _reap_one(
+    run_dir: Path,
+    meta: dict[str, Any],
+    *,
+    fingerprint: str,
+    older_than: timedelta,
+    now: datetime,
+) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    reason = _preflight(run_dir, meta, older_than=older_than, now=now)
+    if reason is not None:
+        return None, _skip(run_dir.name, reason)
+    workspace = runguard.resolve_run_lock_workspace(meta, run_dir)
+    assert workspace is not None
+    try:
+        with runguard.run_lock(workspace, run_dir=run_dir, wait_seconds=0, stale_action="claim"):
+            raw, current = _read_run_bytes(run_dir)
+            if raw is None or current is None:
+                return None, _skip(run_dir.name, "concurrently-changed")
+            if _run_fingerprint(raw) != fingerprint:
+                return None, _skip(run_dir.name, "concurrently-changed")
+            # Under the reaper's newly claimed live lock, re-check run.json
+            # only. Original-owner liveness was already proven before acquire.
+            reason = _revalidate_metadata(current, older_than=older_than, now=now)
+            if reason is not None:
+                return None, _skip(run_dir.name, reason)
+            try:
+                return _terminalize(run_dir, current, workspace=workspace, now=now), None
+            except (run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError):
+                # The sanctioned writer refused this run's transaction (an
+                # unready authority gate, a broken chain). Skip it rather than
+                # abandoning the rest of the scan; the diagnostic is bounded
+                # but may name a path, so it stays out of the contract.
+                return None, _skip(run_dir.name, "write-refused")
+    except runguard.RunLockError:
+        return None, _skip(run_dir.name, "concurrently-changed")
+
+
+def list_orphaned_runs(
+    target: Path,
+    *,
+    limit: int = 8,
+    scan_limit: int = ORPHAN_SCAN_LIMIT,
+) -> list[dict[str, Any]]:
+    """Newest orphaned runs, over a bounded window of run directories.
+
+    ``limit`` bounds the rows returned; ``scan_limit`` bounds how many run
+    directories are opened at all, so a repo with hundreds of runs and no
+    orphan costs the work brief a fixed number of ``run.json`` parses.
+    """
+    root = target.expanduser().resolve() / ".brigade" / "runs"
+    if not root.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    resolved_root = runs_cmd._resolved_runs_root(root)
+    scanned = 0
+    for child in sorted(root.iterdir(), key=lambda path: path.name, reverse=True):
+        if scanned >= scan_limit:
+            break
+        if _classify_child(child, resolved_root) is not None:
+            continue
+        scanned += 1
+        _raw, meta = _read_run_bytes(child)
+        if meta is None or meta.get("status") != "orphaned":
+            continue
+        dirty = meta.get("uncommitted_change_count")
+        count = dirty if isinstance(dirty, int) and not isinstance(dirty, bool) and dirty >= 0 else 0
+        rows.append(
+            {
+                "run_id": child.name,
+                "last_observed_status": meta.get("last_observed_status"),
+                "uncommitted_change_count": min(count, MAX_UNCOMMITTED_CHANGE_COUNT),
+                "suggested_command": f"brigade runs show {child.name}",
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def reap(
+    *,
+    cwd: Path,
+    runs_dir: Path | None,
+    older_than: str = DEFAULT_OLDER_THAN,
+    json_output: bool = False,
+    now: datetime | None = None,
+) -> int:
+    try:
+        threshold = parse_older_than(older_than)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    cwd = cwd.expanduser().resolve()
+    if not cwd.is_dir():
+        print(f"error: --cwd is not a directory: {cwd}", file=sys.stderr)
+        return 2
+    root = runs_dir.expanduser() if runs_dir is not None else cwd / ".brigade" / "runs"
+    if not root.is_dir():
+        print(f"error: runs directory not found: {root}", file=sys.stderr)
+        return 2
+
+    clock = _utc_now(now)
+    resolved_root = runs_cmd._resolved_runs_root(root)
+    reaped: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+    for child in sorted(root.iterdir(), key=lambda path: path.name):
+        classified = _classify_child(child, resolved_root)
+        if classified == "symlink":
+            skipped.append(_skip(child.name, "symlink"))
+            continue
+        if classified == "malformed":
+            skipped.append(_skip(child.name, "malformed"))
+            continue
+        if classified is not None or not child.is_dir():
+            continue
+        raw, meta = _read_run_bytes(child)
+        if raw is None or meta is None:
+            skipped.append(_skip(child.name, "malformed"))
+            continue
+        won, lost = _reap_one(
+            child,
+            meta,
+            fingerprint=_run_fingerprint(raw),
+            older_than=threshold,
+            now=clock,
+        )
+        if won is not None:
+            reaped.append(won)
+        elif lost is not None:
+            skipped.append(lost)
+
+    if json_output:
+        print(
+            json.dumps(
+                {
+                    "schema": SCHEMA,
+                    "older_than": older_than,
+                    "reaped": reaped,
+                    "skipped": skipped,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    print(f"reaped: {len(reaped)}")
+    for row in reaped:
+        print(f"  {row['run_id']} {row['last_observed_status']} -> orphaned dirty={row['uncommitted_change_count']}")
+    if skipped:
+        print(f"skipped: {len(skipped)}")
+        for row in skipped:
+            print(f"  {row['run_id']} {row['reason']}")
+    return 0

--- a/src/brigade/run_redaction.py
+++ b/src/brigade/run_redaction.py
@@ -43,7 +43,7 @@ REASON_CODES = frozenset(
         "other-sensitive-data",
     }
 )
-TERMINAL_STATUSES = frozenset({"ok", "dry-run", "failed", "timeout", "incomplete", "canceled"})
+TERMINAL_STATUSES = frozenset({"ok", "dry-run", "failed", "timeout", "incomplete", "canceled", "orphaned"})
 
 _FILE_MODE = 0o600
 _DIR_MODE = 0o700

--- a/src/brigade/run_shadow.py
+++ b/src/brigade/run_shadow.py
@@ -163,7 +163,7 @@ def _quarantine_corrupt(artifact_path: Path) -> None:
     try:
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
         target = artifact_path.with_name(f"{artifact_path.name}.corrupt-{stamp}")
-        artifact_path.replace(target)
+        run_journal.bound_replace(artifact_path, target)
     except Exception:
         return
 
@@ -181,7 +181,7 @@ def _quarantine_stale_projector(artifact_path: Path) -> bool:
     try:
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
         target = artifact_path.with_name(f".stale-projector-v2-{stamp}")
-        artifact_path.replace(target)
+        run_journal.bound_replace(artifact_path, target)
         return True
     except Exception:
         return False
@@ -225,11 +225,11 @@ def _load_prior_artifact(artifact_path: Path) -> tuple[dict[str, Any] | None, bo
     aside and reported as corrupt so the carry path starts fresh with an
     evidence-unreadable side record instead of raising ``AttributeError``.
     """
-    if not artifact_path.is_file():
+    if not run_journal.bound_is_file(artifact_path):
         return None, False
     try:
-        parsed = json.loads(artifact_path.read_text())
-    except (OSError, ValueError):
+        parsed = json.loads(run_journal.bound_read_text(artifact_path))
+    except (OSError, ValueError, UnicodeDecodeError):
         _quarantine_corrupt(artifact_path)
         return None, True
     if not isinstance(parsed, dict):
@@ -561,14 +561,14 @@ def record_shadow_comparison(run_dir: Path, legacy_snapshot: Mapping[str, Any]) 
     # journal-unreadable before the outer containment returns; a failing evidence
     # write is swallowed silently and leaves the previous artifact in place.
     try:
-        run_dir = Path(run_dir).expanduser().resolve()
+        run_dir = run_journal.normalize_run_dir(run_dir)
         if not isinstance(legacy_snapshot, Mapping):
             return
         status = legacy_snapshot.get("status")
         if not isinstance(status, str) or not status:
             return
         journal_path = run_lifecycle._journal_path(run_dir)
-        if not journal_path.is_file():
+        if not run_journal.bound_is_file(journal_path):
             return
         run_id = run_dir.name
 
@@ -674,16 +674,16 @@ def check_projection_readiness(run_dir: Path) -> ReadinessReport:
     # gate reason branch lands RED-first in its own later task. The outer
     # containment returns evidence-unreadable on any unexpected failure.
     try:
-        run_dir = Path(run_dir).expanduser().resolve()
+        run_dir = run_journal.normalize_run_dir(run_dir)
     except Exception:
         return ReadinessReport(ready=False, reasons=())
     try:
-        if not run_lifecycle._journal_path(run_dir).is_file():
+        if not run_journal.bound_is_file(run_lifecycle._journal_path(run_dir)):
             return ReadinessReport(ready=False, reasons=(REASON_NO_JOURNAL,))
         artifact_path = shadow_artifact_path(run_dir)
-        if not artifact_path.is_file():
+        if not run_journal.bound_is_file(artifact_path):
             return ReadinessReport(ready=False, reasons=(REASON_NO_EVIDENCE,))
-        data = json.loads(artifact_path.read_text())
+        data = json.loads(run_journal.bound_read_text(artifact_path))
         # Version door: a noncurrent projector version closes the gate with
         # the dedicated stale reason BEFORE the schema check fires. Only this
         # reason is returned so callers can distinguish a version rotation

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -1174,6 +1174,11 @@ def _acquire_lock(
         pending = _stale_claims(path)
         if not pending:
             return ownership
+        if stale_action == "claim":
+            # Claim mode takes over this run's lock only. Broad pending-claim
+            # recovery would terminalize unrelated .stale claims that the
+            # reaper has not selected, aged, or containment-checked.
+            return ownership
         _release_lock(path, ownership)
         if _recover_pending_claims(path) and on_reconcile is not None:
             on_reconcile(None)
@@ -1221,7 +1226,9 @@ def run_lock(
     stale-lock-recovery failure receipt so an explicit reaper can terminalize.
     It requires ``run_dir``: the claim path re-verifies the dead owner's
     recorded run directory inside the atomic claim and fails closed rather
-    than deleting a lock that belongs to a different run.
+    than deleting a lock that belongs to a different run. After the lock is
+    acquired, claim mode returns ownership without reconciling unrelated
+    pending ``.stale`` claims.
     """
     if wait_seconds < 0 or (not math.isinf(wait_seconds) and not math.isfinite(wait_seconds)):
         raise ValueError("run lock wait_seconds must be zero, positive, or unbounded")

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -1064,13 +1064,18 @@ def _wait_to_acquire_lock(
     wait_seconds: float,
     poll_interval: float,
     on_reconcile: Callable[[dict[str, object] | None], None] | None = None,
+    stale_action: str = "recover",
 ) -> _LockOwnership:
     def _acquire() -> _LockOwnership:
-        # Forward the callback only when set: the acquire seam is
-        # monkeypatched by tests with fakes that predate it.
-        if on_reconcile is None:
+        # Forward optional kwargs only when set: the acquire seam is
+        # monkeypatched by tests with fakes that predate them.
+        if on_reconcile is None and stale_action == "recover":
             return _acquire_lock(path, run_dir=run_dir)
-        return _acquire_lock(path, run_dir=run_dir, on_reconcile=on_reconcile)
+        if on_reconcile is None:
+            return _acquire_lock(path, run_dir=run_dir, stale_action=stale_action)
+        if stale_action == "recover":
+            return _acquire_lock(path, run_dir=run_dir, on_reconcile=on_reconcile)
+        return _acquire_lock(path, run_dir=run_dir, on_reconcile=on_reconcile, stale_action=stale_action)
 
     if wait_seconds == 0:
         return _acquire()
@@ -1119,6 +1124,7 @@ def _acquire_lock(
     *,
     run_dir: Path | None = None,
     on_reconcile: Callable[[dict[str, object] | None], None] | None = None,
+    stale_action: str = "recover",
 ) -> _LockOwnership:
     """Publish the lock, reconciling a dead-owner lock on the way in.
 
@@ -1143,6 +1149,24 @@ def _acquire_lock(
                     f"another brigade run appears active: {path}. Remove the lock only if no run is active."
                 ) from None
             claimed, owner = stale
+            if stale_action == "claim":
+                # TOCTOU gate: the pre-acquire ``run_lock_state`` verdict was
+                # read before the rename, so the directory now under our
+                # recovery claim may belong to a different run. Re-verify the
+                # claimed dead owner's recorded run_dir inside the atomic
+                # claim path and fail closed on a mismatch: a foreign claim is
+                # restored where possible and never deleted.
+                if run_dir is None or not _owner_matches_run(owner, run_dir.expanduser().resolve()):
+                    if not path.exists():
+                        try:
+                            claimed.rename(path)
+                        except OSError:
+                            pass
+                    raise RunLockError(
+                        f"stale run lock does not belong to this run: {path}. Refusing to claim it."
+                    ) from None
+                shutil.rmtree(claimed, ignore_errors=True)
+                continue
             _invoke_before_terminalize(path, claimed, owner, None)
             if on_reconcile is not None:
                 on_reconcile(owner)
@@ -1187,16 +1211,26 @@ def run_lock(
     wait_seconds: float = 0.0,
     poll_interval: float = 0.1,
     on_reconcile: Callable[[dict[str, object] | None], None] | None = None,
+    stale_action: str = "recover",
 ):
     """Hold the workspace run lock for the block; yields the lock path.
 
     ``on_reconcile`` is invoked when acquiring released a dead-owner lock
     (see ``_acquire_lock``), before the block runs.
+    ``stale_action="claim"`` takes over a dead-owner lock without writing a
+    stale-lock-recovery failure receipt so an explicit reaper can terminalize.
+    It requires ``run_dir``: the claim path re-verifies the dead owner's
+    recorded run directory inside the atomic claim and fails closed rather
+    than deleting a lock that belongs to a different run.
     """
     if wait_seconds < 0 or (not math.isinf(wait_seconds) and not math.isfinite(wait_seconds)):
         raise ValueError("run lock wait_seconds must be zero, positive, or unbounded")
     if poll_interval <= 0:
         raise ValueError("run lock poll_interval must be positive")
+    if stale_action not in {"recover", "claim"}:
+        raise ValueError("run lock stale_action must be recover or claim")
+    if stale_action == "claim" and run_dir is None:
+        raise ValueError("run lock stale_action=claim requires run_dir")
     path = lock_path(cwd)
     path.parent.mkdir(parents=True, exist_ok=True)
     ownership = _wait_to_acquire_lock(
@@ -1205,6 +1239,7 @@ def run_lock(
         wait_seconds=wait_seconds,
         poll_interval=poll_interval,
         on_reconcile=on_reconcile,
+        stale_action=stale_action,
     )
     retain_lock = False
     try:

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -3200,14 +3200,7 @@ def redact(
     return 0
 
 
-_TERMINAL_LIFECYCLE_EVENT_TYPES = frozenset(
-    {
-        "run.completed",
-        "run.failed",
-        "run.interrupted",
-        "run.orphaned",
-    }
-)
+_TERMINAL_LIFECYCLE_EVENT_TYPES = _TERMINAL_BRANCH_EVENT_TYPES
 
 
 def _lifecycle_event_record(event: Any) -> dict[str, object]:

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -2397,7 +2397,7 @@ def _supported_branch_snapshot(parent_run_dir: Path, branch_event: Any) -> tuple
     return projection.snapshot, None
 
 
-_TERMINAL_BRANCH_EVENT_TYPES = frozenset({"run.completed", "run.failed", "run.interrupted"})
+_TERMINAL_BRANCH_EVENT_TYPES = frozenset({"run.completed", "run.failed", "run.interrupted", "run.orphaned"})
 _TERMINAL_PARENT_EVENT_ERROR = "cannot branch a durable child from a terminal parent event"
 
 
@@ -3205,6 +3205,7 @@ _TERMINAL_LIFECYCLE_EVENT_TYPES = frozenset(
         "run.completed",
         "run.failed",
         "run.interrupted",
+        "run.orphaned",
     }
 )
 

--- a/src/brigade/work_cmd/ledger/authority_store.py
+++ b/src/brigade/work_cmd/ledger/authority_store.py
@@ -24,6 +24,7 @@ from ..inbox_lock import verify_canonical_write_locks
 from ... import component_paths, evidence_redaction, provenance, runguard, trust_gate
 from ...untrusted import scan_handoff_injection_heuristics
 
+from ... import dirfd
 from . import descriptor_anchors, import_model
 
 
@@ -56,25 +57,12 @@ def _directory_identity(descriptor: int) -> dict[str, int]:
 
 def _posix_dirfd_available() -> bool:
     """Return whether POSIX openat/O_NOFOLLOW primitives can hold a parent."""
-    return (
-        os.name == "posix"
-        and bool(getattr(os, "O_NOFOLLOW", 0))
-        and bool(getattr(os, "O_DIRECTORY", 0))
-        and os.open in os.supports_dir_fd
-        and os.mkdir in os.supports_dir_fd
-        and os.stat in os.supports_dir_fd
-        and os.unlink in os.supports_dir_fd
-        and os.rename in os.supports_dir_fd
-    )
+    return dirfd.posix_available()
 
 
 def _nt_dirfd_available() -> bool:
     """Return whether Windows handle-relative no-follow operations can be used."""
-    if sys.platform != "win32":
-        return False
-    from .. import nt_dirfd
-
-    return nt_dirfd.available()
+    return dirfd.nt_available()
 
 
 def _dirfd_available() -> bool:
@@ -82,18 +70,15 @@ def _dirfd_available() -> bool:
 
 
 def _dirfd_unavailable(kind: str) -> OSError:
-    return OSError(f"descriptor-relative {kind} are unavailable")
+    return dirfd.unavailable(kind)
 
 
 def _open_directory_nofollow(path: Path) -> int:
     """Open a directory without following a final symlink or reparse point."""
     if _posix_dirfd_available():
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-        return os.open(path, flags)
+        return dirfd._posix_open_directory(path)
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        return nt_dirfd.open_root_directory(path)
+        return dirfd._nt_open_directory(path)
     raise _dirfd_unavailable("directory operations")
 
 
@@ -101,93 +86,69 @@ def _open_file_nofollow(path: Path, flags: int, mode: int = 0o600) -> int:
     """Open a file path without following a final symlink or reparse point."""
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     if nofollow:
-        if flags & os.O_CREAT:
-            return os.open(path, flags | nofollow | getattr(os, "O_CLOEXEC", 0), mode)
-        return os.open(path, flags | nofollow | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_CLOEXEC", 0))
+        return dirfd._posix_open_file(path, flags, mode)
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        return nt_dirfd.open_path_file(path, flags, mode)
+        return dirfd._nt_open_file(path, flags, mode)
     raise OSError("no-follow file open is unavailable")
 
 
 def _dirfd_open_dir(parent: int, name: str) -> int:
     if _posix_dirfd_available():
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-        return os.open(name, flags, dir_fd=parent)
+        return dirfd._posix_open_child_directory(parent, name)
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        return nt_dirfd.open_child_directory(parent, name)
+        return dirfd._nt_open_child_directory(parent, name)
     raise _dirfd_unavailable("directory operations")
 
 
 def _dirfd_mkdir(parent: int, name: str) -> None:
     if _posix_dirfd_available():
-        os.mkdir(name, 0o700, dir_fd=parent)
+        dirfd._posix_mkdir_child(parent, name)
         return
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        nt_dirfd.mkdir_child(parent, name)
+        dirfd._nt_mkdir_child(parent, name)
         return
     raise _dirfd_unavailable("directory operations")
 
 
 def _dirfd_open_file(parent: int, name: str, flags: int, mode: int = 0o600) -> int:
     if _posix_dirfd_available():
-        if flags & os.O_CREAT:
-            return os.open(name, flags, mode, dir_fd=parent)
-        return os.open(name, flags, dir_fd=parent)
+        return dirfd._posix_open_child_file(parent, name, flags, mode)
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        return nt_dirfd.open_file(parent, name, flags, mode)
+        return dirfd._nt_open_child_file(parent, name, flags, mode)
     raise _dirfd_unavailable("import inbox operations")
 
 
 def _dirfd_replace(parent: int, source: str, destination: str) -> None:
     if _posix_dirfd_available():
-        os.replace(source, destination, src_dir_fd=parent, dst_dir_fd=parent)
+        dirfd._posix_replace_children(parent, source, destination)
         return
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        nt_dirfd.replace_children(parent, source, destination)
+        dirfd._nt_replace_children(parent, source, destination)
         return
     raise _dirfd_unavailable("import inbox operations")
 
 
 def _dirfd_unlink(parent: int, name: str) -> None:
     if _posix_dirfd_available():
-        os.unlink(name, dir_fd=parent)
+        dirfd._posix_unlink_child(parent, name)
         return
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        nt_dirfd.unlink_child(parent, name)
+        dirfd._nt_unlink_child(parent, name)
         return
     raise _dirfd_unavailable("import inbox operations")
 
 
 def _dirfd_stat(parent: int, name: str) -> os.stat_result:
     if _posix_dirfd_available():
-        return os.stat(name, dir_fd=parent, follow_symlinks=False)
+        return dirfd._posix_stat_child(parent, name)
     if _nt_dirfd_available():
-        from .. import nt_dirfd
-
-        return nt_dirfd.stat_child(parent, name)
+        return dirfd._nt_stat_child(parent, name)
     raise _dirfd_unavailable("import inbox validation")
 
 
 def _dirfd_fsync(descriptor: int) -> None:
     """Flush a held descriptor; directory fsync is best-effort on Windows."""
-    try:
-        os.fsync(descriptor)
-    except OSError as exc:
-        if sys.platform == "win32" and getattr(exc, "winerror", None) in {1, 5}:
-            return
-        raise
+    dirfd.fsync_directory(descriptor)
 
 
 def _workspace_directory_identity(target: Path) -> dict[str, int]:

--- a/src/brigade/work_cmd/session/briefing.py
+++ b/src/brigade/work_cmd/session/briefing.py
@@ -278,6 +278,9 @@ def _brief_payload(target: Path, *, limit: int = 3, include_code_graph: bool = F
     )
     ledger_task = resolved.get("ledger_task") if isinstance(resolved.get("ledger_task"), dict) else None
     git = helpers._git_snapshot(target)
+    from ... import run_reap
+
+    orphaned_runs = run_reap.list_orphaned_runs(target)
     suggested = _suggested_command(active, resolved["task"], resolved["source"])
     pending = ledger_mod._pending_tasks(target)
     ready_tasks = ledger_mod._ready_tasks(target)
@@ -543,6 +546,7 @@ def _brief_payload(target: Path, *, limit: int = 3, include_code_graph: bool = F
         "next_issue": ledger_mod._task_issue_metadata(ledger_task) if ledger_task else None,
         "next": str(resolved["task"]),
         "suggested_command": suggested,
+        "orphaned_runs": orphaned_runs,
         "update": update_notify.available_update(),
         "cloud_tracker": _cloud_tracker_for_brief(target),
     }
@@ -718,6 +722,21 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
             print(f"issue_labels: {', '.join(str(label) for label in labels)}")
     print(f"next: {helpers._short(str(payload['next']))}")
     print(f"suggested_command: {payload['suggested_command']}")
+
+    orphaned_runs = payload.get("orphaned_runs")
+    if isinstance(orphaned_runs, list) and orphaned_runs:
+        print(f"orphaned_runs: {len(orphaned_runs)}")
+        for row in orphaned_runs:
+            if not isinstance(row, dict):
+                continue
+            print(
+                f"  {row.get('run_id')} last={row.get('last_observed_status')} "
+                f"dirty={row.get('uncommitted_change_count')}"
+            )
+            command = row.get("suggested_command")
+            if isinstance(command, str) and command.strip():
+                print(f"  {command}")
+        print("orphaned_trap: recorded dirty count only; inspect before assuming the tree is clean")
 
     pending = payload["pending_tasks"]
     if isinstance(pending, list) and pending:

--- a/tests/test_aboyeur_run_io.py
+++ b/tests/test_aboyeur_run_io.py
@@ -7,7 +7,16 @@ from pathlib import Path
 
 import pytest
 
-from brigade import aboyeur, dirfd, run_checkpoint, run_dirfd, run_lifecycle, runguard
+from brigade import (
+    aboyeur,
+    dirfd,
+    run_checkpoint,
+    run_dirfd,
+    run_journal,
+    run_lifecycle,
+    run_shadow,
+    runguard,
+)
 
 
 _AUTHORITY_REQUEST_FIELD = "run_journal_authority_requested"
@@ -220,3 +229,120 @@ def test_bound_authority_write_swap_cannot_block_with_outside_bytes(tmp_path: Pa
     written = json.loads((moved / "run.json").read_text())
     assert written["status"] == "planning"
     assert written[_AUTHORITY_REQUEST_FIELD] is True
+
+
+def _journal_payload(status: str, workspace: Path) -> dict[str, object]:
+    return _legacy(status, lifecycle_journal_requested=True, lock_workspace=str(workspace))
+
+
+def _seed_one_pair_journal_ahead(tmp_path: Path) -> tuple[Path, Path, dict[str, object]]:
+    """Activate a journal, then append one unpaired checkpoint/status pair.
+
+    The held shadow artifact lags the tail by exactly one structurally
+    covered pair, which is the only shape ``_genuine_journal_ahead`` accepts.
+    """
+    workspace, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _journal_payload("started", workspace))
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        aboyeur._write_json(run_dir / "run.json", _journal_payload("started", workspace))
+        snapshot = (run_dir / "run.json").read_bytes()
+        run_checkpoint.write_checkpoint(
+            run_dir,
+            snapshot,
+            workspace=workspace,
+            paired_event_type="run.planning.started",
+        )
+        journal = run_lifecycle._journal_path(run_dir)
+        tail = run_journal.read_journal(journal).events[-1].sequence
+        run_journal.append_event(
+            journal,
+            run_id=run_dir.name,
+            event_type="run.planning.started",
+            payload={"detail": "ok"},
+            idempotency_key="test-uncompared:planning",
+            expected_previous_sequence=tail,
+        )
+    artifact = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
+    return workspace, run_dir, artifact
+
+
+def _write_shadow_artifact(run_dir: Path, artifact: dict[str, object]) -> None:
+    path = run_shadow.shadow_artifact_path(run_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+
+
+def _clean_match_artifact(run_id: str) -> dict[str, object]:
+    artifact = run_shadow._empty_artifact(run_id)
+    artifact.update(
+        {
+            "comparisons": 1,
+            "matches": 1,
+            "last_outcome": run_shadow.OUTCOME_MATCH,
+            "last_compared_sequence": 1,
+            "last_compared_event_digest": "a" * 64,
+            "last_error_category": None,
+        }
+    )
+    return artifact
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_genuine_journal_ahead_swap_cannot_authorize_with_outside_shadow(tmp_path: Path) -> None:
+    """Held forged cursor stays untrusted after a same-UID rename/symlink swap."""
+    _, run_dir, genuine = _seed_one_pair_journal_ahead(tmp_path)
+    assert aboyeur._genuine_journal_ahead(run_dir) is True
+
+    outside = tmp_path / "outside-shadow"
+    _write_shadow_artifact(outside, genuine)
+    outside_artifact = run_shadow.shadow_artifact_path(outside)
+    before = outside_artifact.read_bytes()
+
+    held = run_shadow.shadow_artifact_path(run_dir)
+    forged = json.loads(held.read_text())
+    forged["last_compared_event_digest"] = "f" * 64
+    _write_shadow_artifact(run_dir, forged)
+    assert aboyeur._genuine_journal_ahead(run_dir) is False
+
+    with run_dirfd.bound_run_dir(run_dir):
+        _swap_aside(run_dir, outside)
+        assert aboyeur._genuine_journal_ahead(run_dir) is False
+
+    assert outside_artifact.read_bytes() == before
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_prior_clean_match_swap_cannot_authorize_with_outside_shadow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Outside clean-match bytes must not accept a bound catch-up."""
+    _, run_dir = _workspace_run(tmp_path)
+    held_unclean = _clean_match_artifact(run_dir.name)
+    held_unclean["last_outcome"] = run_shadow.OUTCOME_MISMATCH
+    held_unclean["mismatches"] = 1
+    held_unclean["matches"] = 0
+    _write_shadow_artifact(run_dir, held_unclean)
+
+    outside = tmp_path / "outside-clean-match"
+    _write_shadow_artifact(outside, _clean_match_artifact(run_dir.name))
+    outside_artifact = run_shadow.shadow_artifact_path(outside)
+    before = outside_artifact.read_bytes()
+
+    calls = {"n": 0}
+
+    def readiness(_run_dir: Path) -> run_shadow.ReadinessReport:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return run_shadow.ReadinessReport(ready=False, reasons=(run_shadow.REASON_JOURNAL_AHEAD,))
+        return run_shadow.ReadinessReport(ready=True, reasons=())
+
+    monkeypatch.setattr(run_shadow, "check_projection_readiness", readiness)
+    monkeypatch.setattr("brigade.aboyeur.run_io._genuine_journal_ahead", lambda _run_dir: True)
+    monkeypatch.setattr(run_shadow, "record_shadow_comparison", lambda *_args, **_kwargs: None)
+
+    with run_dirfd.bound_run_dir(run_dir):
+        _swap_aside(run_dir, outside)
+        with pytest.raises(run_lifecycle.LifecycleJournalError, match="not a clean match"):
+            aboyeur._authoritative_prior_decision(run_dir, {"status": "started"})
+
+    assert outside_artifact.read_bytes() == before

--- a/tests/test_aboyeur_run_io.py
+++ b/tests/test_aboyeur_run_io.py
@@ -1,0 +1,222 @@
+"""Descriptor-bound run.json reads in aboyeur run-I/O stay on the held inode."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import aboyeur, dirfd, run_checkpoint, run_dirfd, run_lifecycle, runguard
+
+
+_AUTHORITY_REQUEST_FIELD = "run_journal_authority_requested"
+
+
+def _legacy(status: str = "started", **extra: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema": "brigade.run.v1",
+        "schema_version": 1,
+        "status": status,
+        "task": "legacy",
+    }
+    payload.update(extra)
+    return payload
+
+
+def _incomplete_authority(status: str = "started") -> dict[str, object]:
+    return _legacy(status, **{_AUTHORITY_REQUEST_FIELD: True, "projector_version": 1})
+
+
+def _workspace_run(tmp_path: Path) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "20260730-104300-deadbeef"
+    run_dir.mkdir(parents=True)
+    return workspace, run_dir
+
+
+def _write_run_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _outside_canary(tmp_path: Path, payload: dict[str, object], name: str = "outside") -> tuple[Path, Path, bytes]:
+    outside = tmp_path / name
+    outside.mkdir()
+    outside_json = outside / "run.json"
+    _write_run_json(outside_json, payload)
+    return outside, outside_json, outside_json.read_bytes()
+
+
+def _swap_aside(run_dir: Path, outside: Path) -> Path:
+    moved = run_dir.with_name(f"{run_dir.name}.moved")
+    run_dir.rename(moved)
+    run_dir.symlink_to(outside, target_is_directory=True)
+    return moved
+
+
+def _assert_outside_untouched(outside_json: Path, before: bytes) -> None:
+    assert outside_json.read_bytes() == before
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_authority_state_swap_cannot_block_with_outside_bytes(tmp_path: Path) -> None:
+    """Held legacy bytes win; attacker projection metadata must not raise."""
+    _, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _legacy())
+    outside, outside_json, before = _outside_canary(tmp_path, _incomplete_authority())
+
+    with run_dirfd.bound_run_dir(run_dir):
+        _swap_aside(run_dir, outside)
+        assert aboyeur._resolve_authority_state(run_dir) == "legacy"
+
+    _assert_outside_untouched(outside_json, before)
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_authority_state_swap_cannot_authorize_with_outside_bytes(tmp_path: Path) -> None:
+    """Held incomplete authority still fails closed after a same-UID symlink swap."""
+    _, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _incomplete_authority())
+    outside, outside_json, before = _outside_canary(tmp_path, _legacy())
+
+    with run_dirfd.bound_run_dir(run_dir):
+        _swap_aside(run_dir, outside)
+        with pytest.raises(run_lifecycle.LifecycleJournalError, match="missing projection metadata"):
+            aboyeur._resolve_authority_state(run_dir)
+
+    _assert_outside_untouched(outside_json, before)
+
+
+def test_no_binding_authority_state_still_follows_swapped_pathname(tmp_path: Path) -> None:
+    """Unbound callers keep today's pathname follow of a swapped run directory."""
+    _, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _legacy())
+    outside, _, _ = _outside_canary(tmp_path, _incomplete_authority())
+    _swap_aside(run_dir, outside)
+
+    with pytest.raises(run_lifecycle.LifecycleJournalError, match="missing projection metadata"):
+        aboyeur._resolve_authority_state(run_dir)
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_authority_state_malformed_held_run_json_is_legacy(tmp_path: Path) -> None:
+    _, run_dir = _workspace_run(tmp_path)
+    (run_dir / "run.json").write_bytes(b"{not valid json")
+    outside, outside_json, before = _outside_canary(tmp_path, _incomplete_authority())
+
+    with run_dirfd.bound_run_dir(run_dir):
+        _swap_aside(run_dir, outside)
+        assert aboyeur._resolve_authority_state(run_dir) == "legacy"
+
+    _assert_outside_untouched(outside_json, before)
+
+
+def test_no_binding_malformed_run_json_is_legacy(tmp_path: Path) -> None:
+    _, run_dir = _workspace_run(tmp_path)
+    (run_dir / "run.json").write_bytes(b"{not valid json")
+    assert aboyeur._resolve_authority_state(run_dir) == "legacy"
+
+
+def test_no_binding_oversize_run_json_stays_legacy(tmp_path: Path) -> None:
+    _, run_dir = _workspace_run(tmp_path)
+    (run_dir / "run.json").write_bytes(b"x" * (run_dirfd.MAX_READ_BYTES + 1))
+    assert aboyeur._resolve_authority_state(run_dir) == "legacy"
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_oversize_held_run_json_fails_closed(tmp_path: Path) -> None:
+    _, run_dir = _workspace_run(tmp_path)
+    (run_dir / "run.json").write_bytes(b"x" * (run_dirfd.MAX_READ_BYTES + 1))
+
+    with run_dirfd.bound_run_dir(run_dir):
+        with pytest.raises(OSError, match="bound read exceeds byte limit"):
+            aboyeur._resolve_authority_state(run_dir)
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_oversize_outside_cannot_block_authority_state(tmp_path: Path) -> None:
+    _, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _legacy(**{_AUTHORITY_REQUEST_FIELD: True}))
+    outside = tmp_path / "outside-oversize"
+    outside.mkdir()
+    outside_json = outside / "run.json"
+    outside_json.write_bytes(b"x" * (run_dirfd.MAX_READ_BYTES + 1))
+    before = outside_json.read_bytes()
+
+    with run_dirfd.bound_run_dir(run_dir):
+        _swap_aside(run_dir, outside)
+        assert aboyeur._resolve_authority_state(run_dir) == "authority-requested"
+
+    assert outside_json.read_bytes() == before
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_prior_snapshot_swap_cannot_authorize_research_reopen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _legacy("started"))
+    outside, outside_json, before = _outside_canary(
+        tmp_path,
+        _legacy("completed", kind="research", marker="outside-canary"),
+    )
+    paired: list[str | None] = []
+    real_write = run_checkpoint.write_checkpoint
+
+    def capture(*args: object, **kwargs: object) -> object:
+        paired.append(kwargs.get("paired_event_type"))  # type: ignore[arg-type]
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(run_checkpoint, "write_checkpoint", capture)
+    payload = _legacy("running", kind="research")
+
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        with run_dirfd.bound_run_dir(run_dir):
+            moved = _swap_aside(run_dir, outside)
+            aboyeur._write_json(run_dir / "run.json", payload)
+
+    _assert_outside_untouched(outside_json, before)
+    assert json.loads(before)["marker"] == "outside-canary"
+    assert json.loads((moved / "run.json").read_text())["status"] == "running"
+    assert paired == [None]
+
+
+def test_no_binding_prior_snapshot_still_follows_swapped_pathname(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _legacy("started"))
+    outside, _, _ = _outside_canary(tmp_path, _legacy("completed", kind="research"))
+    _swap_aside(run_dir, outside)
+    paired: list[str | None] = []
+    real_write = run_checkpoint.write_checkpoint
+
+    def capture(*args: object, **kwargs: object) -> object:
+        paired.append(kwargs.get("paired_event_type"))  # type: ignore[arg-type]
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(run_checkpoint, "write_checkpoint", capture)
+
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        aboyeur._write_json(run_dir / "run.json", _legacy("running", kind="research"))
+
+    assert paired == ["run.recovery.started"]
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_authority_write_swap_cannot_block_with_outside_bytes(tmp_path: Path) -> None:
+    workspace, run_dir = _workspace_run(tmp_path)
+    _write_run_json(run_dir / "run.json", _legacy("started"))
+    outside, outside_json, before = _outside_canary(tmp_path, _incomplete_authority())
+    payload = _legacy("planning", **{_AUTHORITY_REQUEST_FIELD: True})
+
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        with run_dirfd.bound_run_dir(run_dir):
+            moved = _swap_aside(run_dir, outside)
+            aboyeur._write_json(run_dir / "run.json", payload)
+
+    _assert_outside_untouched(outside_json, before)
+    written = json.loads((moved / "run.json").read_text())
+    assert written["status"] == "planning"
+    assert written[_AUTHORITY_REQUEST_FIELD] is True

--- a/tests/test_dirfd.py
+++ b/tests/test_dirfd.py
@@ -1,0 +1,171 @@
+"""Focused coverage for promoted descriptor-relative primitives."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from brigade import dirfd
+from brigade.work_cmd.ledger import authority_store
+
+
+def _posix_dir_flags() -> int:
+    return os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+
+@pytest.mark.skipif(not dirfd.posix_available(), reason="POSIX dir_fd plus O_NOFOLLOW required")
+def test_open_directory_nofollow_refuses_final_symlink(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+
+    fd = dirfd.open_directory_nofollow(real)
+    try:
+        assert stat.S_ISDIR(os.fstat(fd).st_mode)
+    finally:
+        os.close(fd)
+
+    with pytest.raises(OSError):
+        dirfd.open_directory_nofollow(link)
+
+
+@pytest.mark.skipif(not dirfd.posix_available(), reason="POSIX dir_fd plus O_NOFOLLOW required")
+def test_child_directory_and_file_round_trip(tmp_path: Path) -> None:
+    parent = dirfd.open_directory_nofollow(tmp_path)
+    child = -1
+    created = -1
+    try:
+        dirfd.mkdir_child(parent, "events")
+        child = dirfd.open_child_directory(parent, "events")
+        created = dirfd.open_child_file(
+            child,
+            "lifecycle.jsonl",
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        os.write(created, b"event\n")
+        os.close(created)
+        created = -1
+        named = dirfd.stat_child(child, "lifecycle.jsonl")
+        assert stat.S_ISREG(named.st_mode)
+        assert named.st_size == 6
+        dirfd.replace_children(child, "lifecycle.jsonl", "renamed.jsonl")
+        dirfd.fsync_directory(child)
+        assert (tmp_path / "events" / "renamed.jsonl").read_bytes() == b"event\n"
+        dirfd.unlink_child(child, "renamed.jsonl")
+        with pytest.raises(FileNotFoundError):
+            dirfd.stat_child(child, "renamed.jsonl")
+    finally:
+        if created != -1:
+            os.close(created)
+        if child != -1:
+            os.close(child)
+        os.close(parent)
+
+
+def test_validate_component_rejects_empty_dot_dotdot_separators_and_nul() -> None:
+    assert dirfd.validate_component("run.json") == "run.json"
+    assert dirfd.validate_component("recovery-checkpoints") == "recovery-checkpoints"
+    with pytest.raises(OSError, match="empty"):
+        dirfd.validate_component("")
+    with pytest.raises(OSError, match="contained"):
+        dirfd.validate_component(".")
+    with pytest.raises(OSError, match="contained"):
+        dirfd.validate_component("..")
+    with pytest.raises(OSError, match="single contained name"):
+        dirfd.validate_component("events/lifecycle.jsonl")
+    with pytest.raises(OSError, match="single contained name"):
+        dirfd.validate_component("events\\lifecycle.jsonl")
+    with pytest.raises(OSError, match="single contained name"):
+        dirfd.validate_component("a\x00b")
+
+
+def test_dirfd_unavailable_message_matches_authority_store() -> None:
+    error = dirfd.unavailable("import inbox operations")
+    assert str(error) == "descriptor-relative import inbox operations are unavailable"
+    assert str(authority_store._dirfd_unavailable("import inbox operations")) == str(error)
+
+
+def test_authority_store_aliases_honor_monkeypatched_availability(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(authority_store, "_posix_dirfd_available", lambda: False)
+    monkeypatch.setattr(authority_store, "_nt_dirfd_available", lambda: False)
+    with pytest.raises(OSError, match="descriptor-relative directory operations are unavailable"):
+        authority_store._open_directory_nofollow(tmp_path)
+    with pytest.raises(OSError, match="descriptor-relative import inbox operations are unavailable"):
+        authority_store._dirfd_open_file(3, "inbox.jsonl", os.O_RDONLY)
+
+
+@pytest.mark.skipif(os.open not in os.supports_dir_fd, reason="stand-in NT helpers need POSIX dir_fd")
+def test_authority_store_uses_nt_branch_when_posix_is_patched_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    opened: list[str] = []
+
+    def fake_nt(path: Path) -> int:
+        opened.append(os.fspath(path))
+        return os.open(path, _posix_dir_flags())
+
+    monkeypatch.setattr(authority_store, "_posix_dirfd_available", lambda: False)
+    monkeypatch.setattr(authority_store, "_nt_dirfd_available", lambda: True)
+    monkeypatch.setattr(dirfd, "_nt_open_directory", fake_nt)
+    descriptor = authority_store._open_directory_nofollow(tmp_path)
+    try:
+        assert opened == [os.fspath(tmp_path)]
+        assert stat.S_ISDIR(os.fstat(descriptor).st_mode)
+    finally:
+        os.close(descriptor)
+
+
+@pytest.mark.skipif(os.open not in os.supports_dir_fd, reason="stand-in NT helpers need POSIX dir_fd")
+def test_dirfd_public_api_delegates_to_nt_when_posix_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from brigade.work_cmd import nt_dirfd
+
+    calls: list[tuple[str, object]] = []
+
+    def open_root(path: Path | str, *, writable: bool = True) -> int:
+        del writable
+        calls.append(("root", os.fspath(path)))
+        return os.open(path, _posix_dir_flags())
+
+    def open_child(parent: int, name: str, *, writable: bool = True) -> int:
+        del writable
+        calls.append(("child", name))
+        return os.open(name, _posix_dir_flags(), dir_fd=parent)
+
+    def mkdir_child(parent: int, name: str) -> None:
+        calls.append(("mkdir", name))
+        os.mkdir(name, 0o700, dir_fd=parent)
+
+    monkeypatch.setattr(dirfd, "posix_available", lambda: False)
+    monkeypatch.setattr(dirfd, "nt_available", lambda: True)
+    monkeypatch.setattr(nt_dirfd, "open_root_directory", open_root)
+    monkeypatch.setattr(nt_dirfd, "open_child_directory", open_child)
+    monkeypatch.setattr(nt_dirfd, "mkdir_child", mkdir_child)
+
+    parent = dirfd.open_directory_nofollow(tmp_path)
+    child = -1
+    try:
+        dirfd.mkdir_child(parent, "events")
+        child = dirfd.open_child_directory(parent, "events")
+        assert ("root", os.fspath(tmp_path)) in calls
+        assert ("mkdir", "events") in calls
+        assert ("child", "events") in calls
+    finally:
+        if child != -1:
+            os.close(child)
+        os.close(parent)
+
+
+def test_authority_store_availability_aliases_match_dirfd() -> None:
+    assert authority_store._posix_dirfd_available() is dirfd.posix_available()
+    assert authority_store._nt_dirfd_available() is (sys.platform == "win32")
+    assert authority_store._dirfd_available() is dirfd.available()

--- a/tests/test_localio.py
+++ b/tests/test_localio.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import localio, run_journal
+from brigade import localio, run_dirfd, run_journal
 
 
 def test_read_json_dict_invalid_utf8_returns_none(tmp_path: Path):
@@ -207,6 +207,25 @@ def test_write_text_atomic_writes_lf_not_platform_newline(tmp_path: Path):
     raw = path.read_bytes()
     assert b"\r\n" not in raw
     assert raw.count(b"\n") == 4
+
+
+def test_write_text_atomic_unchanged_without_a_binding(tmp_path: Path):
+    path = tmp_path / "nested" / "receipt.txt"
+    payload = "line\nsecond\n"
+    assert run_dirfd.active_binding_for(path) is None
+    localio.write_text_atomic(path, payload)
+    assert path.read_bytes() == payload.encode("utf-8")
+    assert b"\r\n" not in path.read_bytes()
+    metadata = path.stat()
+    assert stat.S_ISREG(metadata.st_mode)
+
+
+def test_write_bytes_atomic_unchanged_without_a_binding(tmp_path: Path):
+    path = tmp_path / "nested" / "blob.bin"
+    payload = b"\x00\xffhello\n"
+    assert run_dirfd.active_binding_for(path) is None
+    localio.write_bytes_atomic(path, payload)
+    assert path.read_bytes() == payload
 
 
 def test_write_text_exclusive_writes_lf_not_platform_newline(tmp_path: Path):

--- a/tests/test_run_dirfd.py
+++ b/tests/test_run_dirfd.py
@@ -1,0 +1,205 @@
+"""Descriptor-bound run directory transactions stay on the held inode."""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from brigade import dirfd, localio, run_dirfd
+
+
+def _require_bind(run_dir: Path) -> run_dirfd.BoundRunDir:
+    bound = run_dirfd.bind_run_dir(run_dir)
+    if bound is None:
+        pytest.skip("descriptor-bound run directories are unavailable")
+    return bound
+
+
+def _identity(path: Path) -> tuple[int, int]:
+    metadata = path.lstat()
+    return metadata.st_dev, metadata.st_ino
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_write_lands_on_original_inode_after_pathname_symlink_swap(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    original = run_dir / "run.json"
+    attacker = tmp_path / "attacker"
+    attacker.mkdir()
+    (attacker / "run.json").write_text("outside\n", encoding="utf-8")
+
+    with run_dirfd.bound_run_dir(run_dir) as bound:
+        localio.write_text_atomic(original, "inside-before\n")
+        held = bound.identity
+        assert _identity(run_dir) == held
+
+        relocated = tmp_path / "run.orig"
+        run_dir.rename(relocated)
+        run_dir.symlink_to(attacker, target_is_directory=True)
+
+        assert bound.still_bound() is False
+        localio.write_text_atomic(original, "inside-after\n")
+
+        assert (relocated / "run.json").read_bytes() == b"inside-after\n"
+        assert (attacker / "run.json").read_bytes() == b"outside\n"
+        assert _identity(relocated) == held
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_nested_events_and_recovery_checkpoints_stay_on_bound_inode(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    checkpoint = run_dir / "events" / "recovery-checkpoints" / "abc.json"
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    attacker = tmp_path / "attacker"
+    attacker.mkdir()
+    (attacker / "events").mkdir()
+    (attacker / "events" / "recovery-checkpoints").mkdir()
+    (attacker / "events" / "lifecycle.jsonl").write_text("leaked\n", encoding="utf-8")
+    (attacker / "events" / "recovery-checkpoints" / "abc.json").write_text("leaked\n", encoding="utf-8")
+
+    with run_dirfd.bound_run_dir(run_dir) as bound:
+        localio.write_text_atomic(journal, "event-one\n")
+        localio.write_bytes_atomic(checkpoint, b'{"ok":true}\n')
+        relocated = tmp_path / "run.orig"
+        run_dir.rename(relocated)
+        run_dir.symlink_to(attacker, target_is_directory=True)
+        localio.write_text_atomic(journal, "event-two\n")
+        localio.write_bytes_atomic(checkpoint, b'{"ok":false}\n')
+
+        assert bound.still_bound() is False
+        assert (relocated / "events" / "lifecycle.jsonl").read_bytes() == b"event-two\n"
+        assert (relocated / "events" / "recovery-checkpoints" / "abc.json").read_bytes() == b'{"ok":false}\n'
+        assert (attacker / "events" / "lifecycle.jsonl").read_bytes() == b"leaked\n"
+        assert (attacker / "events" / "recovery-checkpoints" / "abc.json").read_bytes() == b"leaked\n"
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_symlinked_intermediate_is_rejected(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (run_dir / "events").symlink_to(outside, target_is_directory=True)
+
+    bound = _require_bind(run_dir)
+    try:
+        with pytest.raises(OSError):
+            bound.dir_fd("events")
+        with pytest.raises(OSError):
+            bound.write_text_atomic(("events",), "lifecycle.jsonl", "nope\n")
+        assert list(outside.iterdir()) == []
+    finally:
+        bound.close()
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_invalid_components_are_rejected(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    with run_dirfd.bound_run_dir(run_dir) as bound:
+        with pytest.raises(OSError):
+            bound.dir_fd("..")
+        with pytest.raises(OSError):
+            bound.dir_fd(".")
+        with pytest.raises(OSError):
+            bound.write_text_atomic(("events/nested",), "run.json", "nope\n")
+        with pytest.raises(OSError):
+            bound.write_bytes_atomic((), "", b"nope")
+        with pytest.raises(OSError):
+            bound.read_bytes("..", "passwd")
+        with pytest.raises(OSError):
+            run_dirfd.active_binding_for(run_dir / ".." / "escape" / "x")
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_active_binding_for_is_lexical_and_does_not_resolve_symlinks(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text("inside\n", encoding="utf-8")
+    alias = tmp_path / "alias"
+    alias.symlink_to(run_dir, target_is_directory=True)
+
+    with run_dirfd.bound_run_dir(run_dir):
+        found = run_dirfd.active_binding_for(run_dir / "run.json")
+        assert found is not None
+        bound, components, name = found
+        assert components == ()
+        assert name == "run.json"
+        assert bound.read_bytes("run.json") == b"inside\n"
+        assert run_dirfd.active_binding_for(alias / "run.json") is None
+        assert run_dirfd.active_binding_for(tmp_path / "other.json") is None
+        with pytest.raises(OSError):
+            run_dirfd.active_binding_for(run_dir / ".." / "escape.json")
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_close_and_error_paths_release_every_fd(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    bound = _require_bind(run_dir)
+    root_fd = bound.dir_fd()
+    events_fd = bound.dir_fd("events", create=True)
+    try:
+        with pytest.raises(OSError):
+            bound.write_text_atomic(("events",), "..", "nope\n")
+    finally:
+        bound.close()
+    with pytest.raises(OSError) as root_exc:
+        os.fstat(root_fd)
+    with pytest.raises(OSError) as events_exc:
+        os.fstat(events_fd)
+    assert root_exc.value.errno == errno.EBADF
+    assert events_exc.value.errno == errno.EBADF
+
+
+@pytest.mark.skipif(not dirfd.posix_available(), reason="POSIX O_CREAT|O_EXCL atomicity")
+def test_posix_atomic_write_cleans_temp_and_leaves_original(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    target = run_dir / "run.json"
+    target.write_bytes(b"keep\n")
+    real_replace = dirfd.replace_children
+
+    def boom(parent: int, source: str, destination: str) -> None:
+        del parent, source, destination
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(dirfd, "replace_children", boom)
+    bound = _require_bind(run_dir)
+    try:
+        with pytest.raises(OSError, match="simulated replace failure"):
+            bound.write_text_atomic((), "run.json", "new\n")
+        assert target.read_bytes() == b"keep\n"
+        leftovers = [path.name for path in run_dir.iterdir() if path.name != "run.json"]
+        assert leftovers == []
+    finally:
+        bound.close()
+        monkeypatch.setattr(dirfd, "replace_children", real_replace)
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bind_run_dir_fails_closed_on_symlink(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+    assert run_dirfd.bind_run_dir(link) is None
+
+
+@pytest.mark.skipif(not dirfd.available(), reason="descriptor-relative primitives required")
+def test_bound_run_dir_context_closes_on_error(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    held: list[int] = []
+    with pytest.raises(RuntimeError, match="boom"):
+        with run_dirfd.bound_run_dir(run_dir) as bound:
+            held.append(bound.dir_fd())
+            raise RuntimeError("boom")
+    with pytest.raises(OSError) as excinfo:
+        os.fstat(held[0])
+    assert excinfo.value.errno == errno.EBADF

--- a/tests/test_run_projector.py
+++ b/tests/test_run_projector.py
@@ -551,7 +551,7 @@ def test_dataclasses_replace_mutation_of_typed_run_event_raises_event_chain_erro
 
 def test_full_field_fixture_preserves_deep_equality_and_copies_nested_values():
     base = _full_base_snapshot()
-    assert len(PRESERVED_FIELDS) == 60
+    assert len(PRESERVED_FIELDS) == 63
     assert DERIVED_FIELDS == {
         "status",
         "projector_version",

--- a/tests/test_run_reap.py
+++ b/tests/test_run_reap.py
@@ -1,0 +1,616 @@
+"""Local orphan-run reaper, Hub stale-history aging, and work-brief surfacing."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from brigade import cli
+from brigade import doctor
+from brigade import dogfood_cmd
+from brigade import fleet_command_deck as deck
+from brigade import fleet_dashboard
+from brigade import fleet_hub
+from brigade import localio
+from brigade import proc
+from brigade import run_checkpoint
+from brigade import run_events
+from brigade import run_journal
+from brigade import run_lifecycle
+from brigade import run_projector
+from brigade import run_reap
+from brigade import runguard
+from brigade import work_cmd
+from tests.work_cmd_test_helpers import _init_git_repo
+
+
+OLD_STARTED = "2026-08-20T12:00:00+00:00"
+NOW = datetime(2026, 8, 28, 18, 0, 0, tzinfo=timezone.utc)
+NODE = "11111111-1111-4111-8111-111111111111"
+# A run that durably opted into lifecycle journaling. Legacy runs omit it and
+# must stay snapshot-only through the reaper.
+JOURNAL_REQUESTED = {"lifecycle_journal_requested": True}
+AUTHORITY_REQUESTED = {"lifecycle_journal_requested": True, "run_journal_authority_requested": True}
+
+
+def _git(repo: Path, *args: str) -> proc.Result:
+    result = proc.run(["git", *args], cwd=repo)
+    assert result.code == 0, result.stderr
+    return result
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "tracked.txt").write_text("base\n")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _write_run(
+    repo: Path,
+    run_id: str,
+    *,
+    status: str = "dispatching",
+    started_at: str = OLD_STARTED,
+    extra: dict | None = None,
+) -> Path:
+    run_dir = repo / ".brigade" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    payload = {
+        "task": "orphan task",
+        "cwd": str(repo),
+        "lock_workspace": str(repo),
+        "orchestrator": "chef",
+        "status": status,
+        "started_at": started_at,
+    }
+    if extra:
+        payload.update(extra)
+    localio.write_json(run_dir / "run.json", payload)
+    return run_dir
+
+
+def _write_stale_lock(repo: Path, run_dir: Path, *, pid: int = 99999999) -> Path:
+    lock_path = repo / ".brigade" / "run.lock"
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{pid}\n")
+    localio.write_json(
+        lock_path / "owner.json",
+        {
+            "schema": "brigade.run_lock.v1",
+            "owner_token": "owner",
+            "pid": pid,
+            "run_dir": str(run_dir.resolve()),
+            "acquired_at": OLD_STARTED,
+        },
+    )
+    return lock_path
+
+
+def _reap(repo: Path, *, older_than: str = "2h", json_output: bool = True, now: datetime = NOW) -> int:
+    return run_reap.reap(
+        cwd=repo,
+        runs_dir=None,
+        older_than=older_than,
+        json_output=json_output,
+        now=now,
+    )
+
+
+def test_parse_older_than_default_and_units():
+    assert run_reap.parse_older_than("2h") == timedelta(hours=2)
+    assert run_reap.parse_older_than("30m") == timedelta(minutes=30)
+    assert run_reap.parse_older_than("90s") == timedelta(seconds=90)
+    assert run_reap.parse_older_than("1d") == timedelta(days=1)
+    with pytest.raises(ValueError):
+        run_reap.parse_older_than("nope")
+
+
+def test_reap_terminalizes_stale_owner_as_orphaned(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    (repo / "secret-name.txt").write_text("dirty\n")
+    (repo / "tracked.txt").write_text("changed\n")
+    run_dir = _write_run(repo, "20260820-120000-orphan01", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "brigade.runs-reap.v1"
+    assert payload["reaped"][0]["run_id"] == "20260820-120000-orphan01"
+    assert payload["reaped"][0]["uncommitted_change_count"] == 2
+    dumped = json.dumps(payload)
+    assert "secret-name.txt" not in dumped
+    assert "tracked.txt" not in dumped
+
+    meta = json.loads((run_dir / "run.json").read_text())
+    assert meta["status"] == "orphaned"
+    assert meta["last_observed_status"] == "dispatching"
+    assert meta["uncommitted_change_count"] == 2
+    assert meta["orphaned_at"]
+    assert meta["finished_at"]
+    assert "secret-name.txt" not in json.dumps(meta)
+
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    assert journal.is_file()
+    events = run_journal.read_journal(journal).events
+    assert events[-1].event_type == "run.orphaned"
+    assert events[-1].payload["status"] == "orphaned"
+    assert events[-1].payload["last_observed_status"] == "dispatching"
+    assert events[-1].payload["uncommitted_change_count"] == 2
+    assert "secret-name.txt" not in journal.read_text()
+
+
+def test_reap_is_idempotent(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-orphan02", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    assert _reap(repo) == 0
+    first = json.loads((run_dir / "run.json").read_text())
+    first_events = run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    capsys.readouterr()
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert payload["skipped"][0]["reason"] == "already-orphaned"
+    second = json.loads((run_dir / "run.json").read_text())
+    assert second == first
+    assert run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events == first_events
+
+
+def _skipped_reasons(capsys, repo: Path) -> dict[str, str]:
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    return {row["run_id"]: row["reason"] for row in payload["skipped"]}
+
+
+def test_reap_skips_live_owner(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    live = _write_run(repo, "20260820-120000-live0001")
+    _write_stale_lock(repo, live, pid=os.getpid())
+    (repo / ".brigade" / "run.lock" / "pid").write_text(f"{os.getpid()}\n")
+    reasons = _skipped_reasons(capsys, repo)
+    assert reasons["20260820-120000-live0001"] == "live"
+    assert json.loads((live / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_reap_skips_too_young_run(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    young = _write_run(repo, "20260828-170000-young001", started_at="2026-08-28T17:00:00+00:00")
+    _write_stale_lock(repo, young)
+    reasons = _skipped_reasons(capsys, repo)
+    assert reasons["20260828-170000-young001"] == "too-young"
+    assert json.loads((young / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_reap_skips_malformed_symlink_and_ambiguous(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    runs = repo / ".brigade" / "runs"
+    runs.mkdir(parents=True)
+    malformed = runs / "20260820-120000-badjson1"
+    malformed.mkdir()
+    (malformed / "run.json").write_text("{not-json")
+    outside = tmp_path / "outside-run"
+    outside.mkdir()
+    localio.write_json(outside / "run.json", {"status": "dispatching", "started_at": OLD_STARTED})
+    (runs / "20260820-120000-symlink1").symlink_to(outside)
+    ambiguous = _write_run(repo, "20260820-120000-nolock01")
+    reasons = _skipped_reasons(capsys, repo)
+    assert reasons["20260820-120000-badjson1"] == "malformed"
+    assert reasons["20260820-120000-symlink1"] == "symlink"
+    assert reasons["20260820-120000-nolock01"] == "ambiguous"
+    assert json.loads((ambiguous / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_reap_one_winner_under_race(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-race0001", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    results: list[int] = []
+
+    def _worker() -> None:
+        results.append(
+            run_reap.reap(
+                cwd=repo,
+                runs_dir=None,
+                older_than="2h",
+                json_output=True,
+                now=NOW,
+            )
+        )
+
+    threads = [threading.Thread(target=_worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+    assert results == [0, 0]
+    meta = json.loads((run_dir / "run.json").read_text())
+    assert meta["status"] == "orphaned"
+    events = run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    assert sum(1 for event in events if event.event_type == "run.orphaned") == 1
+
+
+def test_reap_skips_concurrently_changed_run(tmp_path, capsys, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-changed1")
+    _write_stale_lock(repo, run_dir)
+    real_lock = runguard.run_lock
+
+    def _racing_lock(*args, **kwargs):
+        context = real_lock(*args, **kwargs)
+
+        class _Wrapper:
+            def __enter__(self):
+                path = context.__enter__()
+                payload = json.loads((run_dir / "run.json").read_text())
+                payload["status"] = "ok"
+                payload["finished_at"] = "2026-08-28T17:59:00+00:00"
+                localio.write_json(run_dir / "run.json", payload)
+                return path
+
+            def __exit__(self, *exc):
+                return context.__exit__(*exc)
+
+        return _Wrapper()
+
+    monkeypatch.setattr(runguard, "run_lock", _racing_lock)
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert payload["skipped"][0]["reason"] == "concurrently-changed"
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+
+
+def test_runs_reap_cli_default_older_than_and_readable(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-cli0001")
+    _write_stale_lock(repo, run_dir)
+    assert cli.main(["runs", "reap", "--cwd", str(repo)]) == 0
+    out = capsys.readouterr().out
+    assert "reaped: 1" in out
+    assert "20260820-120000-cli0001" in out
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "orphaned"
+
+
+def test_run_orphaned_is_terminal_across_contracts():
+    assert "run.orphaned" in run_events.EVENT_TYPES
+    assert run_events.EVENT_TYPES["run.orphaned"] == frozenset(
+        {"status", "last_observed_status", "uncommitted_change_count"}
+    )
+    assert run_lifecycle.STATUS_EVENT_TYPE["orphaned"] == "run.orphaned"
+    assert "run.orphaned" in fleet_hub.TERMINAL_STATES
+    assert "run.orphaned" in deck.TERMINAL_STATES
+    assert deck.is_terminal_state("run.orphaned")
+    assert "orphaned_at" in run_projector.PRESERVED_FIELDS
+    assert "last_observed_status" in run_projector.PRESERVED_FIELDS
+    assert "uncommitted_change_count" in run_projector.PRESERVED_FIELDS
+
+
+def test_projector_derives_orphaned_and_keeps_privacy():
+    created = run_events.build_event(
+        run_id="20260820-120000-proj0001",
+        sequence=1,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="create-1",
+        recorded_at="2026-08-20T12:00:00.000000Z",
+        previous_digest=None,
+    )
+    orphaned = run_events.build_event(
+        run_id="20260820-120000-proj0001",
+        sequence=2,
+        event_type="run.orphaned",
+        payload={
+            "status": "orphaned",
+            "last_observed_status": "dispatching",
+            "uncommitted_change_count": 2,
+        },
+        idempotency_key="orphan-1",
+        recorded_at="2026-08-28T18:00:00.000000Z",
+        previous_digest=created["event_digest"],
+    )
+    with pytest.raises(run_events.CanonicalizationError):
+        run_events.build_event(
+            run_id="20260820-120000-proj0001",
+            sequence=2,
+            event_type="run.orphaned",
+            payload={"status": "orphaned", "filenames": ["secret-name.txt"]},
+            idempotency_key="orphan-bad",
+            recorded_at="2026-08-28T18:00:00.000000Z",
+            previous_digest=created["event_digest"],
+        )
+    projection = run_projector.project_run_snapshot(
+        {"status": "started", "schema": "brigade.run.v1"},
+        [created, orphaned],
+        journal_present=True,
+    )
+    assert projection.status == "orphaned"
+
+
+def test_hub_history_ages_old_nonterminal_as_synthetic_stale(tmp_path):
+    db = tmp_path / "fleet.db"
+    conn = fleet_hub.init_db(db)
+    now = datetime(2026, 8, 28, 18, 0, 0, tzinfo=timezone.utc)
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, repo, seat, harness, state, ts, exit_status, capability_fingerprint, received_at) "
+        "VALUES (?, ?, 1, 'old', 'repo', 'coder', 'cursor', 'run.dispatch.requested', ?, NULL, NULL, ?)",
+        (NODE, "old-run", now.isoformat(), (now - timedelta(hours=30)).isoformat()),
+    )
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, repo, seat, harness, state, ts, exit_status, capability_fingerprint, received_at) "
+        "VALUES (?, ?, 1, 'fresh', 'repo', 'coder', 'cursor', 'run.dispatch.requested', ?, NULL, NULL, ?)",
+        (NODE, "fresh-run", now.isoformat(), (now - timedelta(minutes=5)).isoformat()),
+    )
+    conn.commit()
+    active = fleet_hub.latest_status(conn, now=now)
+    history = fleet_hub.latest_status(conn, include_all=True, now=now)
+    conn.close()
+    assert {row["run_id"] for row in active} == {"fresh-run"}
+    by_id = {row["run_id"]: row for row in history}
+    assert by_id["old-run"]["state"] == "run.stale"
+    assert by_id["old-run"]["original_state"] == "run.dispatch.requested"
+    assert by_id["fresh-run"]["state"] == "run.dispatch.requested"
+    assert "original_state" not in by_id["fresh-run"]
+
+
+def test_stale_history_threshold_is_bounded_and_separate_from_liveness(tmp_path):
+    assert fleet_hub.ACTIVE_EVENT_TTL_SECONDS == 30 * 60
+    assert deck.DeckConfig().stale_after_seconds == 1800
+    assert deck.DeckConfig().stale_history_after_seconds == 86400
+    path = tmp_path / "deck.json"
+    path.write_text(
+        json.dumps(
+            {
+                "stations": [{"node_id": NODE, "name": "Alpha", "capacity": 2}],
+                "stale_history_after_seconds": 3600,
+            }
+        )
+    )
+    assert deck.load_config(path).stale_history_after_seconds == 3600
+    path.write_text(
+        json.dumps(
+            {
+                "stations": [{"node_id": NODE, "name": "Alpha", "capacity": 2}],
+                "stale_history_after_seconds": 60,
+            }
+        )
+    )
+    with pytest.raises(deck.DeckConfigError):
+        deck.load_config(path)
+    assert fleet_dashboard.bucket_for("run.stale", age_seconds=0) == "stale"
+    assert fleet_dashboard.bucket_for("run.stale", age_seconds=None) == "stale"
+    assert fleet_dashboard.bucket_for("run.orphaned", age_seconds=0) == "interrupted"
+
+
+def test_work_brief_reports_orphaned_runs_and_dirty_trap(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    dogfood_cmd.init(target=tmp_path)
+    run_dir = tmp_path / ".brigade" / "runs" / "20260820-120000-brief001"
+    run_dir.mkdir(parents=True)
+    localio.write_json(
+        run_dir / "run.json",
+        {
+            "status": "orphaned",
+            "started_at": OLD_STARTED,
+            "orphaned_at": "2026-08-28T18:00:00+00:00",
+            "last_observed_status": "dispatching",
+            "uncommitted_change_count": 3,
+            "task": "stuck work",
+        },
+    )
+    monkeypatch.setattr(work_cmd.helpers.shutil, "which", lambda name: f"/usr/bin/{name}")
+    assert work_cmd.brief(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "orphaned_runs: 1" in out
+    assert "20260820-120000-brief001" in out
+    assert "dirty=3" in out
+    assert "orphaned_trap:" in out
+    assert "brigade runs show" in out
+    capsys.readouterr()
+    assert work_cmd.brief(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["orphaned_runs"][0]["uncommitted_change_count"] == 3
+    assert "secret-name.txt" not in json.dumps(payload)
+    assert payload["orphaned_runs"][0]["suggested_command"].startswith("brigade runs show")
+
+
+def _journal_events(run_dir: Path):
+    return run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+
+
+def _doctor_recovery(repo: Path) -> tuple[str, str, str]:
+    return doctor._check_recovery_checkpoints(repo, full=True)
+
+
+def _bootstrap_journaled_run(repo: Path, run_id: str, *, authority: bool) -> Path:
+    """Create a run the way a real dispatch does, through the sanctioned writer.
+
+    The run.json durable request fields are written first, then one status
+    write under the run lock activates the journal, publishes the first
+    recovery checkpoint, and (for an authority run) projects run.json.
+    """
+    from brigade import aboyeur, receipt_schema
+
+    extra = dict(AUTHORITY_REQUESTED if authority else JOURNAL_REQUESTED)
+    run_dir = _write_run(repo, run_id, status="planning", extra=extra)
+    payload = json.loads((run_dir / "run.json").read_text())
+    payload["status"] = "dispatching"
+    with runguard.run_lock(repo, run_dir=run_dir):
+        aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(payload))
+    _write_stale_lock(repo, run_dir)
+    return run_dir
+
+
+def test_reap_leaves_a_legacy_snapshot_only_run_without_a_journal(tmp_path, capsys):
+    """A run that never requested journaling is terminalized snapshot-only."""
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-legacy01")
+    _write_stale_lock(repo, run_dir)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"][0]["run_id"] == "20260820-120000-legacy01"
+
+    meta = json.loads((run_dir / "run.json").read_text())
+    assert meta["status"] == "orphaned"
+    assert meta["last_observed_status"] == "dispatching"
+    # No journal is manufactured, and no projection metadata is invented.
+    assert not (run_dir / "events" / "lifecycle.jsonl").exists()
+    assert not (run_dir / "events" / "recovery-checkpoints").exists()
+    for derived in ("projector_version", "journal_present", "journal_last_sequence", "journal_last_event_digest"):
+        assert derived not in meta
+
+    status, _name, detail = _doctor_recovery(repo)
+    assert status == doctor.OK, detail
+    assert "fail=0" in detail
+    assert "omitted=1" in detail
+
+
+def test_reap_of_a_journal_requested_run_writes_a_checkpoint_and_orphaned_pair(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    run_dir = _bootstrap_journaled_run(repo, "20260820-120000-journal1", authority=False)
+    before = len(_journal_events(run_dir))
+
+    assert _reap(repo) == 0
+    capsys.readouterr()
+
+    events = _journal_events(run_dir)
+    appended = events[before:]
+    assert [event.event_type for event in appended] == ["run.snapshot.checkpointed", "run.orphaned"]
+    assert appended[-1].payload["status"] == "orphaned"
+    assert appended[-1].payload["last_observed_status"] == "dispatching"
+    checkpoint = run_checkpoint.checkpoint_path(run_dir, appended[0].payload["sha256"])
+    assert checkpoint.is_file()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "orphaned"
+
+    status, _name, detail = _doctor_recovery(repo)
+    assert status == doctor.OK, detail
+    assert "fail=0" in detail
+
+
+def test_reap_of_an_authoritative_run_keeps_projected_cursor_parity(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    run_dir = _bootstrap_journaled_run(repo, "20260820-120000-authori1", authority=True)
+    bootstrapped = json.loads((run_dir / "run.json").read_text())
+    assert bootstrapped["journal_present"] is True
+    before = len(_journal_events(run_dir))
+
+    assert _reap(repo) == 0
+    capsys.readouterr()
+
+    events = _journal_events(run_dir)
+    appended = events[before:]
+    assert [event.event_type for event in appended] == ["run.snapshot.checkpointed", "run.orphaned"]
+
+    meta = json.loads((run_dir / "run.json").read_text())
+    assert meta["status"] == "orphaned"
+    assert meta["last_observed_status"] == "dispatching"
+    # Projected cursor parity: run.json's saved cursor is the journal tail.
+    assert meta["projector_version"] == run_projector.PROJECTOR_VERSION
+    assert meta["journal_present"] is True
+    assert meta["journal_last_sequence"] == len(events)
+    assert meta["journal_last_event_digest"] == events[-1].event_digest
+
+    # No lifecycle projection drift: run.json is exactly the projection of the
+    # latest stripped checkpoint base over the verified event sequence.
+    latest = run_checkpoint.latest_checkpoint_event(events)
+    base = json.loads(run_checkpoint.checkpoint_path(run_dir, latest.payload["sha256"]).read_bytes())
+    projection = run_projector.project_run_snapshot(base, events, journal_present=True)
+    assert projection.to_bytes() == (run_dir / "run.json").read_bytes()
+    assert projection.status == "orphaned"
+
+    status, _name, detail = _doctor_recovery(repo)
+    assert status == doctor.OK, detail
+    assert "fail=0" in detail
+
+
+def test_run_lock_claim_refuses_a_stale_lock_owned_by_another_run(tmp_path):
+    """stale_action='claim' fails closed on a run_dir mismatch, deleting nothing."""
+    repo = _repo(tmp_path)
+    mine = _write_run(repo, "20260820-120000-mine0001")
+    theirs = _write_run(repo, "20260820-120000-theirs01")
+    _write_stale_lock(repo, theirs)
+    lock = repo / ".brigade" / "run.lock"
+    owner_before = (lock / "owner.json").read_text()
+
+    with pytest.raises(runguard.RunLockError) as excinfo:
+        with runguard.run_lock(repo, run_dir=mine, wait_seconds=0, stale_action="claim"):
+            pass
+    assert "does not belong to this run" in str(excinfo.value)
+    assert lock.is_dir()
+    assert (lock / "owner.json").read_text() == owner_before
+    assert json.loads((theirs / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_run_lock_claim_requires_a_run_dir():
+    with pytest.raises(ValueError, match="requires run_dir"):
+        with runguard.run_lock(Path("."), stale_action="claim"):
+            pass
+
+
+def test_reap_fails_closed_when_the_lock_owner_changes_after_preflight(tmp_path, capsys, monkeypatch):
+    """TOCTOU: preflight saw a matching stale lock; the claim path sees another run."""
+    repo = _repo(tmp_path)
+    mine = _write_run(repo, "20260820-120000-toctou01")
+    theirs = _write_run(repo, "20260820-120000-toctou02", status="ok", started_at=OLD_STARTED)
+    _write_stale_lock(repo, theirs)
+    lock = repo / ".brigade" / "run.lock"
+    owner_before = (lock / "owner.json").read_text()
+
+    monkeypatch.setattr(runguard, "run_lock_state", lambda workspace, run_dir: "stale")
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    reasons = {row["run_id"]: row["reason"] for row in payload["skipped"]}
+    assert reasons["20260820-120000-toctou01"] == "concurrently-changed"
+    # The foreign claim survives untouched for its own owner to recover.
+    assert lock.is_dir()
+    assert (lock / "owner.json").read_text() == owner_before
+    assert json.loads((mine / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_list_orphaned_runs_scan_is_bounded(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    assert run_reap.ORPHAN_SCAN_LIMIT == 50
+    for index in range(run_reap.ORPHAN_SCAN_LIMIT + 10):
+        _write_run(repo, f"20260820-1200{index:02d}-bound{index:03d}")
+    buried = _write_run(repo, "20260819-120000-buried01")
+    localio.write_json(
+        buried / "run.json",
+        {"status": "orphaned", "last_observed_status": "dispatching", "uncommitted_change_count": 1},
+    )
+
+    reads: list[Path] = []
+    real_read = run_reap._read_run_bytes
+
+    def _counting_read(run_dir: Path):
+        reads.append(run_dir)
+        return real_read(run_dir)
+
+    monkeypatch.setattr(run_reap, "_read_run_bytes", _counting_read)
+    assert run_reap.list_orphaned_runs(repo) == []
+    assert len(reads) == run_reap.ORPHAN_SCAN_LIMIT
+    # The bound is a window, not a filter: a wider scan still finds the orphan.
+    reads.clear()
+    rows = run_reap.list_orphaned_runs(repo, scan_limit=200)
+    assert [row["run_id"] for row in rows] == ["20260819-120000-buried01"]
+
+
+def test_command_deck_buckets_synthetic_stale_history():
+    assert deck.bucket_for("run.stale", age_seconds=0, stale_after_seconds=1800) == "stale"
+    assert deck.bucket_for("run.stale", age_seconds=None, stale_after_seconds=1800) == "stale"
+    assert deck.bucket_for("run.stale", age_seconds=999_999, stale_after_seconds=1800) == "stale"
+    assert deck.bucket_for("run.stale", age_seconds=0, stale_after_seconds=1800) == fleet_dashboard.bucket_for(
+        "run.stale", age_seconds=0
+    )

--- a/tests/test_run_reap.py
+++ b/tests/test_run_reap.py
@@ -20,6 +20,7 @@ from brigade import fleet_hub
 from brigade import localio
 from brigade import proc
 from brigade import run_checkpoint
+from brigade import run_dirfd
 from brigade import run_events
 from brigade import run_journal
 from brigade import run_lifecycle
@@ -888,3 +889,392 @@ def test_reap_swap_from_inside_the_sanctioned_writer_is_bounded_to_the_run_direc
     assert json.loads(outside_before)["marker"] == "outside-canary"
     assert not (outside / "events").exists()
     assert not (outside / "checkpoints").exists()
+
+
+# --- Descriptor-bound orphan-reaper transaction (phase 2) ---------------------
+#
+# The reaper binds the candidate run directory and runs the whole sanctioned
+# transaction under that binding. Every swap below lands AFTER the binding is
+# taken, from inside one stage of the writer. The invariant under test is the
+# same each time: writes may only reach the original held run inode, or the
+# stage fails closed. Nothing outside the run directory is ever written.
+
+
+def _outside_canary(tmp_path: Path, name: str) -> tuple[Path, Path, bytes]:
+    outside = tmp_path / name
+    outside.mkdir()
+    outside_json = outside / "run.json"
+    localio.write_json(
+        outside_json,
+        {"status": "dispatching", "started_at": OLD_STARTED, "marker": "outside-canary"},
+    )
+    return outside, outside_json, outside_json.read_bytes()
+
+
+def _swap_aside(run_dir: Path, outside: Path) -> Path:
+    """Move the real run directory aside and point its name at ``outside``.
+
+    Unlike an rmtree-then-symlink swap this keeps the original inode reachable
+    under a new name, so a test can prove where a descriptor-relative write
+    actually landed instead of only proving it failed.
+    """
+    moved = run_dir.with_name(f"{run_dir.name}.moved")
+    run_dir.rename(moved)
+    run_dir.symlink_to(outside, target_is_directory=True)
+    return moved
+
+
+def _swap_once(monkeypatch, module, attribute: str, run_dir: Path, outside: Path) -> list[Path]:
+    """Patch one writer stage to swap the run directory on its first call."""
+    real = getattr(module, attribute)
+    moved: list[Path] = []
+
+    def wrapper(*args, **kwargs):
+        if not moved:
+            moved.append(_swap_aside(run_dir, outside))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(module, attribute, wrapper)
+    return moved
+
+
+def _assert_outside_untouched(outside: Path, outside_json: Path, before: bytes) -> None:
+    assert outside_json.read_bytes() == before
+    assert json.loads(before)["marker"] == "outside-canary"
+    assert not (outside / "events").exists()
+    assert not (outside / "revisions").exists()
+    assert sorted(child.name for child in outside.iterdir()) == ["run.json"]
+
+
+def _reap_under_swap(tmp_path, capsys, monkeypatch, module, attribute, *, run_id, extra=None):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, run_id, extra=dict(extra or JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside, outside_json, before = _outside_canary(tmp_path, f"outside-{run_id}")
+    moved = _swap_once(monkeypatch, module, attribute, run_dir, outside)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert moved, "the patched stage never ran, so no swap was exercised"
+    _assert_outside_untouched(outside, outside_json, before)
+    return payload, moved[0]
+
+
+def test_swap_before_journal_activation_never_writes_outside_the_bound_run(tmp_path, capsys, monkeypatch):
+    payload, moved = _reap_under_swap(
+        tmp_path,
+        capsys,
+        monkeypatch,
+        run_lifecycle,
+        "prepare_lifecycle_journal",
+        run_id="20260820-120000-bnd00001",
+    )
+    assert not (moved / "events" / "lifecycle.jsonl").exists() or (moved / "events" / "lifecycle.jsonl").is_file()
+    assert payload["reaped"] or payload["skipped"]
+
+
+def test_swap_before_the_checkpoint_write_never_writes_outside_the_bound_run(tmp_path, capsys, monkeypatch):
+    payload, moved = _reap_under_swap(
+        tmp_path,
+        capsys,
+        monkeypatch,
+        run_checkpoint,
+        "write_checkpoint",
+        run_id="20260820-120000-bnd00002",
+    )
+    checkpoints = moved / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    if payload["reaped"]:
+        assert checkpoints.is_dir()
+    assert payload["reaped"] or payload["skipped"]
+
+
+def test_swap_before_the_lifecycle_append_never_writes_outside_the_bound_run(tmp_path, capsys, monkeypatch):
+    payload, moved = _reap_under_swap(
+        tmp_path,
+        capsys,
+        monkeypatch,
+        run_lifecycle,
+        "record_lifecycle_transition",
+        run_id="20260820-120000-bnd00003",
+    )
+    assert payload["reaped"] or payload["skipped"]
+    assert (moved / "run.json").is_file()
+
+
+def test_swap_before_the_shadow_transition_never_writes_outside_the_bound_run(tmp_path, capsys, monkeypatch):
+    from brigade import run_shadow
+
+    payload, moved = _reap_under_swap(
+        tmp_path,
+        capsys,
+        monkeypatch,
+        run_shadow,
+        "record_shadow_comparison",
+        run_id="20260820-120000-bnd00004",
+    )
+    assert payload["reaped"] or payload["skipped"]
+    assert (moved / "run.json").is_file()
+
+
+def test_swap_before_the_terminal_run_json_write_lands_on_the_original_inode(tmp_path, capsys, monkeypatch):
+    """The last write in the transaction must still reach the bound inode."""
+    repo = _repo(tmp_path)
+    run_id = "20260820-120000-bnd00005"
+    run_dir = _write_run(repo, run_id, extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside, outside_json, before = _outside_canary(tmp_path, "outside-terminal")
+
+    real_write = localio.write_text_atomic
+    moved: list[Path] = []
+
+    def swap_then_write(path: Path, data: str) -> None:
+        if not moved and Path(path).name == "run.json":
+            moved.append(_swap_aside(run_dir, outside))
+        return real_write(path, data)
+
+    monkeypatch.setattr(localio, "write_text_atomic", swap_then_write)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert moved, "the terminal run.json write never ran"
+    _assert_outside_untouched(outside, outside_json, before)
+    assert [row["run_id"] for row in payload["reaped"]] == [run_id]
+    # The descriptor-relative write landed on the inode the reaper bound, which
+    # the swap moved aside; the symlink target never saw it.
+    assert json.loads((moved[0] / "run.json").read_text())["status"] == "orphaned"
+
+
+def test_swap_during_the_reaper_transaction_before_any_writer_fails_closed(tmp_path, capsys, monkeypatch):
+    """A swap that lands between the lock and the binding is a CAS loss."""
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-bnd00006", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside, outside_json, before = _outside_canary(tmp_path, "outside-transaction")
+    moved: list[Path] = []
+    real_lock = runguard.run_lock
+
+    def swap_then_lock(*args, **kwargs):
+        if not moved:
+            moved.append(_swap_aside(run_dir, outside))
+        return real_lock(*args, **kwargs)
+
+    monkeypatch.setattr(runguard, "run_lock", swap_then_lock)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["concurrently-changed"]
+    _assert_outside_untouched(outside, outside_json, before)
+    assert json.loads((moved[0] / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_symlinked_events_directory_fails_closed_and_writes_nothing_outside(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-bnd00007", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside = tmp_path / "outside-events"
+    outside.mkdir()
+    (run_dir / "events").symlink_to(outside, target_is_directory=True)
+    before = (run_dir / "run.json").read_bytes()
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["write-refused"]
+    assert (run_dir / "run.json").read_bytes() == before
+    assert list(outside.iterdir()) == []
+
+
+def test_symlinked_recovery_checkpoints_directory_fails_closed(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-bnd00008", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside = tmp_path / "outside-checkpoints"
+    outside.mkdir()
+    (run_dir / "events").mkdir()
+    (run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME).symlink_to(outside, target_is_directory=True)
+    before = (run_dir / "run.json").read_bytes()
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["write-refused"]
+    assert (run_dir / "run.json").read_bytes() == before
+    assert list(outside.iterdir()) == []
+
+
+def test_write_refused_under_a_swap_retains_the_claimed_lock(tmp_path, capsys, monkeypatch):
+    """Exception cleanup: a refused bound transaction keeps the recovery claim."""
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-bnd00009", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside, outside_json, before = _outside_canary(tmp_path, "outside-refused")
+    moved: list[Path] = []
+
+    def swap_then_refuse(*args, **kwargs):
+        if not moved:
+            moved.append(_swap_aside(run_dir, outside))
+        raise run_checkpoint.CheckpointError("checkpoint refused after swap", category="test")
+
+    monkeypatch.setattr(run_checkpoint, "write_checkpoint", swap_then_refuse)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["write-refused"]
+    _assert_outside_untouched(outside, outside_json, before)
+    owner = json.loads((repo / ".brigade" / "run.lock" / "owner.json").read_text())
+    assert owner["pid"] == os.getpid()
+    assert json.loads((moved[0] / "run.json").read_text())["status"] == "dispatching"
+
+
+def _open_descriptor_count() -> int | None:
+    try:
+        return len(os.listdir("/proc/self/fd"))
+    except OSError:
+        return None
+
+
+def test_the_bound_transaction_closes_every_descriptor_on_both_paths(tmp_path, capsys, monkeypatch):
+    repo = _repo(tmp_path)
+    _write_run(repo, "20260820-120000-bnd00010", extra=dict(JOURNAL_REQUESTED))
+    refused = _write_run(repo, "20260820-120000-bnd00011", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, refused)
+
+    baseline = _open_descriptor_count()
+    if baseline is None:
+        pytest.skip("descriptor accounting needs /proc/self/fd")
+
+    assert _reap(repo) == 0
+    capsys.readouterr()
+    assert _open_descriptor_count() == baseline
+
+    _write_stale_lock(repo, refused)
+
+    def refuse(*args, **kwargs):
+        raise run_checkpoint.CheckpointError("checkpoint refused in test", category="test")
+
+    monkeypatch.setattr(run_checkpoint, "write_checkpoint", refuse)
+    assert _reap(repo) == 0
+    capsys.readouterr()
+    assert _open_descriptor_count() == baseline
+
+
+def test_no_binding_parity_for_ordinary_run_json_writers(tmp_path):
+    """Ordinary callers never activate a binding and keep pathname behavior."""
+    from brigade import aboyeur, receipt_schema
+
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-bnd00012", extra=dict(JOURNAL_REQUESTED))
+    run_json = run_dir / "run.json"
+    assert run_dirfd.active_binding_for(run_json) is None
+
+    payload = json.loads(run_json.read_text())
+    payload["status"] = "planning"
+    with runguard.run_lock(repo, run_dir=run_dir, wait_seconds=0):
+        aboyeur._write_json(run_json, receipt_schema.stamp_run_receipt(payload))
+    assert run_dirfd.active_binding_for(run_json) is None
+    assert json.loads(run_json.read_text())["status"] == "planning"
+    assert (run_dir / "events" / "lifecycle.jsonl").is_file()
+
+
+def test_bound_helpers_match_pathname_helpers_without_a_binding(tmp_path):
+    events = tmp_path / "events"
+    events.mkdir()
+    present = events / "lifecycle.jsonl"
+    present.write_bytes(b"payload\n")
+    missing = events / "absent.jsonl"
+    link = events / "link.jsonl"
+    link.symlink_to(present)
+
+    assert run_journal.bound_is_file(present) is present.is_file()
+    assert run_journal.bound_is_file(missing) is missing.is_file()
+    assert run_journal.bound_is_file(link) is link.is_file()
+    assert run_journal.bound_is_dir(events) is events.is_dir()
+    assert run_journal.bound_exists(link) is link.exists()
+    assert run_journal.bound_lexists(link) is os.path.lexists(link)
+    assert run_journal.bound_read_bytes(present) == present.read_bytes()
+    assert run_journal.bound_read_bytes(link) == present.read_bytes()
+    assert run_journal.bound_lstat(present).st_ino == present.lstat().st_ino
+    assert run_journal.bound_lstat(missing) is None
+    assert run_journal.normalize_run_dir(tmp_path) == tmp_path.expanduser().resolve()
+
+
+def test_bound_helpers_stay_on_the_bound_inode_after_a_swap(tmp_path):
+    """A swap after bind cannot redirect a bound read, stat, or normalization."""
+    from brigade import run_dirfd as dirfd_module
+
+    run_dir = tmp_path / "run"
+    (run_dir / "events").mkdir(parents=True)
+    (run_dir / "run.json").write_bytes(b'{"status": "dispatching"}\n')
+    (run_dir / "events" / "lifecycle.jsonl").write_bytes(b"bound\n")
+
+    outside = tmp_path / "outside"
+    (outside / "events").mkdir(parents=True)
+    (outside / "run.json").write_bytes(b'{"status": "outside"}\n')
+    (outside / "events" / "lifecycle.jsonl").write_bytes(b"outside\n")
+
+    with dirfd_module.bound_run_dir(run_dir) as bound:
+        moved = _swap_aside(run_dir, outside)
+        assert run_journal.normalize_run_dir(run_dir) == bound.path
+        assert run_journal.bound_read_bytes(run_dir / "run.json") == b'{"status": "dispatching"}\n'
+        assert run_journal.bound_read_bytes(run_dir / "events" / "lifecycle.jsonl") == b"bound\n"
+        assert run_journal.bound_is_file(run_dir / "events" / "lifecycle.jsonl")
+        assert run_journal.bound_lstat(run_dir / "run.json") is not None
+    assert (moved / "run.json").read_bytes() == b'{"status": "dispatching"}\n'
+    assert (outside / "run.json").read_bytes() == b'{"status": "outside"}\n'
+
+
+def test_a_symlinked_journal_inside_a_binding_is_refused_not_followed(tmp_path):
+    from brigade import run_dirfd as dirfd_module
+
+    run_dir = tmp_path / "run"
+    (run_dir / "events").mkdir(parents=True)
+    outside = tmp_path / "outside.jsonl"
+    outside.write_bytes(b"outside\n")
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    journal.symlink_to(outside)
+
+    with dirfd_module.bound_run_dir(run_dir):
+        assert run_journal.bound_is_file(journal) is False
+        with pytest.raises(run_journal.RunJournalError) as excinfo:
+            run_journal.ensure_journal(journal)
+    assert "lifecycle.jsonl" in excinfo.value.diagnostic
+    assert outside.read_bytes() == b"outside\n"
+
+
+def test_swap_before_the_sanctioned_writer_poisons_no_write_outside_the_run(tmp_path, capsys, monkeypatch):
+    """The swap lands between the reaper's CAS read and ``aboyeur._write_json``.
+
+    ``aboyeur.run_io`` still reads the prior ``run.json`` snapshot by pathname
+    (its authority and transition gates), so a swap here can feed those gates
+    outside bytes. That is the one residual of this slice: it is a read, and
+    every write in the transaction is descriptor-bound, so the outside
+    directory is never mutated and the run is never silently terminalized
+    somewhere else.
+    """
+    from brigade import receipt_schema
+
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-bnd00013", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside, outside_json, before = _outside_canary(tmp_path, "outside-poison")
+    real_stamp = receipt_schema.stamp_run_receipt
+    moved: list[Path] = []
+
+    def swap_then_stamp(payload):
+        if not moved:
+            moved.append(_swap_aside(run_dir, outside))
+        return real_stamp(payload)
+
+    monkeypatch.setattr(receipt_schema, "stamp_run_receipt", swap_then_stamp)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert moved, "the sanctioned writer never ran"
+    _assert_outside_untouched(outside, outside_json, before)
+    written = json.loads((moved[0] / "run.json").read_text())
+    if payload["reaped"]:
+        assert written["status"] == "orphaned"
+    else:
+        assert written["status"] == "dispatching"

--- a/tests/test_run_reap.py
+++ b/tests/test_run_reap.py
@@ -26,6 +26,7 @@ from brigade import run_journal
 from brigade import run_lifecycle
 from brigade import run_projector
 from brigade import run_reap
+from brigade import run_redaction
 from brigade import runguard
 from brigade import runs_cmd
 from brigade import work_cmd
@@ -268,6 +269,38 @@ def test_reap_skips_malformed_symlink_and_ambiguous(tmp_path, capsys):
     assert json.loads((ambiguous / "run.json").read_text())["status"] == "dispatching"
 
 
+def test_symlinked_default_runs_root_never_terminalizes_the_outside_target(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    outside_root = tmp_path / "outside-runs"
+    run_id = "20260820-120000-symroot1"
+    outside_run = outside_root / run_id
+    outside_run.mkdir(parents=True)
+    localio.write_json(
+        outside_run / "run.json",
+        {
+            "task": "orphan task",
+            "cwd": str(repo),
+            "lock_workspace": str(repo),
+            "orchestrator": "chef",
+            "status": "dispatching",
+            "started_at": OLD_STARTED,
+        },
+    )
+    brigade = repo / ".brigade"
+    brigade.mkdir(exist_ok=True)
+    (brigade / "runs").symlink_to(outside_root)
+    _write_stale_lock(repo, outside_run)
+    before = (outside_run / "run.json").read_bytes()
+
+    assert _reap(repo) == 2
+    err = capsys.readouterr().err
+    assert err == "error: runs directory not found\n"
+    assert (outside_run / "run.json").read_bytes() == before
+    assert json.loads(before)["status"] == "dispatching"
+    lock_owner = json.loads((repo / ".brigade" / "run.lock" / "owner.json").read_text())
+    assert lock_owner["pid"] == 99999999
+
+
 def test_reap_one_winner_under_race(tmp_path):
     repo = _repo(tmp_path)
     run_dir = _write_run(repo, "20260820-120000-race0001", extra=dict(JOURNAL_REQUESTED))
@@ -297,10 +330,7 @@ def test_reap_one_winner_under_race(tmp_path):
     assert sum(1 for event in events if event.event_type == "run.orphaned") == 1
 
 
-def test_reap_skips_concurrently_changed_run(tmp_path, capsys, monkeypatch):
-    repo = _repo(tmp_path)
-    run_dir = _write_run(repo, "20260820-120000-changed1")
-    _write_stale_lock(repo, run_dir)
+def _racing_lock_after_claim(run_dir: Path, mutate):
     real_lock = runguard.run_lock
 
     def _racing_lock(*args, **kwargs):
@@ -310,8 +340,7 @@ def test_reap_skips_concurrently_changed_run(tmp_path, capsys, monkeypatch):
             def __enter__(self):
                 path = context.__enter__()
                 payload = json.loads((run_dir / "run.json").read_text())
-                payload["status"] = "ok"
-                payload["finished_at"] = "2026-08-28T17:59:00+00:00"
+                mutate(payload)
                 localio.write_json(run_dir / "run.json", payload)
                 return path
 
@@ -320,12 +349,67 @@ def test_reap_skips_concurrently_changed_run(tmp_path, capsys, monkeypatch):
 
         return _Wrapper()
 
-    monkeypatch.setattr(runguard, "run_lock", _racing_lock)
+    return _racing_lock
+
+
+def test_reap_skips_concurrently_changed_run(tmp_path, capsys, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-changed1")
+    _write_stale_lock(repo, run_dir)
+
+    def _to_terminal(payload: dict) -> None:
+        payload["status"] = "ok"
+        payload["finished_at"] = "2026-08-28T17:59:00+00:00"
+
+    monkeypatch.setattr(runguard, "run_lock", _racing_lock_after_claim(run_dir, _to_terminal))
     assert _reap(repo) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["reaped"] == []
     assert payload["skipped"][0]["reason"] == "concurrently-changed"
     assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+
+
+def test_nonterminal_cas_loss_retains_the_claimed_lock(tmp_path, capsys, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-casret01")
+    _write_stale_lock(repo, run_dir)
+
+    def _keep_nonterminal(payload: dict) -> None:
+        payload["task"] = "concurrent edit"
+
+    monkeypatch.setattr(runguard, "run_lock", _racing_lock_after_claim(run_dir, _keep_nonterminal))
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert payload["skipped"][0]["reason"] == "concurrently-changed"
+    current = json.loads((run_dir / "run.json").read_text())
+    assert current["status"] == "dispatching"
+    assert current["task"] == "concurrent edit"
+    lock_path = repo / ".brigade" / "run.lock"
+    assert lock_path.is_dir()
+    owner = json.loads((lock_path / "owner.json").read_text())
+    assert Path(owner["run_dir"]) == run_dir.resolve()
+    assert owner["pid"] == os.getpid()
+    assert runguard.run_lock_state(repo, run_dir) == "live"
+
+
+def test_terminal_concurrent_update_releases_the_claimed_lock(tmp_path, capsys, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-casrel01")
+    _write_stale_lock(repo, run_dir)
+
+    def _to_terminal(payload: dict) -> None:
+        payload["status"] = "ok"
+        payload["finished_at"] = "2026-08-28T17:59:00+00:00"
+
+    monkeypatch.setattr(runguard, "run_lock", _racing_lock_after_claim(run_dir, _to_terminal))
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert payload["skipped"][0]["reason"] == "concurrently-changed"
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+    assert not (repo / ".brigade" / "run.lock").exists()
+    assert runguard.run_lock_state(repo, run_dir) == "absent"
 
 
 def test_runs_reap_cli_default_older_than_and_readable(tmp_path, capsys):
@@ -351,6 +435,7 @@ def test_run_orphaned_is_terminal_across_contracts():
     assert "orphaned_at" in run_projector.PRESERVED_FIELDS
     assert "last_observed_status" in run_projector.PRESERVED_FIELDS
     assert "uncommitted_change_count" in run_projector.PRESERVED_FIELDS
+    assert "orphaned" in run_redaction.TERMINAL_STATUSES
 
 
 def test_projector_derives_orphaned_and_keeps_privacy():
@@ -907,6 +992,29 @@ def test_reap_fails_closed_when_the_platform_cannot_bind_a_run_directory(tmp_pat
     assert lock_owner["pid"] == 99999999
 
 
+def test_identity_without_binding_is_unbindable_before_lock(tmp_path, capsys, monkeypatch):
+    """Identity flags without dirfd binding support must not claim the lock."""
+    from brigade import dirfd
+
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-diverg01")
+    _write_stale_lock(repo, run_dir)
+    before = (run_dir / "run.json").read_bytes()
+    lock_before = (repo / ".brigade" / "run.lock" / "owner.json").read_bytes()
+
+    monkeypatch.setattr(dirfd, "available", lambda: False)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["unbindable"]
+    assert payload["skipped"][0]["run_id"] == "20260820-120000-diverg01"
+    assert (run_dir / "run.json").read_bytes() == before
+    assert (repo / ".brigade" / "run.lock" / "owner.json").read_bytes() == lock_before
+    lock_owner = json.loads((repo / ".brigade" / "run.lock" / "owner.json").read_text())
+    assert lock_owner["pid"] == 99999999
+
+
 def test_reap_swap_from_inside_the_sanctioned_writer_is_bounded_to_the_run_directory(tmp_path, capsys, monkeypatch):
     """A swap racing in from inside the writer path must not escape the runs root.
 
@@ -1330,12 +1438,10 @@ def test_a_symlinked_journal_inside_a_binding_is_refused_not_followed(tmp_path):
 def test_swap_before_the_sanctioned_writer_poisons_no_write_outside_the_run(tmp_path, capsys, monkeypatch):
     """The swap lands between the reaper's CAS read and ``aboyeur._write_json``.
 
-    ``aboyeur.run_io`` still reads the prior ``run.json`` snapshot by pathname
-    (its authority and transition gates), so a swap here can feed those gates
-    outside bytes. That is the one residual of this slice: it is a read, and
-    every write in the transaction is descriptor-bound, so the outside
-    directory is never mutated and the run is never silently terminalized
-    somewhere else.
+    Bound reads and shadow reads are descriptor-aware, so a swap here cannot
+    redirect those gates to outside bytes. Every write in the transaction is
+    descriptor-bound: the outside directory is never mutated and the run is
+    never silently terminalized somewhere else.
     """
     from brigade import receipt_schema
 

--- a/tests/test_run_reap.py
+++ b/tests/test_run_reap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -25,6 +26,7 @@ from brigade import run_lifecycle
 from brigade import run_projector
 from brigade import run_reap
 from brigade import runguard
+from brigade import runs_cmd
 from brigade import work_cmd
 from tests.work_cmd_test_helpers import _init_git_repo
 
@@ -614,3 +616,275 @@ def test_command_deck_buckets_synthetic_stale_history():
     assert deck.bucket_for("run.stale", age_seconds=0, stale_after_seconds=1800) == fleet_dashboard.bucket_for(
         "run.stale", age_seconds=0
     )
+
+
+def _pending_stale_claim(repo: Path, run_dir: Path, *, token: str = "pending-other") -> Path:
+    lock = repo / ".brigade" / "run.lock"
+    stale = lock.with_name(f".{lock.name}.unrelated.stale")
+    stale.mkdir(parents=True)
+    (stale / "pid").write_text("99999999\n")
+    localio.write_json(
+        stale / "owner.json",
+        {
+            "schema": "brigade.run_lock.v1",
+            "owner_token": token,
+            "pid": 99999999,
+            "run_dir": str(run_dir.resolve()),
+            "acquired_at": OLD_STARTED,
+        },
+    )
+    return stale
+
+
+def test_run_lock_claim_leaves_unrelated_pending_claim_untouched(tmp_path):
+    """stale_action='claim' must not recover or terminalize a foreign pending claim."""
+    repo = _repo(tmp_path)
+    mine = _write_run(repo, "20260820-120000-claim001")
+    other = _write_run(repo, "20260820-120000-claim002")
+    _write_stale_lock(repo, mine)
+    pending = _pending_stale_claim(repo, other)
+    pending_owner = (pending / "owner.json").read_text()
+    other_before = (other / "run.json").read_bytes()
+
+    with runguard.run_lock(repo, run_dir=mine, wait_seconds=0, stale_action="claim"):
+        pass
+
+    assert pending.is_dir()
+    assert (pending / "owner.json").read_text() == pending_owner
+    assert (other / "run.json").read_bytes() == other_before
+    assert json.loads((other / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_reap_refuses_swapped_run_dir_and_does_not_touch_outside_run_json(tmp_path, capsys, monkeypatch):
+    """A post-containment directory swap must not read or write an outside run.json."""
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-swap0001", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside = tmp_path / "outside-run"
+    outside.mkdir()
+    outside_json = outside / "run.json"
+    localio.write_json(
+        outside_json,
+        {"status": "dispatching", "started_at": OLD_STARTED, "marker": "outside-canary"},
+    )
+    outside_before = outside_json.read_bytes()
+    observed: list[str] = []
+    real_read = run_reap._read_run_bytes
+    real_write = __import__("brigade.aboyeur", fromlist=["_write_json"])._write_json
+
+    def _guarded_read(path: Path):
+        target = path / "run.json"
+        try:
+            if target.resolve() == outside_json.resolve():
+                observed.append("read-outside")
+        except OSError:
+            pass
+        return real_read(path)
+
+    def _guarded_write(path: Path, payload: object) -> None:
+        try:
+            if path.resolve() == outside_json.resolve():
+                observed.append("write-outside")
+        except OSError:
+            pass
+        return real_write(path, payload)
+
+    real_lock = runguard.run_lock
+
+    def _swap_then_lock(*args, **kwargs):
+        shutil.rmtree(run_dir)
+        run_dir.symlink_to(outside, target_is_directory=True)
+        return real_lock(*args, **kwargs)
+
+    monkeypatch.setattr(run_reap, "_read_run_bytes", _guarded_read)
+    monkeypatch.setattr("brigade.aboyeur._write_json", _guarded_write)
+    monkeypatch.setattr(runguard, "run_lock", _swap_then_lock)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert payload["skipped"]
+    assert all(row["reason"] in {"concurrently-changed", "malformed"} for row in payload["skipped"])
+    assert outside_json.read_bytes() == outside_before
+    assert "read-outside" not in observed
+    assert "write-outside" not in observed
+    assert json.loads(outside_before)["marker"] == "outside-canary"
+
+
+def test_reap_json_and_cli_never_echo_control_bearing_run_id_or_status(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    runs = repo / ".brigade" / "runs"
+    runs.mkdir(parents=True)
+    injected = "evil\n\x1b[31mINJECT"
+    nasty = runs / injected
+    nasty.mkdir()
+    localio.write_json(
+        nasty / "run.json",
+        {
+            "task": "inject",
+            "cwd": str(repo),
+            "lock_workspace": str(repo),
+            "orchestrator": "chef",
+            "status": "dispatching\n\x1b[31mINJECT",
+            "started_at": OLD_STARTED,
+        },
+    )
+    planted = _write_run(repo, "20260820-120000-safe0001")
+    localio.write_json(
+        planted / "run.json",
+        {
+            "status": "orphaned",
+            "started_at": OLD_STARTED,
+            "orphaned_at": "2026-08-28T18:00:00+00:00",
+            "last_observed_status": "dispatching\n\x1b[31mINJECT",
+            "uncommitted_change_count": 1,
+        },
+    )
+
+    rows = run_reap.list_orphaned_runs(repo)
+    listed = json.dumps(rows)
+    assert injected not in listed
+    assert "INJECT" not in listed
+    assert "\x1b" not in listed
+    assert rows
+    assert all(row["run_id"] == "20260820-120000-safe0001" for row in rows)
+    assert rows[0]["last_observed_status"] == "unknown"
+
+    assert _reap(repo, json_output=True) == 0
+    json_out = capsys.readouterr().out
+    assert injected not in json_out
+    assert "INJECT" not in json_out
+    assert "\x1b" not in json_out
+    payload = json.loads(json_out)
+    for row in payload["skipped"]:
+        assert row["run_id"] == "malformed" or row["run_id"] == "20260820-120000-safe0001"
+        assert "\n" not in row["run_id"]
+        assert "\x1b" not in row["run_id"]
+
+    assert (
+        run_reap.reap(
+            cwd=repo,
+            runs_dir=None,
+            older_than="2h",
+            json_output=False,
+            now=NOW,
+        )
+        == 0
+    )
+    text = capsys.readouterr().out
+    assert injected not in text
+    assert "INJECT" not in text
+    assert "\x1b" not in text
+
+
+def test_write_refused_retains_the_claimed_lock_so_runs_recover_still_finds_the_run(tmp_path, capsys, monkeypatch):
+    """A refused sanctioned write must leave a matching lock for `runs recover`.
+
+    stale_action='claim' deletes the dead owner's lock as it takes over. If the
+    reaper then released its own lock on a LifecycleJournalError/CheckpointError,
+    the run would be left nonterminal with no lock and no matching .stale claim,
+    and `brigade runs recover` would have nothing to match on.
+    """
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-refuse01")
+    other = _write_run(repo, "20260820-120000-refuse02")
+    _write_stale_lock(repo, run_dir)
+    before = (run_dir / "run.json").read_bytes()
+
+    def _refuse(*args, **kwargs):
+        raise run_checkpoint.CheckpointError("checkpoint refused in test", category="test")
+
+    monkeypatch.setattr(run_checkpoint, "write_checkpoint", _refuse)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    reasons = {row["run_id"]: row["reason"] for row in payload["skipped"]}
+    assert payload["reaped"] == []
+    assert reasons["20260820-120000-refuse01"] == "write-refused"
+    # The refused run is untouched and still nonterminal.
+    assert (run_dir / "run.json").read_bytes() == before
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+    # The retained lock makes the rest of the scan skip: the second run now
+    # sees a live lock in preflight instead of a claimable dead owner.
+    assert reasons["20260820-120000-refuse02"] == "live"
+    assert json.loads((other / "run.json").read_text())["status"] == "dispatching"
+
+    # The lock was retained, not released, and still records this run.
+    lock_path = repo / ".brigade" / "run.lock"
+    assert lock_path.is_dir()
+    owner = json.loads((lock_path / "owner.json").read_text())
+    assert Path(owner["run_dir"]) == run_dir.resolve()
+    assert owner["pid"] == os.getpid()
+    assert runguard.run_lock_state(repo, run_dir) == "live"
+
+    # Once the reaper process is gone the retained lock reads back as a
+    # matching dead-owner stale lock, which is what recovery matches on.
+    dead = 99999998
+    (lock_path / "pid").write_text(f"{dead}\n")
+    owner["pid"] = dead
+    localio.write_json(lock_path / "owner.json", owner)
+    assert runguard.run_lock_state(repo, run_dir) == "stale"
+    assert runs_cmd.recover(run_dir, cwd=repo) == 0
+    capsys.readouterr()
+    assert not lock_path.exists()
+
+
+def test_reap_fails_closed_when_the_platform_cannot_bind_a_run_directory(tmp_path, capsys, monkeypatch):
+    """No no-follow directory primitive means no mutation at all, not a best effort."""
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-nobind1", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    before = (run_dir / "run.json").read_bytes()
+
+    monkeypatch.setattr(run_reap, "_dirfd_identity_available", lambda: False)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["unbindable"]
+    assert payload["skipped"][0]["run_id"] == "20260820-120000-nobind1"
+    # Fail closed means nothing was written: no run.json edit, no journal, no
+    # checkpoint, no shadow artifact, and the dead owner's lock is untouched.
+    assert (run_dir / "run.json").read_bytes() == before
+    assert not (run_dir / "events").exists()
+    assert not (run_dir / "checkpoints").exists()
+    assert not (run_dir / "shadow").exists()
+    lock_owner = json.loads((repo / ".brigade" / "run.lock" / "owner.json").read_text())
+    assert lock_owner["pid"] == 99999999
+
+
+def test_reap_swap_from_inside_the_sanctioned_writer_is_bounded_to_the_run_directory(tmp_path, capsys, monkeypatch):
+    """A swap racing in from inside the writer path must not escape the runs root.
+
+    The swap fires from within the sanctioned writer (the first checkpoint
+    write), which is past every containment check the reaper can make. This
+    pins the current, honest boundary: the reaper must not reap the run and
+    must not leave the outside canary altered by the run.json replace.
+    """
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-inswap01", extra=dict(JOURNAL_REQUESTED))
+    _write_stale_lock(repo, run_dir)
+    outside = tmp_path / "outside-writer"
+    outside.mkdir()
+    outside_json = outside / "run.json"
+    localio.write_json(
+        outside_json,
+        {"status": "dispatching", "started_at": OLD_STARTED, "marker": "outside-canary"},
+    )
+    outside_before = outside_json.read_bytes()
+
+    def _swap_then_refuse(*args, **kwargs):
+        shutil.rmtree(run_dir, ignore_errors=True)
+        run_dir.symlink_to(outside, target_is_directory=True)
+        raise run_checkpoint.CheckpointError("checkpoint refused after swap", category="test")
+
+    monkeypatch.setattr(run_checkpoint, "write_checkpoint", _swap_then_refuse)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["write-refused"]
+    assert outside_json.read_bytes() == outside_before
+    assert json.loads(outside_before)["marker"] == "outside-canary"
+    assert not (outside / "events").exists()
+    assert not (outside / "checkpoints").exists()

--- a/tests/test_run_reap.py
+++ b/tests/test_run_reap.py
@@ -1015,6 +1015,67 @@ def test_identity_without_binding_is_unbindable_before_lock(tmp_path, capsys, mo
     assert lock_owner["pid"] == 99999999
 
 
+def _assert_stale_lock_unclaimed(repo: Path, run_dir: Path, lock_before: bytes) -> None:
+    lock_path = repo / ".brigade" / "run.lock"
+    assert lock_path.is_dir()
+    assert (lock_path / "owner.json").read_bytes() == lock_before
+    owner = json.loads((lock_path / "owner.json").read_text())
+    assert owner["pid"] == 99999999
+    assert Path(owner["run_dir"]) == run_dir.resolve()
+    assert runguard.run_lock_state(repo, run_dir) == "stale"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="platform cannot create FIFOs")
+def test_reap_refuses_fifo_run_json_without_claiming_the_stale_lock(tmp_path, capsys):
+    """A planted FIFO must not block the initial snapshot or take the stale lock."""
+    if not run_reap._dirfd_identity_available():
+        pytest.skip("descriptor bind required to reach the initial snapshot")
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-fifo0001")
+    (run_dir / "run.json").unlink()
+    os.mkfifo(run_dir / "run.json")
+    _write_stale_lock(repo, run_dir)
+    lock_before = (repo / ".brigade" / "run.lock" / "owner.json").read_bytes()
+
+    result: dict[str, object] = {}
+
+    def _call() -> None:
+        result["code"] = _reap(repo)
+
+    worker = threading.Thread(target=_call, daemon=True)
+    worker.start()
+    worker.join(2.0)
+    assert not worker.is_alive(), "reap blocked on a FIFO run.json"
+    assert result["code"] == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["malformed"]
+    assert payload["skipped"][0]["run_id"] == "20260820-120000-fifo0001"
+    _assert_stale_lock_unclaimed(repo, run_dir, lock_before)
+
+
+def test_reap_refuses_oversized_run_json_without_claiming_the_stale_lock(tmp_path, capsys):
+    """An oversized receipt must fail closed as malformed before the lock is claimed."""
+    if not run_reap._dirfd_identity_available():
+        pytest.skip("descriptor bind required to reach the initial snapshot")
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-huge0001")
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["padding"] = "x" * run_redaction.MAX_RUN_JSON_BYTES
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    assert (run_dir / "run.json").stat().st_size > run_redaction.MAX_RUN_JSON_BYTES
+    _write_stale_lock(repo, run_dir)
+    lock_before = (repo / ".brigade" / "run.lock" / "owner.json").read_bytes()
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["malformed"]
+    assert payload["skipped"][0]["run_id"] == "20260820-120000-huge0001"
+    _assert_stale_lock_unclaimed(repo, run_dir, lock_before)
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
 def test_reap_swap_from_inside_the_sanctioned_writer_is_bounded_to_the_run_directory(tmp_path, capsys, monkeypatch):
     """A swap racing in from inside the writer path must not escape the runs root.
 

--- a/tests/test_run_reap.py
+++ b/tests/test_run_reap.py
@@ -196,6 +196,59 @@ def test_reap_skips_too_young_run(tmp_path, capsys):
     assert json.loads((young / "run.json").read_text())["status"] == "dispatching"
 
 
+def test_revalidate_metadata_exact_threshold_is_too_young():
+    """The contract is strictly older than the threshold; equality stays too-young."""
+    started = NOW - timedelta(hours=2)
+    reason = run_reap._revalidate_metadata(
+        {"status": "dispatching", "started_at": started.isoformat()},
+        older_than=timedelta(hours=2),
+        now=NOW,
+    )
+    assert reason == "too-young"
+
+
+def test_reap_missing_cwd_error_is_bounded(tmp_path, capsys):
+    nasty = tmp_path / "cwd\n\x1b[31mINJECT"
+    nasty.write_text("not-a-directory\n")
+    assert (
+        run_reap.reap(
+            cwd=nasty,
+            runs_dir=None,
+            older_than="2h",
+            json_output=True,
+            now=NOW,
+        )
+        == 2
+    )
+    err = capsys.readouterr().err
+    assert err == "error: --cwd is not a directory\n"
+    assert "INJECT" not in err
+    assert "\x1b" not in err
+    assert nasty.name not in err
+    assert str(nasty.resolve()) not in err
+
+
+def test_reap_missing_runs_dir_error_is_bounded(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    nasty = tmp_path / "runs\n\x1b[31mINJECT"
+    assert (
+        run_reap.reap(
+            cwd=repo,
+            runs_dir=nasty,
+            older_than="2h",
+            json_output=True,
+            now=NOW,
+        )
+        == 2
+    )
+    err = capsys.readouterr().err
+    assert err == "error: runs directory not found\n"
+    assert "INJECT" not in err
+    assert "\x1b" not in err
+    assert nasty.name not in err
+    assert str(nasty.resolve()) not in err
+
+
 def test_reap_skips_malformed_symlink_and_ambiguous(tmp_path, capsys):
     repo = _repo(tmp_path)
     runs = repo / ".brigade" / "runs"
@@ -1101,6 +1154,37 @@ def test_symlinked_recovery_checkpoints_directory_fails_closed(tmp_path, capsys)
     assert [row["reason"] for row in payload["skipped"]] == ["write-refused"]
     assert (run_dir / "run.json").read_bytes() == before
     assert list(outside.iterdir()) == []
+
+
+def test_final_write_oserror_retains_the_claimed_lock_and_writes_nothing_outside(tmp_path, capsys, monkeypatch):
+    """A raw OSError from the terminal run.json write must keep the recovery lock."""
+    repo = _repo(tmp_path)
+    run_dir = _write_run(repo, "20260820-120000-oserror1", extra=dict(JOURNAL_REQUESTED))
+    claimed = run_dir.resolve()
+    _write_stale_lock(repo, run_dir)
+    outside, outside_json, before = _outside_canary(tmp_path, "outside-oserror")
+    moved: list[Path] = []
+    real_write = localio.write_text_atomic
+
+    def swap_then_oserror(path: Path, data: str) -> None:
+        if Path(path).name == "run.json":
+            if not moved:
+                moved.append(_swap_aside(run_dir, outside))
+            raise OSError("final sanctioned write refused")
+        return real_write(path, data)
+
+    monkeypatch.setattr(localio, "write_text_atomic", swap_then_oserror)
+
+    assert _reap(repo) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reaped"] == []
+    assert [row["reason"] for row in payload["skipped"]] == ["write-refused"]
+    assert moved, "the terminal run.json write never ran"
+    _assert_outside_untouched(outside, outside_json, before)
+    owner = json.loads((repo / ".brigade" / "run.lock" / "owner.json").read_text())
+    assert owner["pid"] == os.getpid()
+    assert Path(owner["run_dir"]) == claimed
+    assert json.loads((moved[0] / "run.json").read_text())["status"] == "dispatching"
 
 
 def test_write_refused_under_a_swap_retains_the_claimed_lock(tmp_path, capsys, monkeypatch):

--- a/tests/test_run_redaction.py
+++ b/tests/test_run_redaction.py
@@ -115,6 +115,79 @@ def _authority_run(
     return run_dir, projection.snapshot, events
 
 
+def _authority_orphaned_run(tmp_path: Path) -> tuple[Path, dict, list[run_journal.RunEvent]]:
+    run_dir = tmp_path / "workspace" / ".brigade" / "runs" / RUN_ID
+    journal = _journal_path(run_dir)
+    base = {
+        "schema": "brigade.run.v1",
+        "schema_version": 1,
+        "task": "redaction fixture",
+        "status": "orphaned",
+        "cwd": str(tmp_path / "workspace"),
+        "lock_workspace": str(tmp_path / "workspace"),
+        "lifecycle_journal_requested": True,
+        "run_journal_authority_requested": True,
+        "orphaned_at": "2026-07-30T19:00:04.000000Z",
+        "last_observed_status": "started",
+        "uncommitted_change_count": 0,
+    }
+    checkpoint_bytes = run_projector.encode_snapshot_bytes(base)
+    run_checkpoint.publish_checkpoint_file(run_dir, checkpoint_bytes)
+    events = [
+        _append(
+            journal,
+            event_type="run.created",
+            payload={"status": "started"},
+            key="created",
+            prior=0,
+            second=0,
+        ),
+        _append(
+            journal,
+            event_type="run.planning.started",
+            payload={"detail": SECRET},
+            key="planning",
+            prior=1,
+            second=1,
+        ),
+        _append(
+            journal,
+            event_type=run_checkpoint.CHECKPOINT_EVENT_TYPE,
+            payload=run_checkpoint._checkpoint_payload(
+                checkpoint_bytes,
+                paired_event_type="run.orphaned",
+                body_kind="base-stripped",
+            ),
+            key=run_checkpoint._checkpoint_idempotency_key(
+                run_checkpoint._checkpoint_payload(
+                    checkpoint_bytes,
+                    paired_event_type="run.orphaned",
+                    body_kind="base-stripped",
+                )["sha256"],
+                paired_event_type="run.orphaned",
+                body_kind="base-stripped",
+            ),
+            prior=2,
+            second=2,
+        ),
+        _append(
+            journal,
+            event_type="run.orphaned",
+            payload={
+                "status": "orphaned",
+                "last_observed_status": "started",
+                "uncommitted_change_count": 0,
+            },
+            key="orphaned",
+            prior=3,
+            second=3,
+        ),
+    ]
+    projection = run_projector.project_run_snapshot(base, events, journal_present=True)
+    (run_dir / "run.json").write_bytes(projection.to_bytes())
+    return run_dir, projection.snapshot, events
+
+
 def _without_tail_digest(snapshot: dict) -> dict:
     return {key: value for key, value in snapshot.items() if key != "journal_last_event_digest"}
 
@@ -1690,6 +1763,21 @@ def test_redaction_refuses_nonterminal_or_ambiguous_projection_status(tmp_path, 
             operator_confirmed=True,
         )
     assert not (run_dir / "events" / "redactions").exists()
+
+
+def test_redaction_accepts_authoritative_orphaned_run_as_closed(tmp_path):
+    run_dir, snapshot, _ = _authority_orphaned_run(tmp_path)
+    assert snapshot["status"] == "orphaned"
+
+    report = run_redaction.redact_journal(
+        run_dir,
+        sequence_start=2,
+        sequence_end=2,
+        reason=REASON_CODE,
+        operator_confirmed=True,
+    )
+    assert report.sequence_start == 2
+    assert (run_dir / "events" / "redactions").is_dir()
 
 
 def test_overlapping_redactions_are_deterministic_and_idempotent(tmp_path):


### PR DESCRIPTION
Fixes #1262

## What changed

- terminalize dead-owner nonterminal runs as `orphaned`
- separate active Fleet Hub status from terminal and stale history
- bind recovery reads and writes to held run-directory descriptors
- retain recovery locks after nonterminal CAS loss or write refusal
- reject symlinked, FIFO, oversized, and unsupported-platform inputs before mutation
- surface orphaned runs in session briefings and preserve detach lifecycle ownership

## Verification

- full serial Brigade gate: `20260828-230913-work-verify-4b8080`
- post-rebase affected Brigade gate: `20260828-234609-work-verify-45fd35`
- independent review: no remaining findings on the orphan-reaper and Hub-status slice

The post-gate rebase added only unrelated Grok Bot findings and Wazuh commits from main; the affected suite was rerun on the rebased head.

## Rollout

Deploy the Fleet Hub CT first, then Rocinante, Shadowfax, and Gandalf. Preserve the existing model, cloud, and 10/8/4 capacity policy.