### PR TITLE
feat: add approval-gated fleet remediation

### DIFF
--- a/docs/plans/2026-08-28-grokbot-findings-wazuh-remediation.md
+++ b/docs/plans/2026-08-28-grokbot-findings-wazuh-remediation.md
@@ -88,19 +88,19 @@ Fleet Hub receives only the persisted opaque `report_event` object: irreversible
 
 ## Slice 3 test-first recipe
 
-- [ ] Write `tests/test_grokbot_fleet_remediation.py::test_proposal_requires_escalated_current_finding_and_operator_approval`; assert suppress/watch, stale revision, wrong target, missing approval, and expired approval all reject without invoking an executor.
-- [ ] Run `pytest -q tests/test_grokbot_fleet_remediation.py::test_proposal_requires_escalated_current_finding_and_operator_approval`; expect failure because the Wazuh binding and action catalog are absent.
-- [ ] Add the fixed typed catalog and policy binding. The first action must name one registered service/target, one verification ID, one rollback ID, one maintenance window, and one maximum blast radius. No input may contain a command, shell, path, username, address, credential, or environment value.
-- [ ] Run the test; expect it to pass.
-- [ ] Write `test_execute_claims_rechecks_verifies_and_records_receipts`; assert the exact call order is approval read, finding revision read, live-state recheck, Fleet claim, executor, verification, and receipt. Assert a failed verification executes the fixed rollback policy or returns a failed receipt when rollback is not permitted.
-- [ ] Run that test; expect failure because the execution path is absent.
-- [ ] Implement the typed proposal/execution path with single-use approval, current-state binding, Fleet claim/renew/release, replay protection, bounded executor arguments, post-action verification, and sanitized receipts.
-- [ ] Run `pytest -q tests/test_grokbot_fleet_remediation.py tests/test_grokbot_fleet_tools.py tests/test_grokbot_fleet_app.py tests/test_grokbot_fleet_lifecycle.py`; expect all tests to pass.
-- [ ] Write `test_non_catalogued_wazuh_findings_remain_review_only`; assert every suppress/watch/unknown finding and every protected, appliance, family, container, or indirect target remains proposal-ineligible.
-- [ ] Run the test; expect failure if any broad path is accidentally executable; repair policy until it passes.
-- [ ] Verify through Brigade: `brigade work verify run --target . --command "pytest -q tests/test_grokbot_fleet_remediation.py tests/test_grokbot_fleet_tools.py tests/test_grokbot_fleet_app.py tests/test_grokbot_fleet_lifecycle.py" --capture grokbot-fleet-bounded-remediator`; expect a successful receipt.
-- [ ] Run the full repository verification through Brigade after the focused receipt, then perform independent security review for command injection, target substitution, secret leakage, replay, stale approvals, claim loss, and rollback behavior.
-- [ ] Commit only the Slice 3 files with `git add src/brigade/grokbot_fleet tests/test_grokbot_fleet_remediation.py tests/test_grokbot_fleet_*.py && git commit -m "feat: add approval-gated fleet remediation"`.
+- [x] Write `tests/test_grokbot_fleet_remediation.py::test_proposal_requires_escalated_current_finding_and_operator_approval`; assert suppress/watch, stale revision, wrong target, missing approval, and expired approval all reject without invoking an executor.
+- [x] Run `pytest -q tests/test_grokbot_fleet_remediation.py::test_proposal_requires_escalated_current_finding_and_operator_approval`; expect failure because the Wazuh binding and action catalog are absent.
+- [x] Add the fixed typed catalog and policy binding. The first action must name one registered service/target, one verification ID, one rollback ID, one maintenance window, and one maximum blast radius. No input may contain a command, shell, path, username, address, credential, or environment value.
+- [x] Run the test; expect it to pass.
+- [x] Write `test_execute_claims_rechecks_verifies_and_records_receipts`; assert the exact call order is approval read, finding revision read, live-state recheck, Fleet claim, executor, verification, and receipt. Assert a failed verification executes the fixed rollback policy or returns a failed receipt when rollback is not permitted.
+- [x] Run that test; expect failure because the execution path is absent.
+- [x] Implement the typed proposal/execution path with single-use approval, current-state binding, Fleet claim/renew/release, replay protection, bounded executor arguments, post-action verification, and sanitized receipts.
+- [x] Run `pytest -q tests/test_grokbot_fleet_remediation.py tests/test_grokbot_fleet_tools.py tests/test_grokbot_fleet_app.py tests/test_grokbot_fleet_lifecycle.py`; expect all tests to pass.
+- [x] Write `test_non_catalogued_wazuh_findings_remain_review_only`; assert every suppress/watch/unknown finding and every protected, appliance, family, container, or indirect target remains proposal-ineligible.
+- [x] Run the test; expect failure if any broad path is accidentally executable; repair policy until it passes.
+- [x] Verify through Brigade: `brigade work verify run --target . --command "pytest -q tests/test_grokbot_fleet_remediation.py tests/test_grokbot_fleet_tools.py tests/test_grokbot_fleet_app.py tests/test_grokbot_fleet_lifecycle.py" --capture grokbot-fleet-bounded-remediator`; expect a successful receipt. Receipt `20260828-233645-work-verify-88fa05` completed with 46 focused tests passing.
+- [x] Run the full repository verification through Brigade after the focused receipt, then perform independent security review for command injection, target substitution, secret leakage, replay, stale approvals, claim loss, and rollback behavior. Receipts `20260829-160756-work-verify-bbfb45` and `20260829-161747-work-verify-2fa1de` covered 10,479 tests with 82.72% coverage; the xdist-unsafe cases were rerun serially. Final focused remediation receipt `20260829-162423-work-verify-3c22ec` passed 67 tests after the independent review findings were closed.
+- [x] Commit only the Slice 3 files with `git add src/brigade/grokbot_fleet tests/test_grokbot_fleet_remediation.py tests/test_grokbot_fleet_*.py && git commit -m "feat: add approval-gated fleet remediation"` (`bcf53231`).
 
 ## End-to-end acceptance
 

--- a/src/brigade/grokbot_fleet/actions.py
+++ b/src/brigade/grokbot_fleet/actions.py
@@ -18,11 +18,13 @@ from .contracts import (
     FleetError,
     is_offset_datetime,
     omit_undefined,
+    parse_fingerprint,
     parse_identifier,
     parse_opaque_id,
+    parse_wazuh_finding_id,
 )
 from .exec import EXEC_DEFAULT_OUTPUT_BYTES, ExecRequest, Runner, run_exec
-from .probes import PROBE_WORKING_DIRECTORY, _health_class
+from .probes import PROBE_WORKING_DIRECTORY, _health_class, verify_catalogued_service
 from .runtime_config import FLEET_SAFE_SERVICE_UNIT_PATTERN
 
 PROPOSAL_TTL_MS = 15 * 60 * 1000
