### PR TITLE
fix(doctor): accept historical projector metadata

### DIFF
--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -565,6 +565,8 @@ def _recovery_checkpoint_run_verdict(target: Path, run_dir: Path) -> tuple[str, 
 
     if run_bytes == compare_bytes:
         success_reason = "projected snapshot matches run.json" if is_authority else "checkpoint bytes match run.json"
+    elif is_authority and _historical_projection_metadata_matches(compare_obj, run_meta, run_bytes):
+        success_reason = "historical projector metadata matches projection"
     else:
         expected = _reconstruct_stale_lock_recovery_receipt(compare_obj, run_meta)
         if expected is not None and expected == run_meta:
@@ -584,6 +586,31 @@ def _recovery_checkpoint_run_verdict(target: Path, run_dir: Path) -> tuple[str, 
     if pending_dispatch:
         return warn_with_pending(success_reason)
     return "ok", success_reason
+
+
+def _historical_projection_metadata_matches(
+    projected: dict[str, object], recorded: dict[str, object], recorded_bytes: bytes
+) -> bool:
+    """Accept only the v5-to-v6 projector metadata compatibility shape.
+
+    Projector v6 added the default ``kind: work`` field and incremented its
+    metadata version. A v5 authority snapshot is accepted only when its raw
+    bytes equal the canonical v5 projection, keeping every other run.json
+    field and the writer encoding fail-closed.
+    """
+    if (
+        projected.get("projector_version") != 6
+        or recorded.get("projector_version") != 5
+        or projected.get("kind") != "work"
+        or "kind" in recorded
+    ):
+        return False
+    historical = dict(projected)
+    historical.pop("kind")
+    historical["projector_version"] = 5
+    from brigade import run_projector  # lazy: authority compatibility only
+
+    return recorded_bytes == run_projector.encode_snapshot_bytes(historical)
 
 
 def _read_run_meta_fail_safe(run_json_path: Path) -> dict[str, object] | None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2634,6 +2634,93 @@ def test_doctor_authority_base_stripped_matching_projection_is_ok(tmp_path: Path
     assert stripped != projected.to_bytes()
 
 
+def _historical_v5_terminal_snapshot(run_dir: Path, event) -> dict:
+    """Return the v5 form of the current projection for a terminal run."""
+    projected = _authority_projected(run_dir, event)
+    historical = dict(projected.snapshot)
+    historical["projector_version"] = 5
+    historical.pop("kind")
+    return historical
+
+
+def _record_authority_terminal_checkpoint(workspace: Path, run_dir: Path, base: dict):
+    """Append an `ok` terminal event and a tail checkpoint that covers it."""
+    from brigade import run_checkpoint, run_lifecycle, runguard
+
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.record_lifecycle_event(
+            run_dir,
+            event_type="run.completed",
+            payload={"status": "ok"},
+            idempotency_key="historical-v5-terminal",
+            workspace=workspace,
+        )
+        event = run_checkpoint.write_checkpoint(
+            run_dir,
+            _recovery_writer_bytes(base),
+            workspace=workspace,
+            paired_event_type=None,
+            body_kind="base-stripped",
+        )
+    assert event is not None
+    return event
+
+
+def test_doctor_accepts_historical_v5_terminal_projection_metadata(tmp_path: Path):
+    """v6 projector metadata alone does not invalidate a v5 terminal snapshot."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    base = _authority_base(workspace)
+    _activate_authority_recovery_journal_with_checkpoint(workspace, run_dir, base)
+    event = _record_authority_terminal_checkpoint(workspace, run_dir, base)
+    historical = _historical_v5_terminal_snapshot(run_dir, event)
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(historical))
+
+    status, _name, detail = _recovery_check(workspace)
+
+    assert status == doctor_mod.OK, detail
+    assert "fail=0" in detail
+
+
+def test_doctor_rejects_noncanonical_historical_v5_terminal_projection(tmp_path: Path):
+    """Historical compatibility keeps the run.json byte contract fail-closed."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    base = _authority_base(workspace)
+    _activate_authority_recovery_journal_with_checkpoint(workspace, run_dir, base)
+    event = _record_authority_terminal_checkpoint(workspace, run_dir, base)
+    historical = _historical_v5_terminal_snapshot(run_dir, event)
+    reordered = {key: historical[key] for key in reversed(historical)}
+    (run_dir / "run.json").write_bytes(json.dumps(reordered, separators=(",", ":")).encode("utf-8"))
+
+    status, _name, detail = _recovery_check(workspace)
+
+    assert status == doctor_mod.FAIL
+    assert _RUN_ID in detail
+    assert "does not match" in detail
+
+
+def test_doctor_rejects_historical_v5_terminal_projection_substantive_mismatch(tmp_path: Path):
+    """Only projector-owned v5 metadata is compatible; task drift remains a failure."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    base = _authority_base(workspace)
+    _activate_authority_recovery_journal_with_checkpoint(workspace, run_dir, base)
+    event = _record_authority_terminal_checkpoint(workspace, run_dir, base)
+    historical = _historical_v5_terminal_snapshot(run_dir, event)
+    historical["task"] = "wrong-task"
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(historical))
+
+    status, _name, detail = _recovery_check(workspace)
+
+    assert status == doctor_mod.FAIL
+    assert _RUN_ID in detail
+    assert "does not match" in detail
+
+
 def test_doctor_authority_base_stripped_missing_run_json_is_warn(tmp_path: Path):
     """A missing run.json is WARN only when projection succeeds."""
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
## Summary

- Accept canonical projector-v5 authority snapshots when the verified projector-v6 result differs only by the added `kind: work` field and projector version.
- Keep Doctor fail-closed for substantive snapshot changes and noncanonical JSON bytes.
- Add terminal-journal regressions for the accepted metadata shape, serialization drift, and task drift.

## Verification

- `20260829-184613-work-verify-ca840f`: focused gate after rebase, 116 Doctor tests passed.
- `20260829-181101-work-verify-c3c9c8`: full gate, 10,573 tests passed, 11 skipped, 68 subtests passed, 82.74% coverage.
- `20260829-181036-work-verify-aa5eb2`: confirmed two subprocess tests after correcting the shared-venv invocation to include `PYTHONPATH=src`.

Implementation: Brigade `coder` seat, OpenAI `gpt-5.6-terra` at high reasoning. Independent conductor review: OpenAI `gpt-5.6-sol`.

Fixes #1210
