### PR TITLE
chore(ci): bump setup-go to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         working-directory: engines/evidence-ledger
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: stable
       - run: go test ./...
@@ -180,7 +180,7 @@ jobs:
         if: ${{ needs.changes.outputs.notify == 'true' }}
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         if: ${{ needs.changes.outputs.notify == 'true' }}
         with:
           go-version: '1.22'
@@ -201,7 +201,7 @@ jobs:
         run: go test ./internal/config/...
       - name: Setup stable Go for govulncheck
         if: ${{ needs.changes.outputs.notify == 'true' }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: stable
           cache-dependency-path: stations/notify/go.sum
@@ -229,7 +229,7 @@ jobs:
         if: ${{ needs.changes.outputs.notify == 'true' }}
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         if: ${{ needs.changes.outputs.notify == 'true' }}
         with:
           go-version: '1.22'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,7 +139,7 @@ jobs:
         working-directory: engines/evidence-ledger
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: stable
           cache: false
@@ -189,7 +189,7 @@ jobs:
         working-directory: stations/notify
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: stable
           cache: false

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -125,7 +125,7 @@ def test_ci_workflow_notify_jobs_run_go_steps_only_when_notify_paths_change():
         ),
     ):
         section = _workflow_job_section(text, job_name)
-        for uses in ("actions/checkout@v7", "actions/setup-go@v5"):
+        for uses in ("actions/checkout@v7", "actions/setup-go@v7"):
             uses_at = 0
             while True:
                 try:
@@ -193,8 +193,8 @@ def test_ci_workflow_runs_notify_go_commands_from_notify_directory():
     ubuntu = _workflow_job_section(text, "notify-build-and-test")
     assert "runs-on: ubuntu-latest" in ubuntu
     assert "working-directory: stations/notify" in ubuntu
-    # Two setup-go v5 steps: Go 1.22 for build parity, then stable for the scanner.
-    assert ubuntu.count("uses: actions/setup-go@v5") == 2
+    # Two setup-go v7 steps: Go 1.22 for build parity, then stable for the scanner.
+    assert ubuntu.count("uses: actions/setup-go@v7") == 2
     # Both Go setup steps pin the notify go.sum so the root cache warning clears.
     assert ubuntu.count("cache-dependency-path: stations/notify/go.sum") == 2
     # Checkout must not persist credentials (CodeRabbit review comment 3630426956).
@@ -223,7 +223,7 @@ def test_ci_workflow_runs_notify_go_commands_from_notify_directory():
     windows = _workflow_job_section(text, "notify-windows")
     assert "runs-on: windows-latest" in windows
     assert "working-directory: stations/notify" in windows
-    assert "uses: actions/setup-go@v5" in windows
+    assert "uses: actions/setup-go@v7" in windows
     assert "go-version: '1.22'" in windows
     assert "persist-credentials: false" in windows
     assert "cache-dependency-path: stations/notify/go.sum" in windows

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -107,7 +107,7 @@ def test_go_native_build_disables_setup_go_cache_for_the_cross_platform_matrix()
     section = text[text.index("  build-go-native:") : text.index("  assemble-release:")]
 
     setup_go = section[
-        section.index("      - uses: actions/setup-go@v5") : section.index("      - name: Build pure-Go")
+        section.index("      - uses: actions/setup-go@v7") : section.index("      - name: Build pure-Go")
     ]
     assert "go-version: stable" in setup_go
     assert "cache: false" in setup_go


### PR DESCRIPTION
## Summary

- bump `actions/setup-go` from v5 to v7 in CI and publish workflows
- update workflow tests so cache and path assertions stay pinned to the shipped files

Replaces #1303.

## Verification

- `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_ci_workflow.py","tests/test_publish_workflow.py"]' --capture brigade-work`
- 88 passed

Worker seat: `coder`