@@ -35,7 +37,7 @@ MAX_CONSUMED_BYTES = 262_144
 EXECUTABLE_ACTION: dict[str, Any] = {
     "action_id": "restart-service",
     "verification_id": "verify-service",
-    "rollback_id": "rollback-service",
+    "rollback_id": "no-rollback",
     "service_id": "research-bridge",
     "target_alias": "control-plane",
     "finding_kind": "unhealthy-service",
@@ -53,8 +55,50 @@ SHOW_PROPERTIES = (
     "StateChangeTimestampMonotonic",
     "InvocationID",
 )
-RECEIPT_FORBIDDEN = ("stdout", "stderr", "nonce", "finding_revision", "system_revision")
-ACTION_STATE_SUBDIRS = ("proposals", "consumed", "receipts", "reservations")
+RECEIPT_FORBIDDEN = (
+    "stdout",
+    "stderr",
+    "nonce",
+    "finding_revision",
+    "system_revision",
+    "command",
+    "path",
+    "credential",
+    "hostname",
+    "token",
+    "secret",
+    "password",
+    "body",
+    "title",
+    "holder",
+)
+PROPOSAL_BASE_KEYS = frozenset(
+    {
+        "version",
+        "proposal_id",
+        "finding_id",
+        "service_id",
+        "target_alias",
+        "finding_revision",
+        "system_revision",
+        "action_id",
+        "verification_id",
+        "rollback_id",
+        "nonce",
+        "created_at",
+        "expires_at",
+    }
+)
+PROPOSAL_WAZUH_KEYS = PROPOSAL_BASE_KEYS | {
+    "automatic_rollback",
+    "blast_radius",
+    "maintenance_window_id",
+    "wazuh_fingerprint",
+}
+ACTION_STATE_SUBDIRS = ("proposals", "consumed", "receipts", "reservations", "cleanup")
+MAX_CLEANUP = 1
+MAX_CLEANUP_BYTES = 4096
+RECOVERY_JOURNAL_FILENAME = "recovery.json"
 RECEIPT_KINDS = frozenset({"proposal", "approval", "rejection", "execution", "verification"})
 RECEIPT_OUTCOMES = frozenset(
     {
@@ -143,28 +187,14 @@ def _require_datetime(value: object) -> str:
 
 
 def _parse_proposal_record(raw: object, expected: str | None = None) -> dict[str, Any]:
-    if not isinstance(raw, Mapping) or set(raw) != {
-        "version",
-        "proposal_id",
-        "finding_id",
-        "service_id",
-        "target_alias",
-        "finding_revision",
-        "system_revision",
-        "action_id",
-        "verification_id",
-        "rollback_id",
-        "nonce",
-        "created_at",
-        "expires_at",
-    }:
+    if not isinstance(raw, Mapping) or set(raw) not in {PROPOSAL_BASE_KEYS, PROPOSAL_WAZUH_KEYS}:
         _action_state_invalid()
     if raw.get("version") != 1:
         _action_state_invalid()
     record = {
         "version": 1,
         "proposal_id": parse_opaque_id(raw.get("proposal_id")),
-        "finding_id": parse_identifier(raw.get("finding_id")),
+        "finding_id": parse_wazuh_finding_id(raw.get("finding_id")),
         "service_id": raw.get("service_id"),
         "target_alias": raw.get("target_alias"),
         "finding_revision": _parse_revision(raw.get("finding_revision")),
@@ -180,29 +210,22 @@ def _parse_proposal_record(raw: object, expected: str | None = None) -> dict[str
         _action_state_invalid()
     if record["action_id"] != "restart-service" or record["verification_id"] != "verify-service":
         _action_state_invalid()
-    if record["rollback_id"] != "rollback-service":
+    if record["rollback_id"] != "no-rollback":
         _action_state_invalid()
     if expected is not None and record["proposal_id"] != expected:
         _action_state_invalid()
+    if "wazuh_fingerprint" in raw:
+        if raw.get("automatic_rollback") is not False or raw.get("blast_radius") != "one registered service":
+            _action_state_invalid()
+        record["automatic_rollback"] = False
+        record["blast_radius"] = "one registered service"
+        record["wazuh_fingerprint"] = parse_fingerprint(raw.get("wazuh_fingerprint"))
+        record["maintenance_window_id"] = parse_identifier(raw.get("maintenance_window_id"))
     return record
 
 
 def _parse_approval_record(raw: object, expected: str | None = None) -> dict[str, Any]:
-    if not isinstance(raw, Mapping) or set(raw) != {
-        "version",
-        "proposal_id",
-        "finding_id",
-        "service_id",
-        "target_alias",
-        "finding_revision",
-        "system_revision",
-        "action_id",
-        "verification_id",
-        "rollback_id",
-        "nonce",
-        "expires_at",
-        "approved_at",
-    }:
+    if not isinstance(raw, Mapping) or "approved_at" not in raw:
         _action_state_invalid()
     record = {
         **_parse_proposal_record(
@@ -248,6 +271,16 @@ def _parse_revision_claim(raw: object, expected: str | None = None) -> dict[str,
     return record
 
 
+def _receipt_contract(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in receipt.items() if key != "outcome"}
+
+
+def _parse_receipt_contract(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping) or "outcome" in raw:
+        _action_state_invalid()
+    return _receipt_contract(_parse_receipt({**raw, "outcome": "unverified"}))
+
+
 def _parse_reservation(raw: object, expected: str | None = None) -> dict[str, Any]:
     if not isinstance(raw, Mapping) or set(raw) != {
         "version",
@@ -256,26 +289,73 @@ def _parse_reservation(raw: object, expected: str | None = None) -> dict[str, An
         "slot_count",
         "reserved_bytes",
         "created_at",
+        "receipt_contracts",
     }:
         _action_state_invalid()
-    if raw.get("version") != 1:
+    if raw.get("version") != 2:
         _action_state_invalid()
     slot_count = raw.get("slot_count")
     reserved_bytes = raw.get("reserved_bytes")
+    contracts = raw.get("receipt_contracts")
     if not isinstance(slot_count, int) or isinstance(slot_count, bool) or slot_count < 1:
         _action_state_invalid()
     if not isinstance(reserved_bytes, int) or isinstance(reserved_bytes, bool) or reserved_bytes < 1:
         _action_state_invalid()
+    if not isinstance(contracts, list) or len(contracts) != slot_count:
+        _action_state_invalid()
+    parsed_contracts = [_parse_receipt_contract(item) for item in contracts]
+    if len({item["receipt_id"] for item in parsed_contracts}) != len(parsed_contracts):
+        _action_state_invalid()
     record = {
-        "version": 1,
+        "version": 2,
         "reservation_id": parse_opaque_id(raw.get("reservation_id")),
         "proposal_id": parse_opaque_id(raw.get("proposal_id")),
         "slot_count": slot_count,
         "reserved_bytes": reserved_bytes,
         "created_at": _require_datetime(raw.get("created_at")),
+        "receipt_contracts": parsed_contracts,
     }
     if expected is not None and record["reservation_id"] != expected:
         _action_state_invalid()
+    return record
+
+
+def _parse_claim_cleanup(raw: object) -> dict[str, Any]:
+    required = {
+        "version",
+        "proposal_id",
+        "target_alias",
+        "holder",
+        "reservation_id",
+        "terminal_receipts",
+        "receipt_pending",
+        "release_pending",
+    }
+    if not isinstance(raw, Mapping) or set(raw) != required:
+        _action_state_invalid()
+    if raw.get("version") != 2:
+        _action_state_invalid()
+    terminal = raw.get("terminal_receipts")
+    if not isinstance(terminal, list) or not 1 <= len(terminal) <= 2:
+        _action_state_invalid()
+    receipts = [_parse_receipt(item) for item in terminal]
+    proposal_id = parse_opaque_id(raw.get("proposal_id"))
+    if any(item["proposal_id"] != proposal_id for item in receipts):
+        _action_state_invalid()
+    if any(item["kind"] not in {"rejection", "execution", "verification"} for item in receipts):
+        _action_state_invalid()
+    if not isinstance(raw.get("receipt_pending"), bool) or not isinstance(raw.get("release_pending"), bool):
+        _action_state_invalid()
+    record = {
+        "version": 2,
+        "proposal_id": proposal_id,
+        "target_alias": parse_identifier(raw.get("target_alias")),
+        "holder": parse_opaque_id(raw.get("holder")),
+        "reservation_id": parse_opaque_id(raw.get("reservation_id")),
+        "terminal_receipts": receipts,
+        "receipt_pending": raw["receipt_pending"],
+        "release_pending": raw["release_pending"],
+    }
     return record
 
 
@@ -310,13 +390,13 @@ def _parse_receipt(raw: object) -> dict[str, Any]:
         "created_at": _require_datetime(raw.get("created_at")),
     }
     if "finding_id" in raw:
-        receipt["finding_id"] = parse_identifier(raw.get("finding_id"))
+        receipt["finding_id"] = parse_wazuh_finding_id(raw.get("finding_id"))
     for key, expected in (
         ("service_id", "research-bridge"),
         ("target_alias", "control-plane"),
         ("action_id", "restart-service"),
         ("verification_id", "verify-service"),
-        ("rollback_id", "rollback-service"),
+        ("rollback_id", "no-rollback"),
     ):
         if key in raw:
             if raw[key] != expected:
@@ -404,6 +484,26 @@ def _write_exclusive_json(path: Path, record: Mapping[str, Any]) -> None:
                 pass
         if created:
             _unlink_quiet(path)
+        _action_state_invalid()
+
+
+def _replace_json(path: Path, record: Mapping[str, Any]) -> None:
+    """Durably replace one private state record without an unlink gap."""
+    try:
+        existing = path.lstat()
+    except FileNotFoundError:
+        existing = None
+    except OSError:
+        _action_state_invalid()
+    if existing is not None:
+        _assert_owner_file(existing)
+    temporary = path.parent / f".{path.name}.{secrets.token_hex(16)}.tmp"
+    _write_exclusive_json(temporary, record)
+    try:
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    except OSError:
+        _unlink_quiet(temporary)
         _action_state_invalid()
 
 
@@ -554,6 +654,11 @@ class FleetActionStore:
                 _action_state_invalid()
             return _parse_proposal_record(raw, key)
 
+    def is_consumed(self, proposal_id: str) -> bool:
+        with self._lock:
+            key = parse_opaque_id(proposal_id)
+            return _path_exists_nofollow(self._root / "consumed" / f"{key}.json")
+
     def read_approval(self, proposal_id: str) -> dict[str, Any] | None:
         with self._lock:
             key = parse_opaque_id(proposal_id)
@@ -647,12 +752,13 @@ class FleetActionStore:
             reservation_id = secrets.token_hex(16)
             reservation_path = self._root / "reservations" / f"{reservation_id}.json"
             reservation = {
-                "version": 1,
+                "version": 2,
                 "reservation_id": reservation_id,
                 "proposal_id": proposal_id,
                 "slot_count": len(parsed),
                 "reserved_bytes": incoming_bytes,
                 "created_at": _utc_now().isoformat().replace("+00:00", "Z"),
+                "receipt_contracts": [_receipt_contract(item) for item in parsed],
             }
             _write_exclusive_json(reservation_path, reservation)
             _fsync_directory(reservation_path.parent)
@@ -663,30 +769,46 @@ class FleetActionStore:
             self._ensure_ready()
             key = parse_opaque_id(reservation_id)
             reservation_path = self._root / "reservations" / f"{key}.json"
+            parsed = [_parse_receipt(record) for record in records]
+            if not parsed:
+                _action_state_invalid()
             try:
                 raw = _read_safe_json(reservation_path)
             except FileNotFoundError:
-                _action_state_invalid()
+                persisted: list[dict[str, Any]] = []
+                for receipt in parsed:
+                    try:
+                        persisted.append(
+                            _parse_receipt(_read_safe_json(self._root / "receipts" / f"{receipt['receipt_id']}.json"))
+                        )
+                    except FileNotFoundError:
+                        _action_state_invalid()
+                if persisted != parsed:
+                    _action_state_invalid()
+                return
             reservation = _parse_reservation(raw, key)
-            parsed = [_parse_receipt(record) for record in records]
-            if len(parsed) != reservation["slot_count"]:
+            if len(parsed) > reservation["slot_count"]:
+                _action_state_invalid()
+            contracts = {item["receipt_id"]: item for item in reservation["receipt_contracts"]}
+            if len({item["receipt_id"] for item in parsed}) != len(parsed) or any(
+                contracts.get(item["receipt_id"]) != _receipt_contract(item) for item in parsed
+            ):
                 _action_state_invalid()
             incoming = sum(_encoded_size(item) for item in parsed)
             if incoming > reservation["reserved_bytes"]:
                 raise FleetActionStoreError("denied")
-            written: list[Path] = []
-            try:
-                for receipt in parsed:
-                    dest = self._root / "receipts" / f"{receipt['receipt_id']}.json"
+            for receipt in parsed:
+                dest = self._root / "receipts" / f"{receipt['receipt_id']}.json"
+                try:
+                    existing_receipt = _parse_receipt(_read_safe_json(dest))
+                except FileNotFoundError:
                     _write_exclusive_json(dest, receipt)
-                    written.append(dest)
-                _unlink_required(reservation_path)
-                _fsync_directory(reservation_path.parent)
-                _fsync_directory(self._root / "receipts")
-            except Exception:
-                for dest in written:
-                    _unlink_quiet(dest)
-                raise
+                else:
+                    if existing_receipt != receipt:
+                        _action_state_invalid()
+            _unlink_required(reservation_path)
+            _fsync_directory(reservation_path.parent)
+            _fsync_directory(self._root / "receipts")
 
     def release_receipt_reservation(self, reservation_id: str) -> None:
         with self._lock:
@@ -696,6 +818,58 @@ class FleetActionStore:
             if _path_exists_nofollow(reservation_path):
                 _unlink_required(reservation_path)
                 _fsync_directory(reservation_path.parent)
+
+    def write_claim_cleanup(self, record: Mapping[str, Any]) -> None:
+        with self._lock:
+            self._ensure_ready()
+            parsed = _parse_claim_cleanup(record)
+            path = self._root / "cleanup" / RECOVERY_JOURNAL_FILENAME
+            existing: dict[str, Any] | None = None
+            if _path_exists_nofollow(path):
+                try:
+                    existing = _parse_claim_cleanup(_read_safe_json(path))
+                except FileNotFoundError:
+                    existing = None
+                if existing is not None:
+                    if any(
+                        existing[key] != parsed[key]
+                        for key in ("proposal_id", "target_alias", "holder", "reservation_id")
+                    ):
+                        _action_state_invalid()
+                    if not existing["receipt_pending"] and parsed["terminal_receipts"] != existing["terminal_receipts"]:
+                        _action_state_invalid()
+            if existing is None:
+                self._assert_within_bounds(
+                    self._root / "cleanup",
+                    incoming=_encoded_size(parsed),
+                    max_count=MAX_CLEANUP,
+                    max_bytes=MAX_CLEANUP_BYTES,
+                )
+            elif _encoded_size(parsed) > MAX_CLEANUP_BYTES:
+                raise FleetActionStoreError("denied")
+            _replace_json(path, parsed)
+
+    def read_claim_cleanup(self) -> dict[str, Any] | None:
+        with self._lock:
+            self._ensure_ready()
+            path = self._root / "cleanup" / RECOVERY_JOURNAL_FILENAME
+            try:
+                raw = _read_safe_json(path)
+            except FileNotFoundError:
+                return None
+            except FleetError:
+                raise
+            except Exception:
+                _action_state_invalid()
+            return _parse_claim_cleanup(raw)
+
+    def clear_claim_cleanup(self) -> None:
+        with self._lock:
+            self._ensure_ready()
+            path = self._root / "cleanup" / RECOVERY_JOURNAL_FILENAME
+            if _path_exists_nofollow(path):
+                _unlink_required(path)
+                _fsync_directory(path.parent)
 
     def _ensure_ready(self) -> None:
         _assert_owner_dir(self._root, create=True)
@@ -985,3 +1159,29 @@ class ResearchBridgeRestarter:
             _action_unavailable()
         except Exception:
             _action_unavailable()
+
+
+class CatalogRemediator:
+    """Bounded catalog executor: action IDs only, no command or host input."""
+
+    def __init__(self, restarter: ResearchBridgeRestarter):
+        self._restarter = restarter
+
+    def recheck(self, action_id: str) -> dict[str, str]:
+        if action_id != EXECUTABLE_ACTION["action_id"]:
+            raise FleetError("denied", "Fleet request was denied")
+        return self._restarter.observe_research_bridge_revision()
+
+    def execute(self, action_id: str) -> None:
+        if action_id != EXECUTABLE_ACTION["action_id"]:
+            raise FleetError("denied", "Fleet request was denied")
+        self._restarter.restart_research_bridge()
+
+    def verify(self, verification_id: str) -> bool:
+        if verification_id != EXECUTABLE_ACTION["verification_id"]:
+            raise FleetError("denied", "Fleet request was denied")
+        live = self._restarter.observe_research_bridge_revision()
+        return verify_catalogued_service(live)
+
+    def rollback(self, rollback_id: str) -> None:
+        raise FleetError("denied", "Fleet request was denied")

--- a/src/brigade/grokbot_fleet/contracts.py
+++ b/src/brigade/grokbot_fleet/contracts.py
@@ -19,7 +19,36 @@ TOOLS = frozenset(
 )
 IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
 OPAQUE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+FINGERPRINT_RE = re.compile(r"^[0-9a-f]{64}$")
+MAX_WAZUH_FINDING_ID = 128
 DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
+FORBIDDEN_REMEDIATION_INPUT = frozenset(
+    {
+        "address",
+        "command",
+        "credential",
+        "environment",
+        "hostname",
+        "password",
+        "path",
+        "shell",
+        "token",
+        "username",
+    }
+)
+WAZUH_PROPOSAL_FIELDS = frozenset(
+    {
+        "action_id",
+        "blast_radius",
+        "finding_revision",
+        "maintenance_window_id",
+        "rollback_id",
+        "service_id",
+        "target_alias",
+        "verification_id",
+        "wazuh_fingerprint",
+    }
+)
 ERROR_MESSAGES = {
     "invalid_request": "Tool input failed validation",
     "denied": "Fleet request was denied",
@@ -63,8 +92,18 @@ def parse_identifier(value: object, *, maximum: int = 64) -> str:
     return value
 
 
+def parse_wazuh_finding_id(value: object) -> str:
+    return parse_identifier(value, maximum=MAX_WAZUH_FINDING_ID)
+
+
 def parse_opaque_id(value: object) -> str:
     if not isinstance(value, str) or not OPAQUE_ID_RE.fullmatch(value):
+        raise FleetError("invalid_request", ERROR_MESSAGES["invalid_request"])
+    return value
+
+
+def parse_fingerprint(value: object) -> str:
+    if not isinstance(value, str) or not FINGERPRINT_RE.fullmatch(value):
         raise FleetError("invalid_request", ERROR_MESSAGES["invalid_request"])
     return value
 
@@ -98,13 +137,13 @@ def parse_incident_input(raw: object) -> dict[str, str]:
 
 
 def parse_propose_input(raw: object) -> dict[str, str]:
-    if not isinstance(raw, dict) or set(raw) != {"finding_id"}:
+    if not isinstance(raw, dict) or set(raw) != {"finding_id"} or set(raw) & FORBIDDEN_REMEDIATION_INPUT:
         raise FleetError("invalid_request", ERROR_MESSAGES["invalid_request"])
-    return {"finding_id": parse_identifier(raw.get("finding_id"))}
+    return {"finding_id": parse_wazuh_finding_id(raw.get("finding_id"))}
 
 
 def parse_execute_input(raw: object) -> dict[str, str]:
-    if not isinstance(raw, dict) or set(raw) != {"proposal_id"}:
+    if not isinstance(raw, dict) or set(raw) != {"proposal_id"} or set(raw) & FORBIDDEN_REMEDIATION_INPUT:
         raise FleetError("invalid_request", ERROR_MESSAGES["invalid_request"])
     return {"proposal_id": parse_opaque_id(raw.get("proposal_id"))}
 

--- a/src/brigade/grokbot_fleet/lifecycle.py
+++ b/src/brigade/grokbot_fleet/lifecycle.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, NoReturn
 
 from .. import grokbot_mcp, grokbot_ops
-from .actions import FleetActionStore, ResearchBridgeRestarter
+from .actions import CatalogRemediator, FleetActionStore, ResearchBridgeRestarter
 from .contracts import PACK_ID, TOOLS, FleetError
 from .exec import Runner
 from .ledger import FleetLedger
@@ -26,7 +26,7 @@ from .runtime_config import (
     project_fleet_public_registry,
     read_secure_runtime_text,
 )
-from .tools import FleetStewardTools
+from .tools import FleetHubClaims, FleetStewardTools
 
 MAX_REQUEST_BYTES = 16_384
 SERVICE_NAME = "grokbot-fleet-steward"
@@ -208,6 +208,27 @@ def _load_runtime(target: Path) -> tuple[FleetListenerConfig, str]:
     return config, bearer
 
 
+def _optional_wazuh_source(target: Path) -> Any:
+    try:
+        from .. import grokbot_packs
+        from ..grokbot_wazuh.store import WazuhStore
+
+        payload = grokbot_packs._load_instance_config(target, "wazuh-triage")
+        store = WazuhStore(str(payload["ledger_path"]))
+        store.ready()
+    except Exception:
+        return None
+
+    class _Source:
+        def current_finding(self, finding_id: str) -> dict[str, Any] | None:
+            return store.get_finding(finding_id)
+
+        def suppressions(self) -> list[dict[str, str]]:
+            return store.suppressions()
+
+    return _Source()
+
+
 def build_tools_from_config(
     config: FleetListenerConfig,
     *,
@@ -258,6 +279,7 @@ def build_tools_from_config(
         env=probe_env,
         runner=runner,
     )
+    remediator = CatalogRemediator(executor)
     probes = create_fleet_adapters(
         registry=registry,
         systemctl_file=systemctl_file,
@@ -285,6 +307,9 @@ def build_tools_from_config(
         create_nonce=_opaque_id,
         create_receipt_id=_opaque_id,
         secrets=secret_list,
+        wazuh_source=_optional_wazuh_source(config.target),
+        remediator=remediator,
+        claims=FleetHubClaims(),
     )
 
 

--- a/src/brigade/grokbot_fleet/policy.py
+++ b/src/brigade/grokbot_fleet/policy.py
@@ -1,9 +1,12 @@
-"""Read authorization and public host-field projection."""
+"""Read authorization, Wazuh binding, and public host-field projection."""
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Mapping
 
+from ..grokbot_wazuh.policy import classify, is_action_eligible
+from .contracts import ERROR_MESSAGES, FleetError, parse_fingerprint, parse_identifier, parse_wazuh_finding_id
 from .registry import FleetRegistry
 
 HOST_FIELDS: dict[str, tuple[str, ...]] = {
@@ -67,3 +70,134 @@ def authorize_incident_read(registry: FleetRegistry, scope: str) -> dict[str, An
 
 def public_host_fields(tier: str) -> frozenset[str]:
     return frozenset(HOST_FIELDS[tier])
+
+
+REMEDIATION_ALLOWED_TIER = "infrastructure"
+DENIED_REMEDIATION_TIERS = frozenset(
+    {
+        "protected-status-only",
+        "appliance-read-only",
+        "indirect-only",
+    }
+)
+DENIED_REMEDIATION_ADAPTERS = frozenset({"windows", "proxmox-guest", "indirect"})
+DENIED_TARGET_CLASSES = frozenset({"protected", "appliance", "family", "container", "indirect"})
+ENROLLED_WAZUH_AGENTS = {"001": "control-plane"}
+WAZUH_ACTION_CATALOG: dict[str, dict[str, Any]] = {
+    "service-failure": {
+        "action_id": "restart-service",
+        "automatic_rollback": False,
+        "blast_radius": "one registered service",
+        "maintenance_window_id": "control-plane-service",
+        "rollback_id": "no-rollback",
+        "rule_class": "service-failure",
+        "service_id": "research-bridge",
+        "target_alias": "control-plane",
+        "verification_id": "verify-service",
+    }
+}
+WAZUH_REVALIDATION_KEYS = (
+    "action_id",
+    "automatic_rollback",
+    "blast_radius",
+    "finding_id",
+    "finding_revision",
+    "maintenance_window_id",
+    "rollback_id",
+    "service_id",
+    "target_alias",
+    "verification_id",
+    "wazuh_fingerprint",
+)
+MAINTENANCE_WINDOWS: dict[str, dict[str, Any]] = {
+    "control-plane-service": {
+        "end_minute": 4 * 60,
+        "start_minute": 2 * 60,
+        "weekdays": frozenset(range(7)),
+        "window_id": "control-plane-service",
+    }
+}
+
+
+def target_allows_remediation(target: Mapping[str, Any]) -> bool:
+    alias = str(target.get("alias") or "")
+    tier = str(target.get("tier") or "")
+    adapter = str(target.get("adapter") or "")
+    if tier != REMEDIATION_ALLOWED_TIER or tier in DENIED_REMEDIATION_TIERS:
+        return False
+    if adapter in DENIED_REMEDIATION_ADAPTERS:
+        return False
+    labels = {alias.casefold(), tier.casefold(), adapter.casefold()}
+    if labels & DENIED_TARGET_CLASSES:
+        return False
+    if any(token in labels for token in DENIED_TARGET_CLASSES):
+        return False
+    return True
+
+
+def in_maintenance_window(window_id: str, now: datetime) -> bool:
+    window = MAINTENANCE_WINDOWS.get(window_id)
+    if window is None:
+        return False
+    stamp = now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
+    stamp = stamp.astimezone(timezone.utc)
+    if stamp.weekday() not in window["weekdays"]:
+        return False
+    minute = stamp.hour * 60 + stamp.minute
+    return window["start_minute"] <= minute < window["end_minute"]
+
+
+def catalog_for_wazuh_finding(finding: Mapping[str, Any]) -> dict[str, Any] | None:
+    rule_class = finding.get("rule_class")
+    if not isinstance(rule_class, str):
+        return None
+    entry = WAZUH_ACTION_CATALOG.get(rule_class)
+    return None if entry is None else dict(entry)
+
+
+def bind_wazuh_remediation(
+    finding: Mapping[str, Any],
+    *,
+    registry: FleetRegistry,
+    now: datetime,
+    suppressions: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...] = (),
+) -> dict[str, Any]:
+    decision = classify(finding, suppressions=suppressions, now=now)
+    if not is_action_eligible(decision):
+        raise FleetError("denied", ERROR_MESSAGES["denied"])
+    catalog = catalog_for_wazuh_finding(finding)
+    if catalog is None:
+        raise FleetError("denied", ERROR_MESSAGES["denied"])
+    agent_id = finding.get("agent_id")
+    enrolled = ENROLLED_WAZUH_AGENTS.get(agent_id) if isinstance(agent_id, str) else None
+    if enrolled != catalog["target_alias"]:
+        raise FleetError("denied", ERROR_MESSAGES["denied"])
+    try:
+        target = authorize_host_read(registry, catalog["target_alias"])
+    except FleetError as exc:
+        if exc.code in {"not_found", "denied"}:
+            raise FleetError("denied", ERROR_MESSAGES["denied"]) from exc
+        raise
+    if not target_allows_remediation(target):
+        raise FleetError("denied", ERROR_MESSAGES["denied"])
+    if not in_maintenance_window(str(catalog["maintenance_window_id"]), now):
+        raise FleetError("denied", ERROR_MESSAGES["denied"])
+    try:
+        fingerprint = parse_fingerprint(finding.get("fingerprint"))
+        revision = parse_identifier(finding.get("revision"), maximum=64)
+        finding_id = parse_wazuh_finding_id(finding.get("finding_id"))
+    except FleetError as exc:
+        raise FleetError("denied", ERROR_MESSAGES["denied"]) from exc
+    return {
+        "action_id": catalog["action_id"],
+        "automatic_rollback": bool(catalog["automatic_rollback"]),
+        "blast_radius": catalog["blast_radius"],
+        "finding_id": finding_id,
+        "finding_revision": revision,
+        "maintenance_window_id": catalog["maintenance_window_id"],
+        "rollback_id": catalog["rollback_id"],
+        "service_id": catalog["service_id"],
+        "target_alias": catalog["target_alias"],
+        "verification_id": catalog["verification_id"],
+        "wazuh_fingerprint": fingerprint,
+    }

--- a/src/brigade/grokbot_fleet/probes.py
+++ b/src/brigade/grokbot_fleet/probes.py
@@ -115,6 +115,10 @@ def fleet_finding_id(scope: str, kind: str) -> str:
     return f"{scope}:{kind}"
 
 
+def verify_catalogued_service(observation: Mapping[str, Any]) -> bool:
+    return observation.get("health_class") == "healthy"
+
+
 def remediation_for_finding(finding_id: str) -> dict[str, str] | None:
     kinds = sorted(FLEET_FINDING_CATALOG, key=len, reverse=True)
     for kind in kinds:

--- a/src/brigade/grokbot_fleet/tools.py
+++ b/src/brigade/grokbot_fleet/tools.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Mapping, NoReturn
+from typing import Any, Callable, Mapping, NoReturn, Sequence
 
 from .actions import (
-    EXECUTABLE_ACTION,
     PROPOSAL_TTL_MS,
     FleetActionStoreError,
-    finding_revision,
-    is_executable_remediation,
 )
 from .contracts import (
     ERROR_MESSAGES,
@@ -23,13 +20,20 @@ from .contracts import (
     parse_host_status_input,
     parse_identifier,
     parse_incident_input,
+    parse_opaque_id,
     parse_overview_input,
     parse_propose_input,
     parse_service_health_input,
 )
 from .ledger import FleetLedger
 from .normalize import normalize_host_observation, sanitize_detail, utf8_byte_length
-from .policy import authorize_host_read, authorize_incident_read, authorize_service_read
+from .policy import (
+    WAZUH_REVALIDATION_KEYS,
+    authorize_host_read,
+    authorize_incident_read,
+    authorize_service_read,
+    bind_wazuh_remediation,
+)
 from .probes import FLEET_FINDING_CATALOG, FleetProbes, remediation_for_finding
 from .registry import FleetRegistry
 
@@ -209,6 +213,41 @@ def _envelope(
     }
 
 
+class FleetHubClaims:
+    """Injected Fleet claim port. Acquire and release take catalog aliases only."""
+
+    def acquire(self, target_alias: str) -> dict[str, str]:
+        from .. import fleet_client
+
+        parse_identifier(target_alias)
+        decision = fleet_client.acquire_claim(target_alias, role="fleet-steward", job="remediation")
+        if not getattr(decision, "granted", False):
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        holder = getattr(decision, "holder", None)
+        if not isinstance(holder, str) or not holder:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        return {"target_alias": target_alias, "holder": holder}
+
+    def release(self, claim: Mapping[str, str]) -> dict[str, Any]:
+        from .. import fleet_client
+
+        holder = claim.get("holder")
+        alias = claim.get("target_alias")
+        if not isinstance(holder, str) or not isinstance(alias, str):
+            return {"granted": False, "target_alias": alias if isinstance(alias, str) else ""}
+        try:
+            parse_identifier(alias)
+        except FleetError:
+            return {"granted": False, "target_alias": alias}
+        decision = fleet_client.release_claim(alias, holder=holder)
+        return {
+            "granted": bool(getattr(decision, "granted", False)),
+            "holder": holder,
+            "reason": str(getattr(decision, "reason", "")),
+            "target_alias": alias,
+        }
+
+
 class FleetStewardTools:
     """Closed public Fleet Steward tool surface."""
 
@@ -226,6 +265,9 @@ class FleetStewardTools:
         create_nonce: Callable[[], str],
         create_receipt_id: Callable[[], str],
         secrets: list[str],
+        wazuh_source: Any = None,
+        remediator: Any = None,
+        claims: Any = None,
     ):
         self.registry = registry
         self.probes = probes
@@ -238,6 +280,10 @@ class FleetStewardTools:
         self.create_nonce = create_nonce
         self.create_receipt_id = create_receipt_id
         self.secrets = secrets
+        self.wazuh_source = wazuh_source
+        self.remediator = remediator
+        self.claims = claims
+        self._recovery_pending = False
 
     def call_tool(self, name: str, arguments: object) -> dict[str, Any]:
         handlers = {
@@ -273,6 +319,7 @@ class FleetStewardTools:
 
     def _guard(self, work: Callable[[], dict[str, Any]]) -> dict[str, Any]:
         try:
+            self._recover_claim_release()
             result = work()
             if utf8_byte_length(json_dumps(result)) > PUBLIC_RESULT_LIMIT:
                 raise FleetError("protocol_error", ERROR_MESSAGES["protocol_error"])
@@ -437,9 +484,23 @@ class FleetStewardTools:
             "execution_available": False,
         }
 
+    def _active_remediator(self) -> Any:
+        if self.remediator is not None:
+            return self.remediator
+        if hasattr(self.executor, "recheck"):
+            return self.executor
+        raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+
     def _propose_remediation(self, raw: object) -> dict[str, Any]:
         finding_id = parse_propose_input(raw)["finding_id"]
-        raw_finding = self.ledger.finding(finding_id)
+        if self.wazuh_source is not None:
+            wazuh_finding = self.wazuh_source.current_finding(finding_id)
+            if wazuh_finding is not None:
+                return self._propose_wazuh(wazuh_finding)
+        try:
+            raw_finding = self.ledger.finding(finding_id)
+        except FleetError:
+            raise FleetError("denied", ERROR_MESSAGES["denied"]) from None
         if raw_finding is None:
             raise FleetError("denied", ERROR_MESSAGES["denied"])
         finding = self._parse_finding_record(raw_finding, finding_id)
@@ -451,7 +512,7 @@ class FleetStewardTools:
             raise
         catalog = remediation_for_finding(finding["finding_id"])
         if catalog is None:
-            _invalid_observation()
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
         if (
             finding["proposed_action_id"] != catalog["proposed_action_id"]
             or finding["verification_id"] != catalog["verification_id"]
@@ -459,80 +520,7 @@ class FleetStewardTools:
             or finding["blast_radius"] != catalog["blast_radius"]
         ):
             _invalid_observation()
-        if not is_executable_remediation(finding):
-            proposal = self._non_executable_proposal(finding, catalog, target)
-            return _envelope(
-                request_id=self.request_id(),
-                observed_at=_iso(self.now),
-                status="ok",
-                data=proposal,
-                freshness_seconds=target["freshness_seconds"],
-                receipt_ref=None,
-            )
-        revision = self.executor.observe_research_bridge_revision()
-        if revision["health_class"] != "unhealthy":
-            proposal = self._non_executable_proposal(finding, catalog, target)
-            return _envelope(
-                request_id=self.request_id(),
-                observed_at=_iso(self.now),
-                status="ok",
-                data=proposal,
-                freshness_seconds=target["freshness_seconds"],
-                receipt_ref=None,
-            )
-        proposal_id = self.create_proposal_id()
-        nonce = self.create_nonce()
-        created_at = self.now()
-        expires_at = (created_at + timedelta(milliseconds=PROPOSAL_TTL_MS)).isoformat().replace("+00:00", "Z")
-        if created_at.tzinfo is None:
-            expires_at = (created_at + timedelta(milliseconds=PROPOSAL_TTL_MS)).isoformat() + "Z"
-        created_text = _iso(lambda: created_at)
-        record = {
-            "version": 1,
-            "proposal_id": proposal_id,
-            "finding_id": EXECUTABLE_ACTION["finding_id"],
-            "service_id": EXECUTABLE_ACTION["service_id"],
-            "target_alias": EXECUTABLE_ACTION["target_alias"],
-            "finding_revision": finding_revision(finding),
-            "system_revision": revision["system_revision"],
-            "action_id": EXECUTABLE_ACTION["action_id"],
-            "verification_id": EXECUTABLE_ACTION["verification_id"],
-            "rollback_id": EXECUTABLE_ACTION["rollback_id"],
-            "nonce": nonce,
-            "created_at": created_text,
-            "expires_at": expires_at,
-        }
-        self.store.create_proposal(record)
-        self.store.write_receipt(
-            {
-                "version": 1,
-                "receipt_id": self.create_receipt_id(),
-                "kind": "proposal",
-                "proposal_id": proposal_id,
-                "finding_id": record["finding_id"],
-                "service_id": record["service_id"],
-                "target_alias": record["target_alias"],
-                "action_id": record["action_id"],
-                "verification_id": record["verification_id"],
-                "rollback_id": record["rollback_id"],
-                "outcome": "created",
-                "created_at": created_text,
-            }
-        )
-        proposal = {
-            "finding_id": record["finding_id"],
-            "target_alias": record["target_alias"],
-            "policy_tier": target["tier"],
-            "proposed_action_id": "restart-service",
-            "reason": sanitize_detail(finding["reason"], self.secrets),
-            "blast_radius": catalog["blast_radius"],
-            "approval_required": True,
-            "verification_id": "verify-service",
-            "rollback_id": "rollback-service",
-            "execution_available": True,
-            "proposal_id": proposal_id,
-            "expires_at": expires_at,
-        }
+        proposal = self._non_executable_proposal(finding, catalog, target)
         return _envelope(
             request_id=self.request_id(),
             observed_at=_iso(self.now),
@@ -571,23 +559,526 @@ class FleetStewardTools:
         except Exception:
             raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
 
-    def _binding_matches(self, proposal: Mapping[str, Any], approval: Mapping[str, Any]) -> bool:
-        return all(
-            approval.get(key) == proposal.get(key)
-            for key in (
-                "proposal_id",
-                "finding_id",
-                "service_id",
-                "target_alias",
-                "finding_revision",
-                "system_revision",
-                "action_id",
-                "verification_id",
-                "rollback_id",
-                "nonce",
-                "expires_at",
+    def _action_receipt(
+        self,
+        proposal: Mapping[str, Any],
+        binding: Mapping[str, str],
+        *,
+        kind: str,
+        outcome: str,
+        receipt_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "receipt_id": receipt_id or self.create_receipt_id(),
+            "kind": kind,
+            "proposal_id": proposal["proposal_id"],
+            **binding,
+            "outcome": outcome,
+            "created_at": created_at or _iso(self.now),
+        }
+
+    def _commit_terminal(
+        self,
+        reservation_id: str | None,
+        proposal: Mapping[str, Any],
+        binding: Mapping[str, str],
+        outcome: str,
+        claim: Mapping[str, str] | None = None,
+    ) -> list[dict[str, Any]]:
+        record = self._action_receipt(proposal, binding, kind="verification", outcome=outcome)
+        self._secure_reserved_evidence(reservation_id, [record], claim=claim, proposal=proposal)
+        return [record]
+
+    def _release_completed(self, released: object, claim: Mapping[str, str]) -> bool:
+        if released is False:
+            return False
+        if isinstance(released, Mapping):
+            if released.get("target_alias") != claim["target_alias"] or released.get("holder") != claim["holder"]:
+                return False
+            return bool(released.get("granted", False)) or released.get("reason") == "missing"
+        return True
+
+    def _persist_claim_cleanup(
+        self,
+        claim: Mapping[str, str],
+        proposal: Mapping[str, Any],
+        reservation_id: str,
+        terminal_receipts: Sequence[Mapping[str, Any]],
+        *,
+        receipt_pending: bool,
+        release_pending: bool,
+    ) -> None:
+        fenced_claim = self._fenced_claim(claim, expected_alias=str(proposal["target_alias"]))
+        record: dict[str, Any] = {
+            "version": 2,
+            "proposal_id": str(proposal["proposal_id"]),
+            "target_alias": fenced_claim["target_alias"],
+            "holder": fenced_claim["holder"],
+            "reservation_id": reservation_id,
+            "terminal_receipts": [dict(item) for item in terminal_receipts],
+            "receipt_pending": receipt_pending,
+            "release_pending": release_pending,
+        }
+        writer = getattr(self.store, "write_claim_cleanup", None)
+        if not callable(writer):
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        try:
+            writer(record)
+        except Exception:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+
+    def _fenced_claim(self, claim: Mapping[str, Any], *, expected_alias: str) -> dict[str, str]:
+        try:
+            target_alias = parse_identifier(claim.get("target_alias"))
+            holder = parse_opaque_id(claim.get("holder"))
+        except FleetError:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+        if target_alias != expected_alias:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        return {"target_alias": target_alias, "holder": holder}
+
+    def _recover_claim_release(self) -> None:
+        reader = getattr(self.store, "read_claim_cleanup", None)
+        if not callable(reader):
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        try:
+            record = reader()
+        except Exception:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+        if record is None:
+            return
+        if self.claims is None:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        if not isinstance(record, Mapping):
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        proposal_id = record.get("proposal_id")
+        reservation_id = record.get("reservation_id")
+        terminal_receipts = record.get("terminal_receipts")
+        if not isinstance(proposal_id, str) or not isinstance(reservation_id, str):
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        claim = self._fenced_claim(record, expected_alias=str(record.get("target_alias") or ""))
+        if (
+            not isinstance(terminal_receipts, list)
+            or not terminal_receipts
+            or not isinstance(record.get("receipt_pending"), bool)
+            or not isinstance(record.get("release_pending"), bool)
+            or any(
+                not isinstance(item, Mapping) or item.get("proposal_id") != proposal_id for item in terminal_receipts
             )
+        ):
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        if record["receipt_pending"]:
+            try:
+                self.store.commit_reserved_receipts(reservation_id, terminal_receipts)
+                self._persist_claim_cleanup(
+                    claim,
+                    record,
+                    reservation_id,
+                    terminal_receipts,
+                    receipt_pending=False,
+                    release_pending=record["release_pending"],
+                )
+            except Exception:
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+        if record["release_pending"]:
+            try:
+                released = self.claims.release(claim)
+            except Exception:
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+            if not self._release_completed(released, claim):
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+            self._persist_claim_cleanup(
+                claim,
+                record,
+                reservation_id,
+                terminal_receipts,
+                receipt_pending=False,
+                release_pending=False,
+            )
+        clearer = getattr(self.store, "clear_claim_cleanup", None)
+        if not callable(clearer):
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        try:
+            clearer()
+        except Exception:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+        self._recovery_pending = False
+
+    def _secure_reserved_evidence(
+        self,
+        reservation_id: str | None,
+        records: Sequence[Mapping[str, Any]],
+        *,
+        claim: Mapping[str, str] | None = None,
+        proposal: Mapping[str, Any] | None = None,
+    ) -> None:
+        if reservation_id is not None:
+            if claim is not None and proposal is not None:
+                try:
+                    self._persist_claim_cleanup(
+                        claim,
+                        proposal,
+                        reservation_id,
+                        records,
+                        receipt_pending=True,
+                        release_pending=True,
+                    )
+                except FleetError:
+                    self._recovery_pending = True
+                    raise
+            try:
+                self.store.commit_reserved_receipts(reservation_id, records)
+            except Exception:
+                self._recovery_pending = True
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+            if claim is not None and proposal is not None:
+                try:
+                    self._persist_claim_cleanup(
+                        claim,
+                        proposal,
+                        reservation_id,
+                        records,
+                        receipt_pending=False,
+                        release_pending=True,
+                    )
+                except FleetError:
+                    self._recovery_pending = True
+                    raise
+            return
+        for record in records:
+            try:
+                self._write_post_claim(record)
+            except FleetError:
+                if claim is None or proposal is None:
+                    raise
+
+    def _finish_claim_release(
+        self,
+        claim: Mapping[str, str] | None,
+        proposal: Mapping[str, Any],
+        reservation_id: str | None,
+        terminal_receipts: Sequence[Mapping[str, Any]],
+    ) -> None:
+        if claim is None or self.claims is None:
+            return
+        if self._recovery_pending:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        if reservation_id is None or not terminal_receipts:
+            self._recovery_pending = True
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        try:
+            released = self.claims.release(claim)
+        except Exception:
+            released = {"granted": False}
+        if self._release_completed(released, claim):
+            self._persist_claim_cleanup(
+                claim,
+                proposal,
+                reservation_id,
+                terminal_receipts,
+                receipt_pending=False,
+                release_pending=False,
+            )
+            clearer = getattr(self.store, "clear_claim_cleanup", None)
+            if not callable(clearer):
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+            try:
+                clearer()
+            except Exception:
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+            return
+        self._persist_claim_cleanup(
+            claim,
+            proposal,
+            reservation_id,
+            terminal_receipts,
+            receipt_pending=False,
+            release_pending=True,
         )
+        raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+
+    def _terminalize_reserved_receipt(self, record: Mapping[str, Any], outcome: str) -> dict[str, Any]:
+        return {**record, "outcome": outcome}
+
+    def _binding_matches(self, proposal: Mapping[str, Any], approval: Mapping[str, Any]) -> bool:
+        keys = [
+            "proposal_id",
+            "finding_id",
+            "service_id",
+            "target_alias",
+            "finding_revision",
+            "system_revision",
+            "action_id",
+            "verification_id",
+            "rollback_id",
+            "nonce",
+            "expires_at",
+        ]
+        if "wazuh_fingerprint" in proposal:
+            keys.extend(("wazuh_fingerprint", "maintenance_window_id"))
+        return all(approval.get(key) == proposal.get(key) for key in keys)
+
+    def _propose_wazuh(self, finding: Mapping[str, Any]) -> dict[str, Any]:
+        suppressions = self.wazuh_source.suppressions() if self.wazuh_source is not None else ()
+        binding = bind_wazuh_remediation(
+            finding,
+            registry=self.registry,
+            now=self.now(),
+            suppressions=suppressions,
+        )
+        target = authorize_host_read(self.registry, binding["target_alias"])
+        remediator = self._active_remediator()
+        live = remediator.recheck(binding["action_id"])
+        if live.get("health_class") != "unhealthy":
+            proposal = {
+                "finding_id": binding["finding_id"],
+                "target_alias": binding["target_alias"],
+                "policy_tier": target["tier"],
+                "proposed_action_id": binding["action_id"],
+                "reason": sanitize_detail(str(finding.get("reason") or finding.get("title") or ""), self.secrets),
+                "blast_radius": binding["blast_radius"],
+                "approval_required": True,
+                "verification_id": binding["verification_id"],
+                "rollback_id": binding["rollback_id"],
+                "execution_available": False,
+            }
+            return _envelope(
+                request_id=self.request_id(),
+                observed_at=_iso(self.now),
+                status="ok",
+                data=proposal,
+                freshness_seconds=target["freshness_seconds"],
+                receipt_ref=None,
+            )
+        proposal_id = self.create_proposal_id()
+        nonce = self.create_nonce()
+        created_at = self.now()
+        expires_at = (created_at + timedelta(milliseconds=PROPOSAL_TTL_MS)).isoformat().replace("+00:00", "Z")
+        if created_at.tzinfo is None:
+            expires_at = (created_at + timedelta(milliseconds=PROPOSAL_TTL_MS)).isoformat() + "Z"
+        created_text = _iso(lambda: created_at)
+        record = {
+            "version": 1,
+            "proposal_id": proposal_id,
+            "finding_id": binding["finding_id"],
+            "service_id": binding["service_id"],
+            "target_alias": binding["target_alias"],
+            "finding_revision": binding["finding_revision"],
+            "system_revision": live["system_revision"],
+            "action_id": binding["action_id"],
+            "verification_id": binding["verification_id"],
+            "rollback_id": binding["rollback_id"],
+            "nonce": nonce,
+            "created_at": created_text,
+            "expires_at": expires_at,
+            "automatic_rollback": binding["automatic_rollback"],
+            "blast_radius": binding["blast_radius"],
+            "wazuh_fingerprint": binding["wazuh_fingerprint"],
+            "maintenance_window_id": binding["maintenance_window_id"],
+        }
+        self.store.create_proposal(record)
+        self.store.write_receipt(
+            {
+                "version": 1,
+                "receipt_id": self.create_receipt_id(),
+                "kind": "proposal",
+                "proposal_id": proposal_id,
+                "finding_id": record["finding_id"],
+                "service_id": record["service_id"],
+                "target_alias": record["target_alias"],
+                "action_id": record["action_id"],
+                "verification_id": record["verification_id"],
+                "rollback_id": record["rollback_id"],
+                "outcome": "created",
+                "created_at": created_text,
+            }
+        )
+        proposal = {
+            "finding_id": record["finding_id"],
+            "target_alias": record["target_alias"],
+            "policy_tier": target["tier"],
+            "proposed_action_id": binding["action_id"],
+            "reason": sanitize_detail(str(finding.get("reason") or finding.get("title") or ""), self.secrets),
+            "blast_radius": binding["blast_radius"],
+            "approval_required": True,
+            "verification_id": binding["verification_id"],
+            "rollback_id": binding["rollback_id"],
+            "execution_available": True,
+            "proposal_id": proposal_id,
+            "expires_at": expires_at,
+        }
+        return _envelope(
+            request_id=self.request_id(),
+            observed_at=_iso(self.now),
+            status="ok",
+            data=proposal,
+            freshness_seconds=target["freshness_seconds"],
+            receipt_ref=None,
+        )
+
+    def _approval_expired(self, proposal: Mapping[str, Any], approval: Mapping[str, Any] | None) -> bool:
+        if _parse_iso(proposal["expires_at"]) <= self.now():
+            return True
+        if approval is None:
+            return False
+        expires = approval.get("expires_at")
+        return isinstance(expires, str) and _parse_iso(expires) <= self.now()
+
+    def _execute_wazuh(self, proposal_id: str, proposal: Mapping[str, Any]) -> dict[str, Any]:
+        binding = self._public_binding(proposal)
+        approval = self.store.read_approval(proposal_id)
+        if approval is None:
+            self._write_rejection(proposal_id, "denied", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if self._approval_expired(proposal, approval):
+            self._write_rejection(proposal_id, "expired", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if not self._binding_matches(proposal, approval):
+            self._write_rejection(proposal_id, "cross_bound", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if self.wazuh_source is None:
+            self._write_rejection(proposal_id, "stale", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        current = self.wazuh_source.current_finding(proposal["finding_id"])
+        if current is None or current.get("revision") != proposal["finding_revision"]:
+            self._write_rejection(proposal_id, "stale", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if current.get("fingerprint") != proposal.get("wazuh_fingerprint"):
+            self._write_rejection(proposal_id, "stale", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if self.store.is_consumed(proposal_id):
+            self._write_rejection(proposal_id, "replayed", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        bound = bind_wazuh_remediation(
+            current,
+            registry=self.registry,
+            now=self.now(),
+            suppressions=self.wazuh_source.suppressions(),
+        )
+        if any(bound[key] != proposal.get(key) for key in WAZUH_REVALIDATION_KEYS):
+            self._write_rejection(proposal_id, "stale", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        remediator = self._active_remediator()
+        try:
+            live = remediator.recheck(proposal["action_id"])
+        except Exception as exc:
+            self._write_rejection(proposal_id, "failed", binding)
+            if isinstance(exc, FleetError):
+                raise
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from exc
+        if live.get("system_revision") != proposal["system_revision"]:
+            self._write_rejection(proposal_id, "stale", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if live.get("health_class") != "unhealthy":
+            self._write_rejection(proposal_id, "denied", binding)
+            raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if self.claims is None:
+            self._write_rejection(proposal_id, "failed", binding)
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        reservation_id = None
+        original_reservation_id = None
+        claim = None
+        terminal: dict[str, Any] | None = None
+        terminal_receipts: list[dict[str, Any]] = []
+        try:
+            hold_at = _iso(self.now)
+            reserved_rejection = self._action_receipt(
+                proposal, binding, kind="rejection", outcome="unverified", created_at=hold_at
+            )
+            reserved_execution = self._action_receipt(
+                proposal, binding, kind="execution", outcome="unverified", created_at=hold_at
+            )
+            reserved_verification = self._action_receipt(
+                proposal, binding, kind="verification", outcome="unverified", created_at=hold_at
+            )
+            try:
+                reservation_id = self.store.reserve_receipt_capacity(
+                    [reserved_rejection, reserved_execution, reserved_verification]
+                )
+                original_reservation_id = reservation_id
+            except FleetActionStoreError:
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
+            claim = self.claims.acquire(proposal["target_alias"])
+            self._persist_claim_cleanup(
+                claim,
+                proposal,
+                reservation_id,
+                [reserved_execution],
+                receipt_pending=True,
+                release_pending=True,
+            )
+            try:
+                self.store.claim_consumed({**approval, "consumed_at": _iso(self.now)})
+            except FleetActionStoreError as exc:
+                terminal_receipts = [self._terminalize_reserved_receipt(reserved_rejection, exc.outcome)]
+                self._secure_reserved_evidence(reservation_id, terminal_receipts, claim=claim, proposal=proposal)
+                reservation_id = None
+                raise FleetError("denied", ERROR_MESSAGES["denied"]) from exc
+            try:
+                remediator.execute(proposal["action_id"])
+            except Exception as exc:
+                terminal_receipts = [self._terminalize_reserved_receipt(reserved_execution, "failed")]
+                self._secure_reserved_evidence(reservation_id, terminal_receipts, claim=claim, proposal=proposal)
+                reservation_id = None
+                if isinstance(exc, FleetError):
+                    raise
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from exc
+            try:
+                verified = remediator.verify(proposal["verification_id"])
+            except Exception as exc:
+                terminal_receipts = [
+                    self._terminalize_reserved_receipt(reserved_execution, "verified"),
+                    self._terminalize_reserved_receipt(reserved_verification, "failed"),
+                ]
+                self._secure_reserved_evidence(reservation_id, terminal_receipts, claim=claim, proposal=proposal)
+                reservation_id = None
+                if isinstance(exc, FleetError):
+                    raise
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from exc
+            if not verified:
+                terminal_receipts = [
+                    self._terminalize_reserved_receipt(reserved_execution, "verified"),
+                    self._terminalize_reserved_receipt(reserved_verification, "failed"),
+                ]
+                self._secure_reserved_evidence(reservation_id, terminal_receipts, claim=claim, proposal=proposal)
+                reservation_id = None
+                raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+            terminal_receipts = [
+                self._terminalize_reserved_receipt(reserved_execution, "verified"),
+                self._terminalize_reserved_receipt(reserved_verification, "verified"),
+            ]
+            self._secure_reserved_evidence(reservation_id, terminal_receipts, claim=claim, proposal=proposal)
+            reservation_id = None
+            verification_receipt_id = reserved_verification["receipt_id"]
+            terminal = _envelope(
+                request_id=self.request_id(),
+                observed_at=_iso(self.now),
+                status="ok",
+                data={
+                    "proposal_id": proposal["proposal_id"],
+                    "finding_id": proposal["finding_id"],
+                    "service_id": proposal["service_id"],
+                    "target_alias": proposal["target_alias"],
+                    "action_id": proposal["action_id"],
+                    "verification_id": proposal["verification_id"],
+                    "outcome": "verified",
+                    "receipt_ref": verification_receipt_id,
+                },
+                freshness_seconds=authorize_host_read(self.registry, proposal["target_alias"])["freshness_seconds"],
+                receipt_ref=verification_receipt_id,
+            )
+        finally:
+            if reservation_id is not None and not self._recovery_pending:
+                try:
+                    self.store.release_receipt_reservation(reservation_id)
+                except Exception:
+                    pass
+            self._finish_claim_release(claim, proposal, original_reservation_id, terminal_receipts)
+        if terminal is None:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        return terminal
 
     def _execute_remediation(self, raw: object) -> dict[str, Any]:
         proposal_id = parse_execute_input(raw)["proposal_id"]
@@ -600,132 +1091,11 @@ class FleetStewardTools:
             raise
         if proposal is None:
             raise FleetError("denied", ERROR_MESSAGES["denied"])
+        if "wazuh_fingerprint" in proposal:
+            return self._execute_wazuh(proposal_id, proposal)
         binding = self._public_binding(proposal)
-        expired = _parse_iso(proposal["expires_at"]) <= self.now()
-        try:
-            approval = self.store.read_approval(proposal_id)
-        except FleetError as exc:
-            if exc.code == "protocol_error":
-                self._write_rejection(proposal_id, "denied", binding)
-                raise FleetError("denied", ERROR_MESSAGES["denied"]) from exc
-            raise
-        if expired:
-            if approval is not None:
-                try:
-                    self.store.claim_consumed({**approval, "consumed_at": _iso(self.now)})
-                except FleetActionStoreError as exc:
-                    if exc.outcome != "replayed":
-                        self._write_rejection(proposal_id, exc.outcome, binding)
-                        raise FleetError("denied", ERROR_MESSAGES["denied"]) from exc
-            self._write_rejection(proposal_id, "expired", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"])
-        if approval is None:
-            self._write_rejection(proposal_id, "denied", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"])
-        if not self._binding_matches(proposal, approval):
-            self._write_rejection(proposal_id, "cross_bound", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"])
-        raw_finding = self.ledger.finding(proposal["finding_id"])
-        if raw_finding is None:
-            self._write_rejection(proposal_id, "stale", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"])
-        try:
-            finding = self._parse_finding_record(raw_finding, proposal["finding_id"])
-        except FleetError:
-            self._write_rejection(proposal_id, "stale", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"]) from None
-        if not is_executable_remediation(finding) or finding_revision(finding) != proposal["finding_revision"]:
-            self._write_rejection(proposal_id, "stale", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"])
-        try:
-            authorized = authorize_service_read(self.registry, str(EXECUTABLE_ACTION["service_id"]))
-        except FleetError as exc:
-            if exc.code in {"not_found", "denied"}:
-                self._write_rejection(proposal_id, "stale", binding)
-                raise FleetError("denied", ERROR_MESSAGES["denied"]) from exc
-            raise
-        try:
-            live = self.executor.observe_research_bridge_revision()
-        except Exception as exc:
-            self._write_rejection(proposal_id, "failed", binding)
-            if isinstance(exc, FleetError):
-                raise
-            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from exc
-        if live["system_revision"] != proposal["system_revision"]:
-            self._write_rejection(proposal_id, "stale", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"])
-        if live["health_class"] != "unhealthy":
-            self._write_rejection(proposal_id, "denied", binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"])
-        executed_at = _iso(self.now)
-        execution_record = {
-            "version": 1,
-            "receipt_id": self.create_receipt_id(),
-            "kind": "execution",
-            "proposal_id": proposal["proposal_id"],
-            **binding,
-            "outcome": "verified",
-            "created_at": executed_at,
-        }
-        verification_receipt_id = self.create_receipt_id()
-        verification_record = {
-            "version": 1,
-            "receipt_id": verification_receipt_id,
-            "kind": "verification",
-            "proposal_id": proposal["proposal_id"],
-            **binding,
-            "outcome": "verified",
-            "created_at": executed_at,
-        }
-        try:
-            reservation_id = self.store.reserve_receipt_capacity([execution_record, verification_record])
-        except FleetActionStoreError:
-            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
-        try:
-            self.store.claim_consumed({**approval, "consumed_at": _iso(self.now)})
-        except FleetActionStoreError as exc:
-            self.store.release_receipt_reservation(reservation_id)
-            self._write_rejection(proposal_id, exc.outcome, binding)
-            raise FleetError("denied", ERROR_MESSAGES["denied"]) from exc
-        try:
-            self.executor.restart_research_bridge()
-        except Exception:
-            self.store.release_receipt_reservation(reservation_id)
-            self._write_post_claim(
-                {
-                    "version": 1,
-                    "receipt_id": self.create_receipt_id(),
-                    "kind": "verification",
-                    "proposal_id": proposal["proposal_id"],
-                    **binding,
-                    "outcome": "unverified",
-                    "created_at": _iso(self.now),
-                }
-            )
-            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
-        try:
-            self.store.commit_reserved_receipts(reservation_id, [execution_record, verification_record])
-        except Exception:
-            self.store.release_receipt_reservation(reservation_id)
-            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"]) from None
-        execution = {
-            "proposal_id": proposal["proposal_id"],
-            "finding_id": EXECUTABLE_ACTION["finding_id"],
-            "service_id": EXECUTABLE_ACTION["service_id"],
-            "target_alias": EXECUTABLE_ACTION["target_alias"],
-            "action_id": EXECUTABLE_ACTION["action_id"],
-            "verification_id": EXECUTABLE_ACTION["verification_id"],
-            "outcome": "verified",
-            "receipt_ref": verification_receipt_id,
-        }
-        return _envelope(
-            request_id=self.request_id(),
-            observed_at=_iso(self.now),
-            status="ok",
-            data=execution,
-            freshness_seconds=authorized["target"]["freshness_seconds"],
-            receipt_ref=verification_receipt_id,
-        )
+        self._write_rejection(proposal_id, "denied", binding)
+        raise FleetError("denied", ERROR_MESSAGES["denied"])
 
 
 def json_dumps(value: Any) -> str:

--- a/tests/test_grokbot_fleet_actions.py
+++ b/tests/test_grokbot_fleet_actions.py
@@ -517,3 +517,90 @@ def test_live_reservation_is_exclusive_and_token_scoped(tmp_path: Path):
     assert (root / "receipts" / f"{'2' * 32}.json").is_file()
     assert (root / "receipts" / f"{'3' * 32}.json").is_file()
     assert list((root / "reservations").glob("*.json")) == []
+
+
+def test_receipt_reservation_rejects_a_changed_static_contract(tmp_path: Path):
+    store, _root, _approvals = _store(tmp_path)
+    live = _proposal("a" * 32)
+    store.create_proposal(live)
+    reserved = [
+        _receipt("2" * 32, live["proposal_id"], kind="execution", outcome="unverified"),
+        _receipt("3" * 32, live["proposal_id"], kind="verification", outcome="unverified"),
+    ]
+    reservation_id = store.reserve_receipt_capacity(reserved)
+    committed = [
+        {**reserved[0], "outcome": "verified"},
+        {**reserved[1], "outcome": "verified", "verification_id": "different-verification"},
+    ]
+    with pytest.raises(FleetError) as caught:
+        store.commit_reserved_receipts(reservation_id, committed)
+    assert caught.value.code == "protocol_error"
+
+
+def test_receipt_reservation_recovers_only_exact_partially_persisted_receipts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store, root, _approvals = _store(tmp_path)
+    live = _proposal("a" * 32)
+    store.create_proposal(live)
+    reserved = [
+        _receipt("2" * 32, live["proposal_id"], kind="execution", outcome="verified"),
+        _receipt("3" * 32, live["proposal_id"], kind="verification", outcome="verified"),
+    ]
+    reservation_id = store.reserve_receipt_capacity(reserved)
+
+    write_exclusive_json = actions_mod._write_exclusive_json
+
+    def fail_second_terminal_write(path: Path, record: dict[str, object]) -> None:
+        if path.name == f"{'3' * 32}.json":
+            raise OSError("simulated crash")
+        write_exclusive_json(path, record)
+
+    monkeypatch.setattr(actions_mod, "_write_exclusive_json", fail_second_terminal_write)
+    with pytest.raises(OSError, match="simulated crash"):
+        store.commit_reserved_receipts(reservation_id, reserved)
+
+    # The first receipt and the reservation must survive an interrupted second write.
+    assert (root / "receipts" / f"{'2' * 32}.json").is_file()
+    assert (root / "reservations" / f"{reservation_id}.json").is_file()
+    monkeypatch.setattr(actions_mod, "_write_exclusive_json", write_exclusive_json)
+    store.commit_reserved_receipts(reservation_id, reserved)
+
+    assert (root / "receipts" / f"{'2' * 32}.json").is_file()
+    assert (root / "receipts" / f"{'3' * 32}.json").is_file()
+    assert not (root / "reservations" / f"{reservation_id}.json").exists()
+
+    mismatched = [
+        _receipt("4" * 32, live["proposal_id"], kind="execution", outcome="verified"),
+        _receipt("5" * 32, live["proposal_id"], kind="verification", outcome="verified"),
+    ]
+    mismatch_reservation_id = store.reserve_receipt_capacity(mismatched)
+    store.write_receipt({**mismatched[0], "outcome": "failed"})
+
+    with pytest.raises(FleetError) as caught:
+        store.commit_reserved_receipts(mismatch_reservation_id, mismatched)
+
+    assert caught.value.code == "protocol_error"
+    assert (root / "reservations" / f"{mismatch_reservation_id}.json").is_file()
+    assert not (root / "receipts" / f"{'5' * 32}.json").exists()
+
+
+def test_claim_cleanup_replaces_a_provisional_receipt_with_the_terminal_set(tmp_path: Path):
+    store, _root, _approvals = _store(tmp_path)
+    proposal_id = "a" * 32
+    common = {
+        "version": 2,
+        "proposal_id": proposal_id,
+        "target_alias": "control-plane",
+        "holder": "b" * 32,
+        "reservation_id": "c" * 32,
+        "receipt_pending": True,
+        "release_pending": True,
+    }
+    provisional = _receipt("d" * 32, proposal_id, kind="execution", outcome="unverified")
+    terminal = _receipt("e" * 32, proposal_id, kind="rejection", outcome="replayed")
+    store.write_claim_cleanup({**common, "terminal_receipts": [provisional]})
+    store.write_claim_cleanup({**common, "terminal_receipts": [terminal]})
+    cleanup = store.read_claim_cleanup()
+    assert cleanup is not None
+    assert cleanup["terminal_receipts"] == [terminal]

--- a/tests/test_grokbot_fleet_contracts.py
+++ b/tests/test_grokbot_fleet_contracts.py
@@ -14,6 +14,7 @@ from brigade.grokbot_fleet.contracts import (
     parse_overview_input,
     parse_propose_input,
     parse_service_health_input,
+    parse_wazuh_finding_id,
 )
 
 
@@ -86,3 +87,20 @@ def test_strict_tool_inputs_accept_and_reject_extra_keys():
         parse_host_status_input({"alias": "host-a", "extra": True})
     with pytest.raises(FleetError):
         parse_execute_input({"proposal_id": "restart-service"})
+    with pytest.raises(FleetError):
+        parse_propose_input({"finding_id": "finding-1", "command": "bash"})
+    with pytest.raises(FleetError):
+        parse_execute_input({"proposal_id": "a" * 32, "path": "/tmp/x"})
+
+
+def test_wazuh_finding_id_parser_accepts_128_and_rejects_129():
+    accepted = "A" * 128
+    assert parse_wazuh_finding_id(accepted) == accepted
+    assert parse_wazuh_finding_id("001:service-failure:533") == "001:service-failure:533"
+    assert parse_propose_input({"finding_id": accepted})["finding_id"] == accepted
+    for value in ("", "A" * 129, "-leading", "host/sub", "host token"):
+        with pytest.raises(FleetError) as caught:
+            parse_wazuh_finding_id(value)
+        assert caught.value.code == "invalid_request"
+    with pytest.raises(FleetError):
+        parse_propose_input({"finding_id": "A" * 129})

--- a/tests/test_grokbot_fleet_lifecycle.py
+++ b/tests/test_grokbot_fleet_lifecycle.py
@@ -163,6 +163,8 @@ def test_successful_canary_does_not_mutate_ledger_findings_or_action_state(tmp_p
     assert result["auth_rejected_without_bearer"] is True
     assert set(result["tools"]) == set(TOOLS)
     assert snapshot() == before
+    assert "execute_remediation" not in result
+    assert ledger.finding("control-plane:unreachable")["proposed_action_id"] == "inspect-host"
 
 
 def test_runtime_and_state_paths_reject_symlinks(tmp_path: Path):

--- a/tests/test_grokbot_fleet_remediation.py
+++ b/tests/test_grokbot_fleet_remediation.py
@@ -1,0 +1,1265 @@
+"""Approval-gated Fleet Steward remediation bound to Wazuh triage contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+import pytest
+
+from brigade.grokbot_fleet.actions import FleetActionStoreError
+from brigade.grokbot_fleet.contracts import ERROR_MESSAGES, FleetError
+from brigade.grokbot_fleet.ledger import FleetLedger
+from brigade.grokbot_fleet.policy import WAZUH_ACTION_CATALOG, bind_wazuh_remediation
+from brigade.grokbot_fleet.probes import FleetProbes
+from brigade.grokbot_fleet.registry import create_fleet_registry
+from brigade.grokbot_fleet.runtime_config import parse_fleet_private_runtime, project_fleet_public_registry
+from brigade.grokbot_fleet.tools import FleetStewardTools
+from brigade.grokbot_wazuh.contracts import parse_ingest_input
+from brigade.grokbot_wazuh.normalize import normalize_alert
+
+WINDOW_NOW = datetime(2026, 8, 28, 2, 30, tzinfo=timezone.utc)
+RUNTIME = {
+    "version": 1,
+    "roles": {
+        "control-plane": {"adapter": "local"},
+        "hypervisor": {"adapter": "linux", "ssh_alias": "lab-hypervisor"},
+        "worker": {"adapter": "linux", "ssh_alias": "lab-worker.01"},
+    },
+    "services": {
+        "research-bridge": {"unit": "research-bridge.service", "manager": "user"},
+        "virtualization-api": {"unit": "virtualization-api.service", "manager": "system"},
+        "overlay-network": {"unit": "overlay-network.service", "manager": "system"},
+    },
+}
+SENSITIVE_MARKER = "sensitive-marker-do-not-emit"
+FORBIDDEN = (
+    SENSITIVE_MARKER,
+    "/etc/shadow",
+    "bash -c",
+    "curl http",
+    "lab-hypervisor",
+    "research-bridge.service",
+)
+
+
+class _Clock:
+    def __init__(self, stamp: datetime):
+        self.stamp = stamp
+
+    def __call__(self) -> datetime:
+        return self.stamp
+
+
+class _WazuhSource:
+    def __init__(self, findings: list[dict[str, Any]] | None = None):
+        self.findings = {item["finding_id"]: dict(item) for item in findings or []}
+        self.calls: list[tuple[str, str]] = []
+
+    def current_finding(self, finding_id: str) -> dict[str, Any] | None:
+        self.calls.append(("finding", finding_id))
+        found = self.findings.get(finding_id)
+        return None if found is None else dict(found)
+
+    def suppressions(self) -> list[dict[str, str]]:
+        return []
+
+
+class _Remediator:
+    def __init__(
+        self,
+        *,
+        health: str = "unhealthy",
+        revision: str = "c" * 64,
+        verify_ok: bool = True,
+        execute_error: Exception | None = None,
+        verify_error: Exception | None = None,
+    ):
+        self.health = health
+        self.revision = revision
+        self.verify_ok = verify_ok
+        self.execute_error = execute_error
+        self.verify_error = verify_error
+        self.calls: list[tuple[str, str]] = []
+
+    def recheck(self, action_id: str) -> dict[str, str]:
+        self.calls.append(("recheck", action_id))
+        return {"health_class": self.health, "system_revision": self.revision}
+
+    def execute(self, action_id: str) -> None:
+        self.calls.append(("execute", action_id))
+        if self.execute_error is not None:
+            raise self.execute_error
+
+    def verify(self, verification_id: str) -> bool:
+        self.calls.append(("verify", verification_id))
+        if self.verify_error is not None:
+            raise self.verify_error
+        return self.verify_ok
+
+    def rollback(self, rollback_id: str) -> None:
+        self.calls.append(("rollback", rollback_id))
+
+
+class _Claims:
+    def __init__(
+        self,
+        *,
+        grant: bool = True,
+        release_granted: bool = True,
+        release_error: Exception | None = None,
+        release_reason: str = "",
+        release_holder: str | None = None,
+    ):
+        self.grant = grant
+        self.release_granted = release_granted
+        self.release_error = release_error
+        self.release_reason = release_reason
+        self.release_holder = release_holder
+        self.calls: list[tuple[str, str]] = []
+        self.held: list[dict[str, str]] = []
+        self.released: list[dict[str, str]] = []
+
+    def acquire(self, target_alias: str) -> dict[str, str]:
+        self.calls.append(("acquire", target_alias))
+        if not self.grant:
+            raise FleetError("unavailable", ERROR_MESSAGES["unavailable"])
+        claim = {"target_alias": target_alias, "holder": "b" * 32}
+        self.held.append(claim)
+        return claim
+
+    def release(self, claim: Mapping[str, str]) -> dict[str, Any]:
+        self.calls.append(("release", str(claim["target_alias"])))
+        self.released.append(dict(claim))
+        if self.release_error is not None:
+            raise self.release_error
+        if self.release_granted:
+            self.held = [item for item in self.held if item["holder"] != claim.get("holder")]
+        return {
+            "granted": self.release_granted,
+            "holder": self.release_holder or str(claim["holder"]),
+            "reason": self.release_reason,
+            "target_alias": str(claim["target_alias"]),
+        }
+
+
+class _Store:
+    def __init__(
+        self,
+        *,
+        reserve_error: Exception | None = None,
+        commit_error: Exception | None = None,
+        consume_error: Exception | None = None,
+        release_error: Exception | None = None,
+    ) -> None:
+        self.proposals: dict[str, dict[str, Any]] = {}
+        self.approvals: dict[str, dict[str, Any]] = {}
+        self.consumed: dict[str, dict[str, Any]] = {}
+        self.receipts: list[dict[str, Any]] = []
+        self.reservations: dict[str, list[dict[str, Any]]] = {}
+        self.cleanup: dict[str, Any] | None = None
+        self.calls: list[str] = []
+        self.reserve_error = reserve_error
+        self.commit_error = commit_error
+        self.consume_error = consume_error
+        self.release_error = release_error
+        self.before_commit = None
+        self.cleanup_fail_on_call: int | None = None
+        self.cleanup_writes = 0
+
+    def create_proposal(self, record: Mapping[str, Any]) -> None:
+        self.calls.append("create_proposal")
+        self.proposals[record["proposal_id"]] = dict(record)
+
+    def read_proposal(self, proposal_id: str) -> dict[str, Any] | None:
+        self.calls.append("read_proposal")
+        found = self.proposals.get(proposal_id)
+        return None if found is None else dict(found)
+
+    def read_approval(self, proposal_id: str) -> dict[str, Any] | None:
+        self.calls.append("read_approval")
+        found = self.approvals.get(proposal_id)
+        return None if found is None else dict(found)
+
+    def is_consumed(self, proposal_id: str) -> bool:
+        return proposal_id in self.consumed
+
+    def claim_consumed(self, record: Mapping[str, Any]) -> dict[str, Any]:
+        self.calls.append("claim_consumed")
+        if self.consume_error is not None:
+            raise self.consume_error
+        if record["proposal_id"] in self.consumed:
+            raise FleetActionStoreError("replayed")
+        stored = dict(record)
+        self.consumed[record["proposal_id"]] = stored
+        return stored
+
+    def write_receipt(self, record: Mapping[str, Any]) -> None:
+        self.calls.append("write_receipt")
+        if self.reservations:
+            raise FleetActionStoreError("denied")
+        self.receipts.append(dict(record))
+
+    def reserve_receipt_capacity(self, records: list[Mapping[str, Any]]) -> str:
+        self.calls.append("reserve_receipts")
+        if self.reserve_error is not None:
+            raise self.reserve_error
+        reservation_id = "1" * 32
+        self.reservations[reservation_id] = [dict(item) for item in records]
+        return reservation_id
+
+    def commit_reserved_receipts(self, reservation_id: str, records: list[Mapping[str, Any]]) -> None:
+        self.calls.append("commit_receipts")
+        if self.commit_error is not None:
+            raise self.commit_error
+        reserved = {item["receipt_id"]: item for item in self.reservations[reservation_id]}
+        if len({record["receipt_id"] for record in records}) != len(records):
+            raise FleetActionStoreError("denied")
+        for record in records:
+            expected = reserved.get(record["receipt_id"])
+            if expected is None or any(record.get(key) != value for key, value in expected.items() if key != "outcome"):
+                raise FleetActionStoreError("denied")
+        if self.before_commit is not None:
+            self.before_commit(reservation_id, records)
+        for record in records:
+            self.receipts.append(dict(record))
+        self.reservations.pop(reservation_id, None)
+
+    def release_receipt_reservation(self, reservation_id: str) -> None:
+        self.calls.append("release_reservation")
+        if self.release_error is not None:
+            raise self.release_error
+        self.reservations.pop(reservation_id, None)
+
+    def write_claim_cleanup(self, record: Mapping[str, Any]) -> None:
+        self.calls.append("write_cleanup")
+        self.cleanup_writes += 1
+        if self.cleanup_fail_on_call == self.cleanup_writes:
+            raise OSError("cleanup write failed")
+        self.cleanup = dict(record)
+
+    def read_claim_cleanup(self) -> dict[str, Any] | None:
+        self.calls.append("read_cleanup")
+        return None if self.cleanup is None else dict(self.cleanup)
+
+    def clear_claim_cleanup(self) -> None:
+        self.calls.append("clear_cleanup")
+        self.cleanup = None
+
+
+def _alert(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "rule_id": "533",
+        "rule_level": 12,
+        "rule_description": "Service failure",
+        "rule_groups": ["service_availability"],
+        "agent_id": "001",
+        "decoder": "systemd",
+        "timestamp": "2026-08-28T02:30:00Z",
+        "detail": f"unit failed after token {SENSITIVE_MARKER}",
+    }
+    payload.update(overrides)
+    return normalize_alert(parse_ingest_input({"alerts": [payload]})["alerts"][0])
+
+
+def _host_raw(alias: str) -> dict[str, object]:
+    return {
+        "alias": alias,
+        "probe_id": "linux-host-summary-v1",
+        "observed_at": "2026-08-28T02:30:00Z",
+        "reachability": "reachable",
+        "uptime_seconds": 100,
+        "storage_percent": 10,
+        "failed_services": 0,
+        "reboot_pending": False,
+        "detail": "ok",
+    }
+
+
+def _tools(
+    tmp_path,
+    *,
+    wazuh: _WazuhSource | None = None,
+    remediator: _Remediator | None = None,
+    claims: _Claims | None = None,
+    store: _Store | None = None,
+    clock: _Clock | None = None,
+    registry=None,
+):
+    chosen_registry = registry or project_fleet_public_registry(parse_fleet_private_runtime(RUNTIME))
+    ledger = FleetLedger(str(tmp_path / "ledger.json"))
+    ledger.ready()
+
+    def observe_host_raw(target, probe_id):
+        return _host_raw(target["alias"])
+
+    def observe_service_raw(target, service):
+        return {
+            "service_id": service["service_id"],
+            "target_alias": target["alias"],
+            "probe_id": service["probe_id"],
+            "observed_at": "2026-08-28T02:30:00Z",
+            "health_class": "unhealthy",
+            "detail": "Service health is available",
+        }
+
+    probes = FleetProbes(
+        registry=chosen_registry,
+        observe_host_raw=observe_host_raw,
+        observe_service_raw=observe_service_raw,
+        now=lambda: (clock or _Clock(WINDOW_NOW))(),
+        create_receipt_ref=lambda: "receipt-1",
+        secrets=[SENSITIVE_MARKER],
+    )
+    ids = iter(f"{index:032x}" for index in range(10, 40))
+    return FleetStewardTools(
+        registry=chosen_registry,
+        probes=probes,
+        ledger=ledger,
+        store=store or _Store(),
+        executor=_Remediator(),
+        now=clock or _Clock(WINDOW_NOW),
+        request_id=lambda: "req-remediation-1",
+        create_proposal_id=lambda: next(ids),
+        create_nonce=lambda: next(ids),
+        create_receipt_id=lambda: next(ids),
+        secrets=[SENSITIVE_MARKER],
+        wazuh_source=wazuh,
+        remediator=remediator or _Remediator(),
+        claims=claims or _Claims(),
+    )
+
+
+def _approve(store: _Store, proposal_id: str, approved_at: str = "2026-08-28T02:31:00Z") -> None:
+    proposal = store.proposals[proposal_id]
+    store.approvals[proposal_id] = {
+        **{key: proposal[key] for key in proposal if key != "created_at"},
+        "approved_at": approved_at,
+    }
+
+
+def _assert_clean(value: object) -> None:
+    text = repr(value)
+    for needle in FORBIDDEN:
+        assert needle not in text
+
+
+def test_proposal_requires_escalated_current_finding_and_operator_approval(tmp_path):
+    catalog = WAZUH_ACTION_CATALOG["service-failure"]
+    assert catalog["action_id"] == "restart-service"
+    assert catalog["verification_id"] == "verify-service"
+    assert catalog["rollback_id"] == "no-rollback"
+    assert catalog["target_alias"] == "control-plane"
+    assert catalog["maintenance_window_id"]
+    assert catalog["blast_radius"] == "one registered service"
+    for key in ("command", "path", "username", "address", "credential", "environment"):
+        assert key not in catalog
+
+    watch = _alert(
+        rule_id="550",
+        rule_level=7,
+        rule_description="Port change",
+        rule_groups=["syslog"],
+        decoder="syslog",
+        detail="Observed port change",
+    )
+    suppress = _alert(
+        rule_id="80790",
+        rule_level=3,
+        rule_description="SCA check failed",
+        rule_groups=["sca"],
+        decoder="sca",
+        detail="Repeated SCA compliance finding",
+    )
+    current = _alert()
+    wrong_target = _alert(agent_id="002")
+    remediator = _Remediator()
+    store = _Store()
+    tools = _tools(
+        tmp_path,
+        wazuh=_WazuhSource([watch, suppress, current, wrong_target]),
+        remediator=remediator,
+        store=store,
+    )
+
+    for finding in (watch, suppress, wrong_target):
+        with pytest.raises(FleetError) as caught:
+            tools.propose_remediation({"finding_id": finding["finding_id"]})
+        assert caught.value.code == "denied"
+        _assert_clean(caught.value)
+
+    bound = bind_wazuh_remediation(current, registry=tools.registry, now=WINDOW_NOW)
+    assert bound["target_alias"] == "control-plane"
+    assert bound["wazuh_fingerprint"] == current["fingerprint"]
+    assert bound["finding_revision"] == current["revision"]
+
+    proposed = tools.propose_remediation({"finding_id": current["finding_id"]})
+    proposal_id = proposed["data"]["proposal_id"]
+    assert proposed["data"]["execution_available"] is True
+    assert proposed["data"]["approval_required"] is True
+    assert "command" not in proposed["data"]
+    _assert_clean(proposed)
+
+    with pytest.raises(FleetError) as missing:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert missing.value.code == "denied"
+    _assert_clean(missing.value)
+
+    _approve(store, proposal_id)
+    stale_source = tools.wazuh_source
+    assert stale_source is not None
+    stale_source.findings[current["finding_id"]]["revision"] = "d" * 64
+    with pytest.raises(FleetError) as stale:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert stale.value.code == "denied"
+    stale_source.findings[current["finding_id"]]["revision"] = current["revision"]
+
+    store.approvals[proposal_id]["expires_at"] = "2026-08-28T02:00:00Z"
+    with pytest.raises(FleetError) as expired:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert expired.value.code == "denied"
+
+    assert [kind for kind, _name in remediator.calls if kind in {"execute", "rollback"}] == []
+
+
+def test_execute_claims_rechecks_verifies_and_records_receipts(tmp_path, monkeypatch):
+    current = _alert()
+    remediator = _Remediator()
+    claims = _Claims()
+    store = _Store()
+    wazuh = _WazuhSource([current])
+    tools = _tools(tmp_path, wazuh=wazuh, remediator=remediator, claims=claims, store=store)
+    proposed = tools.propose_remediation({"finding_id": current["finding_id"]})
+    proposal_id = proposed["data"]["proposal_id"]
+    _approve(store, proposal_id)
+    remediator.calls.clear()
+    wazuh.calls.clear()
+    store.calls.clear()
+    claims.calls.clear()
+
+    executed = tools.execute_remediation({"proposal_id": proposal_id})
+    assert executed["data"]["outcome"] == "verified"
+    assert executed["data"]["action_id"] == "restart-service"
+    _assert_clean(executed)
+    assert remediator.calls == [
+        ("recheck", "restart-service"),
+        ("execute", "restart-service"),
+        ("verify", "verify-service"),
+    ]
+    assert wazuh.calls == [("finding", current["finding_id"])]
+    store_work = [call for call in store.calls if call != "read_cleanup"]
+    assert store_work[:2] == ["read_proposal", "read_approval"]
+    assert "write_receipt" in store.calls or "commit_receipts" in store.calls
+    assert claims.calls == [("acquire", "control-plane"), ("release", "control-plane")]
+    assert claims.held == []
+    assert not any("bash" in name or " " in name for _kind, name in remediator.calls)
+
+    with pytest.raises(FleetError) as replayed:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert replayed.value.code == "denied"
+    assert remediator.calls == [
+        ("recheck", "restart-service"),
+        ("execute", "restart-service"),
+        ("verify", "verify-service"),
+    ]
+
+    failed_store = _Store()
+    failed_claims = _Claims()
+    failed_remediator = _Remediator(verify_ok=False)
+    failed_tools = _tools(
+        tmp_path / "fail",
+        wazuh=_WazuhSource([current]),
+        remediator=failed_remediator,
+        claims=failed_claims,
+        store=failed_store,
+    )
+    failed_proposed = failed_tools.propose_remediation({"finding_id": current["finding_id"]})
+    failed_id = failed_proposed["data"]["proposal_id"]
+    _approve(failed_store, failed_id)
+    failed_remediator.calls.clear()
+    with pytest.raises(FleetError):
+        failed_tools.execute_remediation({"proposal_id": failed_id})
+    assert failed_remediator.calls == [
+        ("recheck", "restart-service"),
+        ("execute", "restart-service"),
+        ("verify", "verify-service"),
+    ]
+    assert failed_claims.calls[-1] == ("release", "control-plane")
+    assert failed_claims.held == []
+    assert any(item.get("outcome") == "failed" for item in failed_store.receipts)
+    assert not any(kind == "rollback" for kind, _name in failed_remediator.calls)
+
+    from brigade.grokbot_fleet import policy as policy_mod
+
+    monkeypatch.setitem(policy_mod.WAZUH_ACTION_CATALOG["service-failure"], "automatic_rollback", True)
+    no_rb_store = _Store()
+    no_rb_claims = _Claims()
+    no_rb_remediator = _Remediator(verify_ok=False)
+    no_rb_tools = _tools(
+        tmp_path / "norb",
+        wazuh=_WazuhSource([current]),
+        remediator=no_rb_remediator,
+        claims=no_rb_claims,
+        store=no_rb_store,
+    )
+    no_rb_proposed = no_rb_tools.propose_remediation({"finding_id": current["finding_id"]})
+    no_rb_id = no_rb_proposed["data"]["proposal_id"]
+    _approve(no_rb_store, no_rb_id)
+    no_rb_remediator.calls.clear()
+    with pytest.raises(FleetError):
+        no_rb_tools.execute_remediation({"proposal_id": no_rb_id})
+    assert [kind for kind, _name in no_rb_remediator.calls] == ["recheck", "execute", "verify"]
+    assert any(item.get("outcome") == "failed" for item in no_rb_store.receipts)
+    assert no_rb_claims.held == []
+
+    lost_store = _Store()
+    lost_claims = _Claims(grant=False)
+    lost_remediator = _Remediator()
+    lost_tools = _tools(
+        tmp_path / "lost",
+        wazuh=_WazuhSource([current]),
+        remediator=lost_remediator,
+        claims=lost_claims,
+        store=lost_store,
+    )
+    lost_proposed = lost_tools.propose_remediation({"finding_id": current["finding_id"]})
+    lost_id = lost_proposed["data"]["proposal_id"]
+    _approve(lost_store, lost_id)
+    lost_remediator.calls.clear()
+    with pytest.raises(FleetError) as lost:
+        lost_tools.execute_remediation({"proposal_id": lost_id})
+    assert lost.value.code == "unavailable"
+    assert [kind for kind, _name in lost_remediator.calls] == ["recheck"]
+    assert lost_claims.held == []
+
+
+def test_current_wazuh_binding_must_match_every_catalogued_field(tmp_path):
+    from brigade.grokbot_fleet import policy as policy_mod
+
+    changes = {
+        "action_id": "different-action",
+        "automatic_rollback": True,
+        "blast_radius": "two registered services",
+        "maintenance_window_id": "alternate-control-plane-service",
+        "rollback_id": "different-rollback",
+        "service_id": "different-service",
+        "verification_id": "different-verification",
+    }
+    for field, replacement in changes.items():
+        current = _alert()
+        remediator = _Remediator()
+        store = _Store()
+        tools = _tools(
+            tmp_path / field,
+            wazuh=_WazuhSource([current]),
+            remediator=remediator,
+            store=store,
+        )
+        proposal = tools.propose_remediation({"finding_id": current["finding_id"]})
+        _approve(store, proposal["data"]["proposal_id"])
+        remediator.calls.clear()
+        catalog = policy_mod.WAZUH_ACTION_CATALOG["service-failure"]
+        original = catalog[field]
+        if field == "maintenance_window_id":
+            policy_mod.MAINTENANCE_WINDOWS[replacement] = dict(policy_mod.MAINTENANCE_WINDOWS[original])
+            policy_mod.MAINTENANCE_WINDOWS[replacement]["window_id"] = replacement
+        catalog[field] = replacement
+        try:
+            with pytest.raises(FleetError) as caught:
+                tools.execute_remediation({"proposal_id": proposal["data"]["proposal_id"]})
+            assert caught.value.code == "denied"
+            assert remediator.calls == []
+        finally:
+            catalog[field] = original
+            if field == "maintenance_window_id":
+                del policy_mod.MAINTENANCE_WINDOWS[replacement]
+
+
+def test_reservation_contract_and_recovery_journal_precede_terminal_commit(tmp_path):
+    store = _Store()
+    tools, proposal_id, _remediator, claims, store = _ready_approved(tmp_path, store=store)
+    observed: list[list[dict[str, Any]]] = []
+
+    def capture_before_commit(_reservation_id: str, records: list[Mapping[str, Any]]) -> None:
+        journal = store.read_claim_cleanup()
+        assert isinstance(journal, dict)
+        assert journal["receipt_pending"] is True
+        assert journal["release_pending"] is True
+        assert journal["terminal_receipts"] == [dict(record) for record in records]
+        observed.append([dict(record) for record in records])
+
+    store.before_commit = capture_before_commit
+    result = tools.execute_remediation({"proposal_id": proposal_id})
+    assert result["data"]["outcome"] == "verified"
+    assert len(observed) == 1
+    assert claims.calls == [("acquire", "control-plane"), ("release", "control-plane")]
+
+
+def test_non_catalogued_wazuh_findings_remain_review_only(tmp_path):
+    remediator = _Remediator()
+    disconnected = _alert(
+        rule_id="504",
+        rule_level=12,
+        rule_description="Agent disconnected",
+        rule_groups=["agent_disconnected"],
+        decoder="agent-buffer",
+        detail="Wazuh agent stopped sending keepalive",
+    )
+    storage = _alert(
+        rule_id="530",
+        rule_level=12,
+        rule_description="Critical storage",
+        rule_groups=["syslog"],
+        decoder="df",
+        detail="Root filesystem is critically full",
+    )
+    brute = _alert(
+        rule_id="5712",
+        rule_level=12,
+        rule_description="Auth brute force",
+        rule_groups=["syslog_sshd"],
+        decoder="sshd",
+        detail="Repeated authentication failures",
+    )
+    unknown = _alert(
+        rule_id="99999",
+        rule_level=7,
+        rule_description="Unknown event",
+        rule_groups=["other"],
+        decoder="other",
+        detail="Unrecognized observation",
+    )
+    watch = _alert(
+        rule_id="550",
+        rule_level=7,
+        rule_description="Port change",
+        rule_groups=["syslog"],
+        decoder="syslog",
+        detail="Observed port change",
+    )
+    suppress = _alert(
+        rule_id="80790",
+        rule_level=3,
+        rule_description="SCA check failed",
+        rule_groups=["sca"],
+        decoder="sca",
+        detail="Repeated SCA compliance finding",
+    )
+    findings = [disconnected, storage, brute, unknown, watch, suppress]
+    tools = _tools(tmp_path, wazuh=_WazuhSource(findings), remediator=remediator)
+    for finding in findings:
+        with pytest.raises(FleetError) as caught:
+            tools.propose_remediation({"finding_id": finding["finding_id"]})
+        assert caught.value.code == "denied"
+        _assert_clean(caught.value)
+    assert remediator.calls == []
+
+    for tier, adapter, alias in (
+        ("protected-status-only", "local", "control-plane"),
+        ("appliance-read-only", "local", "control-plane"),
+        ("indirect-only", "indirect", "control-plane"),
+        ("infrastructure", "windows", "control-plane"),
+        ("infrastructure", "proxmox-guest", "control-plane"),
+    ):
+        registry = create_fleet_registry(
+            {
+                "targets": [
+                    {
+                        "alias": alias,
+                        "tier": tier,
+                        "adapter": adapter,
+                        "probe_ids": ["linux-host-summary-v1"],
+                        "timeout_ms": 12_000,
+                        "freshness_seconds": 60,
+                    }
+                ],
+                "services": [
+                    {
+                        "service_id": "research-bridge",
+                        "target_alias": alias,
+                        "probe_id": "linux-host-summary-v1",
+                    }
+                ],
+            }
+        )
+        blocked = _tools(
+            tmp_path / f"{tier}-{adapter}",
+            wazuh=_WazuhSource([_alert()]),
+            remediator=_Remediator(),
+            registry=registry,
+        )
+        with pytest.raises(FleetError) as caught:
+            blocked.propose_remediation({"finding_id": "001:service-failure:533"})
+        assert caught.value.code == "denied"
+        _assert_clean(caught.value)
+
+
+def test_observer_findings_remain_non_executable_without_wazuh_source(tmp_path):
+    remediator = _Remediator()
+    tools = _tools(tmp_path, remediator=remediator)
+    tools.ledger.replace_findings(
+        "control-plane",
+        [
+            {
+                "finding_id": "control-plane:unreachable",
+                "target_alias": "control-plane",
+                "proposed_action_id": "inspect-host",
+                "reason": "Host is unreachable",
+                "blast_radius": "one registered host",
+                "verification_id": "verify-host-reachability",
+                "rollback_id": "no-rollback",
+                "observed_at": "2026-08-28T02:30:00Z",
+                "incident_receipt_ref": "receipt-1",
+            }
+        ],
+    )
+    proposed = tools.propose_remediation({"finding_id": "control-plane:unreachable"})
+    assert proposed["data"]["execution_available"] is False
+    assert "proposal_id" not in proposed["data"]
+    assert remediator.calls == []
+
+
+def test_legacy_actionable_ledger_finding_never_creates_or_executes_proposals(tmp_path):
+    remediator = _Remediator()
+    store = _Store()
+    claims = _Claims()
+    tools = _tools(tmp_path, remediator=remediator, store=store, claims=claims)
+    tools.ledger.replace_findings(
+        "research-bridge",
+        [
+            {
+                "finding_id": "research-bridge:unhealthy-service",
+                "target_alias": "control-plane",
+                "proposed_action_id": "restart-service",
+                "reason": "Service health is unhealthy",
+                "blast_radius": "one registered service",
+                "verification_id": "verify-service",
+                "rollback_id": "rollback-service",
+                "observed_at": "2026-08-28T02:30:00Z",
+                "incident_receipt_ref": "receipt-1",
+            }
+        ],
+    )
+    proposed = tools.propose_remediation({"finding_id": "research-bridge:unhealthy-service"})
+    assert proposed["data"]["execution_available"] is False
+    assert "proposal_id" not in proposed["data"]
+    assert store.proposals == {}
+    assert remediator.calls == []
+    assert claims.calls == []
+
+    leftover_id = "a" * 32
+    store.proposals[leftover_id] = {
+        "version": 1,
+        "proposal_id": leftover_id,
+        "finding_id": "research-bridge:unhealthy-service",
+        "service_id": "research-bridge",
+        "target_alias": "control-plane",
+        "finding_revision": "b" * 64,
+        "system_revision": "c" * 64,
+        "action_id": "restart-service",
+        "verification_id": "verify-service",
+        "rollback_id": "no-rollback",
+        "nonce": "d" * 32,
+        "created_at": "2026-08-28T02:30:00Z",
+        "expires_at": "2026-08-28T02:45:00Z",
+    }
+    _approve(store, leftover_id)
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": leftover_id})
+    assert caught.value.code == "denied"
+    assert remediator.calls == []
+    assert "claim_consumed" not in store.calls
+    assert leftover_id not in store.consumed
+
+
+def test_missing_wazuh_source_or_finding_fails_closed(tmp_path):
+    current = _alert()
+    remediator = _Remediator()
+    store = _Store()
+    tools = _tools(tmp_path, wazuh=_WazuhSource([current]), remediator=remediator, store=store)
+    proposed = tools.propose_remediation({"finding_id": current["finding_id"]})
+    proposal_id = proposed["data"]["proposal_id"]
+    _approve(store, proposal_id)
+    remediator.calls.clear()
+
+    tools.wazuh_source = None
+    with pytest.raises(FleetError) as missing_source:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert missing_source.value.code == "denied"
+    assert remediator.calls == []
+    assert "claim_consumed" not in store.calls
+
+    tools.wazuh_source = _WazuhSource()
+    with pytest.raises(FleetError) as missing_finding:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert missing_finding.value.code == "denied"
+    assert remediator.calls == []
+    assert "claim_consumed" not in store.calls
+
+    miss_tools = _tools(
+        tmp_path / "miss",
+        wazuh=_WazuhSource(),
+        remediator=_Remediator(),
+        store=_Store(),
+    )
+    with pytest.raises(FleetError) as missed_propose:
+        miss_tools.propose_remediation({"finding_id": current["finding_id"]})
+    assert missed_propose.value.code == "denied"
+    assert miss_tools.store.proposals == {}
+
+
+def _ready_approved(tmp_path, **overrides):
+    current = _alert()
+    store = overrides.pop("store", _Store())
+    remediator = overrides.pop("remediator", _Remediator())
+    claims = overrides.pop("claims", _Claims())
+    wazuh = overrides.pop("wazuh", _WazuhSource([current]))
+    tools = _tools(
+        tmp_path,
+        wazuh=wazuh,
+        remediator=remediator,
+        claims=claims,
+        store=store,
+        **overrides,
+    )
+    proposed = tools.propose_remediation({"finding_id": current["finding_id"]})
+    proposal_id = proposed["data"]["proposal_id"]
+    _approve(store, proposal_id)
+    remediator.calls.clear()
+    claims.calls.clear()
+    store.calls.clear()
+    return tools, proposal_id, remediator, claims, store
+
+
+def test_capacity_exhaustion_before_mutation_skips_claim_and_execute(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims()
+    store = _Store(reserve_error=FleetActionStoreError("denied"))
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    assert remediator.calls == [("recheck", "restart-service")]
+    assert claims.calls == []
+    assert "claim_consumed" not in store.calls
+    assert proposal_id not in store.consumed
+
+
+def test_executor_failure_writes_terminal_receipt_before_release(tmp_path):
+    remediator = _Remediator(execute_error=FleetError("unavailable", ERROR_MESSAGES["unavailable"]))
+    claims = _Claims()
+    store = _Store()
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    assert remediator.calls == [("recheck", "restart-service"), ("execute", "restart-service")]
+    assert any(item.get("outcome") in {"failed", "unverified"} for item in store.receipts)
+    assert claims.calls[-1] == ("release", "control-plane")
+    assert claims.held == []
+    assert "reserve_receipts" in store.calls
+    assert store.calls.index("reserve_receipts") < store.calls.index("claim_consumed")
+
+
+def test_verifier_failure_writes_terminal_receipt_before_release(tmp_path):
+    remediator = _Remediator(verify_error=RuntimeError("probe exploded"))
+    claims = _Claims()
+    store = _Store()
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    _assert_clean(caught.value)
+    assert remediator.calls == [
+        ("recheck", "restart-service"),
+        ("execute", "restart-service"),
+        ("verify", "verify-service"),
+    ]
+    assert any(item.get("outcome") in {"failed", "unverified"} for item in store.receipts)
+    assert claims.calls[-1] == ("release", "control-plane")
+    assert claims.held == []
+
+
+def test_receipt_commit_failure_writes_terminal_receipt_before_release(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims()
+    store = _Store(commit_error=FleetActionStoreError("denied"))
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    journal = store.read_claim_cleanup()
+    assert isinstance(journal, dict)
+    assert journal["receipt_pending"] is True
+    assert journal["release_pending"] is True
+    assert journal["terminal_receipts"]
+    assert claims.calls == [("acquire", "control-plane")]
+    assert claims.held == [{"target_alias": "control-plane", "holder": "b" * 32}]
+
+
+def test_claim_release_false_preserves_receipt_and_surfaces_unavailable(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims(release_granted=False)
+    store = _Store()
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    assert any(item.get("kind") == "verification" and item.get("outcome") == "verified" for item in store.receipts)
+    assert any(item.get("kind") == "execution" and item.get("outcome") == "verified" for item in store.receipts)
+    assert proposal_id in store.consumed
+    assert remediator.calls == [
+        ("recheck", "restart-service"),
+        ("execute", "restart-service"),
+        ("verify", "verify-service"),
+    ]
+    journal = store.read_claim_cleanup()
+    assert isinstance(journal, dict)
+    assert journal["proposal_id"] == proposal_id
+    assert journal["receipt_pending"] is False
+    assert journal["release_pending"] is True
+
+
+def test_claim_release_exception_preserves_receipt_and_surfaces_unavailable(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims(release_error=RuntimeError("hub dropped"))
+    store = _Store()
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    _assert_clean(caught.value)
+    assert any(item.get("kind") == "verification" and item.get("outcome") == "verified" for item in store.receipts)
+    assert proposal_id in store.consumed
+    journal = store.read_claim_cleanup()
+    assert isinstance(journal, dict)
+    assert journal["proposal_id"] == proposal_id
+    assert journal["receipt_pending"] is False
+    assert journal["release_pending"] is True
+
+
+def test_policy_and_action_records_use_128_character_wazuh_finding_id(tmp_path):
+    from brigade.grokbot_fleet.actions import FleetActionStore, write_fleet_approval_file
+    from brigade.grokbot_fleet.contracts import parse_wazuh_finding_id
+    from brigade.grokbot_fleet.policy import bind_wazuh_remediation
+
+    long_id = "A" * 128
+    assert parse_wazuh_finding_id(long_id) == long_id
+    current = {**_alert(), "finding_id": long_id}
+    tools = _tools(tmp_path)
+    bound = bind_wazuh_remediation(current, registry=tools.registry, now=WINDOW_NOW)
+    assert bound["finding_id"] == long_id
+
+    actions = tmp_path / "actions"
+    approvals = tmp_path / "approvals"
+    actions.mkdir(mode=0o700)
+    approvals.mkdir(mode=0o700)
+    store = FleetActionStore(action_state_path=str(actions), approval_dir=str(approvals))
+    store.ready()
+    proposal = {
+        "version": 1,
+        "proposal_id": "a" * 32,
+        "finding_id": long_id,
+        "service_id": "research-bridge",
+        "target_alias": "control-plane",
+        "finding_revision": current["revision"],
+        "system_revision": "c" * 64,
+        "action_id": "restart-service",
+        "verification_id": "verify-service",
+        "rollback_id": "no-rollback",
+        "nonce": "d" * 32,
+        "created_at": "2026-08-28T02:30:00Z",
+        "expires_at": "2026-08-28T02:45:00Z",
+        "wazuh_fingerprint": current["fingerprint"],
+        "maintenance_window_id": "control-plane-service",
+        "automatic_rollback": False,
+        "blast_radius": "one registered service",
+    }
+    store.create_proposal(proposal)
+    loaded = store.read_proposal(proposal["proposal_id"])
+    assert loaded is not None
+    assert loaded["finding_id"] == long_id
+    write_fleet_approval_file(
+        str(approvals),
+        {**{key: proposal[key] for key in proposal if key != "created_at"}, "approved_at": "2026-08-28T02:31:00Z"},
+    )
+    approval = store.read_approval(proposal["proposal_id"])
+    assert approval is not None
+    assert approval["finding_id"] == long_id
+
+
+def _has_terminal_failure_evidence(store: _Store) -> bool:
+    if any(
+        item.get("kind") in {"rejection", "verification", "execution"}
+        and item.get("outcome") in {"failed", "unverified", "replayed", "denied"}
+        for item in store.receipts
+    ):
+        return True
+    cleanup = store.cleanup
+    return isinstance(cleanup, dict) and bool(cleanup.get("terminal_receipts"))
+
+
+def test_failed_claim_release_retries_after_restart_without_reexecuting(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims(release_granted=False)
+    store = _Store()
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    _assert_clean(caught.value)
+    assert remediator.calls == [
+        ("recheck", "restart-service"),
+        ("execute", "restart-service"),
+        ("verify", "verify-service"),
+    ]
+    cleanup = store.read_claim_cleanup()
+    assert isinstance(cleanup, dict)
+    assert cleanup["proposal_id"] == proposal_id
+    assert cleanup["target_alias"] == "control-plane"
+    assert cleanup["holder"] == "b" * 32
+    assert cleanup["terminal_receipts"]
+    assert cleanup["receipt_pending"] is False
+    assert cleanup["release_pending"] is True
+    assert "receipt_ref" not in cleanup
+    assert all("b" * 32 not in json.dumps(item) for item in store.receipts)
+    assert claims.released[-1]["holder"] == "b" * 32
+
+    remediator.calls.clear()
+    claims.calls.clear()
+    claims.release_granted = True
+    recovered = _tools(
+        tmp_path,
+        wazuh=tools.wazuh_source,
+        remediator=remediator,
+        claims=claims,
+        store=store,
+    )
+    overview = recovered.fleet_overview({})
+    _assert_clean(overview)
+    assert "b" * 32 not in json.dumps(overview)
+    assert remediator.calls == []
+    assert claims.calls == [("release", "control-plane")]
+    assert claims.released[-1]["holder"] == "b" * 32
+    assert claims.held == []
+    assert store.read_claim_cleanup() is None
+
+
+def test_recovery_accepts_only_the_same_missing_fence_after_a_post_release_write_failure(tmp_path):
+    store = _Store()
+    store.cleanup_fail_on_call = 4
+    tools, proposal_id, remediator, claims, store = _ready_approved(tmp_path, store=store)
+
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    assert claims.held == []
+    cleanup = store.read_claim_cleanup()
+    assert isinstance(cleanup, dict)
+    assert cleanup["receipt_pending"] is False
+    assert cleanup["release_pending"] is True
+
+    remediator.calls.clear()
+    claims.calls.clear()
+    claims.release_granted = False
+    claims.release_reason = "missing"
+    recovered = _tools(
+        tmp_path,
+        wazuh=tools.wazuh_source,
+        remediator=remediator,
+        claims=claims,
+        store=store,
+    )
+    recovered.fleet_overview({})
+    assert remediator.calls == []
+    assert claims.calls == [("release", "control-plane")]
+    assert store.read_claim_cleanup() is None
+
+    blocked_store = _Store()
+    blocked_tools, blocked_id, blocked_remediator, blocked_claims, blocked_store = _ready_approved(
+        tmp_path / "different-holder", store=blocked_store
+    )
+    blocked_store.cleanup_fail_on_call = 4
+    with pytest.raises(FleetError):
+        blocked_tools.execute_remediation({"proposal_id": blocked_id})
+    blocked_claims.release_granted = False
+    blocked_claims.release_reason = "missing"
+    blocked_claims.release_holder = "c" * 32
+    recovered_blocked = _tools(
+        tmp_path / "different-holder",
+        wazuh=blocked_tools.wazuh_source,
+        remediator=blocked_remediator,
+        claims=blocked_claims,
+        store=blocked_store,
+    )
+    with pytest.raises(FleetError) as blocked:
+        recovered_blocked.fleet_overview({})
+    assert blocked.value.code == "unavailable"
+    assert blocked_store.read_claim_cleanup() is not None
+
+
+def test_failed_claim_release_writes_mode_0600_cleanup_with_holder(tmp_path, monkeypatch):
+    from brigade.grokbot_fleet import actions as actions_mod
+    from brigade.grokbot_fleet.actions import FleetActionStore, write_fleet_approval_file
+
+    monkeypatch.setattr(actions_mod, "_utc_now", lambda: WINDOW_NOW)
+    actions = tmp_path / "actions"
+    approvals = tmp_path / "approvals"
+    actions.mkdir(mode=0o700)
+    approvals.mkdir(mode=0o700)
+    os.chmod(actions, 0o700)
+    os.chmod(approvals, 0o700)
+    store = FleetActionStore(action_state_path=str(actions), approval_dir=str(approvals))
+    store.ready()
+    current = _alert()
+    remediator = _Remediator()
+    claims = _Claims(release_granted=False)
+    tools = _tools(
+        tmp_path,
+        wazuh=_WazuhSource([current]),
+        remediator=remediator,
+        claims=claims,
+        store=store,
+    )
+    proposed = tools.propose_remediation({"finding_id": current["finding_id"]})
+    proposal_id = proposed["data"]["proposal_id"]
+    proposal = store.read_proposal(proposal_id)
+    assert proposal is not None
+    write_fleet_approval_file(
+        str(approvals),
+        {**{key: proposal[key] for key in proposal if key != "created_at"}, "approved_at": "2026-08-28T02:31:00Z"},
+    )
+    remediator.calls.clear()
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    _assert_clean(caught.value)
+    cleanup_files = list((actions / "cleanup").glob("*.json"))
+    assert len(cleanup_files) == 1
+    info = cleanup_files[0].stat()
+    assert stat.S_IMODE(info.st_mode) == 0o600
+    payload = json.loads(cleanup_files[0].read_text(encoding="utf-8"))
+    assert payload["proposal_id"] == proposal_id
+    assert payload["target_alias"] == "control-plane"
+    assert payload["holder"] == "b" * 32
+    assert payload["terminal_receipts"]
+    assert payload["receipt_pending"] is False
+    assert payload["release_pending"] is True
+    assert "receipt_ref" not in payload
+    for path in (actions / "receipts").glob("*.json"):
+        assert "b" * 32 not in path.read_text(encoding="utf-8")
+
+
+def test_consume_failure_keeps_terminal_evidence_when_reservation_release_fails(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims()
+    store = _Store(consume_error=FleetActionStoreError("replayed"), release_error=OSError("busy"))
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code in {"denied", "unavailable"}
+    _assert_clean(caught.value)
+    assert remediator.calls == [("recheck", "restart-service")]
+    assert "execute" not in {kind for kind, _name in remediator.calls}
+    assert _has_terminal_failure_evidence(store)
+    assert claims.calls[-1] == ("release", "control-plane")
+
+
+def test_receipt_commit_failure_keeps_terminal_evidence_when_reservation_release_fails(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims()
+    store = _Store(commit_error=FleetActionStoreError("denied"), release_error=OSError("busy"))
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "unavailable"
+    _assert_clean(caught.value)
+    assert remediator.calls == [
+        ("recheck", "restart-service"),
+        ("execute", "restart-service"),
+        ("verify", "verify-service"),
+    ]
+    assert _has_terminal_failure_evidence(store)
+    assert claims.calls == [("acquire", "control-plane")]
+
+
+def test_terminal_recovery_journal_replays_exact_receipts_before_fenced_claim_release(tmp_path):
+    remediator = _Remediator()
+    claims = _Claims(release_granted=False)
+    store = _Store(commit_error=FleetActionStoreError("denied"), release_error=OSError("busy"))
+    tools, proposal_id, remediator, claims, store = _ready_approved(
+        tmp_path, remediator=remediator, claims=claims, store=store
+    )
+
+    with pytest.raises(FleetError) as initial:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert initial.value.code == "unavailable"
+    journal = store.read_claim_cleanup()
+    assert isinstance(journal, dict)
+    assert journal["version"] == 2
+    assert journal["proposal_id"] == proposal_id
+    assert journal["target_alias"] == "control-plane"
+    assert journal["holder"] == "b" * 32
+    assert journal["reservation_id"] == "1" * 32
+    assert journal["receipt_pending"] is True
+    assert journal["release_pending"] is True
+    assert "receipt_ref" not in journal
+    assert [item["kind"] for item in journal["terminal_receipts"]] == ["execution", "verification"]
+    assert all(item["outcome"] == "verified" for item in journal["terminal_receipts"])
+    reserved = {item["receipt_id"]: item for item in store.reservations["1" * 32]}
+    assert {item["receipt_id"] for item in journal["terminal_receipts"]} <= set(reserved)
+    for receipt in journal["terminal_receipts"]:
+        assert all(
+            receipt.get(key) == value for key, value in reserved[receipt["receipt_id"]].items() if key != "outcome"
+        )
+    assert "release_reservation" not in store.calls
+    assert all("b" * 32 not in json.dumps(item) for item in store.receipts)
+
+    calls_before_retry = list(remediator.calls)
+    journal_before_retry = dict(journal)
+    with pytest.raises(FleetError) as blocked:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert blocked.value.code == "unavailable"
+    assert remediator.calls == calls_before_retry
+    assert store.read_claim_cleanup() == journal_before_retry
+
+    remediator.calls.clear()
+    claims.release_granted = True
+    claims.release_error = None
+    store.commit_error = None
+    recovered = _tools(
+        tmp_path,
+        wazuh=tools.wazuh_source,
+        remediator=remediator,
+        claims=claims,
+        store=store,
+    )
+    overview = recovered.fleet_overview({})
+    _assert_clean(overview)
+    assert remediator.calls == []
+    assert store.read_claim_cleanup() is None
+    assert store.reservations == {}
+    assert store.receipts[-2:] == journal_before_retry["terminal_receipts"]
+    assert all("b" * 32 not in json.dumps(item) for item in store.receipts)
+    assert claims.released[-1] == {"target_alias": "control-plane", "holder": "b" * 32}

--- a/tests/test_grokbot_fleet_tools.py
+++ b/tests/test_grokbot_fleet_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +39,7 @@ class _Store:
         self.consumed = {}
         self.receipts = []
         self.reservations = {}
+        self.claim_cleanup = None
         self._reservation_seq = 0
 
     def create_proposal(self, record):
@@ -86,6 +86,15 @@ class _Store:
 
     def release_receipt_reservation(self, reservation_id):
         self.reservations.pop(reservation_id, None)
+
+    def write_claim_cleanup(self, record):
+        self.claim_cleanup = dict(record)
+
+    def read_claim_cleanup(self):
+        return self.claim_cleanup
+
+    def clear_claim_cleanup(self):
+        self.claim_cleanup = None
 
 
 class _Executor:
@@ -161,6 +170,24 @@ def _tools(tmp_path, *, fail_aliases=(), store=None, executor=None):
     )
 
 
+def _leftover_observer_proposal(proposal_id: str, nonce: str) -> dict[str, object]:
+    return {
+        "version": 1,
+        "proposal_id": proposal_id,
+        "finding_id": "research-bridge:unhealthy-service",
+        "service_id": "research-bridge",
+        "target_alias": "control-plane",
+        "finding_revision": "b" * 64,
+        "system_revision": "c" * 64,
+        "action_id": "restart-service",
+        "verification_id": "verify-service",
+        "rollback_id": "no-rollback",
+        "nonce": nonce,
+        "created_at": "2026-08-27T12:00:00Z",
+        "expires_at": "2027-08-27T12:15:00Z",
+    }
+
+
 def test_overview_preserves_order_and_bounds_unavailable_targets(tmp_path):
     tools = _tools(tmp_path, fail_aliases=("hypervisor",))
     result = tools.fleet_overview({})
@@ -199,23 +226,11 @@ def test_propose_and_execute_follow_fail_closed_replay_rules(tmp_path):
     tools.incident_bundle({"scope": "research-bridge"})
     finding = tools.ledger.finding("research-bridge:unhealthy-service")
     proposed = tools.propose_remediation({"finding_id": finding["finding_id"]})
-    assert proposed["data"]["execution_available"] is True
+    assert proposed["data"]["execution_available"] is False
     assert proposed["data"]["approval_required"] is True
-    proposal_id = proposed["data"]["proposal_id"]
-    with pytest.raises(FleetError) as denied:
-        tools.execute_remediation({"proposal_id": proposal_id})
-    assert denied.value.code == "denied"
-    store.approvals[proposal_id] = {
-        **store.proposals[proposal_id],
-        "approved_at": "2026-08-27T12:01:00Z",
-    }
-    store.approvals[proposal_id].pop("created_at")
-    executed = tools.execute_remediation({"proposal_id": proposal_id})
-    assert executed["data"]["outcome"] == "verified"
-    assert executor.restarted == 1
-    with pytest.raises(FleetError):
-        tools.execute_remediation({"proposal_id": proposal_id})
-    assert executor.restarted == 1
+    assert "proposal_id" not in proposed["data"]
+    assert store.proposals == {}
+    assert executor.restarted == 0
 
 
 def test_unsupported_findings_propose_without_execution(tmp_path):
@@ -260,7 +275,11 @@ def test_repeated_rejected_execution_does_not_unbounded_receipts(tmp_path: Path)
     tools.create_receipt_id = lambda: next(ids)
     tools.incident_bundle({"scope": "research-bridge"})
     proposed = tools.propose_remediation({"finding_id": "research-bridge:unhealthy-service"})
-    proposal_id = proposed["data"]["proposal_id"]
+    assert proposed["data"]["execution_available"] is False
+    assert "proposal_id" not in proposed["data"]
+    proposal_id = next(ids)
+    leftover = _leftover_observer_proposal(proposal_id, next(ids))
+    store.create_proposal(leftover)
     receipts = actions / "receipts"
     before = len(list(receipts.glob("*.json")))
     for _ in range(20):
@@ -273,17 +292,6 @@ def test_repeated_rejected_execution_does_not_unbounded_receipts(tmp_path: Path)
         )
     after = len(list(receipts.glob("*.json")))
     assert after - before <= 1
-    approval = {
-        **{
-            key: store.read_proposal(proposal_id)[key]
-            for key in store.read_proposal(proposal_id)
-            if key != "created_at"
-        },
-        "approved_at": now.isoformat().replace("+00:00", "Z"),
-    }
-    write_fleet_approval_file(str(approvals), approval)
-    executed = tools.execute_remediation({"proposal_id": proposal_id})
-    assert executed["data"]["outcome"] == "verified"
 
 
 def _write_live_receipt(
@@ -329,9 +337,12 @@ def test_execute_remediation_denies_saturated_live_receipts_before_claim_or_rest
     tools.create_receipt_id = lambda: next(ids)
     tools.incident_bundle({"scope": "research-bridge"})
     proposed = tools.propose_remediation({"finding_id": "research-bridge:unhealthy-service"})
-    proposal_id = proposed["data"]["proposal_id"]
+    assert proposed["data"]["execution_available"] is False
+    proposal_id = next(ids)
+    store.create_proposal(_leftover_observer_proposal(proposal_id, next(ids)))
     _write_live_receipt(store, next(ids), proposal_id, outcome="denied")
     _write_live_receipt(store, next(ids), proposal_id, outcome="stale")
+    _write_live_receipt(store, next(ids), proposal_id, outcome="expired")
     assert len(list((actions / "receipts").glob("*.json"))) == 3
     approval = {
         **{
@@ -348,23 +359,6 @@ def test_execute_remediation_denies_saturated_live_receipts_before_claim_or_rest
     assert caught.value.message == ERROR_MESSAGES[caught.value.code]
     assert executor.restarted == 0
     assert list((actions / "consumed").glob("*.json")) == []
-
-    monkeypatch.setattr(actions_mod, "MAX_RECEIPTS", 8)
-    executed = tools.execute_remediation({"proposal_id": proposal_id})
-    assert executed["data"]["outcome"] == "verified"
-    assert executed["data"]["receipt_ref"]
-    assert (actions / "receipts" / f"{executed['data']['receipt_ref']}.json").is_file()
-    execution_receipts = []
-    verification_receipts = []
-    for path in (actions / "receipts").glob("*.json"):
-        payload = path.read_text(encoding="utf-8")
-        if '"kind": "execution"' in payload or '"kind":"execution"' in payload:
-            execution_receipts.append(path)
-        if '"kind": "verification"' in payload or '"kind":"verification"' in payload:
-            verification_receipts.append(path)
-    assert execution_receipts
-    assert verification_receipts
-    assert executor.restarted == 1
 
 
 def test_execute_remediation_releases_stale_reservation_capacity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -394,7 +388,9 @@ def test_execute_remediation_releases_stale_reservation_capacity(tmp_path: Path,
     tools.create_receipt_id = lambda: next(ids)
     tools.incident_bundle({"scope": "research-bridge"})
     proposed = tools.propose_remediation({"finding_id": "research-bridge:unhealthy-service"})
-    proposal_id = proposed["data"]["proposal_id"]
+    assert proposed["data"]["execution_available"] is False
+    proposal_id = next(ids)
+    store.create_proposal(_leftover_observer_proposal(proposal_id, next(ids)))
     approval = {
         **{
             key: store.read_proposal(proposal_id)[key]
@@ -406,8 +402,8 @@ def test_execute_remediation_releases_stale_reservation_capacity(tmp_path: Path,
     write_fleet_approval_file(str(approvals), approval)
     with pytest.raises(FleetError) as caught:
         tools.execute_remediation({"proposal_id": proposal_id})
-    assert caught.value.code == "unavailable"
-    assert executor.restarted == 1
+    assert caught.value.code == "denied"
+    assert executor.restarted == 0
     assert list((actions / "reservations").glob("*.json")) == []
     receipt_id = next(ids)
     _write_live_receipt(store, receipt_id, proposal_id, outcome="failed")
@@ -435,53 +431,18 @@ def test_replay_loser_cannot_drop_winner_reservation_and_winner_commits_after_on
     tools.create_receipt_id = lambda: next(ids)
     tools.incident_bundle({"scope": "research-bridge"})
     proposed = tools.propose_remediation({"finding_id": "research-bridge:unhealthy-service"})
-    proposal_id = proposed["data"]["proposal_id"]
+    assert proposed["data"]["execution_available"] is False
+    proposal_id = next(ids)
+    leftover = _leftover_observer_proposal(proposal_id, next(ids))
+    store.create_proposal(leftover)
     approval = {
-        **{
-            key: store.read_proposal(proposal_id)[key]
-            for key in store.read_proposal(proposal_id)
-            if key != "created_at"
-        },
+        **{key: leftover[key] for key in leftover if key != "created_at"},
         "approved_at": now.isoformat().replace("+00:00", "Z"),
     }
     write_fleet_approval_file(str(approvals), approval)
-
-    loser_codes: list[str] = []
-    reservation_after_loser: dict[str, object] | None = None
-    real_claim = store.claim_consumed
-
-    def claim_then_replay(record):
-        nonlocal reservation_after_loser
-        claimed = real_claim(record)
-        try:
-            tools.execute_remediation({"proposal_id": proposal_id})
-            loser_codes.append("ok")
-        except FleetError as exc:
-            loser_codes.append(exc.code)
-            assert exc.message == ERROR_MESSAGES[exc.code]
-        paths = sorted((actions / "reservations").glob("*.json"))
-        assert len(paths) == 1
-        reservation_after_loser = json.loads(paths[0].read_text(encoding="utf-8"))
-        reservation_after_loser["path_stem"] = paths[0].stem
-        return claimed
-
-    store.claim_consumed = claim_then_replay  # type: ignore[method-assign]
-    winner = tools.execute_remediation({"proposal_id": proposal_id})
-    assert winner["data"]["outcome"] == "verified"
-    assert executor.restarted == 1
-    assert loser_codes == ["unavailable"]
-    assert reservation_after_loser is not None
-    assert reservation_after_loser["proposal_id"] == proposal_id
-    assert reservation_after_loser["reservation_id"] != proposal_id
-    assert reservation_after_loser["reservation_id"] == reservation_after_loser["path_stem"]
-    execution_receipts = []
-    verification_receipts = []
-    for path in (actions / "receipts").glob("*.json"):
-        payload = path.read_text(encoding="utf-8")
-        if '"kind": "execution"' in payload or '"kind":"execution"' in payload:
-            execution_receipts.append(path)
-        if '"kind": "verification"' in payload or '"kind":"verification"' in payload:
-            verification_receipts.append(path)
-    assert len(execution_receipts) == 1
-    assert len(verification_receipts) == 1
+    with pytest.raises(FleetError) as caught:
+        tools.execute_remediation({"proposal_id": proposal_id})
+    assert caught.value.code == "denied"
+    assert executor.restarted == 0
+    assert list((actions / "consumed").glob("*.json")) == []
     assert list((actions / "reservations").glob("*.json")) == []


### PR DESCRIPTION
## Summary

- Bind Fleet Steward's first executable action to a current Wazuh `research-bridge` unhealthy-service finding.
- Require an expiring, single-use operator approval, full catalog revalidation, and an exact fenced Fleet claim before execution.
- Reserve exact terminal receipts before mutation and recover interrupted receipt commits or claim releases from a mode-0600 journal.

## Safety boundaries

- The executable catalog is limited to `control-plane`, `research-bridge`, `restart-service`, and `verify-service` during the fixed maintenance window.
- Inputs cannot supply commands, shells, paths, addresses, credentials, environment values, arbitrary targets, or rollback behavior.
- Non-catalogued Wazuh findings and legacy Fleet ledger findings remain review-only.
- This PR does not enable a live action or standing approval. The first production canary remains operator-approved.

## Verification

- Post-rebase Fleet Steward gate: Brigade receipt `20260829-162541-work-verify-0f9c35`, 67 tests passed.
- Full repository gate: Brigade receipt `20260829-160756-work-verify-bbfb45`, 10,471 passed, 9 skipped, 82.72% coverage. The 8 xdist-unsafe tests passed serially in receipt `20260829-161747-work-verify-2fa1de`.
- Content and history guard: clean across `origin/main..HEAD`.

Refs #1255
