### PR TITLE
feat(fleet): publish interactive session presence

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -74,7 +74,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade untrusted` (extras): 2 command path(s)
 - `brigade update`: 1 command path(s)
 - `brigade version`: 1 command path(s)
-- `brigade work`: 155 command path(s)
+- `brigade work`: 156 command path(s)
 - `brigade workflow` (extras): 3 command path(s)
 
 ## Commands
@@ -708,7 +708,6 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade work doctor`
 - `brigade work end`
 - `brigade work hook-run`
-- `brigade work presence-hook`
 - `brigade work hooks install`
 - `brigade work hooks status`
 - `brigade work hooks uninstall`
@@ -804,6 +803,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade work plan-promote`
 - `brigade work plan-proposals`
 - `brigade work plans`
+- `brigade work presence-hook`
 - `brigade work ready`
 - `brigade work reassign`
 - `brigade work rebind-authority`

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -28,7 +28,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade dogfood` (extras): 1 command path(s)
 - `brigade evidence`: 11 command path(s)
 - `brigade extras`: 3 command path(s)
-- `brigade fleet`: 14 command path(s)
+- `brigade fleet`: 15 command path(s)
 - `brigade friction` (extras): 3 command path(s)
 - `brigade guard`: 1 command path(s)
 - `brigade handoff`: 17 command path(s)
@@ -201,6 +201,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade fleet preference pull`
 - `brigade fleet preference set`
 - `brigade fleet serve`
+- `brigade fleet sessions`
 - `brigade fleet sink`
 - `brigade fleet status`
 - `brigade friction add` (extras)
@@ -707,6 +708,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade work doctor`
 - `brigade work end`
 - `brigade work hook-run`
+- `brigade work presence-hook`
 - `brigade work hooks install`
 - `brigade work hooks status`
 - `brigade work hooks uninstall`

--- a/docs/fleet-sync.md
+++ b/docs/fleet-sync.md
@@ -174,6 +174,91 @@ after the journal write completes and the lock is released):
   undelivered) rather than written to a possibly-readable directory.
 - `brigade fleet status [--all] [--json]`.
 
+## Interactive session presence
+
+The Hub stores live Claude, Codex/T3, and Cursor editor sessions as a separate
+authority from run events and repo claims. Sessions are advisory: they never
+acquire a claim, consume station capacity, or block work.
+
+`brigade fleet sessions` lists active rows from `GET /sessions`.
+`brigade fleet sessions --all` adds ended and expired history.
+`brigade fleet sessions --json` prints the same bounded list the Hub returns.
+
+```json
+[
+  {
+    "node_id": "11111111-1111-4111-8111-111111111111",
+    "harness": "claude",
+    "session_id": "sess-example",
+    "repo_identity": "github.com/example/project",
+    "identity_scope": "fleet",
+    "repo_label": "project",
+    "checkout_path": "/tmp/example/project",
+    "branch": "topic",
+    "dirty_paths": ["src/a.py"],
+    "dirty_truncated": false,
+    "state": "active",
+    "started_at": "2026-08-29T12:00:00+00:00",
+    "heartbeat_at": "2026-08-29T12:01:00+00:00",
+    "ended_at": null,
+    "ttl_seconds": 900,
+    "expires_at": 1787997660.0
+  }
+]
+```
+
+`brigade work brief --json` publishes the current Codex/T3 thread when
+`CODEX_THREAD_ID` is set, then projects overlap against other live rows. A
+warning never blocks the brief or takes a lock.
+
+```json
+{
+  "interactive_sessions": {"published": true},
+  "overlap_warnings": [
+    {
+      "node_id": "22222222-2222-4222-8222-222222222222",
+      "harness": "cursor",
+      "session_id": "sess-other",
+      "branch": "main",
+      "checkout_path": "/tmp/other/project",
+      "age": 120,
+      "paths": ["src/a.py"],
+      "partial": false
+    }
+  ]
+}
+```
+
+Data bounds: at most 64 dirty paths, 512 characters each, 32 KiB encoded JSON,
+128-character opaque harness and session IDs, 512-character repository
+identity, 256-character label and branch, 1,024-character checkout path. Active
+lists cap at 500 rows; history caps at 1,000.
+
+TTL is 120 through 3,600 seconds, default 900. Expiry is a read-time
+classification. An upsert after expiry starts a new active interval. Missing
+end callbacks rely on TTL; no adapter starts a daemon.
+
+Node credentials remain the write identity. The Hub derives `node_id` from the
+bearer token. Public rows never include remotes, tokens, diffs, prompts,
+transcripts, or file contents. A credential-bearing origin URL is stored only
+as its credential-free identity, such as `github.com/example/project`.
+
+Session heartbeats are not placed in the run-event spool. Replaying an old
+heartbeat could resurrect expired presence. A failed heartbeat is discarded;
+the next live hook refresh is authoritative. Hub outage is fail-open for
+editor hooks.
+
+Harness coverage: Claude `SessionStart` / relevant `PostToolUse` / accepted
+`Stop`; Codex and T3 Code through the shared work-loop brief using
+`CODEX_THREAD_ID` as harness `codex`; Cursor managed `sessionStart`,
+`postToolUse`, and `sessionEnd`. Cursor Cloud stays on the existing cloud
+tracker. Overlap warnings require matching repository identity and at least
+one identical dirty path. They are advisory only.
+
+The Command Deck renders a separate Interactive sessions panel and marks repo
+rows with exact live dirty-path overlap. Those rows never join `LiveRun`,
+station `busy`, cloud capacity, run collisions, or outcome history.
+
 ## Phase 3 surface
 
 Hub-served Fleet dashboard (`src/brigade/fleet_dashboard.py`, routed by

--- a/docs/phase-fleet-interactive-session-presence-plan.md
+++ b/docs/phase-fleet-interactive-session-presence-plan.md
@@ -1,0 +1,514 @@
+# Fleet interactive session presence implementation plan
+
+## Goal
+
+Implement issue #1261 from
+`docs/phase-fleet-interactive-session-presence.md`: the Fleet Hub becomes the
+authoritative view of interactive Claude, Codex/T3, and Cursor session presence,
+with bounded dirty paths and advisory overlap warnings.
+
+Execute tasks in order and tick every checkbox as it completes. Each behavior
+change starts with a failing test, uses the smallest implementation that passes,
+and is committed before the next task. Do not add dependencies, daemons,
+exclusive session locks, fleet plans, or diff transport.
+
+## Architecture
+
+`fleet_session_presence.py` owns local Git identity, snapshots, and pure overlap
+projection. `fleet_hub_sessions.py` owns schema version 14 session state and
+transactions. The existing Hub, HTTP, client, CLI, hooks, work brief, and Deck
+modules only adapt those two domains. Node credentials remain the write identity.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| Create `src/brigade/fleet_session_presence.py` | Safe local identity, dirty paths, session snapshots, overlap projection. |
+| Create `src/brigade/fleet_hub_sessions.py` | Schema, validation, upsert/end transactions, safe list. |
+| Modify `src/brigade/fleet_hub.py` | Schema version 14 initialization and run-event `repo_identity`. |
+| Modify `src/brigade/fleet_hub_http.py` | Authenticated `/sessions` routes. |
+| Modify `src/brigade/fleet_client.py` | Session transport and run-event identity. |
+| Modify `src/brigade/cli/fleet.py` | `brigade fleet sessions`. |
+| Modify `src/brigade/cli/work/registration.py` | Internal managed presence-hook parser. |
+| Modify `src/brigade/cli/work/dispatching.py` | Internal managed presence-hook dispatch. |
+| Modify `src/brigade/claude_hooks/runtime.py` | Claude start, refresh, and accepted-stop publication. |
+| Modify `src/brigade/cursor_user_cmd.py` | Cursor start, refresh, and end publication. |
+| Modify `src/brigade/work_cmd/session/briefing.py` | Codex/T3 startup publication and overlap warnings. |
+| Modify `src/brigade/fleet_command_deck.py` | Separate session panel and repo overlap marker. |
+| Create `tests/test_fleet_session_presence.py` | Identity, dirty path, overlap, and Hub-domain tests. |
+| Modify `tests/test_fleet_sync.py` | HTTP, auth, migration, client, and run identity tests. |
+| Modify `tests/test_fleet_claims.py` | Schema-upgrade compatibility assertions. |
+| Modify `tests/test_claude_hooks_runtime.py` | Claude lifecycle publication tests. |
+| Modify `tests/test_claude_hooks_envelope.py` | Hook stdout and failure isolation tests. |
+| Modify `tests/test_cursor_user_cmd.py` | Generated hook publication contract. |
+| Modify `tests/test_work_cmd_session.py` | Codex/T3 presence and overlap brief tests. |
+| Modify `tests/test_fleet_command_deck.py` | Session panel, escaping, and capacity tests. |
+
+## Blast radius
+
+`brigade code affected` on the six existing core modules returned 116 impacted
+files and 122 statically attributed test groups. Direct behavior-lock suites are
+the eight test files named above plus `tests/test_fleet_dashboard.py` and
+`tests/test_cli_inventory_contract.py`. The implementation must run through
+`brigade run` so `run.json` records the code-graph brief.
+
+### Task 1: local snapshot and Hub session authority
+
+**Files:**
+
+- Create `src/brigade/fleet_session_presence.py`
+- Create `src/brigade/fleet_hub_sessions.py`
+- Modify `src/brigade/fleet_hub.py`
+- Create `tests/test_fleet_session_presence.py`
+- Modify `tests/test_fleet_claims.py`
+
+- [x] Write failing local identity and dirty-path tests using only fake remotes.
+
+```python
+def test_remote_forms_have_one_credential_free_identity(git_repo, monkeypatch):
+    identities = []
+    for remote in (
+        "https://github.com/example/project.git",
+        "https://user:secret@github.com/example/project.git",  # content-guard: allow email
+        "ssh://git@github.com/example/project.git",  # content-guard: allow email
+        "git@github.com:example/project.git",  # content-guard: allow email
+    ):
+        _set_origin(git_repo, remote)
+        identities.append(presence.repository_identity(git_repo))
+    assert {item.value for item in identities} == {"github.com/example/project"}
+    assert all(item.scope == "fleet" for item in identities)
+    assert "secret" not in repr(identities)
+
+def test_dirty_paths_are_bounded_relative_and_rename_safe(git_repo):
+    _seed_dirty_paths(git_repo, count=70, include_rename=True)
+    snapshot = presence.collect_dirty_paths(git_repo)
+    assert len(snapshot.paths) == 64
+    assert snapshot.truncated is True
+    assert all(not Path(path).is_absolute() and ".." not in Path(path).parts for path in snapshot.paths)
+    assert "renamed file.txt" in snapshot.paths
+    assert all(not path.startswith(".brigade/") for path in snapshot.paths)
+```
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_fleet_session_presence.py"]' --capture brigade-work
+```
+
+Expect collection failure because `brigade.fleet_session_presence` does not
+exist. Capture the failed outcome before implementing.
+
+- [x] Implement the local immutable shapes and exact public functions.
+
+```python
+DEFAULT_TTL_SECONDS = 900
+MIN_TTL_SECONDS = 120
+MAX_TTL_SECONDS = 3600
+MAX_DIRTY_PATHS = 64
+MAX_DIRTY_PATH_CHARS = 512
+MAX_DIRTY_JSON_BYTES = 32 * 1024
+
+@dataclass(frozen=True)
+class RepositoryIdentity:
+    value: str
+    scope: Literal["fleet", "node"]
+
+@dataclass(frozen=True)
+class DirtyPathSnapshot:
+    paths: tuple[str, ...]
+    truncated: bool
+
+@dataclass(frozen=True)
+class SessionSnapshot:
+    harness: str
+    session_id: str
+    repo_identity: str
+    identity_scope: str
+    repo_label: str
+    checkout_path: str
+    branch: str | None
+    dirty_paths: tuple[str, ...]
+    dirty_truncated: bool
+    ttl_seconds: int = DEFAULT_TTL_SECONDS
+
+```
+
+The exact public functions are `repository_identity(target: Path) ->
+RepositoryIdentity`, `collect_dirty_paths(target: Path) -> DirtyPathSnapshot`,
+`build_snapshot(target: Path, *, harness: str, session_id: str, ttl_seconds: int
+= DEFAULT_TTL_SECONDS) -> SessionSnapshot`, and `overlap_warnings(current:
+SessionSnapshot, rows: Sequence[Mapping[str, object]], *, current_node: str) ->
+list[dict[str, object]]`.
+
+Use `subprocess.run(["git", "remote", "get-url", "origin"], shell=False,
+timeout=5, cwd=target)` for the remote and `subprocess.run(["git", "status",
+"--porcelain=v1", "-z", "--untracked-files=all"], shell=False, timeout=5,
+cwd=target)` for paths. Parse NUL records, consume
+the second path for rename/copy status, normalize separators to `/`, sort, and
+deduplicate. Do not call `runguard.dirty_paths`, whose line parser does not carry
+the required NUL and truncation contract.
+
+- [x] Write failing schema, transaction, and migration tests.
+
+```python
+def test_schema_13_migrates_to_14_without_touching_existing_rows(tmp_path):
+    db = _schema_13_database(tmp_path)
+    conn = fleet_hub.init_db(db)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 14
+    assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM interactive_sessions").fetchone()[0] == 0
+
+def test_upsert_retry_refresh_end_and_expiry(conn, monkeypatch):
+    first = sessions.handle_session(conn, _upsert(), caller_node=NODE_A)
+    retry = sessions.handle_session(conn, _upsert(branch="topic"), caller_node=NODE_A)
+    assert retry[1]["session"]["started_at"] == first[1]["session"]["started_at"]
+    assert retry[1]["session"]["branch"] == "topic"
+    assert sessions.handle_session(conn, _end(), caller_node=NODE_A)[0] == 200
+    assert sessions.list_sessions(conn) == []
+    assert sessions.list_sessions(conn, include_all=True)[0]["state"] == "ended"
+```
+
+- [x] Implement `fleet_hub_sessions.py` with these entry points.
+
+```python
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS interactive_sessions (
+    node_id TEXT NOT NULL,
+    harness TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    repo_identity TEXT NOT NULL,
+    identity_scope TEXT NOT NULL,
+    repo_label TEXT NOT NULL,
+    checkout_path TEXT NOT NULL,
+    branch TEXT,
+    dirty_paths_json TEXT NOT NULL,
+    dirty_truncated INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    heartbeat_at TEXT NOT NULL,
+    ended_at TEXT,
+    ttl_seconds INTEGER NOT NULL,
+    expires_at REAL NOT NULL,
+    PRIMARY KEY (node_id, harness, session_id, repo_identity)
+);
+"""
+```
+
+The exact public entry points are `init_schema(conn: sqlite3.Connection) ->
+None`, `handle_session(conn: sqlite3.Connection, raw: object, *, caller_node:
+str | None) -> tuple[int, dict[str, object]]`, and `list_sessions(conn:
+sqlite3.Connection, *, include_all: bool = False, now_epoch: float | None =
+None) -> list[dict[str, object]]`.
+
+`handle_session` accepts only `upsert` and `end`. Validate the complete body,
+derive the owner from `caller_node`, then use one `BEGIN IMMEDIATE` transaction.
+An admin compatibility write has `caller_node=None` and therefore requires a
+validated body `node_id`; normal node writes reject body `node_id`. Public rows
+never include private auth material. Default reads cap at 500, history at 1,000.
+
+- [x] Set `fleet_hub.SCHEMA_VERSION = 14`, call
+  `fleet_hub_sessions.init_schema(conn)` from the startup migration, and add the
+  nullable `repo_identity` events column. Keep every prior migration additive.
+
+- [x] Run Task 1 green through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_fleet_session_presence.py","tests/test_fleet_claims.py"]' --capture brigade-work
+```
+
+Expect exit 0 and all selected tests passed.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/fleet_session_presence.py src/brigade/fleet_hub_sessions.py src/brigade/fleet_hub.py tests/test_fleet_session_presence.py tests/test_fleet_claims.py
+git commit -m "feat(fleet): add interactive session authority" -m "Co-Authored-By: Cursor <cursoragent@cursor.com>"  # content-guard: allow email
+```
+
+### Task 2: HTTP, client, CLI, and run identity
+
+**Files:**
+
+- Modify `src/brigade/fleet_hub_http.py`
+- Modify `src/brigade/fleet_client.py`
+- Modify `src/brigade/cli/fleet.py`
+- Modify `tests/test_fleet_sync.py`
+- Modify `tests/test_cli_inventory_contract.py`
+
+- [x] Write failing HTTP and auth tests.
+
+```python
+def test_session_routes_auth_and_node_identity(hub_server):
+    assert _request(hub_server, "GET", "/sessions")[0] == 401
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(node_id=NODE_B), token=NODE_A_TOKEN)[0] == 400
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(), token=NODE_A_TOKEN)[0] == 200
+    status, body = _request_json(hub_server, "GET", "/sessions", token=NODE_A_TOKEN)
+    assert status == 200 and body["sessions"][0]["node_id"] == NODE_A
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(), cookie=_dashboard_cookie())[0] == 401
+
+def test_revoked_node_cannot_refresh_session(hub_server):
+    _create_session(hub_server, NODE_A_TOKEN)
+    _revoke_node(hub_server, NODE_A)
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(), token=NODE_A_TOKEN)[0] == 401
+```
+
+- [x] Run the two tests through Brigade and expect 404 failures for `/sessions`.
+
+- [x] Route `GET /sessions` beside the authenticated status reads and
+  `POST /sessions` beside node-authenticated writes. Node tokens may read and
+  mutate their own rows. Admin reads are allowed. Admin writes retain the
+  existing `allow_admin_writes` gate. Cookies do not reach either route.
+
+- [x] Write failing client and CLI tests.
+
+```python
+def test_client_upsert_end_and_fetch_use_node_token(monkeypatch, session_snapshot):
+    calls = _record_hub_calls(monkeypatch)
+    assert fleet_client.upsert_session(session_snapshot) is True
+    assert fleet_client.end_session(session_snapshot) is True
+    assert fleet_client.fetch_sessions() == [_safe_session_row()]
+    assert [call.path for call in calls] == ["/sessions", "/sessions", "/sessions"]
+    assert all("Authorization" in call.headers for call in calls)
+
+def test_fleet_sessions_cli_is_bounded_and_safe(monkeypatch, capsys):
+    monkeypatch.setattr(fleet_client, "fetch_sessions", lambda **_: [_safe_session_row()])
+    assert cli.main(["fleet", "sessions", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["repo_identity"] == "github.com/example/project"
+    assert "dirty_paths" in payload[0]
+```
+
+- [x] Implement exact client entry points. Mutations return `False` on any
+  ordinary exception and never spool. Reads raise `FleetClientError`.
+
+The exact entry points are `upsert_session(snapshot: SessionSnapshot, *,
+hub_url: str | None = None) -> bool`, `end_session(snapshot: SessionSnapshot, *,
+hub_url: str | None = None) -> bool`, and `fetch_sessions(*, hub_url: str | None
+= None, include_all: bool = False) -> list[dict[str, Any]]`.
+
+- [x] Add `brigade fleet sessions [--all] [--json]`. Text columns are NODE,
+  HARNESS, SESSION, REPO, BRANCH, DIRTY, AGE, EXPIRES. Pass every cell through
+  `_safe_table_cell`. JSON prints only the list returned by `fetch_sessions`.
+
+- [x] Add `repo_identity` to event validation, insertion, status projection,
+  and client event construction. `report_journal_event` derives it from the
+  journal workspace with `repository_identity`; failures leave it `None`.
+
+- [x] Run Task 2 green through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_fleet_sync.py","tests/test_fleet_claims.py","tests/test_cli_inventory_contract.py","tests/test_fleet_session_presence.py"]' --capture brigade-work
+```
+
+- [x] Commit:
+
+```bash
+git add src/brigade/fleet_hub_http.py src/brigade/fleet_client.py src/brigade/cli/fleet.py src/brigade/fleet_hub.py tests/test_fleet_sync.py tests/test_fleet_claims.py tests/test_cli_inventory_contract.py tests/test_fleet_session_presence.py
+git commit -m "feat(fleet): expose interactive sessions" -m "Co-Authored-By: Cursor <cursoragent@cursor.com>"  # content-guard: allow email
+```
+
+### Task 3: harness publication and overlap briefing
+
+**Files:**
+
+- Modify `src/brigade/cli/work/registration.py`
+- Modify `src/brigade/cli/work/dispatching.py`
+- Modify `src/brigade/claude_hooks/runtime.py`
+- Modify `src/brigade/cursor_user_cmd.py`
+- Modify `src/brigade/work_cmd/session/briefing.py`
+- Modify `tests/test_claude_hooks_runtime.py`
+- Modify `tests/test_claude_hooks_envelope.py`
+- Modify `tests/test_cursor_user_cmd.py`
+- Modify `tests/test_work_cmd_session.py`
+
+- [x] Write failing managed presence-hook tests.
+
+```python
+def test_presence_hook_upserts_and_ends_without_printing_payload(tmp_path, monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: calls.append(("upsert", snap)) or True)
+    monkeypatch.setattr(fleet_client, "end_session", lambda snap: calls.append(("end", snap)) or True)
+    assert cli.main(["work", "presence-hook", "--target", str(tmp_path), "--harness", "codex", "--session", "thread-1", "--event", "start"]) == 0
+    assert cli.main(["work", "presence-hook", "--target", str(tmp_path), "--harness", "codex", "--session", "thread-1", "--event", "end"]) == 0
+    assert [item[0] for item in calls] == ["upsert", "end"]
+    assert capsys.readouterr().out == ""
+```
+
+- [x] Add `work presence-hook` with two exact input modes. Explicit mode has
+  required target, harness, session, and event choices `start`, `heartbeat`,
+  `end`. Cursor mode is `--harness cursor --stdin --context cursor-work-loop`;
+  it reads one bounded JSON object, derives the event from `hook_event_name`,
+  takes `session_id` or `conversation_id`, and takes the first
+  `workspace_roots` item. Both modes resolve the local snapshot and call the
+  typed client. The command always exits 0 for adapter safety. Explicit mode
+  prints nothing. Cursor mode prints the existing `additional_context` JSON for
+  `sessionStart` and `{}` for `postToolUse` and `sessionEnd`. It never accepts
+  node ID, repo identity, dirty paths, or checkout path from argv or JSON.
+
+- [x] Write failing Claude lifecycle tests.
+
+```python
+def test_claude_presence_start_refresh_and_accepted_stop(target, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id="s1"))
+    runtime.handle_payload("PostToolUse", _write_payload(target, session_id="s1"))
+    runtime.handle_payload("Stop", _payload(target, "Stop", session_id="s1", stop_hook_active=False))
+    assert [call.action for call in calls] == ["upsert", "upsert", "end"]
+
+def test_blocked_stop_does_not_end_presence(target, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+    result = runtime.handle_payload("Stop", _unverified_write_stop(target, session_id="s1"))
+    assert result["decision"] == "block"
+    assert all(call.action != "end" for call in calls)
+```
+
+- [x] Add one `_publish_presence(event, target, session_id)` wrapper in
+  `fleet_session_presence.py`. Claude runtime calls it after target/session
+  validation. `SessionStart` calls `upsert`; relevant `PostToolUse` calls
+  `upsert` after state updates; Stop calls `end` only immediately before a
+  successful `None` or non-blocking context return. Publication exceptions are
+  swallowed and never alter the existing hook envelope.
+
+- [x] Write failing Cursor hook tests, then change `_hook_text()` to the exact
+  shell adapter `exec brigade work presence-hook --harness cursor --stdin
+  --context cursor-work-loop`. Register the same managed command for
+  `sessionStart`, `postToolUse`, and `sessionEnd`, preserving foreign entries in
+  all three arrays. Cursor's documented common input supplies
+  `conversation_id`, `hook_event_name`, and `workspace_roots`; session start/end
+  also supply `session_id`. If identity or workspace is absent, publication is
+  skipped and the required JSON output still prints. Tests must prove planted
+  prompt, transcript, user-email, tool-output, and credential fields never
+  appear in argv, stdout, logs, or a client snapshot.
+
+- [x] Write failing work-brief tests for Codex/T3 and overlap.
+
+```python
+def test_work_brief_publishes_codex_thread_and_warns_on_exact_overlap(tmp_target, monkeypatch, capsys):
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-1")
+    monkeypatch.setattr(fleet_client, "fetch_sessions", lambda **_: [_other_session(dirty_paths=["src/a.py"])])
+    _make_dirty(tmp_target, "src/a.py")
+    assert briefing.brief(target=tmp_target, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["interactive_sessions"]["published"] is True
+    assert payload["overlap_warnings"][0]["paths"] == ["src/a.py"]
+```
+
+Resolve the current harness/session in this order: explicit managed hook fields,
+`CODEX_THREAD_ID` as harness `codex` (including T3 Code), then no publication.
+Brief publication is best-effort. Fetch failure adds a bounded
+`interactive_sessions.error` and no warning. Text output prints at most three
+warnings and eight paths each. JSON preserves the full bounded projection.
+
+- [x] Run Task 3 green through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_claude_hooks_runtime.py","tests/test_claude_hooks_envelope.py","tests/test_cursor_user_cmd.py","tests/test_work_cmd_session.py","tests/test_fleet_session_presence.py"]' --capture brigade-work
+```
+
+- [x] Commit:
+
+```bash
+git add src/brigade/fleet_session_presence.py src/brigade/cli/work/registration.py src/brigade/cli/work/dispatching.py src/brigade/claude_hooks/runtime.py src/brigade/cursor_user_cmd.py src/brigade/work_cmd/session/briefing.py tests/test_claude_hooks_runtime.py tests/test_claude_hooks_envelope.py tests/test_cursor_user_cmd.py tests/test_work_cmd_session.py tests/test_fleet_session_presence.py
+git commit -m "feat(work): publish interactive fleet presence" -m "Co-Authored-By: Cursor <cursoragent@cursor.com>"  # content-guard: allow email
+```
+
+### Task 4: Command Deck projection, documentation, and completion gate
+
+**Files:**
+
+- Modify `src/brigade/fleet_command_deck.py`
+- Modify `tests/test_fleet_command_deck.py`
+- Modify `tests/test_fleet_dashboard.py`
+- Modify `docs/fleet-sync.md`
+- Modify `docs/technical-guide.md`
+- Modify `docs/phase-fleet-interactive-session-presence-plan.md`
+
+- [x] Write failing Deck tests.
+
+```python
+def test_deck_sessions_are_separate_escaped_and_do_not_consume_capacity(conn, now):
+    _seed_session(conn, checkout_path='<script>alert(1)</script>', dirty_paths=["src/a.py"])
+    sessions = deck.fetch_interactive_sessions(conn, now=now)
+    view = deck.build_view(
+        deck.DeckConfig(stations=(deck.StationConfig(NODE_A, "Alpha", 10),)),
+        live_runs=[],
+        claims=[],
+        enrolled_labels={NODE_A: "Alpha"},
+        last_heard={},
+        outcomes=[],
+        failed_outcomes=[],
+        observers=[],
+        now=now,
+        interactive_sessions=sessions,
+    )
+    html = deck.render_deck(view, nonce="nonce", now=now)
+    assert "Interactive sessions" in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "<script>alert(1)</script>" not in html
+    assert view.stations[0].busy == 0
+
+def test_repo_page_marks_only_exact_live_dirty_overlap(conn, now):
+    _seed_session(conn, node=NODE_A, dirty_paths=["src/a.py"])
+    _seed_session(conn, node=NODE_B, dirty_paths=["src/a.py"])
+    sessions = deck.fetch_interactive_sessions(conn, now=now)
+    view = deck.build_view(
+        deck.DeckConfig(stations=(deck.StationConfig(NODE_A, "Alpha", 10),)),
+        live_runs=[],
+        claims=[],
+        enrolled_labels={NODE_A: "Alpha", NODE_B: "Bravo"},
+        last_heard={},
+        outcomes=[],
+        failed_outcomes=[],
+        observers=[],
+        now=now,
+        interactive_sessions=sessions,
+    )
+    assert view.repos[0].interactive_overlap is True
+```
+
+- [x] Add a capped `fetch_interactive_sessions(conn, now)` query through
+  `fleet_hub_sessions.list_sessions`, then project a separate panel. Never add
+  these rows to `LiveRun`, station `busy`, cloud capacity, run collisions, or
+  outcome history. Repo overlap uses the pure exact-path algorithm.
+
+- [x] Document the command, data bounds, TTL semantics, credential boundary,
+  no-spool rule, harness coverage, and the fact that warnings are advisory.
+  Include `brigade fleet sessions --json` and `brigade work brief --json`
+  examples containing only fake identities and paths.
+
+- [x] Run the focused completion gate through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_fleet_session_presence.py","tests/test_fleet_sync.py","tests/test_fleet_claims.py","tests/test_fleet_command_deck.py","tests/test_fleet_dashboard.py","tests/test_claude_hooks_runtime.py","tests/test_claude_hooks_envelope.py","tests/test_cursor_user_cmd.py","tests/test_work_cmd_session.py","tests/test_cli_inventory_contract.py"]' --capture brigade-work
+```
+
+Expect exit 0 with ruff, format, version sync, snapshots, mypy, and every
+selected pytest file passing.
+
+- [x] Tick every completed checkbox in this plan and commit:
+
+```bash
+git add src/brigade/fleet_command_deck.py tests/test_fleet_command_deck.py tests/test_fleet_dashboard.py docs/fleet-sync.md docs/technical-guide.md docs/phase-fleet-interactive-session-presence-plan.md
+git commit -m "feat(fleet): show interactive session overlap" -m "Co-Authored-By: Cursor <cursoragent@cursor.com>"  # content-guard: allow email
+```
+
+- [x] Run the full completion gate once, without `--no-reuse`:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify"]' --timeout 3600 --capture brigade-work
+```
+
+Status 75 means another full gate owns this checkout. Do not retry it. Wait for
+that receipt or report the gate as externally occupied.
+
+The single completion run `20260829-185326-work-verify-043f4f` reached 90%
+before the 3,600-second bound expired. Its three recorded failures were
+diagnosed separately: one unrelated harness test passed unchanged, and two
+Cloud Tracker tests were polluted by the operator host's live Jules key. The
+fixture isolation repair passed in focused receipt
+`20260829-195709-work-verify-85a7f2`. The full gate was not retried.
+
+- [x] Inspect the final diff against this plan, run `git diff --check
+origin/main...HEAD`, write and lint a Memory Handoff, and stop at a clean feature
+branch ready for review. Do not deploy, push, open a PR, merge, or cut a release
+without the user's next instruction.

--- a/docs/phase-fleet-interactive-session-presence.md
+++ b/docs/phase-fleet-interactive-session-presence.md
@@ -1,0 +1,277 @@
+# Fleet interactive session presence
+
+## Goal
+
+Make the Fleet Hub the source of truth for interactive agent presence so an
+agent can see overlapping work before it starts or rebases. The Hub stores only
+bounded operational metadata: repository identity, checkout path, branch,
+harness, session identity, dirty paths, timestamps, and lifecycle state. It
+never receives diffs, prompts, transcripts, tool arguments, file contents, or
+credentials.
+
+This is issue #1261. Fleet-wide plans and campaigns are a later slice. This
+slice supplies the live session and overlap substrate those plans will use.
+
+## Decision
+
+Use a dedicated Hub session authority with a typed client and harness adapters.
+
+Alternatives considered:
+
+1. Derive presence from generic run events. Rejected because interactive work
+   has no run lifecycle, and event replay cannot safely express TTL refresh,
+   exact current state, or bounded dirty-path replacement.
+2. Poll worktrees from each host. Rejected because it creates a second local
+   authority, cannot identify harness sessions, and misses cloud or detached
+   worktrees.
+3. Treat repository claims as session presence. Rejected because claims are
+   exclusive execution fences. Interactive presence is advisory and several
+   sessions may legitimately inspect the same repository.
+
+## User-visible contract
+
+- `brigade fleet sessions` lists active sessions from the Hub.
+- `brigade fleet sessions --all` includes ended and expired history.
+- `brigade fleet sessions --json` emits the same bounded fields as the HTTP
+  projection.
+- `brigade work brief` includes an `overlap_warnings` section when another live
+  session has the same repository identity and at least one identical dirty
+  path. A warning never blocks work or acquires a lock.
+- The Command Deck shows live interactive sessions separately from Brigade runs
+  and cloud workers. Sessions do not consume station worker capacity.
+- `brigade fleet status` run rows gain `repo_identity` when the reporting node
+  can derive it. Existing rows and clients remain readable when it is absent.
+
+## Authority and data flow
+
+1. A harness adapter resolves the Brigade target, repository identity, branch,
+   checkout path, and bounded dirty paths locally.
+2. `fleet_client` sends a node-authenticated session operation. The Hub derives
+   `node_id` from the bearer token and rejects a body that tries to select it.
+3. The Hub atomically upserts or ends the one row keyed by
+   `(node_id, harness, session_id, repo_identity)`.
+4. Reads exclude ended and expired rows by default. `--all` is history only.
+5. Consumers query the Hub. They never scan another machine's worktree or infer
+   live state from old events.
+
+Hub unavailability is fail-open for editor hooks: the editor continues and the
+hook writes no competing local queue. Read commands surface the Hub error. A
+later heartbeat repairs presence after connectivity returns.
+
+## Harness coverage
+
+- Claude Code: the managed `SessionStart` hook upserts, bounded `PostToolUse`
+  refreshes after relevant tools, and an accepted `Stop` ends the session. A
+  blocked Stop leaves the row active until a later accepted Stop or TTL expiry.
+- Codex and T3 Code: the shared work-loop entrypoint recognizes the existing
+  Codex thread identity and upserts presence when the session brief starts.
+  Supported post-tool hooks call the same bounded refresh command. T3 Code uses
+  the Codex harness identity rather than inventing a second identity.
+- Cursor: managed `sessionStart`, `postToolUse`, and `sessionEnd` hooks call the
+  same bounded presence command. The start hook preserves the existing
+  work-loop context output; refresh and end return empty JSON objects. Cursor
+  Cloud omits editor-lifetime start/end hooks, so its tasks remain represented
+  by the existing cloud tracker rather than duplicated as interactive sessions.
+- Other harnesses: a small internal `brigade work presence-hook` command accepts
+  only explicit lifecycle, harness, session, and target fields. It exists for
+  managed adapters, not as a second status store.
+
+No adapter starts a daemon. Missing end callbacks are handled by TTL.
+
+## Repository identity
+
+`src/brigade/fleet_session_presence.py` owns identity and local snapshot rules.
+
+For a Git worktree with an `origin` remote:
+
+1. Parse HTTPS, SSH URL, and SCP-like forms without invoking a shell.
+2. Remove user information, password, query, fragment, leading slash, and one
+   trailing `.git`.
+3. Lowercase the host. Preserve repository path case except for hosts whose
+   repository paths are documented as case-insensitive.
+4. Emit a bounded value such as `github.com/escoffier-labs/brigade`.
+
+The raw remote URL is never sent or persisted. A remote containing an embedded
+credential must produce the same credential-free identity as its clean form.
+
+Without a usable remote, emit `local:<sha256>` from a canonical local Git common
+directory identity and mark `identity_scope="node"`. Node-scoped identities do
+not match sessions from another node. This is honest degradation, not a claim
+of cross-machine identity.
+
+## Session schema
+
+Add schema version 14 and one table:
+
+```sql
+CREATE TABLE interactive_sessions (
+    node_id TEXT NOT NULL,
+    harness TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    repo_identity TEXT NOT NULL,
+    identity_scope TEXT NOT NULL,
+    repo_label TEXT NOT NULL,
+    checkout_path TEXT NOT NULL,
+    branch TEXT,
+    dirty_paths_json TEXT NOT NULL,
+    dirty_truncated INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    heartbeat_at TEXT NOT NULL,
+    ended_at TEXT,
+    ttl_seconds INTEGER NOT NULL,
+    expires_at REAL NOT NULL,
+    PRIMARY KEY (node_id, harness, session_id, repo_identity)
+);
+```
+
+Allowed state is `active` or `ended`. Expiry is a read-time classification and
+does not rewrite history. An upsert after expiry starts a new active interval by
+replacing `started_at`; an exact active retry preserves `started_at`. End is
+idempotent. Heartbeats may replace branch and dirty paths, but cannot change the
+row identity.
+
+Bounds:
+
+- harness and session ID: 128 characters, opaque identity alphabet
+- repository identity: 512 characters
+- repository label and branch: 256 characters
+- checkout path: 1,024 characters
+- dirty paths: at most 64 entries, each at most 512 characters, total encoded
+  JSON at most 32 KiB
+- TTL: 120 through 3,600 seconds, default 900
+- list response: at most 500 active rows or 1,000 history rows
+
+Every string rejects control characters. Dirty paths must be repository-relative
+Git paths. Absolute paths and `..` components are rejected. The server validates
+the complete body before a transaction.
+
+## HTTP and client contract
+
+Add authenticated `GET /sessions` and `POST /sessions`.
+
+`POST /sessions` actions:
+
+- `upsert`: insert or refresh one active row
+- `end`: end an exact row owned by the caller node
+
+The node token may mutate only its derived node identity. The admin token may
+read sessions but cannot write unless the server is in the existing explicit
+admin-write compatibility mode. Dashboard cookies remain dashboard-only.
+
+`fleet_client` owns all transport, auth classification, encryption checks, and
+bounded timeouts. Hooks call the client, never the HTTP surface. Session
+heartbeats are not placed in the run-event spool because replaying an old
+heartbeat could resurrect expired presence. A failed heartbeat is discarded;
+the next live hook refresh is authoritative.
+
+## Dirty-path collection and overlap
+
+Collect paths from one bounded `git status --porcelain=v1 -z` invocation. Parse
+rename pairs without line splitting, exclude `.brigade/`, sort, deduplicate, and
+set `dirty_truncated=true` when the count or encoded-size cap is reached.
+
+An overlap warning requires all of:
+
+- both sessions are active and unexpired
+- repository identities and identity scopes match
+- the other row is not the current `(node, harness, session)`
+- the exact normalized dirty-path intersection is nonempty
+
+The warning contains node, harness, session ID, branch, checkout path, age, and
+at most eight overlapping paths. It never includes a diff or file content.
+Truncated path sets produce a visible `partial=true` marker. No warning is
+interpreted as proof that no overlap exists when either side is truncated.
+
+## Module boundaries
+
+| File | Responsibility |
+| --- | --- |
+| New `src/brigade/fleet_session_presence.py` | Local repository identity, dirty-path snapshot, overlap projection, validation constants. |
+| New `src/brigade/fleet_hub_sessions.py` | Session schema, migration helpers, request validation, transactions, safe list projections. |
+| Modify `src/brigade/fleet_hub.py` | Schema version and delegated session schema initialization. |
+| Modify `src/brigade/fleet_hub_http.py` | Authenticated `/sessions` routing only. |
+| Modify `src/brigade/fleet_client.py` | Typed session upsert, end, and list transport. |
+| Modify `src/brigade/cli/fleet.py` | `brigade fleet sessions` read surface. |
+| Modify `src/brigade/claude_hooks/runtime.py` | Lifecycle calls through the presence helper. |
+| Modify `src/brigade/cursor_user_cmd.py` | Managed Cursor session-start publication. |
+| Modify `src/brigade/work_cmd/session/briefing.py` | Startup publication and advisory overlap section. |
+| Modify `src/brigade/fleet_command_deck.py` | Separate interactive-session projection and rendering. |
+
+The Hub domain stays outside `fleet_hub.py` to avoid extending that module's
+already broad schema and request surface.
+
+## Acceptance tests
+
+### Hub and client
+
+- schema 13 upgrades to 14 without changing existing event, claim, cloud,
+  model, Grok Bot, or preference rows
+- a fresh schema 14 database opens from every supported request path
+- caller node identity overrides or rejects any body node identity
+- active retry preserves `started_at`; refresh replaces bounded mutable fields
+- end is fenced to the exact row and idempotent
+- expired and ended rows are absent by default and present under `all=1`
+- admin, node, revoked, unknown, and dashboard-cookie auth boundaries match the
+  contract
+- malformed, oversized, absolute, traversal, control-bearing, and secret-like
+  remote inputs are rejected without partial writes
+- client errors never include bearer values or raw response bodies
+
+### Identity and overlap
+
+- HTTPS, SSH, SCP-like, credential-bearing, and `.git` remote forms normalize
+  to the same safe repository identity
+- a missing remote produces node-scoped identity and never cross-matches nodes
+- rename, spaces, non-ASCII names, count truncation, and byte truncation are
+  parsed deterministically
+- exact overlap warns once, same-session rows are excluded, and disjoint paths
+  do not warn
+- truncated observations mark the result partial
+
+### Harnesses and UI
+
+- Claude SessionStart, relevant PostToolUse, accepted Stop, blocked Stop, Hub
+  outage, and hook timeout preserve the existing stdout envelope contract
+- Codex/T3 thread identity publishes once through work brief without printing
+  the session payload
+- Cursor's managed session-start, post-tool, and session-end hooks publish the
+  expected lifecycle, preserve start context, and consume stdin safely
+- `fleet sessions` text and JSON stay bounded and terminal-safe
+- the Command Deck escapes every field, shows sessions separately, and never
+  counts them against 10/8/4 station capacity
+- no prompt, transcript, tool input, diff, file content, remote credential,
+  bearer, or fencing token appears in SQLite, HTTP JSON, HTML, hook stdout, or
+  logs
+
+## Rollout
+
+1. Merge and run the full Brigade verification gate once.
+2. Back up the Hub database and deploy the Hub first so schema 14 and the new
+   routes are available.
+3. Deploy Rocinante, Shadowfax, and Gandalf clients without copying identities
+   or tokens.
+4. Update managed Claude and Cursor hooks through their normal merge-safe
+   installers. Update the Codex/T3 work-loop hook only through its managed user
+   configuration path.
+5. Start one bounded session per host, modify distinct scratch paths, and prove
+   no warning. Modify the same fake path on two hosts and prove one warning.
+6. End the Claude and Cursor sessions, then wait for one Codex TTL expiry.
+   Confirm all disappear from the active view while history remains under
+   `--all`.
+7. Confirm claims, model policy, cloud policy, Grok Bot projections, deck config,
+   and station capacities remain unchanged.
+
+Rollback may run the prior client against schema 14 because the migration is
+additive. The prior Hub binary must be refused after schema 14 rather than
+silently opening a newer database. Restore the pre-deploy backup only if a full
+Hub rollback is required.
+
+## Out of scope
+
+- cross-worktree file locks or automatic claim acquisition
+- automatic interruption, cancellation, rebase, merge, or branch mutation
+- diff or file-content transport
+- cloud-provider task internals already covered by the cloud tracker
+- durable fleet plans, campaigns, dependencies, and agent assignment
+- hard host-wide worker admission beyond existing model and cloud leases

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -808,7 +808,50 @@ It writes or verifies `.brigade/dogfood.toml`, creates local artifact directorie
 
 Start-of-day commands:
 
-- `brigade work brief` shows branch state, active sessions, pending tasks, import counts, latest dogfood run, and the command to continue.
+- `brigade work brief` shows branch state, active sessions, pending tasks, import counts, latest dogfood run, and the command to continue. When a Codex or T3 thread id is present it also publishes bounded interactive presence to the Fleet Hub and may print advisory `overlap:` lines. Those warnings never block work or acquire a claim. `brigade work brief --json` includes `interactive_sessions` and `overlap_warnings`:
+
+```json
+{
+  "interactive_sessions": {"published": true},
+  "overlap_warnings": [
+    {
+      "node_id": "22222222-2222-4222-8222-222222222222",
+      "harness": "cursor",
+      "session_id": "sess-other",
+      "branch": "main",
+      "checkout_path": "/tmp/other/project",
+      "age": 120,
+      "paths": ["src/a.py"],
+      "partial": false
+    }
+  ]
+}
+```
+
+- `brigade fleet sessions [--all] [--json]` lists live interactive Claude, Codex/T3, and Cursor sessions from the Fleet Hub. `--all` is ended and expired history. JSON is the Hub list, not a second schema. Sessions are advisory presence: they do not consume station capacity, do not enter the run-event spool, and never carry remotes, tokens, diffs, or file contents. TTL is 120-3600 seconds (default 900); expiry is read-time. Node credentials remain the write identity.
+
+```json
+[
+  {
+    "node_id": "11111111-1111-4111-8111-111111111111",
+    "harness": "claude",
+    "session_id": "sess-example",
+    "repo_identity": "github.com/example/project",
+    "identity_scope": "fleet",
+    "repo_label": "project",
+    "checkout_path": "/tmp/example/project",
+    "branch": "topic",
+    "dirty_paths": ["src/a.py"],
+    "dirty_truncated": false,
+    "state": "active",
+    "started_at": "2026-08-29T12:00:00+00:00",
+    "heartbeat_at": "2026-08-29T12:01:00+00:00",
+    "ended_at": null,
+    "ttl_seconds": 900,
+    "expires_at": 1787997660.0
+  }
+]
+```
 - `brigade work status` is the quick dashboard for branch state, dogfood readiness, paths, latest run, and extracted next step.
 - `brigade work doctor` checks dogfood config, security config, evidence bundles, Codex CLI, artifact paths, handoff inbox, task acceptance, issue-backed tasks, stale active sessions, ignore coverage, and latest run context.
 - `brigade work hooks install|update|status|uninstall` manages the project-scoped Claude Code work-loop package while preserving foreign settings and hooks. Pass `--scope user` to install the same package into the Claude user home (`$CLAUDE_CONFIG_DIR` or `~/.claude`): a packaged hook script under `hooks/` and managed entries in `settings.json`, with ownership tracked in `brigade/claude-hooks.json`. User-scope `--target <wired-workspace>` pins `hook-run`; omit it for multi-repo mode. Project-scope install refuses the home directory (that path is Claude Code's user settings). The runtime entrypoint is `brigade work hook-run [--target]`; it is called by Claude Code rather than by operators. After two consecutive timeouts against one session target the handler latches off for the rest of the session. The work-loop snapshot fingerprint skips normally-gitignored directories such as model caches, virtualenvs (`.venv`), `__pycache__`, `node_modules`, and generated databases.

--- a/src/brigade/claude_hooks/presence.py
+++ b/src/brigade/claude_hooks/presence.py
@@ -1,0 +1,15 @@
+"""Claude hook adapter for Fleet interactive session presence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def emit_presence(event: str, target: Path, session_id: str) -> None:
+    """Publish session presence without changing the hook envelope."""
+    try:
+        from ..fleet_session_presence import _publish_presence
+
+        _publish_presence(event, target, session_id)
+    except Exception:
+        return

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -20,7 +20,7 @@ from .. import localio
 from ..component_paths import cache_root
 from ..work_cmd.verification import _tree_fingerprint
 from ..wiring import resolve_wired_target
-from . import compaction_marker, envelope
+from . import compaction_marker, envelope, presence
 from .package import PACKAGE_REF
 from .paths import is_operator_home, resolved_path
 from .session_state import (
@@ -2378,6 +2378,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
     if event != "Stop":
         _touch_session_targets(session_id, target, payload, task_epoch=task_epoch)
     if event == "SessionStart":
+        presence.emit_presence("SessionStart", target, session_id)
         # True starts and Claude's inject-capable compact source both clear any
         # leftover marker so UserPromptSubmit does not double-inject.
         try:
@@ -2518,6 +2519,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
             state.pop("pending_bash_started_at", None)
             state.pop("pending_write_at", None)
             _write_session_state_preserving_latch(target, session_id, state, log_target=target)
+            presence.emit_presence("PostToolUse", target, session_id)
         elif state.get("pending_bash_fingerprint") is not None:
             state.pop("pending_bash_fingerprint", None)
             state.pop("pending_bash_started_at", None)
@@ -2611,6 +2613,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
                     "If this work produced durable knowledge, write a Memory Handoff in "
                     "`.claude/memory-handoffs/` before finishing."
                 )
+            presence.emit_presence("Stop", target, session_id)
             return _additional_context(
                 "Stop",
                 "",
@@ -2619,6 +2622,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
                 records=records,
             )
         if handoff_target is not None:
+            presence.emit_presence("Stop", target, session_id)
             return _additional_context(
                 "Stop",
                 "",
@@ -2629,6 +2633,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
                     "`.claude/memory-handoffs/` before finishing.",
                 ],
             )
+        presence.emit_presence("Stop", target, session_id)
     return None
 
 

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import sys
 from datetime import datetime, timezone
@@ -21,6 +22,46 @@ def _safe_table_cell(value: object) -> str:
     return "".join(ch if ch.isprintable() else ascii(ch)[1:-1] for ch in text)
 
 
+def _format_duration(seconds: int) -> str:
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _format_remaining(expires_at: object, *, now: datetime | None = None) -> str:
+    """Bounded remaining TTL from a Hub epoch or ISO timestamp."""
+    current = now or datetime.now(timezone.utc)
+    epoch: float | None = None
+    if isinstance(expires_at, bool):
+        return "-"
+    if isinstance(expires_at, (int, float)):
+        epoch = float(expires_at)
+    elif isinstance(expires_at, str) and expires_at:
+        try:
+            stamp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        except ValueError:
+            try:
+                epoch = float(expires_at)
+            except ValueError:
+                return "-"
+        else:
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=timezone.utc)
+            epoch = stamp.timestamp()
+    if epoch is None:
+        return "-"
+    if not math.isfinite(epoch):
+        return "-"
+    remaining = int(epoch - current.timestamp())
+    if remaining <= 0:
+        return "expired"
+    return _format_duration(remaining)
+
+
 def _format_age(ts: object, *, now: datetime | None = None) -> str:
     """Human-readable age of an ISO-8601 timestamp ("42s", "3m", "2h", "5d")."""
     if not isinstance(ts, str) or not ts:
@@ -33,13 +74,7 @@ def _format_age(ts: object, *, now: datetime | None = None) -> str:
         then = then.replace(tzinfo=timezone.utc)
     current = now or datetime.now(timezone.utc)
     seconds = max(0, int((current - then).total_seconds()))
-    if seconds < 60:
-        return f"{seconds}s"
-    if seconds < 3600:
-        return f"{seconds // 60}m"
-    if seconds < 86400:
-        return f"{seconds // 3600}h"
-    return f"{seconds // 86400}d"
+    return _format_duration(seconds)
 
 
 def register(sub: argparse._SubParsersAction) -> None:
@@ -115,6 +150,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_status.add_argument("--all", action="store_true", help="Include terminal runs.")
     p_status.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
     p_status.set_defaults(func=_dispatch_status)
+
+    p_sessions = fleet_sub.add_parser("sessions", help="Show interactive sessions from the fleet hub.")
+    p_sessions.add_argument("--all", action="store_true", help="Include ended and expired sessions.")
+    p_sessions.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
+    p_sessions.set_defaults(func=_dispatch_sessions)
 
     p_flush = fleet_sub.add_parser("flush", help="Re-POST locally spooled events to the fleet hub.")
     p_flush.set_defaults(func=_dispatch_flush)
@@ -370,6 +410,49 @@ def _dispatch_sink(args: argparse.Namespace) -> int:
     from .. import fleet_export
 
     return fleet_export.dispatch_sink(args)
+
+
+def _dispatch_sessions(args: argparse.Namespace) -> int:
+    import json as _json
+
+    from .. import fleet_client
+
+    try:
+        sessions = fleet_client.fetch_sessions(include_all=args.all)
+    except fleet_client.FleetClientError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(_json.dumps(sessions, indent=2, sort_keys=True))
+        return 0
+    headers = ("NODE", "HARNESS", "SESSION", "REPO", "BRANCH", "DIRTY", "AGE", "EXPIRES")
+    rows = []
+    for session in sessions:
+        dirty = session.get("dirty_paths")
+        dirty_count = len(dirty) if isinstance(dirty, list) else 0
+        dirty_cell = f"{dirty_count}+" if session.get("dirty_truncated") else str(dirty_count)
+        rows.append(
+            [
+                _safe_table_cell(str(session.get("node_id") or "-")),
+                _safe_table_cell(str(session.get("harness") or "-")),
+                _safe_table_cell(str(session.get("session_id") or "-")),
+                _safe_table_cell(str(session.get("repo_identity") or "-")),
+                _safe_table_cell(str(session.get("branch") or "-")),
+                _safe_table_cell(dirty_cell),
+                _safe_table_cell(_format_age(session.get("heartbeat_at"))),
+                _safe_table_cell(_format_remaining(session.get("expires_at"))),
+            ]
+        )
+    widths = [
+        max(len(header), *(len(row[index]) for row in rows)) if rows else len(header)
+        for index, header in enumerate(headers)
+    ]
+    print("  ".join(header.ljust(width) for header, width in zip(headers, widths, strict=True)))
+    for row in rows:
+        print("  ".join(cell.ljust(width) for cell, width in zip(row, widths, strict=True)))
+    if not rows:
+        print("(no active fleet sessions)")
+    return 0
 
 
 def _dispatch_status(args: argparse.Namespace) -> int:

--- a/src/brigade/cli/work/dispatching.py
+++ b/src/brigade/cli/work/dispatching.py
@@ -79,6 +79,17 @@ def _dispatch_impl(args) -> int:
         if args.target is None:
             return hook_run(event=args.event, package=args.package)
         return hook_run(event=args.event, package=args.package, target=args.target)
+    if args.work_command == "presence-hook":
+        from ...fleet_session_presence import run_presence_hook
+
+        return run_presence_hook(
+            target=args.target,
+            harness=args.harness,
+            session=args.session,
+            event=args.event,
+            stdin=args.stdin,
+            context=args.context,
+        )
     if args.work_command == "sweep":
         if args.sweep_args:
             if args.sweep_args[0] != "closeout":

--- a/src/brigade/cli/work/registration.py
+++ b/src/brigade/cli/work/registration.py
@@ -111,6 +111,13 @@ def register(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Pin hook work to this wired workspace. Sessions outside it no-op.",
     )
+    p_work_presence_hook = work_sub.add_parser("presence-hook", help=argparse.SUPPRESS)
+    p_work_presence_hook.add_argument("--target", "-t", type=Path, default=None)
+    p_work_presence_hook.add_argument("--harness", required=True)
+    p_work_presence_hook.add_argument("--session", default=None)
+    p_work_presence_hook.add_argument("--event", choices=("start", "heartbeat", "end"), default=None)
+    p_work_presence_hook.add_argument("--stdin", action="store_true")
+    p_work_presence_hook.add_argument("--context", default=None)
     p_work_sweep = work_sub.add_parser("sweep", help="Run an explicit daily scanner sweep.")
     p_work_sweep.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
     p_work_sweep.add_argument("--scanner", default=None, help="Run one scanner id instead of due scanners.")

--- a/src/brigade/cursor_user_cmd.py
+++ b/src/brigade/cursor_user_cmd.py
@@ -11,6 +11,8 @@ from . import __version__, component_bins, harness_profiles, localio
 
 STATE_VERSION = 1
 MANAGED_MCP_NAMES = ("brigade", "graphtrail", "miseledger")
+_MANAGED_HOOK_EVENTS = ("sessionStart", "postToolUse", "sessionEnd")
+_MANAGED_HOOK_COMMAND = "exec brigade work presence-hook --harness cursor --stdin --context cursor-work-loop"
 
 
 def _home_dir() -> Path:
@@ -88,21 +90,7 @@ In a Brigade-wired repository, invoke the global `brigade-work` skill before sub
 
 
 def _hook_text() -> str:
-    context = (
-        "BRIGADE WORK LOOP: In a Brigade-wired repository, invoke the global brigade-work skill before substantive "
-        "work. Start with brigade work brief --target .. Run checks that should count through brigade work verify "
-        "run with --capture brigade-work. Capture failures, export new receipts to MiseLedger when installed, and "
-        "finish durable work with a Memory Handoff."
-    )
-    return (
-        "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' "
-        + _shell_single_quote(_json_text({"additional_context": context}).strip())
-        + "\n"
-    )
-
-
-def _shell_single_quote(value: str) -> str:
-    return "'" + value.replace("'", "'\"'\"'") + "'"
+    return "#!/bin/sh\n" + _MANAGED_HOOK_COMMAND + "\n"
 
 
 def _desired_files(root: Path) -> dict[Path, tuple[str, bool, str]]:
@@ -208,41 +196,69 @@ def _read_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     return payload, None
 
 
-def _hook_entry(root: Path) -> dict[str, str]:
-    return {"command": str(root / "hooks" / "brigade-session-start")}
+def _hook_entry(root: Path | None = None) -> dict[str, str]:
+    # hooks.json keeps this direct command. ~/.cursor/hooks/brigade-session-start
+    # is a compatibility executable only; do not redirect the command at that file.
+    del root
+    return {"command": _MANAGED_HOOK_COMMAND}
 
 
-def _plan_hook(root: Path, state: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None, str | None]:
+def _plan_hook_event(hooks: dict[str, Any], state: dict[str, Any], event: str, path: Path) -> dict[str, Any]:
+    item: dict[str, Any] = {"surface": "hook-config", "path": str(path), "name": event}
+    entries = hooks.get(event)
+    if entries is None:
+        entries = []
+    if not isinstance(entries, list):
+        item.update(status="conflict", action="skip", detail=f"existing {event} hooks must be a list")
+        return item
+    desired = _hook_entry()
+    desired_fp = _digest_value(desired)
+    if desired in entries:
+        item.update(status="current", action="none", desired_fingerprint=desired_fp)
+        return item
+    prior = state["hooks"].get(event)
+    prior_index = next((index for index, entry in enumerate(entries) if _digest_value(entry) == prior), None)
+    if prior_index is None:
+        item.update(status="missing", action="create", desired_fingerprint=desired_fp)
+    else:
+        item.update(status="changed", action="update", desired_fingerprint=desired_fp, prior_index=prior_index)
+    return item
+
+
+def _plan_hook(root: Path, state: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any] | None, str | None]:
     path = root / "hooks.json"
     doc, error = _read_json_object(path)
-    item: dict[str, Any] = {"surface": "hook-config", "path": str(path), "name": "sessionStart"}
     if doc is None:
-        item.update(status="conflict", action="skip", detail=error or "could not read hooks configuration")
-        return item, None, error
+        items = [
+            {
+                "surface": "hook-config",
+                "path": str(path),
+                "name": event,
+                "status": "conflict",
+                "action": "skip",
+                "detail": error or "could not read hooks configuration",
+            }
+            for event in _MANAGED_HOOK_EVENTS
+        ]
+        return items, None, error
     hooks = doc.get("hooks")
     if hooks is None:
         hooks = {}
     if not isinstance(hooks, dict):
-        item.update(status="conflict", action="skip", detail="existing hooks field must be an object")
-        return item, None, str(item["detail"])
-    entries = hooks.get("sessionStart")
-    if entries is None:
-        entries = []
-    if not isinstance(entries, list):
-        item.update(status="conflict", action="skip", detail="existing sessionStart hooks must be a list")
-        return item, None, str(item["detail"])
-    desired = _hook_entry(root)
-    desired_fp = _digest_value(desired)
-    if desired in entries:
-        item.update(status="current", action="none", desired_fingerprint=desired_fp)
-    else:
-        prior = state["hooks"].get("sessionStart")
-        prior_index = next((index for index, entry in enumerate(entries) if _digest_value(entry) == prior), None)
-        if prior_index is None:
-            item.update(status="missing", action="create", desired_fingerprint=desired_fp)
-        else:
-            item.update(status="changed", action="update", desired_fingerprint=desired_fp, prior_index=prior_index)
-    return item, doc, None
+        detail = "existing hooks field must be an object"
+        items = [
+            {
+                "surface": "hook-config",
+                "path": str(path),
+                "name": event,
+                "status": "conflict",
+                "action": "skip",
+                "detail": detail,
+            }
+            for event in _MANAGED_HOOK_EVENTS
+        ]
+        return items, None, detail
+    return [_plan_hook_event(hooks, state, event, path) for event in _MANAGED_HOOK_EVENTS], doc, None
 
 
 def _plan_mcp(root: Path, state: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any] | None, str | None]:
@@ -316,9 +332,9 @@ def install(*, write: bool = False, json_output: bool = False) -> int:
         _file_item(root, path, text, executable, surface, state)
         for path, (text, executable, surface) in desired_files.items()
     ]
-    hook_item, hooks_doc, _ = _plan_hook(root, state)
+    hook_items, hooks_doc, _ = _plan_hook(root, state)
     mcp_items, mcp_doc, _ = _plan_mcp(root, state)
-    items.extend([hook_item, *mcp_items])
+    items.extend([*hook_items, *mcp_items])
     state_error = state.get("_read_error")
     if state_error:
         items.append(
@@ -355,21 +371,28 @@ def install(*, write: bool = False, json_output: bool = False) -> int:
             elif _relative(root, path) in state["files"]:
                 next_state["files"][_relative(root, path)] = state["files"][_relative(root, path)]
 
-        if hooks_doc is not None and hook_item["status"] != "conflict":
+        hook_changed = False
+        if hooks_doc is not None and all(item["status"] != "conflict" for item in hook_items):
             hooks = hooks_doc.setdefault("hooks", {})
-            entries = hooks.setdefault("sessionStart", [])
-            desired_hook = _hook_entry(root)
-            if hook_item["action"] == "create":
-                entries.append(desired_hook)
-            elif hook_item["action"] == "update":
-                entries[hook_item["prior_index"]] = desired_hook
-            if hook_item["action"] != "none":
+            desired_hook = _hook_entry()
+            for hook_item in hook_items:
+                event = str(hook_item["name"])
+                entries = hooks.setdefault(event, [])
+                if hook_item["action"] == "create":
+                    entries.append(desired_hook)
+                    hook_changed = True
+                elif hook_item["action"] == "update":
+                    entries[hook_item["prior_index"]] = desired_hook
+                    hook_changed = True
+                next_state["hooks"][event] = hook_item["desired_fingerprint"]
+            if hook_changed:
                 path = root / "hooks.json"
                 localio.write_text_atomic(path, _coowned_json_text(hooks_doc))
                 files_written.append(str(path))
-            next_state["hooks"]["sessionStart"] = hook_item["desired_fingerprint"]
-        elif "sessionStart" in state["hooks"]:
-            next_state["hooks"]["sessionStart"] = state["hooks"]["sessionStart"]
+        else:
+            for event in _MANAGED_HOOK_EVENTS:
+                if event in state["hooks"]:
+                    next_state["hooks"][event] = state["hooks"][event]
 
         if mcp_doc is not None:
             servers = mcp_doc.setdefault("mcpServers", {})
@@ -475,14 +498,17 @@ def uninstall(*, write: bool = False, json_output: bool = False) -> int:
         items.append(item)
 
     hook_path = root / "hooks.json"
-    hook_fp = state["hooks"].get("sessionStart")
     hook_removed = False
-    if hook_fp:
-        doc, error = _read_json_object(hook_path)
-        hook_item: dict[str, Any] = {"surface": "hook-config", "path": str(hook_path), "name": "sessionStart"}
+    hook_doc, hook_error = _read_json_object(hook_path)
+    hook_changed = False
+    for event in _MANAGED_HOOK_EVENTS:
+        hook_fp = state["hooks"].get(event)
+        if not hook_fp:
+            continue
+        hook_item: dict[str, Any] = {"surface": "hook-config", "path": str(hook_path), "name": event}
         entries = None
-        if doc is not None and isinstance(doc.get("hooks"), dict):
-            entries = doc["hooks"].get("sessionStart", [])
+        if hook_doc is not None and isinstance(hook_doc.get("hooks"), dict):
+            entries = hook_doc["hooks"].get(event, [])
         index = (
             next((i for i, entry in enumerate(entries) if _digest_value(entry) == hook_fp), None)
             if isinstance(entries, list)
@@ -491,18 +517,24 @@ def uninstall(*, write: bool = False, json_output: bool = False) -> int:
         if index is not None:
             hook_item.update(status="managed", action="remove")
             if write:
-                assert doc is not None and isinstance(entries, list)
+                assert hook_doc is not None and isinstance(entries, list)
                 entries.pop(index)
                 if not entries:
-                    doc["hooks"].pop("sessionStart", None)
-                localio.write_text_atomic(hook_path, _coowned_json_text(doc))
+                    hook_doc["hooks"].pop(event, None)
+                hook_changed = True
                 hook_removed = True
         elif not hook_path.exists():
             hook_item.update(status="absent", action="none")
         else:
-            hook_item.update(status="conflict", action="preserve", detail=error or "managed hook was edited or removed")
+            hook_item.update(
+                status="conflict",
+                action="preserve",
+                detail=hook_error or "managed hook was edited or removed",
+            )
             conflicts.append(hook_item)
         items.append(hook_item)
+    if write and hook_changed and hook_doc is not None:
+        localio.write_text_atomic(hook_path, _coowned_json_text(hook_doc))
 
     mcp_path = root / "mcp.json"
     mcp_doc, mcp_error = _read_json_object(mcp_path)
@@ -556,9 +588,14 @@ def doctor(*, json_output: bool = False) -> int:
     skill_dir = root / "skills" / "brigade-work"
     hook_script = root / "hooks" / "brigade-session-start"
     hooks_doc, _ = _read_json_object(root / "hooks.json")
-    hook_entries: object = None
+    hook_ok = _file_matches(hook_script, desired[hook_script][0]) and bool(hook_script.stat().st_mode & 0o111)
+    desired_hook = _hook_entry()
     if hooks_doc is not None and isinstance(hooks_doc.get("hooks"), dict):
-        hook_entries = hooks_doc["hooks"].get("sessionStart")
+        for event in _MANAGED_HOOK_EVENTS:
+            entries = hooks_doc["hooks"].get(event)
+            hook_ok = hook_ok and isinstance(entries, list) and desired_hook in entries
+    else:
+        hook_ok = False
     mcp_doc, _ = _read_json_object(root / "mcp.json")
     live_servers = mcp_doc.get("mcpServers") if mcp_doc is not None else None
     checks = [
@@ -579,10 +616,7 @@ def doctor(*, json_output: bool = False) -> int:
         ),
         _check(
             "session-hook",
-            _file_matches(hook_script, desired[hook_script][0])
-            and bool(hook_script.stat().st_mode & 0o111)
-            and isinstance(hook_entries, list)
-            and _hook_entry(root) in hook_entries,
+            hook_ok,
             str(root / "hooks.json"),
         ),
     ]

--- a/src/brigade/fleet_client.py
+++ b/src/brigade/fleet_client.py
@@ -98,8 +98,11 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    from .fleet_session_presence import SessionSnapshot
 
 from . import toml_compat as tomllib
 
@@ -127,6 +130,8 @@ CLAIM_TIMEOUT_SECONDS = 2.5
 # reason to start provider work locally.
 CLOUD_TIMEOUT_SECONDS = 2.5
 MAX_CLOUD_RESPONSE_BYTES = 64 * 1024
+MAX_ACTIVE_SESSIONS_RESPONSE_BYTES = 20 * 1024 * 1024
+MAX_SESSION_HISTORY_RESPONSE_BYTES = 40 * 1024 * 1024
 # 4xx statuses that are transient or operator-fixable: keep the spool. 403
 # is a credential mismatch (a node token that is not this node's, or the
 # admin token on a hub without --allow-admin-writes), fixed by config.
@@ -179,6 +184,14 @@ _SHARED_TOKEN_WARNING = (
     "Enroll this machine with 'brigade fleet nodes add <node_id>' and set [fleet] node_token_file "
     "in ~/.brigade/fleet.toml"
 )
+
+
+@dataclass(frozen=True)
+class SessionWriteResult:
+    """Bounded publication outcome. ``reason`` never includes secrets or bodies."""
+
+    ok: bool
+    reason: str | None = None
 
 
 class FleetClientError(RuntimeError):
@@ -925,6 +938,14 @@ def report_journal_event(envelope: dict[str, Any], *, journal_path: Path | None 
         raw_payload = envelope.get("payload")
         payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
         workspace = find_workspace_for_path(journal_path) if journal_path is not None else None
+        repo_identity = None
+        if workspace is not None:
+            try:
+                from .fleet_session_presence import repository_identity
+
+                repo_identity = repository_identity(workspace).value
+            except Exception:
+                repo_identity = None
         event = {
             "run_id": envelope.get("run_id"),
             "repo": workspace.name if workspace is not None else None,
@@ -934,6 +955,7 @@ def report_journal_event(envelope: dict[str, Any], *, journal_path: Path | None 
             "ts": envelope.get("recorded_at"),
             "sequence": envelope.get("sequence"),
             "digest": envelope.get("event_digest"),
+            "repo_identity": repo_identity,
         }
         if not all(event[k] is not None for k in ("run_id", "state", "ts", "sequence", "digest")):
             return False
@@ -1359,6 +1381,130 @@ def inspect_claim(target: str, **kwargs: Any) -> ClaimDecision:
     dead (issue #1141). Never raises; ``reason`` explains a failure."""
     kwargs.pop("ttl_seconds", None)
     return _claim_op("inspect", target, holder=None, **kwargs)
+
+
+def _session_admin_write_node_id() -> tuple[str | None, str | None]:
+    """Return a body node ID and failure reason for shared-admin writes."""
+    settings = load_fleet_settings()
+    if settings["node_token"] or not settings["admin_token"]:
+        return None, None
+    resolved = resolve_node_id()
+    if not _node_id_is_claimable(resolved):
+        return None, "unknown_node_identity"
+    return resolved, None
+
+
+def _session_request_body(snapshot: SessionSnapshot, *, action: str, node_id: str | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "action": action,
+        "harness": snapshot.harness,
+        "session_id": snapshot.session_id,
+        "repo_identity": snapshot.repo_identity,
+    }
+    if node_id is not None:
+        body["node_id"] = node_id
+    if action == "end":
+        return body
+    body.update(
+        {
+            "identity_scope": snapshot.identity_scope,
+            "repo_label": snapshot.repo_label,
+            "checkout_path": snapshot.checkout_path,
+            "branch": snapshot.branch,
+            "dirty_paths": list(snapshot.dirty_paths),
+            "dirty_truncated": snapshot.dirty_truncated,
+            "ttl_seconds": snapshot.ttl_seconds,
+        }
+    )
+    return body
+
+
+def _classify_session_write_error(exc: BaseException) -> str:
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, urllib.error.HTTPError):
+        return f"http_status:{exc.code}"
+    if isinstance(exc, urllib.error.URLError):
+        return "connection_error"
+    name = type(exc).__name__
+    if name == "timeout" or "Timeout" in name:
+        return "timeout"
+    return name[:80]
+
+
+def _post_session(snapshot: SessionSnapshot, *, action: str, hub_url: str | None) -> SessionWriteResult:
+    """POST /sessions. Never spools; ordinary failures return a bounded reason."""
+    try:
+        config = load_fleet_config()
+        hub = hub_url or config["hub_url"]
+        if not hub:
+            return SessionWriteResult(ok=False, reason="hub_unconfigured")
+        node_id, identity_reason = _session_admin_write_node_id()
+        if identity_reason is not None:
+            return SessionWriteResult(ok=False, reason=identity_reason)
+        request = urllib.request.Request(
+            hub.rstrip("/") + "/sessions",
+            data=json.dumps(_session_request_body(snapshot, action=action, node_id=node_id)).encode("utf-8"),
+            headers={"Content-Type": "application/json", "Authorization": f"Bearer {config['token']}"},
+            method="POST",
+        )
+        with _hub_open(request, timeout=REPORT_TIMEOUT_SECONDS) as response:
+            if response.status == 200:
+                return SessionWriteResult(ok=True)
+            return SessionWriteResult(ok=False, reason=f"http_status:{response.status}")
+    except Exception as exc:
+        return SessionWriteResult(ok=False, reason=_classify_session_write_error(exc))
+
+
+def publish_session(snapshot: SessionSnapshot, *, hub_url: str | None = None) -> SessionWriteResult:
+    """Refresh one interactive session and return a bounded non-secret status."""
+    return _post_session(snapshot, action="upsert", hub_url=hub_url)
+
+
+def upsert_session(snapshot: SessionSnapshot, *, hub_url: str | None = None) -> bool:
+    """Refresh one interactive session. Returns False on any ordinary failure."""
+    return publish_session(snapshot, hub_url=hub_url).ok
+
+
+def end_session(snapshot: SessionSnapshot, *, hub_url: str | None = None) -> bool:
+    """End one interactive session. Returns False on any ordinary failure."""
+    return _post_session(snapshot, action="end", hub_url=hub_url).ok
+
+
+def _read_bounded_response(response: object, *, limit: int) -> bytes:
+    reader = getattr(response, "read", None)
+    if reader is None:
+        raise FleetClientError("fleet hub sessions response could not be read")
+    try:
+        data = reader(limit + 1)
+    except TypeError as exc:
+        raise FleetClientError("fleet hub sessions response does not support bounded reads") from exc
+    if not isinstance(data, (bytes, bytearray)):
+        raise FleetClientError("fleet hub sessions response was not bytes")
+    if len(data) > limit:
+        raise FleetClientError("fleet hub sessions response exceeded the size limit")
+    return bytes(data)
+
+
+def fetch_sessions(*, hub_url: str | None = None, include_all: bool = False) -> list[dict[str, Any]]:
+    """GET /sessions from the hub; raises FleetClientError when unreachable."""
+    config = load_fleet_config()
+    hub = hub_url or config["hub_url"]
+    if not hub:
+        raise FleetClientError("no fleet hub configured (~/.brigade/fleet.toml [fleet] hub_url)")
+    url = hub.rstrip("/") + ("/sessions?all=1" if include_all else "/sessions")
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {config['token']}"})
+    try:
+        with _hub_open(request, timeout=REPORT_TIMEOUT_SECONDS) as response:
+            limit = MAX_SESSION_HISTORY_RESPONSE_BYTES if include_all else MAX_ACTIVE_SESSIONS_RESPONSE_BYTES
+            raw = _read_bounded_response(response, limit=limit)
+            payload = json.loads(raw.decode("utf-8"))
+    except FleetClientError:
+        raise
+    except Exception as exc:
+        raise FleetClientError(f"fleet hub sessions failed: {type(exc).__name__}") from exc
+    sessions = payload.get("sessions") if isinstance(payload, dict) else None
+    return list(sessions) if isinstance(sessions, list) else []
 
 
 def fetch_claims(*, hub_url: str | None = None, include_all: bool = False) -> list[dict[str, Any]]:

--- a/src/brigade/fleet_command_deck.py
+++ b/src/brigade/fleet_command_deck.py
@@ -37,9 +37,10 @@ FAILURE_STATE_SUFFIXES = (
     ".timed_out",
     ".timeout",
 )
-ACTIVE_LIMIT, OBSERVER_LIMIT, RAIL_FAILURE_LIMIT = 200, 8, 10
+ACTIVE_LIMIT, OBSERVER_LIMIT, RAIL_FAILURE_LIMIT, SESSION_LIMIT = 200, 8, 10, 500
 CLOUD_PROVIDER_LIMIT, CLOUD_LEASE_LIMIT = 8, 16
 CLOUD_TEXT_LIMIT = 256
+SESSION_REPO_IDENTITY_LIMIT, SESSION_CHECKOUT_PATH_LIMIT = 512, 1024
 BUCKET_RANK = {"failed": 0, "awaiting approval": 1, "stale": 2, "running": 3, "queued": 4}
 INTERNAL_OUTCOME_STATES = frozenset({"run.dispatch.completed", "run.synthesis.completed"})
 
@@ -111,6 +112,7 @@ class LiveRun:
     bucket: str
     age_seconds: int | None
     elapsed_seconds: int | None
+    repo_identity: str = ""
 
 
 @dataclass(frozen=True)
@@ -153,6 +155,24 @@ class RepoRow:
     claim: Claim | None
     live: tuple[LiveRun, ...]
     collision: bool
+    interactive_overlap: bool = False
+    repo_identity: str = ""
+
+
+@dataclass(frozen=True)
+class InteractiveSession:
+    """One live interactive session. Separate from runs and station capacity."""
+
+    node_id: str
+    harness: str
+    session_id: str
+    repo_identity: str
+    identity_scope: str
+    repo_label: str
+    checkout_path: str
+    branch: str | None
+    dirty_paths: tuple[str, ...]
+    dirty_truncated: bool
 
 
 @dataclass(frozen=True)
@@ -185,6 +205,7 @@ class DeckView:
     outcomes: tuple[LiveRun, ...]
     observers: tuple[tuple[str, str], ...]
     cloud_workers: tuple[CloudWorker, ...] = ()
+    interactive_sessions: tuple[InteractiveSession, ...] = ()
 
 
 def resolve_config_path(flag_value: str | Path | None, environ: Mapping[str, str]) -> Path | None:
@@ -299,7 +320,7 @@ def collides(target: str, live_runs: Sequence[LiveRun], claims: Mapping[str, Cla
 
 
 _LATEST_ROWS = (
-    "SELECT node_id, run_id, repo, seat, harness, state, ts, received_at FROM ("
+    "SELECT node_id, run_id, repo, seat, harness, state, ts, received_at, repo_identity FROM ("
     "  SELECT e.*, ROW_NUMBER() OVER ("
     "    PARTITION BY node_id, run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
     "  ) AS rn FROM events e"
@@ -337,7 +358,7 @@ def fetch_live_runs(conn: sqlite3.Connection, *, now: datetime, stale_after_seco
     rows = conn.execute(query, (*TERMINAL_STATES, cutoff, *AWAITING_STATES)).fetchall()
     started = fetch_started_at(conn, [(row[0], row[1]) for row in rows])
     runs: list[LiveRun] = []
-    for node_id, run_id, repo, seat, harness, state, _ts, received_at in rows:
+    for node_id, run_id, repo, seat, harness, state, _ts, received_at, repo_identity in rows:
         age = _age_seconds(received_at, now)
         runs.append(
             LiveRun(
@@ -350,6 +371,7 @@ def fetch_live_runs(conn: sqlite3.Connection, *, now: datetime, stale_after_seco
                 bucket=bucket_for(state, age_seconds=age, stale_after_seconds=stale_after_seconds),
                 age_seconds=age,
                 elapsed_seconds=_elapsed_seconds(started.get((node_id, run_id)), now),
+                repo_identity=repo_identity or "",
             )
         )
     return runs
@@ -455,8 +477,8 @@ def cloud_workers_from_snapshot(snapshot: Mapping[str, object]) -> tuple[CloudWo
     return tuple(sorted(workers, key=lambda worker: worker.provider)[:CLOUD_PROVIDER_LIMIT])
 
 
-def _safe_display_text(value: object) -> str:
-    return _strip_controls(value)[:CLOUD_TEXT_LIMIT] if isinstance(value, str) else ""
+def _safe_display_text(value: object, *, limit: int = CLOUD_TEXT_LIMIT) -> str:
+    return _strip_controls(value)[:limit] if isinstance(value, str) else ""
 
 
 def fetch_last_heard(conn: sqlite3.Connection, node_ids: Sequence[str]) -> dict[str, str]:
@@ -469,6 +491,13 @@ def fetch_last_heard(conn: sqlite3.Connection, node_ids: Sequence[str]) -> dict[
         ids,
     ).fetchall()
     return {row[0]: row[1] for row in rows}
+
+
+def fetch_interactive_sessions(conn: sqlite3.Connection, *, now: datetime) -> list[dict[str, object]]:
+    """Active unexpired sessions via the Hub session authority. Capped separately."""
+    from . import fleet_hub_sessions
+
+    return fleet_hub_sessions.list_sessions(conn, now_epoch=now.timestamp())[:SESSION_LIMIT]
 
 
 def fetch_observers(conn: sqlite3.Connection, configured: frozenset[str]) -> list[tuple[str, str]]:
@@ -493,6 +522,7 @@ def _live_run_from_row(row: tuple, *, bucket: str | None = None) -> LiveRun:
         bucket=row[5] if bucket is None else bucket,
         age_seconds=None,
         elapsed_seconds=None,
+        repo_identity=(row[8] or "") if len(row) > 8 else "",
     )
 
 
@@ -527,6 +557,134 @@ def _display_claim(claim: Claim | None, enrolled_labels: Mapping[str, str]) -> C
     )
 
 
+def _interactive_session(raw: Mapping[str, object]) -> InteractiveSession:
+    dirty = raw.get("dirty_paths")
+    paths = tuple(item for item in dirty if isinstance(item, str)) if isinstance(dirty, (list, tuple)) else ()
+    branch = raw.get("branch")
+    return InteractiveSession(
+        node_id=_safe_display_text(raw.get("node_id")),
+        harness=_safe_display_text(raw.get("harness")),
+        session_id=_safe_display_text(raw.get("session_id")),
+        repo_identity=_safe_display_text(raw.get("repo_identity"), limit=SESSION_REPO_IDENTITY_LIMIT),
+        identity_scope=_safe_display_text(raw.get("identity_scope")) or "fleet",
+        repo_label=_safe_display_text(raw.get("repo_label")),
+        checkout_path=_safe_display_text(raw.get("checkout_path"), limit=SESSION_CHECKOUT_PATH_LIMIT),
+        branch=_safe_display_text(branch) if isinstance(branch, str) else None,
+        dirty_paths=paths,
+        dirty_truncated=bool(raw.get("dirty_truncated")),
+    )
+
+
+def _session_dirty_paths(raw: Mapping[str, object]) -> set[str]:
+    from .fleet_session_presence import _normalize_overlap_path, _row_dirty_paths
+
+    paths = {_normalize_overlap_path(path) for path in _row_dirty_paths(raw.get("dirty_paths"))}
+    paths.discard("")
+    return paths
+
+
+def _session_row_label(session: InteractiveSession) -> str:
+    label = session.repo_label.strip() if session.repo_label else ""
+    if label:
+        return label[:256]
+    identity = session.repo_identity
+    if "/" in identity:
+        identity = identity.rsplit("/", 1)[-1]
+    return (identity or "session")[:256]
+
+
+def _session_identity_display_targets(
+    active_runs: Sequence[LiveRun],
+    claims_by_target: Mapping[str, Claim],
+    session_rows: Sequence[InteractiveSession],
+) -> dict[str, set[str]]:
+    """Map canonical repo identity to existing run/claim display targets or a label."""
+    mapped: dict[str, set[str]] = {}
+    occupied = {run.repo for run in active_runs if run.repo} | set(claims_by_target)
+    for run in active_runs:
+        if run.repo_identity and run.repo:
+            mapped.setdefault(run.repo_identity, set()).add(run.repo)
+    for session in session_rows:
+        if not session.repo_identity:
+            continue
+        targets = mapped.setdefault(session.repo_identity, set())
+        if targets:
+            continue
+        if session.repo_identity in claims_by_target:
+            targets.add(session.repo_identity)
+            continue
+        label = _session_row_label(session)
+        if label in occupied:
+            label = _identity_bearing_session_label(session, occupied)
+        occupied.add(label)
+        targets.add(label)
+    return mapped
+
+
+def _identity_bearing_session_label(session: InteractiveSession, occupied: set[str]) -> str:
+    """Render a session-only repo row that cannot collide with a run/claim label."""
+    identity = session.repo_identity.strip()
+    label = _session_row_label(session)
+    candidate = f"{label} ({identity})" if identity and identity != label else identity or label
+    candidate = candidate[:256]
+    if candidate not in occupied:
+        return candidate
+    bounded_identity = identity[:256]
+    if bounded_identity and bounded_identity not in occupied:
+        return bounded_identity
+    suffix = 2
+    while True:
+        suffix_text = f" #{suffix}"
+        extra = f"{candidate[: 256 - len(suffix_text)]}{suffix_text}"
+        if extra not in occupied:
+            return extra
+        suffix += 1
+
+
+def _repo_row_has_exact_overlap(
+    target: str,
+    *,
+    active_runs: Sequence[LiveRun],
+    overlap_identities: set[str],
+    row_identity: str,
+) -> bool:
+    """Mark a run row only from exact ``run.repo_identity``; session-only by identity."""
+    live = tuple(run for run in active_runs if run.repo == target)
+    if live:
+        return any(run.repo_identity and run.repo_identity in overlap_identities for run in live)
+    return bool(row_identity) and row_identity in overlap_identities
+
+
+def _exact_path_overlap_targets(sessions: Sequence[Mapping[str, object]]) -> set[str]:
+    """Repos whose live sessions share at least one exact normalized dirty path."""
+    groups: dict[tuple[str, str, str], list[Mapping[str, object]]] = {}
+    for session in sessions:
+        identity = str(session.get("repo_identity") or "")
+        if not identity:
+            continue
+        scope = str(session.get("identity_scope") or "fleet")
+        node_id = str(session.get("node_id") or "")
+        groups.setdefault((identity, scope, node_id if scope == "node" else ""), []).append(session)
+    overlapped: set[str] = set()
+    for (identity, _scope, _node), rows in groups.items():
+        unique: list[Mapping[str, object]] = []
+        seen: set[tuple[str, str, str]] = set()
+        for row in rows:
+            key = (str(row.get("node_id") or ""), str(row.get("harness") or ""), str(row.get("session_id") or ""))
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(row)
+        for index, left in enumerate(unique):
+            left_paths = _session_dirty_paths(left)
+            if not left_paths:
+                continue
+            if any(left_paths & _session_dirty_paths(right) for right in unique[index + 1 :]):
+                overlapped.add(identity)
+                break
+    return overlapped
+
+
 def build_view(
     config: DeckConfig,
     *,
@@ -539,6 +697,7 @@ def build_view(
     observers: Sequence[tuple[str, str]],
     now: datetime,
     cloud_workers: Sequence[CloudWorker] = (),
+    interactive_sessions: Sequence[Mapping[str, object]] = (),
 ) -> DeckView:
     del now
     active_runs = tuple(run for run in live_runs if not is_terminal_state(run.state) and run.bucket != "stale")
@@ -547,6 +706,8 @@ def build_view(
     collision_targets = {
         target for target in {run.repo for run in active_runs} if collides(target, active_runs, claims_by_target)
     }
+    session_rows = tuple(_interactive_session(item) for item in interactive_sessions)
+    overlap_targets = _exact_path_overlap_targets(interactive_sessions)
     stations: list[StationView] = []
     for station in config.stations:
         tiles = tuple(
@@ -590,6 +751,24 @@ def build_view(
         for target, claim in sorted(claims_by_target.items())
         if target in collision_targets
     )
+    identity_to_display = _session_identity_display_targets(active_runs, claims_by_target, session_rows)
+    run_identities = {run.repo_identity for run in active_runs if run.repo_identity}
+    repo_targets = {run.repo for run in active_runs} | set(claims_by_target)
+    session_only_targets = {
+        target
+        for identity, targets in identity_to_display.items()
+        if identity not in run_identities
+        for target in targets
+        if target not in repo_targets
+    }
+    repo_targets |= session_only_targets
+    identity_for_target: dict[str, str] = {}
+    for identity, targets in identity_to_display.items():
+        for target in targets:
+            identity_for_target.setdefault(target, identity)
+    for run in active_runs:
+        if run.repo and run.repo_identity:
+            identity_for_target.setdefault(run.repo, run.repo_identity)
     repos = tuple(
         sorted(
             (
@@ -598,10 +777,17 @@ def build_view(
                     claim=display_claims.get(target),
                     live=tuple(run for run in active_runs if run.repo == target),
                     collision=target in collision_targets,
+                    interactive_overlap=_repo_row_has_exact_overlap(
+                        target,
+                        active_runs=active_runs,
+                        overlap_identities=overlap_targets,
+                        row_identity=identity_for_target.get(target, ""),
+                    ),
+                    repo_identity=identity_for_target.get(target, ""),
                 )
-                for target in {run.repo for run in active_runs} | set(claims_by_target)
+                for target in repo_targets
             ),
-            key=lambda row: (not row.collision, row.target),
+            key=lambda row: (not row.collision, not row.interactive_overlap, row.target),
         )
     )
     return DeckView(
@@ -611,6 +797,7 @@ def build_view(
         outcomes=tuple(outcomes),
         observers=tuple(observers),
         cloud_workers=tuple(cloud_workers[:CLOUD_PROVIDER_LIMIT]),
+        interactive_sessions=session_rows,
     )
 
 
@@ -780,6 +967,18 @@ def render_deck(view: DeckView, *, nonce: str, now: datetime) -> str:
         )
         + "</section>"
     )
+    session_items = "".join(_interactive_session_html(session) for session in view.interactive_sessions)
+    parts.append(
+        '<section class="panel" aria-labelledby="interactive-sessions"><header>'
+        '<h2 id="interactive-sessions">Interactive sessions</h2>'
+        f'<p class="panel-count">{len(view.interactive_sessions)} session(s)</p></header>'
+        + (
+            f'<ul class="attention-list">{session_items}</ul>'
+            if session_items
+            else '<p class="empty">No interactive sessions.</p>'
+        )
+        + "</section>"
+    )
     rail_items = "".join(
         f'<li><span class="attention-kind">{_esc(entry.kind)}</span> &middot; {_esc(entry.repo)} &middot; '
         f'{_esc(entry.node_id[:12])} &middot; <span title="{_esc(entry.run_id or entry.node_id)}">'
@@ -822,7 +1021,7 @@ def render_repos(view: DeckView, *, nonce: str, now: datetime) -> str:
         f"<td>{_esc(_owner_text(row.claim))}</td>"
         f"<td>{_esc(str(row.claim.ttl_remaining) + 's left') if row.claim else ''}</td>"
         f"<td>{_esc(', '.join(f'{run.node_id[:12]}:{run.state}' for run in row.live))}</td>"
-        f'<td class="flag">{_esc("! collision") if row.collision else ""}</td>'
+        f'<td class="flag">{_esc(_repo_flags(row))}</td>'
         "</tr>"
         for row in view.repos
     )
@@ -866,6 +1065,28 @@ def _tile_html(tile: Tile) -> str:
         + collision_html
         + "</article>"
     )
+
+
+def _interactive_session_html(session: InteractiveSession) -> str:
+    dirty = f"{len(session.dirty_paths)}+" if session.dirty_truncated else str(len(session.dirty_paths))
+    branch = session.branch or "-"
+    return (
+        "<li>"
+        f"{_esc(session.repo_label or session.repo_identity)} &middot; "
+        f"{_esc(session.harness)}/{_esc(session.session_id)} &middot; "
+        f"{_esc(session.checkout_path)} &middot; "
+        f"{_esc(branch)} &middot; {_esc(dirty)} dirty"
+        "</li>"
+    )
+
+
+def _repo_flags(row: RepoRow) -> str:
+    flags: list[str] = []
+    if row.collision:
+        flags.append("! collision")
+    if row.interactive_overlap:
+        flags.append("! overlap")
+    return " ".join(flags)
 
 
 def _cloud_worker_html(worker: CloudWorker) -> str:

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -118,7 +118,7 @@ from .fleet_hub_status import (
     latest_status as latest_status,
 )
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 DEFAULT_PORT = 3774
 MAX_BODY_BYTES = 8 * 1024 * 1024
 
@@ -187,7 +187,7 @@ EVENT_FIELDS = {
     "digest": str,
 }
 OPTIONAL_STR_FIELDS = ("repo", "seat", "harness")
-OPTIONAL_EVENT_STR_FIELDS = ("capability_fingerprint",)
+OPTIONAL_EVENT_STR_FIELDS = ("capability_fingerprint", "repo_identity")
 OPTIONAL_EVENT_INT_FIELDS = ("exit_status",)
 
 # Terminal run_event.v1 lifecycle types (see run_events.EVENT_TYPES), plus
@@ -218,6 +218,7 @@ CREATE TABLE IF NOT EXISTS events (
     ts TEXT NOT NULL,
     exit_status INTEGER,
     capability_fingerprint TEXT,
+    repo_identity TEXT,
     received_at TEXT NOT NULL,
     PRIMARY KEY (node_id, run_id, sequence, digest)
 );
@@ -260,7 +261,7 @@ _CLAIMS_ADDITIVE_COLUMNS = (
     "lock_acquired_at",
     "lock_run_dir",
 )
-_EVENTS_ADDITIVE_COLUMNS = ("exit_status", "capability_fingerprint")
+_EVENTS_ADDITIVE_COLUMNS = ("exit_status", "capability_fingerprint", "repo_identity")
 
 # Per-node credentials (schema v4, issue #1150): node_id -> SHA-256 of the
 # node's bearer token. The plaintext token is returned once by the add
@@ -526,6 +527,10 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
     fleet_hub_grokbot.ensure_schema(conn)
     # v12 -> v13: one-row run preference pin (#1223).
     fleet_hub_preference.ensure_schema(conn)
+    # v13 -> v14: interactive session presence (#1261) and nullable event repo identity.
+    from . import fleet_hub_sessions
+
+    fleet_hub_sessions.init_schema(conn)
     conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 
 
@@ -653,7 +658,14 @@ def _validate_event(raw: Any) -> dict[str, Any]:
         value = raw.get(field)
         if isinstance(value, str):
             _reject_controls(value, field, kind="event")
-        event[field] = value if isinstance(value, str) and value.strip() else None
+        cleaned = value if isinstance(value, str) and value.strip() else None
+        if field == "repo_identity" and cleaned is not None:
+            cleaned = cleaned.strip()
+            from .fleet_session_presence import validate_repo_identity
+
+            if validate_repo_identity(cleaned) is None:
+                raise FleetHubError("event field 'repo_identity' must be a credential-free identity")
+        event[field] = cleaned
     for field in OPTIONAL_EVENT_INT_FIELDS:
         value = raw.get(field)
         if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value < 0):
@@ -692,7 +704,7 @@ def store_events(conn: sqlite3.Connection, raw_events: Any, *, caller_node: str 
         cursor = conn.execute(
             "INSERT OR IGNORE INTO events "
             "(node_id, run_id, sequence, digest, repo, seat, harness, state, ts, exit_status, "
-            "capability_fingerprint, received_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "capability_fingerprint, repo_identity, received_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 event["node_id"],
                 event["run_id"],
@@ -705,6 +717,7 @@ def store_events(conn: sqlite3.Connection, raw_events: Any, *, caller_node: str 
                 event["ts"],
                 event["exit_status"],
                 event["capability_fingerprint"],
+                event["repo_identity"],
                 received_at,
             ),
         )

--- a/src/brigade/fleet_hub_http.py
+++ b/src/brigade/fleet_hub_http.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlencode
 
-from . import fleet_command_deck, fleet_dashboard, fleet_hub_grokbot
+from . import fleet_command_deck, fleet_dashboard, fleet_hub_grokbot, fleet_hub_sessions
 from . import fleet_hub as _hub
 from .fleet_hub import (
     DASHBOARD_COOKIE,
@@ -86,6 +86,14 @@ def handle_node_request(*args: Any, **kwargs: Any) -> Any:
 
 def list_claims(*args: Any, **kwargs: Any) -> Any:
     return _hub.list_claims(*args, **kwargs)
+
+
+def handle_session(*args: Any, **kwargs: Any) -> Any:
+    return fleet_hub_sessions.handle_session(*args, **kwargs)
+
+
+def list_sessions(*args: Any, **kwargs: Any) -> Any:
+    return fleet_hub_sessions.list_sessions(*args, **kwargs)
 
 
 def list_model_policy(*args: Any, **kwargs: Any) -> Any:
@@ -416,6 +424,7 @@ def make_handler(
                 station_ids = [station.node_id for station in frozen_deck.stations]
                 last_heard = fleet_command_deck.fetch_last_heard(conn, station_ids)
                 observers = fleet_command_deck.fetch_observers(conn, frozenset(station_ids))
+                interactive_sessions = fleet_command_deck.fetch_interactive_sessions(conn, now=now)
             except sqlite3.Error as exc:
                 self._send_html(500, f"hub database error: {exc}\n", content_type=plain)
                 return
@@ -432,6 +441,7 @@ def make_handler(
                 observers=observers,
                 now=now,
                 cloud_workers=cloud_workers,
+                interactive_sessions=interactive_sessions,
             )
             nonce = secrets.token_urlsafe(16)
             page = render(view, nonce=nonce, now=now)
@@ -451,7 +461,7 @@ def make_handler(
             if path.startswith(_DASHBOARD_PREFIX):
                 self._serve_dashboard(path, query)
                 return
-            if path in ("/status", "/claims", "/nodes", "/cloud", "/models", "/preference"):
+            if path in ("/status", "/claims", "/nodes", "/cloud", "/models", "/preference", "/sessions"):
                 if self._bearer() is None:
                     self._send_json(401, {"error": "unauthorized"})
                     return
@@ -486,6 +496,8 @@ def make_handler(
                         payload = {"models": list_model_policy(conn)}
                     elif path == "/preference":
                         payload = {"preference": get_run_preference(conn)}
+                    elif path == "/sessions":
+                        payload = {"sessions": list_sessions(conn, include_all=include_all)}
                     else:
                         payload = {"claims": list_claims(conn, include_all=include_all)}
                 except sqlite3.Error as exc:
@@ -546,7 +558,7 @@ def make_handler(
 
         def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
             path = self.path.partition("?")[0]
-            if path not in ("/events", "/claims", "/nodes", "/cloud", "/models", "/grokbot"):
+            if path not in ("/events", "/claims", "/nodes", "/cloud", "/models", "/grokbot", "/sessions"):
                 self._send_json(404, {"error": "not found"})
                 return
             if self._bearer() is None:
@@ -572,7 +584,7 @@ def make_handler(
                     if not is_admin:
                         self._send_json(403, {"error": "the admin token is required to manage nodes"})
                         return
-                elif path in ("/events", "/claims") and is_admin and not allow_admin_writes:
+                elif path in ("/events", "/claims", "/sessions") and is_admin and not allow_admin_writes:
                     self._send_json(
                         403,
                         {
@@ -600,6 +612,8 @@ def make_handler(
                     status, body_payload = 200, dict(store_events(conn, parsed, caller_node=caller_node))
                 elif path == "/claims":
                     status, body_payload = handle_claim(conn, parsed, caller_node=caller_node)
+                elif path == "/sessions":
+                    status, body_payload = handle_session(conn, parsed, caller_node=caller_node)
                 elif path == "/cloud":
                     if (
                         is_admin

--- a/src/brigade/fleet_hub_sessions.py
+++ b/src/brigade/fleet_hub_sessions.py
@@ -1,0 +1,372 @@
+"""Fleet Hub authority for interactive session presence (schema version 14)."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from . import fleet_hub
+from .fleet_hub import FleetHubError
+from .fleet_session_presence import (
+    DEFAULT_TTL_SECONDS,
+    MAX_DIRTY_JSON_BYTES,
+    MAX_DIRTY_PATH_CHARS,
+    MAX_DIRTY_PATHS,
+    MAX_TTL_SECONDS,
+    MIN_TTL_SECONDS,
+    validate_repo_identity,
+)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS interactive_sessions (
+    node_id TEXT NOT NULL,
+    harness TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    repo_identity TEXT NOT NULL,
+    identity_scope TEXT NOT NULL,
+    repo_label TEXT NOT NULL,
+    checkout_path TEXT NOT NULL,
+    branch TEXT,
+    dirty_paths_json TEXT NOT NULL,
+    dirty_truncated INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    heartbeat_at TEXT NOT NULL,
+    ended_at TEXT,
+    ttl_seconds INTEGER NOT NULL,
+    expires_at REAL NOT NULL,
+    PRIMARY KEY (node_id, harness, session_id, repo_identity)
+);
+"""
+
+ACTIONS = frozenset({"upsert", "end"})
+IDENTITY_SCOPES = frozenset({"fleet", "node"})
+OPAQUE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+LIST_ACTIVE_LIMIT = 500
+LIST_HISTORY_LIMIT = 1000
+_UPSERT_FIELDS = frozenset(
+    {
+        "action",
+        "harness",
+        "session_id",
+        "repo_identity",
+        "identity_scope",
+        "repo_label",
+        "checkout_path",
+        "branch",
+        "dirty_paths",
+        "dirty_truncated",
+        "ttl_seconds",
+        "node_id",
+    }
+)
+_END_FIELDS = frozenset({"action", "harness", "session_id", "repo_identity", "node_id"})
+_SESSION_COLUMNS = (
+    "node_id, harness, session_id, repo_identity, identity_scope, repo_label, "
+    "checkout_path, branch, dirty_paths_json, dirty_truncated, state, started_at, "
+    "heartbeat_at, ended_at, ttl_seconds, expires_at"
+)
+
+
+def init_schema(conn: sqlite3.Connection) -> None:
+    """Create the interactive_sessions table (v13 -> v14 additive migration)."""
+    conn.execute(SCHEMA)
+
+
+def handle_session(
+    conn: sqlite3.Connection,
+    raw: object,
+    *,
+    caller_node: str | None,
+) -> tuple[int, dict[str, object]]:
+    """Validate and apply one upsert or end. Owner comes from ``caller_node``."""
+    request = _validate_session_request(raw, caller_node=caller_node)
+    now = fleet_hub._now_epoch()
+    now_iso = fleet_hub._epoch_to_iso(now)
+    opened = False
+    if conn.in_transaction is False:
+        conn.execute("BEGIN IMMEDIATE")
+        opened = True
+    try:
+        payload: dict[str, object] | None
+        if request["action"] == "upsert":
+            payload = _upsert_session(conn, request, now=now, now_iso=now_iso)
+        else:
+            payload = _end_session(conn, request, now_iso=now_iso)
+        if opened:
+            conn.commit()
+    except BaseException:
+        if opened:
+            conn.rollback()
+        raise
+    return 200, {"session": payload}
+
+
+def list_sessions(
+    conn: sqlite3.Connection,
+    *,
+    include_all: bool = False,
+    now_epoch: float | None = None,
+) -> list[dict[str, object]]:
+    """Active unexpired sessions, or history when ``include_all`` is set."""
+    now = fleet_hub._now_epoch() if now_epoch is None else now_epoch
+    limit = LIST_HISTORY_LIMIT if include_all else LIST_ACTIVE_LIMIT
+    rows = conn.execute(
+        f"SELECT {_SESSION_COLUMNS} FROM interactive_sessions "
+        "WHERE (? = 1 OR (state = 'active' AND expires_at > ?)) "
+        "ORDER BY heartbeat_at DESC, started_at DESC, node_id, harness, session_id "
+        "LIMIT ?",
+        (int(include_all), now, limit),
+    ).fetchall()
+    return [_session_payload(row) for row in rows]
+
+
+def _validate_session_request(raw: object, *, caller_node: str | None) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise FleetHubError("session request must be a JSON object")
+    action = raw.get("action")
+    if action not in ACTIONS:
+        raise FleetHubError("session field 'action' must be 'upsert' or 'end'")
+    allowed = _UPSERT_FIELDS if action == "upsert" else _END_FIELDS
+    unknown = set(raw) - allowed
+    if unknown:
+        raise FleetHubError(f"session request has unsupported field {sorted(unknown)[0]!r}")
+    if caller_node is None:
+        node_id = _required_text(raw.get("node_id"), "node_id", limit=128)
+        if fleet_hub.CLAIM_ID_PATTERN.match(node_id) is None:
+            raise FleetHubError("session field 'node_id' is not a valid node identity")
+    else:
+        if "node_id" in raw:
+            raise FleetHubError("session field 'node_id' is not allowed on node writes")
+        node_id = caller_node
+        if fleet_hub.CLAIM_ID_PATTERN.match(node_id) is None:
+            raise FleetHubError("session field 'node_id' is not a valid node identity")
+    request: dict[str, Any] = {
+        "action": action,
+        "node_id": node_id,
+        "harness": _opaque_id(raw.get("harness"), "harness"),
+        "session_id": _opaque_id(raw.get("session_id"), "session_id"),
+        "repo_identity": _repo_identity(raw.get("repo_identity")),
+    }
+    if action == "end":
+        return request
+    request["identity_scope"] = _identity_scope(raw.get("identity_scope"))
+    request["repo_label"] = _required_text(raw.get("repo_label"), "repo_label", limit=256)
+    request["checkout_path"] = _required_text(raw.get("checkout_path"), "checkout_path", limit=1024)
+    request["branch"] = _optional_text(raw.get("branch"), "branch", limit=256)
+    request["dirty_paths"] = _dirty_paths(raw.get("dirty_paths"))
+    truncated = raw.get("dirty_truncated")
+    if not isinstance(truncated, bool):
+        raise FleetHubError("session field 'dirty_truncated' must be a boolean")
+    request["dirty_truncated"] = truncated
+    ttl = raw.get("ttl_seconds", DEFAULT_TTL_SECONDS)
+    if isinstance(ttl, bool) or not isinstance(ttl, int) or ttl < MIN_TTL_SECONDS or ttl > MAX_TTL_SECONDS:
+        raise FleetHubError(
+            f"session field 'ttl_seconds' must be an integer from {MIN_TTL_SECONDS} to {MAX_TTL_SECONDS}"
+        )
+    request["ttl_seconds"] = ttl
+    return request
+
+
+def _required_text(raw: object, field: str, *, limit: int) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise FleetHubError(f"session field {field!r} must be a non-empty string")
+    value = raw.strip()
+    fleet_hub._reject_controls(value, field, kind="session")
+    if len(value) > limit:
+        raise FleetHubError(f"session field {field!r} must be at most {limit} characters")
+    return value
+
+
+def _optional_text(raw: object, field: str, *, limit: int) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise FleetHubError(f"session field {field!r} must be a string")
+    value = raw.strip()
+    if not value:
+        return None
+    fleet_hub._reject_controls(value, field, kind="session")
+    if len(value) > limit:
+        raise FleetHubError(f"session field {field!r} must be at most {limit} characters")
+    return value
+
+
+def _opaque_id(raw: object, field: str) -> str:
+    value = _required_text(raw, field, limit=128)
+    if OPAQUE_ID_RE.match(value) is None:
+        raise FleetHubError(f"session field {field!r} must be an opaque identity")
+    return value
+
+
+def _identity_scope(raw: object) -> str:
+    value = _required_text(raw, "identity_scope", limit=16)
+    if value not in IDENTITY_SCOPES:
+        raise FleetHubError("session field 'identity_scope' must be 'fleet' or 'node'")
+    return value
+
+
+def _repo_identity(raw: object) -> str:
+    value = _required_text(raw, "repo_identity", limit=512)
+    if validate_repo_identity(value) is None:
+        raise FleetHubError("session field 'repo_identity' must be a credential-free identity")
+    return value
+
+
+def _dirty_paths(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        raise FleetHubError("session field 'dirty_paths' must be an array of strings")
+    if len(raw) > MAX_DIRTY_PATHS:
+        raise FleetHubError(f"session field 'dirty_paths' must have at most {MAX_DIRTY_PATHS} entries")
+    paths: list[str] = []
+    for item in raw:
+        if not isinstance(item, str) or not item:
+            raise FleetHubError("session field 'dirty_paths' must be an array of strings")
+        fleet_hub._reject_controls(item, "dirty_paths", kind="session")
+        normalized = item.replace("\\", "/")
+        candidate = Path(normalized)
+        if candidate.is_absolute() or ".." in candidate.parts or normalized.startswith("/"):
+            raise FleetHubError("session field 'dirty_paths' must be repository-relative Git paths")
+        if len(normalized) > MAX_DIRTY_PATH_CHARS:
+            raise FleetHubError(
+                f"session field 'dirty_paths' entries must be at most {MAX_DIRTY_PATH_CHARS} characters"
+            )
+        paths.append(normalized)
+    encoded = json.dumps(paths, ensure_ascii=False).encode("utf-8")
+    if len(encoded) > MAX_DIRTY_JSON_BYTES:
+        raise FleetHubError("session field 'dirty_paths' exceeds the encoded size limit")
+    return paths
+
+
+def _upsert_session(
+    conn: sqlite3.Connection,
+    request: dict[str, Any],
+    *,
+    now: float,
+    now_iso: str,
+) -> dict[str, object]:
+    dirty_json = json.dumps(request["dirty_paths"], ensure_ascii=False)
+    conn.execute(
+        "INSERT INTO interactive_sessions ("
+        "node_id, harness, session_id, repo_identity, identity_scope, repo_label, "
+        "checkout_path, branch, dirty_paths_json, dirty_truncated, state, started_at, "
+        "heartbeat_at, ended_at, ttl_seconds, expires_at"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NULL, ?, ?) "
+        "ON CONFLICT(node_id, harness, session_id, repo_identity) DO UPDATE SET "
+        "identity_scope = excluded.identity_scope, "
+        "repo_label = excluded.repo_label, "
+        "checkout_path = excluded.checkout_path, "
+        "branch = excluded.branch, "
+        "dirty_paths_json = excluded.dirty_paths_json, "
+        "dirty_truncated = excluded.dirty_truncated, "
+        "state = 'active', "
+        "started_at = CASE WHEN interactive_sessions.state = 'active' "
+        "AND interactive_sessions.expires_at > ? THEN interactive_sessions.started_at "
+        "ELSE excluded.started_at END, "
+        "heartbeat_at = excluded.heartbeat_at, "
+        "ended_at = NULL, "
+        "ttl_seconds = excluded.ttl_seconds, "
+        "expires_at = excluded.expires_at",
+        (
+            request["node_id"],
+            request["harness"],
+            request["session_id"],
+            request["repo_identity"],
+            request["identity_scope"],
+            request["repo_label"],
+            request["checkout_path"],
+            request["branch"],
+            dirty_json,
+            int(request["dirty_truncated"]),
+            now_iso,
+            now_iso,
+            request["ttl_seconds"],
+            now + request["ttl_seconds"],
+            now,
+        ),
+    )
+    payload = _fetch_session(
+        conn,
+        request["node_id"],
+        request["harness"],
+        request["session_id"],
+        request["repo_identity"],
+    )
+    if payload is None:
+        raise FleetHubError("session row was not stored")
+    return payload
+
+
+def _end_session(conn: sqlite3.Connection, request: dict[str, Any], *, now_iso: str) -> dict[str, object] | None:
+    conn.execute(
+        "UPDATE interactive_sessions SET state = 'ended', "
+        "ended_at = COALESCE(ended_at, ?), heartbeat_at = ? "
+        "WHERE node_id = ? AND harness = ? AND session_id = ? AND repo_identity = ?",
+        (
+            now_iso,
+            now_iso,
+            request["node_id"],
+            request["harness"],
+            request["session_id"],
+            request["repo_identity"],
+        ),
+    )
+    return _fetch_session(
+        conn,
+        request["node_id"],
+        request["harness"],
+        request["session_id"],
+        request["repo_identity"],
+        required=False,
+    )
+
+
+def _fetch_session(
+    conn: sqlite3.Connection,
+    node_id: str,
+    harness: str,
+    session_id: str,
+    repo_identity: str,
+    *,
+    required: bool = True,
+) -> dict[str, object] | None:
+    row = conn.execute(
+        f"SELECT {_SESSION_COLUMNS} FROM interactive_sessions "
+        "WHERE node_id = ? AND harness = ? AND session_id = ? AND repo_identity = ?",
+        (node_id, harness, session_id, repo_identity),
+    ).fetchone()
+    if row is None:
+        if required:
+            raise FleetHubError("session row was not stored")
+        return None
+    return _session_payload(row)
+
+
+def _session_payload(row: tuple[Any, ...]) -> dict[str, object]:
+    try:
+        dirty_paths = json.loads(row[8])
+    except json.JSONDecodeError:
+        dirty_paths = []
+    if not isinstance(dirty_paths, list):
+        dirty_paths = []
+    return {
+        "node_id": row[0],
+        "harness": row[1],
+        "session_id": row[2],
+        "repo_identity": row[3],
+        "identity_scope": row[4],
+        "repo_label": row[5],
+        "checkout_path": row[6],
+        "branch": row[7],
+        "dirty_paths": dirty_paths,
+        "dirty_truncated": bool(row[9]),
+        "state": row[10],
+        "started_at": row[11],
+        "heartbeat_at": row[12],
+        "ended_at": row[13],
+        "ttl_seconds": row[14],
+        "expires_at": row[15],
+    }

--- a/src/brigade/fleet_hub_status.py
+++ b/src/brigade/fleet_hub_status.py
@@ -60,7 +60,8 @@ def latest_status(
     ``original_state``. Event history itself is not rewritten.
     """
     rows = conn.execute(
-        "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, capability_fingerprint, received_at FROM ("
+        "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, "
+        "capability_fingerprint, repo_identity, received_at FROM ("
         "  SELECT e.*, ROW_NUMBER() OVER ("
         "    PARTITION BY node_id, run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
         "  ) AS rn FROM events e"
@@ -72,7 +73,7 @@ def latest_status(
         state = row[5]
         if not include_all and (
             fleet_command_deck.is_terminal_state(state)
-            or not _received_at_is_active(row[11], now=current, ttl_seconds=active_ttl_seconds)
+            or not _received_at_is_active(row[12], now=current, ttl_seconds=active_ttl_seconds)
         ):
             continue
         entry = {
@@ -87,10 +88,11 @@ def latest_status(
             "digest": row[8],
             "exit_status": row[9],
             "capability_fingerprint": row[10],
-            "received_at": row[11],
+            "repo_identity": row[11],
+            "received_at": row[12],
         }
         if include_all and not fleet_command_deck.is_terminal_state(state):
-            age = _received_at_age_seconds(row[11], now=current)
+            age = _received_at_age_seconds(row[12], now=current)
             if age is not None and age > stale_history_after_seconds:
                 entry["original_state"] = state
                 entry["state"] = "run.stale"

--- a/src/brigade/fleet_session_presence.py
+++ b/src/brigade/fleet_session_presence.py
@@ -1,0 +1,671 @@
+"""Local interactive-session identity, dirty-path snapshots, and overlap projection.
+
+This module never persists remotes, credentials, diffs, or file contents. The
+Hub receives only the bounded operational snapshot built here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, Mapping, Sequence
+from urllib.parse import unquote, urlparse
+
+DEFAULT_TTL_SECONDS = 900
+MIN_TTL_SECONDS = 120
+MAX_TTL_SECONDS = 3600
+MAX_DIRTY_PATHS = 64
+MAX_DIRTY_PATH_CHARS = 512
+MAX_DIRTY_JSON_BYTES = 32 * 1024
+MAX_OVERLAP_PATHS = 8
+MAX_PRESENCE_STDIN_BYTES = 1_048_576
+MAX_PRESENCE_ERROR_CHARS = 200
+MAX_REPO_IDENTITY_CHARS = 512
+_IDENTITY_CACHE_LIMIT = 32
+_GIT_DIR_FILE_LIMIT = 4096
+_CURSOR_WRITE_TOOLS = frozenset(
+    {
+        "Write",
+        "StrReplace",
+        "Delete",
+        "EditNotebook",
+        "NotebookEdit",
+        "Edit",
+        "TabWrite",
+        "MultiEdit",
+        "ApplyPatch",
+        "apply_patch",
+        "search_replace",
+        "write_file",
+    }
+)
+CURSOR_WORK_LOOP_CONTEXT = (
+    "BRIGADE WORK LOOP: In a Brigade-wired repository, invoke the global brigade-work skill before substantive "
+    "work. Start with brigade work brief --target .. Run checks that should count through brigade work verify "
+    "run with --capture brigade-work. Capture failures, export new receipts to MiseLedger when installed, and "
+    "finish durable work with a Memory Handoff."
+)
+_CURSOR_HOOK_EVENTS = {
+    "sessionStart": "start",
+    "postToolUse": "heartbeat",
+    "sessionEnd": "end",
+}
+_UPSERT_EVENTS = frozenset({"SessionStart", "PostToolUse", "start", "heartbeat"})
+_END_EVENTS = frozenset({"Stop", "end"})
+
+_SCP_REMOTE = re.compile(r"^(?:(?P<user>[^@/]+)@)?(?P<host>[^:/\s]+):(?P<path>.+)$")
+_SECRET_LIKE_IDENTITY = re.compile(r"(?i)(://|token=|password=|[^/]+:[^/@]+@)")
+_ENCODED_PATH_SEP = re.compile(r"%2[fF]|%5[cC]")
+_CASEFOLD_HOSTS = frozenset(
+    {
+        "github.com",
+        "gist.github.com",
+        "gitlab.com",
+        "bitbucket.org",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RepositoryIdentity:
+    value: str
+    scope: Literal["fleet", "node"]
+
+
+@dataclass(frozen=True)
+class DirtyPathSnapshot:
+    paths: tuple[str, ...]
+    truncated: bool
+
+
+@dataclass(frozen=True)
+class SessionSnapshot:
+    harness: str
+    session_id: str
+    repo_identity: str
+    identity_scope: str
+    repo_label: str
+    checkout_path: str
+    branch: str | None
+    dirty_paths: tuple[str, ...]
+    dirty_truncated: bool
+    ttl_seconds: int = DEFAULT_TTL_SECONDS
+
+
+_IDENTITY_CACHE: dict[str, tuple[RepositoryIdentity, int | None]] = {}
+
+
+def clear_repository_identity_cache() -> None:
+    """Drop the process-local repository identity cache."""
+    _IDENTITY_CACHE.clear()
+
+
+def validate_repo_identity(value: str) -> str | None:
+    """Return a credential-free identity, or None when the value is unsafe."""
+    if not value or len(value) > MAX_REPO_IDENTITY_CHARS:
+        return None
+    if _contains_controls(value):
+        return None
+    if _SECRET_LIKE_IDENTITY.search(value) is not None:
+        return None
+    return value
+
+
+def repository_identity(target: Path) -> RepositoryIdentity:
+    """Return a credential-free repository identity for ``target``."""
+    try:
+        key = str(target.resolve())
+    except OSError:
+        key = str(target)
+    stamp = _identity_cache_stamp(target)
+    cached = _IDENTITY_CACHE.get(key)
+    if cached is not None and cached[1] == stamp:
+        return cached[0]
+    remote = _origin_url(target)
+    parsed = _parse_remote(remote) if remote else None
+    identity = _local_identity(target) if parsed is None else RepositoryIdentity(value=parsed, scope="fleet")
+    _IDENTITY_CACHE[key] = (identity, stamp)
+    while len(_IDENTITY_CACHE) > _IDENTITY_CACHE_LIMIT:
+        _IDENTITY_CACHE.pop(next(iter(_IDENTITY_CACHE)))
+    return identity
+
+
+def collect_dirty_paths(target: Path) -> DirtyPathSnapshot:
+    """Collect bounded, repository-relative dirty paths from one porcelain -z run."""
+    try:
+        completed = subprocess.run(
+            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            shell=False,
+            timeout=5,
+            cwd=target,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return DirtyPathSnapshot(paths=(), truncated=True)
+    if completed.returncode != 0:
+        return DirtyPathSnapshot(paths=(), truncated=True)
+    collected: list[str] = []
+    skipped = False
+    for raw_path in _parse_porcelain_z(completed.stdout):
+        normalized = _normalize_dirty_path(raw_path)
+        if normalized is None:
+            if raw_path and not _is_excluded_brigade_path(raw_path):
+                skipped = True
+            continue
+        collected.append(normalized)
+    unique = sorted(set(collected))
+    truncated = skipped or len(unique) > MAX_DIRTY_PATHS
+    bounded = unique[:MAX_DIRTY_PATHS]
+    while bounded:
+        encoded = json.dumps(bounded, ensure_ascii=False).encode("utf-8")
+        if len(encoded) <= MAX_DIRTY_JSON_BYTES:
+            break
+        bounded = bounded[:-1]
+        truncated = True
+    return DirtyPathSnapshot(paths=tuple(bounded), truncated=truncated)
+
+
+def build_snapshot(
+    target: Path,
+    *,
+    harness: str,
+    session_id: str,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> SessionSnapshot:
+    """Build one immutable local session snapshot for Hub publication."""
+    identity = repository_identity(target)
+    dirty = collect_dirty_paths(target)
+    checkout = str(target.resolve())
+    label = identity.value.rsplit("/", 1)[-1]
+    if identity.scope == "node":
+        label = target.name or label
+    return SessionSnapshot(
+        harness=harness,
+        session_id=session_id,
+        repo_identity=identity.value,
+        identity_scope=identity.scope,
+        repo_label=label[:256],
+        checkout_path=checkout,
+        branch=_current_branch(target),
+        dirty_paths=dirty.paths,
+        dirty_truncated=dirty.truncated,
+        ttl_seconds=_clamp_ttl(ttl_seconds),
+    )
+
+
+def overlap_warnings(
+    current: SessionSnapshot,
+    rows: Sequence[Mapping[str, object]],
+    *,
+    current_node: str,
+) -> list[dict[str, object]]:
+    """Return advisory overlap warnings for other live sessions on the same identity."""
+    now = time.time()
+    warnings: list[dict[str, object]] = []
+    current_paths = {_normalize_overlap_path(path) for path in current.dirty_paths}
+    current_paths.discard("")
+    for row in rows:
+        if not _row_is_live(row, now=now):
+            continue
+        if str(row.get("repo_identity") or "") != current.repo_identity:
+            continue
+        if str(row.get("identity_scope") or "") != current.identity_scope:
+            continue
+        node_id = str(row.get("node_id") or "")
+        if current.identity_scope == "node" and node_id != current_node:
+            continue
+        harness = str(row.get("harness") or "")
+        session_id = str(row.get("session_id") or "")
+        if node_id == current_node and harness == current.harness and session_id == current.session_id:
+            continue
+        other_paths = {_normalize_overlap_path(path) for path in _row_dirty_paths(row.get("dirty_paths"))}
+        other_paths.discard("")
+        intersection = sorted(current_paths & other_paths)
+        if not intersection:
+            continue
+        other_truncated = bool(row.get("dirty_truncated"))
+        warnings.append(
+            {
+                "node_id": node_id,
+                "harness": harness,
+                "session_id": session_id,
+                "branch": row.get("branch"),
+                "checkout_path": row.get("checkout_path"),
+                "age": _age_seconds(row.get("started_at"), now),
+                "paths": intersection[:MAX_OVERLAP_PATHS],
+                "partial": current.dirty_truncated or other_truncated,
+            }
+        )
+    return warnings
+
+
+def _clamp_ttl(ttl_seconds: int) -> int:
+    return min(MAX_TTL_SECONDS, max(MIN_TTL_SECONDS, int(ttl_seconds)))
+
+
+def _origin_url(target: Path) -> str | None:
+    completed = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        shell=False,
+        timeout=5,
+        cwd=target,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    remote = completed.stdout.strip()
+    return remote or None
+
+
+def _local_identity(target: Path) -> RepositoryIdentity:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        shell=False,
+        timeout=5,
+        cwd=target,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if completed.returncode == 0 and completed.stdout.strip():
+        raw = completed.stdout.strip()
+        path = Path(raw) if Path(raw).is_absolute() else target / raw
+        try:
+            canonical = str(path.resolve())
+        except OSError:
+            canonical = str(target.resolve())
+    else:
+        canonical = str(target.resolve())
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    return RepositoryIdentity(value=f"local:{digest}", scope="node")
+
+
+def _parse_remote(remote: str) -> str | None:
+    value = remote.strip()
+    if not value or "\x00" in value or _contains_controls(value):
+        return None
+    if "://" in value:
+        parsed = urlparse(value)
+        host = (parsed.hostname or "").strip().lower()
+        raw_path = parsed.path or ""
+    else:
+        match = _SCP_REMOTE.fullmatch(value)
+        if match is None:
+            return None
+        host = match.group("host").strip().lower()
+        raw_path = match.group("path") or ""
+        if len(host) == 1:
+            return None
+    if not host or "/" in host:
+        return None
+    path = _decode_remote_path(raw_path)
+    if path is None:
+        return None
+    path = path.strip("/")
+    if path.lower().endswith(".git"):
+        path = path[:-4]
+    path = path.strip("/")
+    if not path or path.startswith(".") or ".." in Path(path).parts:
+        return None
+    if host in _CASEFOLD_HOSTS:
+        path = path.lower()
+    identity = f"{host}/{path}"
+    return validate_repo_identity(identity)
+
+
+def _parse_porcelain_z(payload: str) -> list[str]:
+    parts = payload.split("\0")
+    paths: list[str] = []
+    index = 0
+    while index < len(parts):
+        record = parts[index]
+        index += 1
+        if not record:
+            continue
+        status = record[:2]
+        path = record[3:] if len(record) > 3 else ""
+        if "R" in status or "C" in status:
+            # Porcelain -z emits dest\0origin. Keep dest and consume origin.
+            if index < len(parts):
+                index += 1
+        if path:
+            paths.append(path)
+    return paths
+
+
+def _decode_remote_path(path: str) -> str | None:
+    """Decode a remote path without collapsing encoded separators into ``/``."""
+    parts: list[str] = []
+    for raw_segment in path.replace("\\", "/").split("/"):
+        if not raw_segment:
+            continue
+        if _ENCODED_PATH_SEP.search(raw_segment):
+            return None
+        segment = unquote(raw_segment)
+        if _ENCODED_PATH_SEP.search(segment):
+            return None
+        if "/" in segment or "\\" in segment or _contains_controls(segment):
+            return None
+        parts.append(segment)
+    return "/".join(parts)
+
+
+def _contains_controls(value: str) -> bool:
+    return any(ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F for ch in value)
+
+
+def _read_bounded_text(path: Path, *, limit: int = _GIT_DIR_FILE_LIMIT) -> str | None:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_size > limit:
+            return None
+        raw = os.read(fd, limit + 1)
+        if len(raw) > limit:
+            return None
+        return raw.decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+
+def _linked_worktree_config(git_file: Path, target: Path) -> Path | None:
+    text = _read_bounded_text(git_file)
+    if text is None:
+        return None
+    gitdir: Path | None = None
+    for line in text.splitlines():
+        if line.lower().startswith("gitdir:"):
+            value = line.split(":", 1)[1].strip()
+            gitdir = Path(value) if Path(value).is_absolute() else target / value
+            break
+    if gitdir is None:
+        return None
+    commondir_file = gitdir / "commondir"
+    if commondir_file.is_file():
+        common_raw = (_read_bounded_text(commondir_file) or "").strip()
+        if common_raw:
+            common = Path(common_raw) if Path(common_raw).is_absolute() else gitdir / common_raw
+            config = common / "config"
+            if config.is_file():
+                return config
+    config = gitdir / "config"
+    return config if config.is_file() else None
+
+
+def _identity_cache_stamp(target: Path) -> int | None:
+    git_meta = target / ".git"
+    try:
+        if git_meta.is_file():
+            config = _linked_worktree_config(git_meta, target)
+            return config.stat().st_mtime_ns if config is not None else None
+        return (git_meta / "config").stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def _is_excluded_brigade_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.startswith(".brigade/")
+
+
+def _normalize_dirty_path(path: str) -> str | None:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    if not normalized or normalized.startswith(".brigade/"):
+        return None
+    if len(normalized) > MAX_DIRTY_PATH_CHARS:
+        return None
+    candidate = Path(normalized)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    if normalized.startswith("/") or normalized.startswith("~"):
+        return None
+    return normalized
+
+
+def _current_branch(target: Path) -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        shell=False,
+        timeout=5,
+        cwd=target,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    branch = completed.stdout.strip()
+    if not branch or branch == "HEAD":
+        return None
+    return branch
+
+
+def _row_is_live(row: Mapping[str, object], *, now: float) -> bool:
+    if str(row.get("state") or "active") != "active":
+        return False
+    expires_at = row.get("expires_at")
+    if isinstance(expires_at, (int, float)) and not isinstance(expires_at, bool):
+        return float(expires_at) > now
+    if isinstance(expires_at, str) and expires_at:
+        try:
+            stamp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=timezone.utc)
+            return stamp.timestamp() > now
+        except ValueError:
+            return False
+    return True
+
+
+def _row_dirty_paths(raw: object) -> list[str]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(item) for item in raw if isinstance(item, str)]
+
+
+def _normalize_overlap_path(path: str) -> str:
+    return _normalize_dirty_path(path) or ""
+
+
+def _hub_url_configured() -> bool:
+    try:
+        from . import fleet_client
+
+        return bool(fleet_client.load_fleet_config().get("hub_url"))
+    except Exception:
+        return False
+
+
+def _publish_presence(event: str, target: Path, session_id: str, *, harness: str = "claude") -> None:
+    """Best-effort Hub publication. Exceptions never escape to hook callers."""
+    try:
+        from . import fleet_client
+
+        if not _hub_url_configured():
+            return
+        snapshot = build_snapshot(target, harness=harness, session_id=session_id)
+        if event in _END_EVENTS:
+            fleet_client.end_session(snapshot)
+        elif event in _UPSERT_EVENTS:
+            fleet_client.upsert_session(snapshot)
+    except Exception:
+        return
+
+
+def run_presence_hook(
+    *,
+    target: Path | None = None,
+    harness: str | None = None,
+    session: str | None = None,
+    event: str | None = None,
+    stdin: bool = False,
+    context: str | None = None,
+) -> int:
+    """Publish or end one interactive session. Always exits 0 for adapter safety."""
+    try:
+        if harness == "cursor" and stdin and context == "cursor-work-loop":
+            _run_cursor_presence_hook()
+            return 0
+        _run_explicit_presence_hook(target=target, harness=harness, session=session, event=event)
+    except Exception:
+        if harness == "cursor" and stdin and context == "cursor-work-loop":
+            _print_cursor_hook_output(None)
+    return 0
+
+
+def _run_explicit_presence_hook(
+    *,
+    target: Path | None,
+    harness: str | None,
+    session: str | None,
+    event: str | None,
+) -> None:
+    if target is None or not harness or not session or event not in {"start", "heartbeat", "end"}:
+        return
+    _publish_presence(event, target, session, harness=harness)
+
+
+def _run_cursor_presence_hook() -> None:
+    payload = _read_bounded_json_object()
+    hook_event = payload.get("hook_event_name") if payload else None
+    mapped = _CURSOR_HOOK_EVENTS.get(hook_event) if isinstance(hook_event, str) else None
+    session_id = _cursor_session_id(payload)
+    workspace = _cursor_workspace(payload)
+    target = _cursor_presence_target(workspace)
+    if mapped and session_id and target is not None:
+        if mapped == "heartbeat":
+            if _cursor_tool_is_write_capable(payload):
+                _publish_presence("heartbeat", target, session_id, harness="cursor")
+        else:
+            _publish_presence(mapped, target, session_id, harness="cursor")
+    _print_cursor_hook_output(hook_event if isinstance(hook_event, str) else None)
+
+
+def _cursor_presence_target(workspace: Path | None) -> Path | None:
+    """Match Claude's user-scope boundary: wired Cursor targets only, never home."""
+    if workspace is None:
+        return None
+    try:
+        resolved = workspace.expanduser().resolve()
+        home = Path.home().expanduser().resolve()
+    except OSError:
+        return None
+    if resolved == home:
+        return None
+    from .wiring import resolve_wired_target
+
+    target = resolve_wired_target(str(resolved), harness="cursor")
+    if target is None:
+        return None
+    try:
+        return None if target.resolve() == home else target
+    except OSError:
+        return None
+
+
+def _cursor_tool_is_write_capable(payload: Mapping[str, object] | None) -> bool:
+    if payload is None:
+        return False
+    tool = payload.get("tool_name")
+    if tool is None:
+        tool = payload.get("tool")
+    return isinstance(tool, str) and tool in _CURSOR_WRITE_TOOLS
+
+
+def _cursor_session_id(payload: Mapping[str, object] | None) -> str | None:
+    if payload is None:
+        return None
+    for key in ("session_id", "conversation_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _cursor_workspace(payload: Mapping[str, object] | None) -> Path | None:
+    if payload is None:
+        return None
+    roots = payload.get("workspace_roots")
+    if not isinstance(roots, list) or not roots:
+        return None
+    first = roots[0]
+    if not isinstance(first, str) or not first:
+        return None
+    return Path(first)
+
+
+def _print_cursor_hook_output(hook_event: str | None) -> None:
+    if hook_event == "sessionStart":
+        print(json.dumps({"additional_context": CURSOR_WORK_LOOP_CONTEXT}, indent=2, sort_keys=True))
+        return
+    print("{}")
+
+
+def _read_bounded_json_object() -> dict[str, object] | None:
+    buffer = getattr(sys.stdin, "buffer", None)
+    if buffer is not None:
+        raw = buffer.read(MAX_PRESENCE_STDIN_BYTES + 1)
+    else:
+        text = sys.stdin.read(MAX_PRESENCE_STDIN_BYTES + 1)
+        raw = text.encode("utf-8") if isinstance(text, str) else text
+    if not raw or len(raw) > MAX_PRESENCE_STDIN_BYTES:
+        return None
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _bounded_presence_error(exc: BaseException) -> str:
+    text = f"{type(exc).__name__}: {exc}"
+    return text[:MAX_PRESENCE_ERROR_CHARS]
+
+
+def _age_seconds(started_at: object, now: float) -> int:
+    if not isinstance(started_at, str) or not started_at:
+        return 0
+    try:
+        stamp = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return max(0, int(now - stamp.timestamp()))

--- a/src/brigade/work_cmd/session/briefing.py
+++ b/src/brigade/work_cmd/session/briefing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import inspect
+import os
 import re
 import shlex
 import shutil
@@ -549,7 +550,48 @@ def _brief_payload(target: Path, *, limit: int = 3, include_code_graph: bool = F
         "orphaned_runs": orphaned_runs,
         "update": update_notify.available_update(),
         "cloud_tracker": _cloud_tracker_for_brief(target),
+        **_interactive_presence_for_brief(target),
     }
+
+
+def _interactive_presence_for_brief(target: Path) -> dict[str, Any]:
+    from ... import fleet_client
+    from ... import fleet_session_presence as presence
+
+    session_id = (os.environ.get("CODEX_THREAD_ID") or "").strip()
+    if not session_id:
+        return {"interactive_sessions": {"published": False}, "overlap_warnings": []}
+    if not presence._hub_url_configured():
+        return {
+            "interactive_sessions": {"published": False, "status": "hub_unconfigured"},
+            "overlap_warnings": [],
+        }
+    try:
+        snapshot = presence.build_snapshot(target, harness="codex", session_id=session_id)
+        result = fleet_client.publish_session(snapshot)
+        published = bool(result.ok)
+    except Exception as exc:
+        return {
+            "interactive_sessions": {"published": False, "error": presence._bounded_presence_error(exc)},
+            "overlap_warnings": [],
+        }
+    interactive: dict[str, Any] = {"published": published}
+    if not published:
+        interactive["status"] = result.reason or "unpublished"
+    try:
+        rows = fleet_client.fetch_sessions()
+    except Exception as exc:
+        interactive["error"] = presence._bounded_presence_error(exc)
+        return {"interactive_sessions": interactive, "overlap_warnings": []}
+    try:
+        warnings = presence.overlap_warnings(
+            snapshot,
+            rows,
+            current_node=fleet_client.resolve_node_id(target),
+        )
+    except Exception:
+        warnings = []
+    return {"interactive_sessions": interactive, "overlap_warnings": warnings}
 
 
 def _cloud_tracker_for_brief(target: Path) -> dict[str, Any]:
@@ -605,6 +647,19 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
             print(f"  ... {len(dirty) - 8} more")
     else:
         print("git: unavailable")
+    warnings = payload.get("overlap_warnings")
+    if isinstance(warnings, list):
+        for warning in warnings[:3]:
+            if not isinstance(warning, dict):
+                continue
+            raw_paths = warning.get("paths")
+            paths: list[Any] = raw_paths if isinstance(raw_paths, list) else []
+            shown = [str(path) for path in paths[:8]]
+            print(
+                "overlap: "
+                f"{warning.get('node_id')} {warning.get('harness')} "
+                f"{warning.get('session_id')} {' '.join(shown)}"
+            )
 
     active = payload["active_session"]
     if isinstance(active, dict):

--- a/tests/test_claude_hooks_envelope.py
+++ b/tests/test_claude_hooks_envelope.py
@@ -246,3 +246,17 @@ def test_env_caps_are_honored(monkeypatch):
 def test_path_redaction_strips_home_prefix():
     home = str(Path.home().expanduser().resolve())
     assert envelope.redact_paths(f"{home}/secret/log") == "~/secret/log"
+
+
+def test_presence_exception_does_not_change_session_start_envelope(tmp_path: Path, monkeypatch):
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(runtime, "_run_brief", lambda _repo: "alpha\nbeta")
+    monkeypatch.setattr(runtime, "_run_recall", lambda *_args, **_kwargs: "")
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("hub unavailable")
+
+    monkeypatch.setattr("brigade.fleet_session_presence._publish_presence", boom)
+    result = runtime.handle_payload("SessionStart", _payload(target, "SessionStart"))
+    assert result["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "alpha" in result["hookSpecificOutput"]["additionalContext"]

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+from types import SimpleNamespace
+
 from brigade import cli, localio
 from brigade.claude_hooks import envelope
 from brigade.claude_hooks.package import PACKAGE_REF
@@ -55,6 +57,46 @@ def _payload(target: Path, event: str, *, session_id: str = "session-1", **extra
         "hook_event_name": event,
         **extra,
     }
+
+
+@pytest.fixture
+def target(tmp_path: Path) -> Path:
+    return _wired_claude(tmp_path)
+
+
+def _write_payload(target: Path, session_id: str = "s1"):
+    return _payload(
+        target,
+        "PostToolUse",
+        session_id=session_id,
+        tool_name="Write",
+        tool_input={"file_path": str(target / "src.py"), "content": "x\n"},
+    )
+
+
+def _unverified_write_stop(target: Path, session_id: str = "s1"):
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id=session_id))
+    runtime.handle_payload("PostToolUse", _write_payload(target, session_id=session_id))
+    return _payload(target, "Stop", session_id=session_id, stop_hook_active=False)
+
+
+def _capture_presence(monkeypatch):
+    calls = []
+
+    def upsert(snap, **_kwargs):
+        calls.append(SimpleNamespace(action="upsert", snapshot=snap))
+        return True
+
+    def end(snap, **_kwargs):
+        calls.append(SimpleNamespace(action="end", snapshot=snap))
+        return True
+
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr("brigade.fleet_client.upsert_session", upsert)
+    monkeypatch.setattr("brigade.fleet_client.end_session", end)
+    monkeypatch.setattr(runtime, "_run_brief", lambda _repo: "work brief: test")
+    monkeypatch.setattr(runtime, "_run_recall", lambda *_args, **_kwargs: "")
+    return calls
 
 
 def test_session_start_injects_brief_once_per_repo(tmp_path: Path, monkeypatch):
@@ -3035,3 +3077,49 @@ def test_resume_source_keeps_current_task_gate(tmp_path: Path, monkeypatch):
     runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id=session_id, source="resume"))
     blocked = runtime.handle_payload("Stop", _payload(target, "Stop", session_id=session_id, stop_hook_active=False))
     assert blocked["decision"] == "block"
+
+
+def test_runtime_presence_shim_lives_outside_runtime():
+    from brigade.claude_hooks import presence as presence_mod
+
+    assert not hasattr(runtime, "_emit_presence")
+    assert hasattr(presence_mod, "emit_presence")
+    assert presence_mod.emit_presence.__doc__
+
+
+def test_claude_presence_start_refresh_and_accepted_stop(target, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id="s1"))
+    runtime.handle_payload("PostToolUse", _write_payload(target, session_id="s1"))
+    state = runtime.read_session_state(target, "s1")
+    write_at = state["last_verification_write_at"]
+    run_dir = target / ".brigade" / "work" / "verify-runs" / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "status": "completed",
+                "started_at": write_at,
+                "completed_at": write_at,
+                "target": str(target.resolve()),
+                "harness_session": {
+                    "harness": "claude",
+                    "fingerprint": state["session_fingerprint"],
+                },
+            }
+        )
+        + "\n"
+    )
+    runtime.handle_payload("Stop", _payload(target, "Stop", session_id="s1", stop_hook_active=False))
+    assert [call.action for call in calls] == ["upsert", "upsert", "end"]
+    assert Path(calls[-1].snapshot.checkout_path) == target.resolve()
+    end_calls = [call for call in calls if call.action == "end"]
+    assert len(end_calls) == 1
+
+
+def test_blocked_stop_does_not_end_presence(target, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+    result = runtime.handle_payload("Stop", _unverified_write_stop(target, session_id="s1"))
+    assert result["decision"] == "block"
+    assert all(call.action != "end" for call in calls)

--- a/tests/test_cloud_tracker.py
+++ b/tests/test_cloud_tracker.py
@@ -28,7 +28,7 @@ def _prompt_hash(text: str) -> str:
 
 def _isolate_hosted_providers(monkeypatch) -> None:
     """Keep observe_providers tests off the host's live Cursor/Codex inventory."""
-    for key in ("CURSOR_API_KEY", "CURSOR_CLOUD_API_KEY", "BG_AGENT_API_KEY"):
+    for key in ("CURSOR_API_KEY", "CURSOR_CLOUD_API_KEY", "BG_AGENT_API_KEY", "JULES_API_KEY"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setattr(codex_cloud, "list_tasks", lambda **kwargs: [])
 

--- a/tests/test_cursor_user_cmd.py
+++ b/tests/test_cursor_user_cmd.py
@@ -1,9 +1,21 @@
+import io
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
-from brigade import cli, cursor_user_cmd
+from brigade import cli, cursor_user_cmd, fleet_client
+
+
+def _wire_cursor_workspace(path: Path) -> Path:
+    brigade = path / ".brigade"
+    brigade.mkdir(parents=True, exist_ok=True)
+    (brigade / "config.json").write_text(
+        json.dumps({"version": 1, "depth": "repo", "harnesses": ["cursor"], "owner": "cursor"}),
+        encoding="utf-8",
+    )
+    return path
 
 
 def _use_home(monkeypatch, home: Path) -> None:
@@ -57,8 +69,11 @@ def test_cursor_user_install_merges_all_surfaces_and_is_idempotent(tmp_path, mon
     assert hook.stat().st_mode & 0o111
 
     hooks = json.loads((cursor / "hooks.json").read_text())
+    managed = cursor_user_cmd._hook_entry()
     assert hooks["hooks"]["beforeSubmitPrompt"] == [{"command": "keep-hook"}]
-    assert hooks["hooks"]["sessionStart"] == [{"command": str(hook)}]
+    assert managed in hooks["hooks"]["sessionStart"]
+    assert managed in hooks["hooks"]["postToolUse"]
+    assert managed in hooks["hooks"]["sessionEnd"]
 
     mcp = json.loads((cursor / "mcp.json").read_text())
     assert mcp["settings"] == {"keep": True}
@@ -169,7 +184,13 @@ def test_cursor_user_install_rejects_malformed_coowned_json(tmp_path, monkeypatc
     assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 1
     payload = json.loads(capsys.readouterr().out)
 
-    assert len(payload["conflicts"]) == 2
+    assert len(payload["conflicts"]) == 4
+    assert {item.get("name") for item in payload["conflicts"] if item.get("surface") == "hook-config"} == {
+        "sessionStart",
+        "postToolUse",
+        "sessionEnd",
+    }
+    assert sum(item.get("surface") == "mcp-config" for item in payload["conflicts"]) == 1
     assert hooks_path.read_text() == "{bad hooks"
     assert mcp_path.read_text() == "[]"
 
@@ -313,7 +334,8 @@ def test_cursor_user_uninstall_reload_requires_an_actual_change(tmp_path, monkey
     state_path.write_text(json.dumps(state))
     hooks_path = cursor / "hooks.json"
     hooks = json.loads(hooks_path.read_text())
-    hooks["hooks"].pop("sessionStart")
+    for event in ("sessionStart", "postToolUse", "sessionEnd"):
+        hooks["hooks"].pop(event, None)
     hooks_path.write_text(json.dumps(hooks))
 
     assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 1
@@ -340,3 +362,240 @@ def test_cursor_user_uninstall_treats_missing_mcp_config_as_already_removed(
     mcp_items = [item for item in payload["items"] if item["surface"] == "mcp-config"]
     assert all(item["status"] == "absent" for item in mcp_items)
     assert not (cursor / "brigade" / "install-state.json").exists()
+
+
+_MANAGED_CURSOR_HOOK = "exec brigade work presence-hook --harness cursor --stdin --context cursor-work-loop"
+_CURSOR_HOOK_EVENTS = ("sessionStart", "postToolUse", "sessionEnd")
+_PLANTED_SECRETS = {
+    "prompt": "PLANTED_PROMPT_DO_NOT_LEAK",
+    "transcript": "PLANTED_TRANSCRIPT_DO_NOT_LEAK",
+    "user_email": "planted-user@example.com",
+    "tool_output": "PLANTED_TOOL_OUTPUT_DO_NOT_LEAK",
+    "credential": "PLANTED_CREDENTIAL_DO_NOT_LEAK",
+}
+
+
+def test_cursor_hook_text_is_the_presence_adapter():
+    text = cursor_user_cmd._hook_text()
+    assert text.startswith("#!/bin/sh\n")
+    assert text.splitlines()[-1] == _MANAGED_CURSOR_HOOK
+    assert cursor_user_cmd._hook_entry() == {"command": _MANAGED_CURSOR_HOOK}
+    assert "hooks/brigade-session-start" not in cursor_user_cmd._hook_entry()["command"]
+
+
+def test_cursor_install_registers_presence_hook_on_three_events_and_keeps_foreign(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    cursor = tmp_path / ".cursor"
+    cursor.mkdir()
+    (cursor / "hooks.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "hooks": {
+                    "sessionStart": [{"command": "keep-start"}],
+                    "postToolUse": [{"command": "keep-post"}],
+                    "sessionEnd": [{"command": "keep-end"}],
+                },
+            }
+        )
+    )
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    hooks = json.loads((cursor / "hooks.json").read_text())
+    managed = {"command": _MANAGED_CURSOR_HOOK}
+    assert hooks["hooks"]["sessionStart"][0] == {"command": "keep-start"}
+    assert hooks["hooks"]["postToolUse"][0] == {"command": "keep-post"}
+    assert hooks["hooks"]["sessionEnd"][0] == {"command": "keep-end"}
+    for event in _CURSOR_HOOK_EVENTS:
+        assert managed in hooks["hooks"][event]
+
+
+def test_cursor_presence_hook_prints_context_and_drops_planted_fields(tmp_path, monkeypatch, capsys):
+    snapshots = []
+    logs = []
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: snapshots.append(snap) or True)
+    monkeypatch.setattr(fleet_client, "end_session", lambda snap: snapshots.append(snap) or True)
+
+    def fake_log(*args, **kwargs):
+        logs.append((args, kwargs))
+
+    monkeypatch.setattr("brigade.fleet_session_presence._log_presence", fake_log, raising=False)
+
+    workspace = _wire_cursor_workspace(tmp_path)
+    planted = {
+        "conversation_id": "conv-1",
+        "session_id": "sess-1",
+        "hook_event_name": "sessionStart",
+        "workspace_roots": [str(workspace)],
+        **_PLANTED_SECRETS,
+        "node_id": "planted-node",
+        "repo_identity": "evil.com/stolen",
+        "dirty_paths": ["secret.diff"],
+        "checkout_path": "/stolen/checkout",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(planted)))
+    argv = ["work", "presence-hook", "--harness", "cursor", "--stdin", "--context", "cursor-work-loop"]
+    assert cli.main(argv) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert "additional_context" in payload
+    blob = " ".join(
+        [
+            captured.out,
+            captured.err,
+            json.dumps(argv),
+            json.dumps([snap.__dict__ for snap in snapshots], default=str),
+            repr(logs),
+        ]
+    )
+    for secret in _PLANTED_SECRETS.values():
+        assert secret not in blob
+    assert snapshots
+    assert snapshots[0].harness == "cursor"
+    assert snapshots[0].session_id == "sess-1"
+    assert snapshots[0].repo_identity != "evil.com/stolen"
+    assert snapshots[0].checkout_path != "/stolen/checkout"
+    assert "secret.diff" not in snapshots[0].dirty_paths
+
+
+def test_cursor_presence_hook_prints_empty_object_for_refresh_and_end(tmp_path, monkeypatch, capsys):
+    workspace = _wire_cursor_workspace(tmp_path)
+    calls = []
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: calls.append(("upsert", snap)) or True)
+    monkeypatch.setattr(fleet_client, "end_session", lambda snap: calls.append(("end", snap)) or True)
+    for event, extra in (("postToolUse", {"tool_name": "Write"}), ("sessionEnd", {})):
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "conversation_id": "conv-1",
+                        "session_id": "sess-1",
+                        "hook_event_name": event,
+                        "workspace_roots": [str(workspace)],
+                        **extra,
+                    }
+                )
+            ),
+        )
+        assert (
+            cli.main(["work", "presence-hook", "--harness", "cursor", "--stdin", "--context", "cursor-work-loop"]) == 0
+        )
+        assert json.loads(capsys.readouterr().out) == {}
+    assert [item[0] for item in calls] == ["upsert", "end"]
+
+
+def test_cursor_presence_hook_skips_publish_when_workspace_missing(tmp_path, monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: calls.append(snap) or True)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "sessionStart", "conversation_id": "conv-1"})),
+    )
+    assert cli.main(["work", "presence-hook", "--harness", "cursor", "--stdin", "--context", "cursor-work-loop"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "additional_context" in payload
+    assert calls == []
+
+
+def test_cursor_presence_fails_open_on_unwired_workspace_and_operator_home(tmp_path, monkeypatch, capsys):
+    calls = []
+    git_calls = []
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: calls.append(snap) or True)
+    real_run = __import__("subprocess").run
+
+    def counted(cmd, *args, **kwargs):
+        git_calls.append(list(cmd))
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr("subprocess.run", counted)
+    home = _wire_cursor_workspace(tmp_path / "home")
+    nested_home = home / "nested"
+    nested_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home.resolve()))
+    unwired = tmp_path / "unwired"
+    unwired.mkdir()
+    for workspace in (unwired, home, nested_home):
+        git_calls.clear()
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "conversation_id": "conv-1",
+                        "session_id": "sess-1",
+                        "hook_event_name": "sessionStart",
+                        "workspace_roots": [str(workspace)],
+                    }
+                )
+            ),
+        )
+        assert (
+            cli.main(["work", "presence-hook", "--harness", "cursor", "--stdin", "--context", "cursor-work-loop"]) == 0
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert "additional_context" in payload
+        assert calls == []
+        assert git_calls == []
+
+
+def test_cursor_post_tool_use_skips_non_write_and_publishes_writes(tmp_path, monkeypatch, capsys):
+    workspace = _wire_cursor_workspace(tmp_path)
+    subprocess = __import__("subprocess")
+    subprocess.run(["git", "init"], cwd=workspace, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "dev@example.com"], cwd=workspace, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Example Dev"], cwd=workspace, check=True, capture_output=True)
+    (workspace / "README.md").write_text("ok\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=workspace, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=workspace, check=True, capture_output=True)
+    calls = []
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: calls.append(snap) or True)
+
+    def run_hook(tool_name: str) -> None:
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "conversation_id": "conv-1",
+                        "session_id": "sess-1",
+                        "hook_event_name": "postToolUse",
+                        "tool_name": tool_name,
+                        "workspace_roots": [str(workspace)],
+                    }
+                )
+            ),
+        )
+        assert (
+            cli.main(["work", "presence-hook", "--harness", "cursor", "--stdin", "--context", "cursor-work-loop"]) == 0
+        )
+        assert json.loads(capsys.readouterr().out) == {}
+
+    run_hook("Read")
+    assert calls == []
+    run_hook("Write")
+    assert len(calls) == 1
+    run_hook("Write")
+    assert len(calls) == 2
+
+
+def test_cursor_installed_hook_file_has_shebang_and_stays_executable(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    hook = tmp_path / ".cursor" / "hooks" / "brigade-session-start"
+    text = hook.read_text(encoding="utf-8")
+    assert text.startswith("#!/")
+    assert _MANAGED_CURSOR_HOOK in text
+    assert hook.stat().st_mode & 0o111
+    assert json.loads((tmp_path / ".cursor" / "hooks.json").read_text())["hooks"]["sessionStart"][-1] == {
+        "command": _MANAGED_CURSOR_HOOK
+    }

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from brigade import fleet_client, fleet_hub
+from brigade import fleet_hub_sessions as sessions
 
 NODE_A = "11111111-1111-4111-8111-111111111111"
 NODE_B = "22222222-2222-4222-8222-222222222222"
@@ -2207,3 +2208,155 @@ class TestExitOrphanReleaseHardening:
         assert reacquire_finished.wait(10), "late re-acquire never committed"
         leaked = [c for c in fleet_client.fetch_claims(include_all=True) if c["target"] == "repo-a"]
         assert len(leaked) == 1, "expected exactly the post-final-retry commit to leak as the documented residual"
+
+
+def _schema_13_database(tmp_path: Path) -> Path:
+    db = tmp_path / "schema13.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE events (
+            node_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            sequence INTEGER NOT NULL,
+            digest TEXT NOT NULL,
+            repo TEXT,
+            seat TEXT,
+            harness TEXT,
+            state TEXT NOT NULL,
+            ts TEXT NOT NULL,
+            exit_status INTEGER,
+            capability_fingerprint TEXT,
+            received_at TEXT NOT NULL,
+            PRIMARY KEY (node_id, run_id, sequence, digest)
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO events VALUES ("
+        "'node-a', 'run-1', 1, 'digest-1', NULL, NULL, NULL, "
+        "'run.started', '2026-01-01T00:00:00+00:00', NULL, NULL, "
+        "'2026-01-01T00:00:00+00:00')"
+    )
+    conn.execute("PRAGMA user_version=13")
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _upsert(**overrides: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "action": "upsert",
+        "harness": "claude",
+        "session_id": "sess-1",
+        "repo_identity": "github.com/example/project",
+        "identity_scope": "fleet",
+        "repo_label": "project",
+        "checkout_path": "/tmp/project",
+        "branch": "main",
+        "dirty_paths": ["src/a.py"],
+        "dirty_truncated": False,
+        "ttl_seconds": 900,
+    }
+    body.update(overrides)
+    return body
+
+
+def _end(**overrides: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "action": "end",
+        "harness": "claude",
+        "session_id": "sess-1",
+        "repo_identity": "github.com/example/project",
+    }
+    body.update(overrides)
+    return body
+
+
+class TestInteractiveSessions:
+    @pytest.fixture()
+    def conn(self, tmp_path: Path):
+        connection = fleet_hub.init_db(tmp_path / "sessions.db")
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    def test_schema_13_migrates_to_14_without_touching_existing_rows(self, tmp_path):
+        db = _schema_13_database(tmp_path)
+        conn = fleet_hub.init_db(db)
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 14
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM interactive_sessions").fetchone()[0] == 0
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(events)").fetchall()}
+        assert "repo_identity" in columns
+        conn.close()
+
+    def test_upsert_retry_refresh_end_and_expiry(self, conn, monkeypatch):
+        first = sessions.handle_session(conn, _upsert(), caller_node=NODE_A)
+        retry = sessions.handle_session(conn, _upsert(branch="topic"), caller_node=NODE_A)
+        assert retry[1]["session"]["started_at"] == first[1]["session"]["started_at"]
+        assert retry[1]["session"]["branch"] == "topic"
+        assert sessions.handle_session(conn, _end(), caller_node=NODE_A)[0] == 200
+        assert sessions.list_sessions(conn) == []
+        assert sessions.list_sessions(conn, include_all=True)[0]["state"] == "ended"
+
+    def test_expired_active_rows_are_hidden_until_history(self, conn, monkeypatch):
+        clock = {"now": 1_700_000_000.0}
+        monkeypatch.setattr(fleet_hub, "_now_epoch", lambda: clock["now"])
+        sessions.handle_session(conn, _upsert(ttl_seconds=120), caller_node=NODE_A)
+        assert len(sessions.list_sessions(conn)) == 1
+        first_started = sessions.list_sessions(conn)[0]["started_at"]
+        clock["now"] += 121
+        assert sessions.list_sessions(conn) == []
+        history = sessions.list_sessions(conn, include_all=True)
+        assert history[0]["state"] == "active"
+        refreshed = sessions.handle_session(conn, _upsert(branch="later"), caller_node=NODE_A)
+        assert refreshed[1]["session"]["started_at"] != first_started
+        assert refreshed[1]["session"]["branch"] == "later"
+
+    def test_node_writes_reject_body_node_id_and_admin_requires_it(self, conn):
+        with pytest.raises(fleet_hub.FleetHubError, match="node_id"):
+            sessions.handle_session(conn, _upsert(node_id=NODE_A), caller_node=NODE_A)
+        assert sessions.list_sessions(conn, include_all=True) == []
+        with pytest.raises(fleet_hub.FleetHubError, match="node_id"):
+            sessions.handle_session(conn, _upsert(), caller_node=None)
+        assert sessions.list_sessions(conn, include_all=True) == []
+        status, payload = sessions.handle_session(conn, _upsert(node_id=NODE_B), caller_node=None)
+        assert status == 200
+        assert payload["session"]["node_id"] == NODE_B
+
+    def test_validation_rejects_before_any_write(self, conn):
+        with pytest.raises(fleet_hub.FleetHubError):
+            sessions.handle_session(conn, _upsert(dirty_paths=["/etc/passwd"]), caller_node=NODE_A)
+        with pytest.raises(fleet_hub.FleetHubError):
+            sessions.handle_session(conn, _upsert(dirty_paths=["../secret"]), caller_node=NODE_A)
+        with pytest.raises(fleet_hub.FleetHubError):
+            sessions.handle_session(
+                conn,
+                _upsert(
+                    repo_identity="https://user:secret@github.com/example/project.git"  # content-guard: allow email
+                ),
+                caller_node=NODE_A,
+            )
+        with pytest.raises(fleet_hub.FleetHubUnprocessable):
+            sessions.handle_session(conn, _upsert(branch="topic\x1b"), caller_node=NODE_A)
+        assert sessions.list_sessions(conn, include_all=True) == []
+
+    def test_public_rows_omit_auth_material(self, conn):
+        sessions.handle_session(conn, _upsert(), caller_node=NODE_A)
+        row = sessions.list_sessions(conn)[0]
+        serialized = json.dumps(row)
+        assert "secret" not in serialized
+        assert "token" not in serialized
+        assert "holder" not in serialized
+        assert "Authorization" not in serialized
+
+    def test_handle_session_does_not_commit_caller_owned_transaction(self, conn):
+        conn.execute("BEGIN IMMEDIATE")
+        assert conn.in_transaction
+        status, _payload = sessions.handle_session(conn, _upsert(), caller_node=NODE_A)
+        assert status == 200
+        assert conn.in_transaction
+        conn.rollback()
+        assert sessions.list_sessions(conn, include_all=True) == []

--- a/tests/test_fleet_command_deck.py
+++ b/tests/test_fleet_command_deck.py
@@ -13,6 +13,7 @@ import pytest
 
 from brigade import fleet_command_deck as deck
 from brigade import fleet_hub
+from brigade import fleet_hub_sessions
 
 NODE_A = "11111111-1111-4111-8111-111111111111"
 NODE_B = "22222222-2222-4222-8222-222222222222"
@@ -30,6 +31,7 @@ CREATE TABLE IF NOT EXISTS events (
     state TEXT NOT NULL,
     ts TEXT NOT NULL,
     received_at TEXT NOT NULL,
+    repo_identity TEXT,
     PRIMARY KEY (node_id, run_id, sequence, digest)
 );
 """
@@ -72,8 +74,222 @@ def _insert(
 def conn() -> sqlite3.Connection:
     conn = sqlite3.connect(":memory:")
     conn.execute(_EVENTS_SCHEMA)
+    fleet_hub_sessions.init_schema(conn)
     yield conn
     conn.close()
+
+
+@pytest.fixture()
+def now() -> datetime:
+    return NOW
+
+
+def _seed_session(
+    conn: sqlite3.Connection,
+    *,
+    node: str = NODE_A,
+    checkout_path: str = "/tmp/project",
+    dirty_paths: list[str] | None = None,
+    harness: str = "claude",
+    session_id: str | None = None,
+    repo_identity: str = "github.com/example/project",
+    identity_scope: str = "fleet",
+    repo_label: str = "project",
+    branch: str = "main",
+) -> None:
+    paths = dirty_paths if dirty_paths is not None else ["src/a.py"]
+    started = NOW.isoformat()
+    conn.execute(
+        "INSERT INTO interactive_sessions ("
+        "node_id, harness, session_id, repo_identity, identity_scope, repo_label, "
+        "checkout_path, branch, dirty_paths_json, dirty_truncated, state, started_at, "
+        "heartbeat_at, ended_at, ttl_seconds, expires_at"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 'active', ?, ?, NULL, 900, ?)",
+        (
+            node,
+            harness,
+            session_id or f"sess-{node[:8]}",
+            repo_identity,
+            identity_scope,
+            repo_label,
+            checkout_path,
+            branch,
+            json.dumps(paths),
+            started,
+            started,
+            NOW.timestamp() + 900,
+        ),
+    )
+
+
+def test_deck_sessions_are_separate_escaped_and_do_not_consume_capacity(conn, now):
+    _seed_session(conn, checkout_path="<script>alert(1)</script>", dirty_paths=["src/a.py"])
+    sessions = deck.fetch_interactive_sessions(conn, now=now)
+    view = deck.build_view(
+        deck.DeckConfig(stations=(deck.StationConfig(NODE_A, "Alpha", 10),)),
+        live_runs=[],
+        claims=[],
+        enrolled_labels={NODE_A: "Alpha"},
+        last_heard={},
+        outcomes=[],
+        failed_outcomes=[],
+        observers=[],
+        now=now,
+        interactive_sessions=sessions,
+    )
+    html = deck.render_deck(view, nonce="nonce", now=now)
+    assert "Interactive sessions" in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "<script>alert(1)</script>" not in html
+    assert view.stations[0].busy == 0
+
+
+def test_repo_page_marks_only_exact_live_dirty_overlap(conn, now):
+    repo_identity = "github.com/example/" + ("a" * 300)
+    _seed_session(conn, node=NODE_A, dirty_paths=["src/a.py"], repo_identity=repo_identity)
+    _seed_session(conn, node=NODE_B, dirty_paths=["src/a.py"], repo_identity=repo_identity)
+    sessions = deck.fetch_interactive_sessions(conn, now=now)
+    view = deck.build_view(
+        deck.DeckConfig(stations=(deck.StationConfig(NODE_A, "Alpha", 10),)),
+        live_runs=[],
+        claims=[],
+        enrolled_labels={NODE_A: "Alpha", NODE_B: "Bravo"},
+        last_heard={},
+        outcomes=[],
+        failed_outcomes=[],
+        observers=[],
+        now=now,
+        interactive_sessions=sessions,
+    )
+    assert view.repos[0].target == "project"
+    assert view.repos[0].interactive_overlap is True
+    assert view.repos[0].repo_identity == repo_identity
+    assert all(row.target != repo_identity for row in view.repos)
+
+
+def test_live_run_plus_two_sessions_marks_run_row_without_identity_duplicate(conn, now):
+    identity = "github.com/example/project"
+    _insert(conn, NODE_A, "run-1", 1, "run.started", repo="project")
+    conn.execute("UPDATE events SET repo_identity = ? WHERE run_id = ?", (identity, "run-1"))
+    _seed_session(conn, node=NODE_A, dirty_paths=["src/a.py"], repo_identity=identity, repo_label="project")
+    _seed_session(conn, node=NODE_B, dirty_paths=["src/a.py"], repo_identity=identity, repo_label="project")
+    sessions = deck.fetch_interactive_sessions(conn, now=now)
+    runs = [
+        deck.LiveRun(
+            node_id=NODE_A,
+            run_id="run-1",
+            repo="project",
+            seat="seat",
+            harness="claude",
+            state="run.started",
+            bucket="running",
+            age_seconds=10,
+            elapsed_seconds=10,
+            repo_identity=identity,
+        )
+    ]
+    view = deck.build_view(
+        deck.DeckConfig(stations=(deck.StationConfig(NODE_A, "Alpha", 10),)),
+        live_runs=runs,
+        claims=[],
+        enrolled_labels={NODE_A: "Alpha", NODE_B: "Bravo"},
+        last_heard={},
+        outcomes=[],
+        failed_outcomes=[],
+        observers=[],
+        now=now,
+        interactive_sessions=sessions,
+    )
+    targets = [row.target for row in view.repos]
+    assert targets == ["project"]
+    assert identity not in targets
+    assert view.repos[0].interactive_overlap is True
+    assert view.repos[0].repo_identity == identity
+
+
+def test_unrelated_brigade_basename_does_not_attach_session_overlap(conn, now):
+    run_identity = "github.com/example/brigade"
+    session_identity = "github.com/other/brigade"
+    _seed_session(
+        conn,
+        node=NODE_A,
+        dirty_paths=["src/a.py"],
+        repo_identity=session_identity,
+        repo_label="brigade",
+    )
+    _seed_session(
+        conn,
+        node=NODE_B,
+        dirty_paths=["src/a.py"],
+        repo_identity=session_identity,
+        repo_label="brigade",
+        session_id="sess-other",
+    )
+    sessions = deck.fetch_interactive_sessions(conn, now=now)
+    runs = [
+        deck.LiveRun(
+            node_id=NODE_A,
+            run_id="run-brigade",
+            repo="brigade",
+            seat="seat",
+            harness="claude",
+            state="run.started",
+            bucket="running",
+            age_seconds=10,
+            elapsed_seconds=10,
+            repo_identity=run_identity,
+        )
+    ]
+    view = deck.build_view(
+        deck.DeckConfig(stations=(deck.StationConfig(NODE_A, "Alpha", 10),)),
+        live_runs=runs,
+        claims=[],
+        enrolled_labels={NODE_A: "Alpha", NODE_B: "Bravo"},
+        last_heard={},
+        outcomes=[],
+        failed_outcomes=[],
+        observers=[],
+        now=now,
+        interactive_sessions=sessions,
+    )
+    run_row = next(row for row in view.repos if row.live)
+    session_row = next(row for row in view.repos if row.interactive_overlap)
+    assert run_row.target == "brigade"
+    assert run_row.interactive_overlap is False
+    assert run_row.repo_identity == run_identity
+    assert session_row.target != "brigade"
+    assert session_row.target != run_row.target
+    assert session_row.repo_identity == session_identity
+    assert session_row.live == ()
+    html = deck.render_repos(view, nonce="nonce", now=now)
+    assert ">brigade<" in html
+    assert session_row.target in html
+    assert html.count("! overlap") == 1
+
+
+def test_identity_bearing_session_label_stays_unique_when_truncated():
+    identity = "github.com/example/" + ("x" * 300)
+    session = deck.InteractiveSession(
+        node_id=NODE_A,
+        harness="claude",
+        session_id="sess-long",
+        repo_identity=identity,
+        identity_scope="fleet",
+        repo_label="x" * 300,
+        checkout_path="/tmp/project",
+        branch="main",
+        dirty_paths=("src/a.py",),
+        dirty_truncated=False,
+    )
+    candidate = f"{session.repo_label} ({identity})"[:256]
+    bounded_identity = identity[:256]
+    occupied = {candidate, bounded_identity}
+
+    label = deck._identity_bearing_session_label(session, occupied)
+
+    assert len(label) <= 256
+    assert label not in occupied
+    assert label.endswith(" #2")
 
 
 def seed_events(

--- a/tests/test_fleet_dashboard.py
+++ b/tests/test_fleet_dashboard.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from brigade import fleet_dashboard, fleet_hub
+from brigade import fleet_dashboard, fleet_hub, fleet_hub_sessions
 
 NODE_A = "11111111-1111-4111-8111-111111111111"
 NODE_B = "22222222-2222-4222-8222-222222222222"
@@ -528,6 +528,65 @@ class TestPureRendering:
         )
         assert 'nonce="abc"' in page
         assert "Fleet: Repos" in page
+
+
+def test_interactive_sessions_stay_off_legacy_boards_and_station_capacity(tmp_path):
+    config_path = tmp_path / "deck.json"
+    config_path.write_text(
+        json.dumps({"stations": [{"node_id": NODE_A, "name": "Alpha", "capacity": 10}]}),
+        encoding="utf-8",
+    )
+    db = tmp_path / "hub" / "fleet.db"
+    server = fleet_hub.make_server(
+        "127.0.0.1",
+        0,
+        db,
+        TOKEN,
+        allow_admin_writes=True,
+        deck_config_path=config_path,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        hub = ("127.0.0.1", server.server_address[1])
+        conn = fleet_hub.open_db(db)
+        try:
+            status, _payload = fleet_hub_sessions.handle_session(
+                conn,
+                {
+                    "action": "upsert",
+                    "node_id": NODE_A,
+                    "harness": "claude",
+                    "session_id": "sess-board",
+                    "repo_identity": "github.com/example/project",
+                    "identity_scope": "fleet",
+                    "repo_label": "project",
+                    "checkout_path": "<script>alert(1)</script>",
+                    "branch": "main",
+                    "dirty_paths": ["src/a.py"],
+                    "dirty_truncated": False,
+                    "ttl_seconds": 900,
+                },
+                caller_node=None,
+            )
+            assert status == 200
+        finally:
+            conn.close()
+        status, _headers, deck_body = _request(hub, "GET", "/deck", headers=_bearer())
+        assert status == 200
+        assert "Interactive sessions" in deck_body
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in deck_body
+        assert "<script>alert(1)</script>" not in deck_body
+        assert "0/10 busy" in deck_body
+        status, _headers, machines = _request(hub, "GET", "/view/machines", headers=_bearer())
+        assert status == 200
+        assert "sess-board" not in machines
+        assert "<script>alert(1)</script>" not in machines
+        assert "No fleet events recorded yet." in machines
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 TAILSCALE_USER = "tailscale-user@example.invalid"

--- a/tests/test_fleet_session_presence.py
+++ b/tests/test_fleet_session_presence.py
@@ -1,0 +1,323 @@
+"""Local repository identity, dirty-path snapshots, and overlap projection."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from types import SimpleNamespace
+
+from brigade import fleet_session_presence as presence
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "dev@example.com")
+    _git(repo, "config", "user.name", "Example Dev")
+    (repo / "README.md").write_text("ok\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _set_origin(repo: Path, remote: str) -> None:
+    existing = subprocess.run(
+        ["git", "remote"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if "origin" in existing.stdout.split():
+        _git(repo, "remote", "remove", "origin")
+    _git(repo, "remote", "add", "origin", remote)
+
+
+def _seed_dirty_paths(repo: Path, *, count: int, include_rename: bool = False) -> None:
+    brigade_dir = repo / ".brigade"
+    brigade_dir.mkdir(exist_ok=True)
+    (brigade_dir / "run.lock").write_text("local-only\n", encoding="utf-8")
+    if include_rename:
+        source = repo / "to-rename.txt"
+        source.write_text("rename-me\n", encoding="utf-8")
+        _git(repo, "add", "to-rename.txt")
+        _git(repo, "commit", "-m", "seed rename source")
+        _git(repo, "mv", "to-rename.txt", "renamed file.txt")
+    for index in range(count):
+        (repo / f"z-dirty-{index:03d}.txt").write_text(f"{index}\n", encoding="utf-8")
+
+
+def test_remote_forms_have_one_credential_free_identity(git_repo, monkeypatch):
+    identities = []
+    for remote in (
+        "https://github.com/example/project.git",
+        "https://user:secret@github.com/example/project.git",  # content-guard: allow email
+        "ssh://git@github.com/example/project.git",  # content-guard: allow email
+        "git@github.com:example/project.git",  # content-guard: allow email
+    ):
+        _set_origin(git_repo, remote)
+        identities.append(presence.repository_identity(git_repo))
+    assert {item.value for item in identities} == {"github.com/example/project"}
+    assert all(item.scope == "fleet" for item in identities)
+    assert "secret" not in repr(identities)
+
+
+def test_dirty_paths_are_bounded_relative_and_rename_safe(git_repo):
+    _seed_dirty_paths(git_repo, count=70, include_rename=True)
+    snapshot = presence.collect_dirty_paths(git_repo)
+    assert len(snapshot.paths) == 64
+    assert snapshot.truncated is True
+    assert all(not Path(path).is_absolute() and ".." not in Path(path).parts for path in snapshot.paths)
+    assert "renamed file.txt" in snapshot.paths
+    assert all(not path.startswith(".brigade/") for path in snapshot.paths)
+
+
+def test_missing_remote_is_node_scoped_and_uses_local_digest(git_repo):
+    identity = presence.repository_identity(git_repo)
+    common = _git(git_repo, "rev-parse", "--git-common-dir").stdout.strip()
+    common_path = Path(common) if Path(common).is_absolute() else git_repo / common
+    digest = hashlib.sha256(str(common_path.resolve()).encode()).hexdigest()
+    assert identity.scope == "node"
+    assert identity.value == f"local:{digest}"
+
+
+def test_overlap_warns_once_and_skips_same_session_or_disjoint_paths():
+    current = presence.SessionSnapshot(
+        harness="claude",
+        session_id="sess-a",
+        repo_identity="github.com/example/project",
+        identity_scope="fleet",
+        repo_label="project",
+        checkout_path="/tmp/project",
+        branch="topic",
+        dirty_paths=("src/a.py", "src/b.py"),
+        dirty_truncated=False,
+    )
+    other = {
+        "node_id": "node-b",
+        "harness": "cursor",
+        "session_id": "sess-b",
+        "repo_identity": "github.com/example/project",
+        "identity_scope": "fleet",
+        "checkout_path": "/other/project",
+        "branch": "main",
+        "dirty_paths": ["src/b.py", "src/c.py"],
+        "dirty_truncated": False,
+        "state": "active",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "expires_at": 9_999_999_999.0,
+    }
+    same_session = {
+        **other,
+        "node_id": "node-a",
+        "harness": "claude",
+        "session_id": "sess-a",
+        "dirty_paths": ["src/a.py"],
+    }
+    disjoint = {**other, "session_id": "sess-c", "dirty_paths": ["docs/readme.md"]}
+    warnings = presence.overlap_warnings(
+        current,
+        [other, same_session, disjoint],
+        current_node="node-a",
+    )
+    assert len(warnings) == 1
+    assert warnings[0]["node_id"] == "node-b"
+    assert warnings[0]["paths"] == ["src/b.py"]
+    assert warnings[0]["partial"] is False
+
+
+def test_overlap_marks_truncated_observations_partial():
+    current = presence.SessionSnapshot(
+        harness="claude",
+        session_id="sess-a",
+        repo_identity="github.com/example/project",
+        identity_scope="fleet",
+        repo_label="project",
+        checkout_path="/tmp/project",
+        branch="topic",
+        dirty_paths=("src/a.py",),
+        dirty_truncated=True,
+    )
+    other = {
+        "node_id": "node-b",
+        "harness": "cursor",
+        "session_id": "sess-b",
+        "repo_identity": "github.com/example/project",
+        "identity_scope": "fleet",
+        "checkout_path": "/other/project",
+        "branch": "main",
+        "dirty_paths": ["src/a.py"],
+        "dirty_truncated": True,
+        "state": "active",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "expires_at": 9_999_999_999.0,
+    }
+    warnings = presence.overlap_warnings(current, [other], current_node="node-a")
+    assert warnings[0]["partial"] is True
+    assert warnings[0]["paths"] == ["src/a.py"]
+
+
+def test_git_status_timeout_is_partial_never_clean(git_repo, monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=["git"], timeout=5)
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    snapshot = presence.collect_dirty_paths(git_repo)
+    assert snapshot.paths == ()
+    assert snapshot.truncated is True
+
+
+def test_git_status_missing_binary_is_partial_never_clean(git_repo, monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    snapshot = presence.collect_dirty_paths(git_repo)
+    assert snapshot.paths == ()
+    assert snapshot.truncated is True
+
+
+def test_git_status_nonzero_is_partial_never_clean(git_repo, monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(args=["git"], returncode=128, stdout="", stderr="fatal"),
+    )
+    snapshot = presence.collect_dirty_paths(git_repo)
+    assert snapshot.paths == ()
+    assert snapshot.truncated is True
+
+
+def test_normalized_brigade_skips_are_not_partial(git_repo, monkeypatch):
+    real_run = subprocess.run
+
+    def fake(cmd, *args, **kwargs):
+        if list(cmd[:2]) == ["git", "status"]:
+            return SimpleNamespace(returncode=0, stdout="?? ./.brigade/local.lock\0?? .brigade/other\0")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake)
+    snapshot = presence.collect_dirty_paths(git_repo)
+    assert snapshot.paths == ()
+    assert snapshot.truncated is False
+
+
+def test_encoded_path_separators_reject_before_and_after_one_decode(git_repo):
+    presence.clear_repository_identity_cache()
+    decoded = presence._parse_remote("https://github.com/example/project/extra.git")
+    assert decoded == "github.com/example/project/extra"
+    for remote in (
+        "https://github.com/example/project%2Fextra.git",
+        "https://github.com/example/project%252Fextra.git",
+        "https://github.com/example/project%2fextra.git",
+        "git@github.com:example/project%2Fextra.git",
+    ):
+        assert presence._parse_remote(remote) is None
+        _set_origin(git_repo, remote)
+        presence.clear_repository_identity_cache()
+        identity = presence.repository_identity(git_repo)
+        assert identity.scope == "node"
+        assert identity.value.startswith("local:")
+        assert "%2F" not in identity.value
+        assert "%252F" not in identity.value
+    presence.clear_repository_identity_cache()
+
+
+def test_decoded_remote_rejects_controls_and_secret_like_ambiguity():
+    assert presence._parse_remote("https://github.com/example/pro%00ject.git") is None
+    assert presence._parse_remote("https://github.com/example/token%3Dabc.git") is None
+    assert presence._parse_remote(  # content-guard: allow email
+        "https://user:secret@github.com/example/project.git"
+    ) == ("github.com/example/project")
+
+
+def test_repository_identity_is_cached_and_invalidates_when_remote_changes(git_repo):
+    presence.clear_repository_identity_cache()
+    _set_origin(git_repo, "https://github.com/example/project.git")
+    first = presence.repository_identity(git_repo)
+    assert first.value == "github.com/example/project"
+    second = presence.repository_identity(git_repo)
+    assert second == first
+    _set_origin(git_repo, "https://github.com/example/other.git")
+    third = presence.repository_identity(git_repo)
+    assert third.value == "github.com/example/other"
+    presence.clear_repository_identity_cache()
+
+
+def test_publish_presence_skips_git_when_hub_unconfigured(git_repo, monkeypatch):
+    git_calls = []
+    real_run = subprocess.run
+
+    def counted(cmd, *args, **kwargs):
+        git_calls.append(list(cmd))
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", counted)
+    calls = []
+    monkeypatch.setattr("brigade.fleet_client.upsert_session", lambda snap: calls.append(snap) or True)
+    presence._publish_presence("SessionStart", git_repo, "s1")
+    assert calls == []
+    assert git_calls == []
+
+
+def test_worktree_identity_cache_follows_common_config(git_repo, tmp_path):
+    presence.clear_repository_identity_cache()
+    _set_origin(git_repo, "https://github.com/example/project.git")
+    worktree = tmp_path / "linked-worktree"
+    _git(git_repo, "worktree", "add", str(worktree), "HEAD")
+    first = presence.repository_identity(worktree)
+    assert first.value == "github.com/example/project"
+    _set_origin(git_repo, "https://github.com/example/other.git")
+    second = presence.repository_identity(worktree)
+    assert second.value == "github.com/example/other"
+    presence.clear_repository_identity_cache()
+
+
+def test_git_metadata_read_rejects_oversized_and_nonregular_paths(tmp_path):
+    oversized = tmp_path / "oversized"
+    oversized.write_bytes(b"x" * (presence._GIT_DIR_FILE_LIMIT + 1))
+    assert presence._read_bounded_text(oversized) is None
+
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    assert presence._read_bounded_text(directory) is None
+
+
+def test_publish_presence_maps_events_and_swallows_errors(git_repo, monkeypatch):
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    calls = []
+    monkeypatch.setattr(
+        "brigade.fleet_client.upsert_session",
+        lambda snap: calls.append(("upsert", snap)) or True,
+    )
+    monkeypatch.setattr(
+        "brigade.fleet_client.end_session",
+        lambda snap: calls.append(("end", snap)) or True,
+    )
+    presence._publish_presence("SessionStart", git_repo, "s1")
+    presence._publish_presence("PostToolUse", git_repo, "s1")
+    presence._publish_presence("Stop", git_repo, "s1")
+    assert [item[0] for item in calls] == ["upsert", "upsert", "end"]
+    assert all(item[1].harness == "claude" and item[1].session_id == "s1" for item in calls)
+
+    monkeypatch.setattr(
+        "brigade.fleet_client.upsert_session",
+        lambda snap: (_ for _ in ()).throw(RuntimeError("hub down")),
+    )
+    presence._publish_presence("SessionStart", git_repo, "s2")

--- a/tests/test_fleet_sync.py
+++ b/tests/test_fleet_sync.py
@@ -519,6 +519,7 @@ class TestJournalHook:
         assert seen[0]["ts"] == event.recorded_at
         assert seen[0]["run_id"] == "runA"
         assert seen[0]["repo"] == "ws"
+        assert seen[0]["repo_identity"] is not None
         # The real resolver returns the per-machine home identity, not the
         # workspace-local one that also exists here.
         assert fleet_client.resolve_node_id(journal) == NODE_A
@@ -568,6 +569,7 @@ class TestJournalHook:
         assert spooled["node_id"] == NODE_A
         assert spooled["repo"] == "ws"
         assert spooled["state"] == "run.created"
+        assert isinstance(spooled["repo_identity"], str) and spooled["repo_identity"]
 
     def test_no_hub_configured_does_not_spool(self, tmp_path, monkeypatch):
         from brigade import node as node_mod
@@ -1262,3 +1264,331 @@ class TestHubHardening:
 def test_conftest_clears_fleet_env():
     assert "BRIGADE_FLEET_HUB_URL" not in os.environ
     assert "BRIGADE_FLEET_TOKEN" not in os.environ
+
+
+ADMIN_TOKEN = "admin-token-sessions-12345"
+NODE_A_TOKEN = ""
+NODE_B_TOKEN = ""
+
+
+@pytest.fixture()
+def hub_server(tmp_path):
+    global NODE_A_TOKEN, NODE_B_TOKEN
+    db = tmp_path / "hub" / "sessions.db"
+    server = fleet_hub.make_server("127.0.0.1", 0, db, ADMIN_TOKEN, allow_admin_writes=False)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    NODE_A_TOKEN = _enroll_node(url, NODE_A)
+    NODE_B_TOKEN = _enroll_node(url, NODE_B)
+    try:
+        yield url
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _enroll_node(url: str, node_id: str) -> str:
+    status, payload = _request(url, "POST", "/nodes", body={"action": "add", "node_id": node_id}, token=ADMIN_TOKEN)
+    assert status == 200 and payload["added"] is True, payload
+    return str(payload["token"])
+
+
+def _request(hub, method: str, path: str, *, body=None, token=None, cookie=None) -> tuple[int, dict]:
+    headers: dict[str, str] = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    if cookie is not None:
+        headers["Cookie"] = cookie
+    data = json.dumps(body).encode() if body is not None else None
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(hub + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            return exc.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return exc.code, {}
+
+
+def _request_json(hub, method: str, path: str, *, body=None, token=None, cookie=None) -> tuple[int, dict]:
+    return _request(hub, method, path, body=body, token=token, cookie=cookie)
+
+
+def _upsert(**overrides: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "action": "upsert",
+        "harness": "claude",
+        "session_id": "sess-1",
+        "repo_identity": "github.com/example/project",
+        "identity_scope": "fleet",
+        "repo_label": "project",
+        "checkout_path": "/tmp/project",
+        "branch": "main",
+        "dirty_paths": ["src/a.py"],
+        "dirty_truncated": False,
+        "ttl_seconds": 900,
+    }
+    body.update(overrides)
+    return body
+
+
+def _dashboard_cookie() -> str:
+    return f"{fleet_hub.DASHBOARD_COOKIE}={fleet_hub.dashboard_cookie_value(ADMIN_TOKEN)}"
+
+
+def _create_session(hub, token: str) -> None:
+    status, payload = _request(hub, "POST", "/sessions", body=_upsert(), token=token)
+    assert status == 200, payload
+
+
+def _revoke_node(hub, node_id: str) -> None:
+    status, payload = _request(hub, "POST", "/nodes", body={"action": "revoke", "node_id": node_id}, token=ADMIN_TOKEN)
+    assert status == 200, payload
+
+
+def test_session_routes_auth_and_node_identity(hub_server):
+    assert _request(hub_server, "GET", "/sessions")[0] == 401
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(node_id=NODE_B), token=NODE_A_TOKEN)[0] == 400
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(), token=NODE_A_TOKEN)[0] == 200
+    status, body = _request_json(hub_server, "GET", "/sessions", token=NODE_A_TOKEN)
+    assert status == 200 and body["sessions"][0]["node_id"] == NODE_A
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(), cookie=_dashboard_cookie())[0] == 401
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(node_id=NODE_A), token=ADMIN_TOKEN)[0] == 403
+
+
+def test_session_admin_writes_include_local_node_id(monkeypatch, session_snapshot, tmp_path):
+    home = tmp_path / "operator"
+    _plant_home_identity(home, NODE_A)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("BRIGADE_HOME", str(home / ".brigade"))
+    calls = _record_hub_calls(monkeypatch, node_token=None, admin_token=ADMIN_TOKEN)
+    assert fleet_client.upsert_session(session_snapshot) is True
+    assert calls[0].body["node_id"] == NODE_A
+    assert "unknown" not in json.dumps(calls[0].body)
+
+
+def test_session_admin_unknown_identity_fails_open_without_unknown(monkeypatch, session_snapshot):
+    monkeypatch.setattr(fleet_client, "resolve_node_id", lambda base_path=None: "unknown")
+    calls = _record_hub_calls(monkeypatch, node_token=None, admin_token=ADMIN_TOKEN)
+    result = fleet_client.publish_session(session_snapshot)
+    assert result.ok is False
+    assert result.reason == "unknown_node_identity"
+    assert calls == []
+
+
+def test_session_admin_enabled_hub_accepts_body_node_id(tmp_path):
+    db = tmp_path / "hub" / "admin-sessions.db"
+    server = fleet_hub.make_server("127.0.0.1", 0, db, ADMIN_TOKEN, allow_admin_writes=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        status, payload = _request(url, "POST", "/sessions", body=_upsert(node_id=NODE_A), token=ADMIN_TOKEN)
+        assert status == 200, payload
+        assert payload["session"]["node_id"] == NODE_A
+        listed = _request(url, "GET", "/sessions", token=ADMIN_TOKEN)[1]
+        assert listed["sessions"][0]["node_id"] == NODE_A
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_revoked_node_cannot_refresh_session(hub_server):
+    _create_session(hub_server, NODE_A_TOKEN)
+    _revoke_node(hub_server, NODE_A)
+    assert _request(hub_server, "POST", "/sessions", body=_upsert(), token=NODE_A_TOKEN)[0] == 401
+
+
+def _safe_session_row() -> dict[str, object]:
+    return {
+        "node_id": NODE_A,
+        "harness": "claude",
+        "session_id": "sess-1",
+        "repo_identity": "github.com/example/project",
+        "identity_scope": "fleet",
+        "repo_label": "project",
+        "checkout_path": "/tmp/project",
+        "branch": "main",
+        "dirty_paths": ["src/a.py"],
+        "dirty_truncated": False,
+        "state": "active",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "heartbeat_at": "2026-01-01T00:00:00+00:00",
+        "ended_at": None,
+        "ttl_seconds": 900,
+        "expires_at": 9_999_999_999.0,
+    }
+
+
+@pytest.fixture()
+def session_snapshot():
+    from brigade.fleet_session_presence import SessionSnapshot
+
+    return SessionSnapshot(
+        harness="claude",
+        session_id="sess-1",
+        repo_identity="github.com/example/project",
+        identity_scope="fleet",
+        repo_label="project",
+        checkout_path="/tmp/project",
+        branch="main",
+        dirty_paths=("src/a.py",),
+        dirty_truncated=False,
+    )
+
+
+def _record_hub_calls(monkeypatch, *, node_token: str | None = "node-token", admin_token: str | None = None):
+    from types import SimpleNamespace
+    from urllib.parse import urlparse
+
+    calls: list[SimpleNamespace] = []
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self, size: int = -1):
+            payload = json.dumps({"sessions": [_safe_session_row()]}).encode()
+            return payload if size < 0 else payload[:size]
+
+    def fake_open(request, timeout=None):
+        parsed = urlparse(request.full_url)
+        raw = request.data or b"{}"
+        calls.append(
+            SimpleNamespace(
+                path=parsed.path,
+                headers=dict(request.header_items()),
+                body=json.loads(raw.decode()) if raw else {},
+            )
+        )
+        return FakeResponse()
+
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    if node_token:
+        monkeypatch.setenv("BRIGADE_FLEET_NODE_TOKEN", node_token)
+    else:
+        monkeypatch.delenv("BRIGADE_FLEET_NODE_TOKEN", raising=False)
+    if admin_token:
+        monkeypatch.setenv("BRIGADE_FLEET_TOKEN", admin_token)
+    else:
+        monkeypatch.delenv("BRIGADE_FLEET_TOKEN", raising=False)
+    monkeypatch.setattr(fleet_client, "_hub_open", fake_open)
+    return calls
+
+
+def test_client_upsert_end_and_fetch_use_node_token(monkeypatch, session_snapshot):
+    calls = _record_hub_calls(monkeypatch)
+    assert fleet_client.upsert_session(session_snapshot) is True
+    assert fleet_client.end_session(session_snapshot) is True
+    assert fleet_client.fetch_sessions() == [_safe_session_row()]
+    assert [call.path for call in calls] == ["/sessions", "/sessions", "/sessions"]
+    assert all("Authorization" in call.headers for call in calls)
+    assert all("node_id" not in call.body for call in calls if call.body)
+
+
+def test_fleet_sessions_cli_is_bounded_and_safe(monkeypatch, capsys):
+    from brigade import cli
+
+    monkeypatch.setattr(fleet_client, "fetch_sessions", lambda **_: [_safe_session_row()])
+    assert cli.main(["fleet", "sessions", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["repo_identity"] == "github.com/example/project"
+    assert "dirty_paths" in payload[0]
+
+
+def test_event_repo_identity_is_stored_and_projected(hub):
+    url, token, _db = hub
+    event = {**_event(), "repo_identity": "github.com/example/project"}
+    assert _post(url, token, event)[0] == 200
+    rows = _get(url, "/status", token)[1]["runs"]
+    assert rows[0]["repo_identity"] == "github.com/example/project"
+
+
+def test_event_repo_identity_rejects_secret_like_controls_and_oversize():
+    from brigade import fleet_hub
+
+    with pytest.raises(fleet_hub.FleetHubError):
+        fleet_hub._validate_event(  # content-guard: allow email
+            {**_event(), "repo_identity": "https://user:secret@github.com/example/project.git"}
+        )
+    with pytest.raises(fleet_hub.FleetHubError):
+        fleet_hub._validate_event({**_event(), "repo_identity": "github.com/example/" + ("a" * 500)})
+    with pytest.raises((fleet_hub.FleetHubError, fleet_hub.FleetHubUnprocessable)):
+        fleet_hub._validate_event({**_event(), "repo_identity": "github.com/example/pro\x1bject"})
+    accepted = fleet_hub._validate_event({**_event(), "repo_identity": "github.com/example/project"})
+    assert accepted["repo_identity"] == "github.com/example/project"
+
+
+def test_fetch_sessions_fails_closed_on_oversized_body(monkeypatch):
+    class HugeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self, size: int = -1):
+            assert size > 0
+            return b"x" * size
+
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setenv("BRIGADE_FLEET_NODE_TOKEN", "node-token")
+    monkeypatch.setattr(fleet_client, "_hub_open", lambda *_args, **_kwargs: HugeResponse())
+    with pytest.raises(fleet_client.FleetClientError, match="size"):
+        fleet_client.fetch_sessions()
+
+
+def test_fetch_sessions_refuses_unbounded_response_reader(monkeypatch):
+    class UnboundedOnlyResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b'{"sessions":[]}'
+
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setenv("BRIGADE_FLEET_NODE_TOKEN", "node-token")
+    monkeypatch.setattr(fleet_client, "_hub_open", lambda *_args, **_kwargs: UnboundedOnlyResponse())
+    with pytest.raises(fleet_client.FleetClientError, match="bounded reads"):
+        fleet_client.fetch_sessions()
+
+
+def test_fleet_sessions_text_renders_remaining_ttl_not_raw_epoch(monkeypatch, capsys):
+    from brigade import cli
+
+    row = _safe_session_row()
+    row["expires_at"] = 1_700_000_900.0
+    row["heartbeat_at"] = "2026-01-01T00:00:00+00:00"
+    monkeypatch.setattr(fleet_client, "fetch_sessions", lambda **_: [row])
+    monkeypatch.setattr("brigade.cli.fleet.datetime", __import__("datetime").datetime)
+    from datetime import datetime, timezone
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc)
+
+    monkeypatch.setattr("brigade.cli.fleet.datetime", FrozenDateTime)
+    assert cli.main(["fleet", "sessions"]) == 0
+    out = capsys.readouterr().out
+    assert "1700000900" not in out
+    assert "900s" in out or "15m" in out or "expired" in out

--- a/tests/test_harness_user_scope_slice2.py
+++ b/tests/test_harness_user_scope_slice2.py
@@ -266,9 +266,10 @@ def test_cursor_managed_plugin_rule_hook_surface(tmp_path, monkeypatch, capsys):
     hook_script = home / ".cursor" / "hooks" / "brigade-session-start"
     assert hook_script.is_file()
     assert hook_script.stat().st_mode & 0o111
-    entries = json.loads(hooks_json.read_text())["hooks"]["sessionStart"]
-    assert foreign_entry in entries
-    assert {"command": str(hook_script)} in entries
+    hooks = json.loads(hooks_json.read_text())["hooks"]
+    assert foreign_entry in hooks["sessionStart"]
+    managed_entry = {"command": "exec brigade work presence-hook --harness cursor --stdin --context cursor-work-loop"}
+    assert managed_entry in hooks["sessionStart"]
 
 
 def test_cursor_edited_managed_rule_reports_conflict_and_preserves_edit(tmp_path, monkeypatch, capsys):

--- a/tests/test_work_cmd_session.py
+++ b/tests/test_work_cmd_session.py
@@ -1,24 +1,33 @@
 import json
-import subprocess
 import os
+import subprocess
 from datetime import datetime, timezone
+
+import pytest
 
 from brigade import aboyeur
 from brigade import cli
 from brigade import center_cmd
 from brigade import dogfood_cmd
+from brigade import fleet_client
 from brigade import localio
 from brigade import repos_cmd
 from brigade import security_cmd
 from brigade import work_cmd
 from brigade.install import install_selection
 from brigade.selection import Selection
+from brigade.work_cmd.session import briefing
 
 from tests.work_cmd_test_helpers import (
     _write_json,
     _init_git_repo,
     _plan_task_id,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_codex_thread_id(monkeypatch):
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
 
 
 def test_work_status_reports_repo_and_dogfood_state(tmp_path, monkeypatch, capsys):
@@ -1947,3 +1956,239 @@ def test_work_inspection_cli(tmp_path, monkeypatch):
         ("show", {"target": tmp_path, "session": "abc123"}),
         ("recap", {"target": tmp_path, "limit": 3, "since": "2026-05-26"}),
     ]
+
+
+def test_presence_hook_upserts_and_ends_without_printing_payload(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    calls = []
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: calls.append(("upsert", snap)) or True)
+    monkeypatch.setattr(fleet_client, "end_session", lambda snap: calls.append(("end", snap)) or True)
+    assert (
+        cli.main(
+            [
+                "work",
+                "presence-hook",
+                "--target",
+                str(tmp_path),
+                "--harness",
+                "codex",
+                "--session",
+                "thread-1",
+                "--event",
+                "start",
+            ]
+        )
+        == 0
+    )
+    assert (
+        cli.main(
+            [
+                "work",
+                "presence-hook",
+                "--target",
+                str(tmp_path),
+                "--harness",
+                "codex",
+                "--session",
+                "thread-1",
+                "--event",
+                "end",
+            ]
+        )
+        == 0
+    )
+    assert [item[0] for item in calls] == ["upsert", "end"]
+    assert capsys.readouterr().out == ""
+
+
+def test_presence_hook_heartbeat_upserts_and_stays_silent(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    calls = []
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: calls.append(snap) or True)
+    assert (
+        cli.main(
+            [
+                "work",
+                "presence-hook",
+                "--target",
+                str(tmp_path),
+                "--harness",
+                "codex",
+                "--session",
+                "thread-2",
+                "--event",
+                "heartbeat",
+            ]
+        )
+        == 0
+    )
+    assert len(calls) == 1
+    assert calls[0].harness == "codex"
+    assert calls[0].session_id == "thread-2"
+    assert capsys.readouterr().out == ""
+
+
+def test_presence_hook_always_exits_zero_when_client_raises(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr(
+        fleet_client,
+        "upsert_session",
+        lambda snap: (_ for _ in ()).throw(RuntimeError("hub down")),
+    )
+    assert (
+        cli.main(
+            [
+                "work",
+                "presence-hook",
+                "--target",
+                str(tmp_path),
+                "--harness",
+                "codex",
+                "--session",
+                "thread-1",
+                "--event",
+                "start",
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out == ""
+
+
+def test_presence_hook_rejects_identity_fields_on_argv(tmp_path):
+    parser = cli._build_parser()
+    for flag in ("--node-id", "--repo-identity", "--dirty-paths", "--checkout-path"):
+        try:
+            parser.parse_args(
+                [
+                    "work",
+                    "presence-hook",
+                    "--target",
+                    str(tmp_path),
+                    "--harness",
+                    "codex",
+                    "--session",
+                    "thread-1",
+                    "--event",
+                    "start",
+                    flag,
+                    "planted",
+                ]
+            )
+        except SystemExit:
+            continue
+        raise AssertionError(f"{flag} must not be accepted")
+
+
+def _other_session(dirty_paths):
+    return {
+        "node_id": "node-b",
+        "harness": "cursor",
+        "session_id": "sess-b",
+        "repo_identity": "github.com/example/project",
+        "identity_scope": "fleet",
+        "checkout_path": "/other/project",
+        "branch": "main",
+        "dirty_paths": dirty_paths,
+        "dirty_truncated": False,
+        "state": "active",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "expires_at": 9_999_999_999.0,
+    }
+
+
+def _make_dirty(target, relpath):
+    target.mkdir(parents=True, exist_ok=True)
+    _init_git_repo(target)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/example/project.git"],
+        cwd=target,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    path = target / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("dirty\n", encoding="utf-8")
+
+
+def test_work_brief_publishes_codex_thread_and_warns_on_exact_overlap(tmp_target, monkeypatch, capsys):
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-1")
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr(fleet_client, "publish_session", lambda snap: fleet_client.SessionWriteResult(ok=True))
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: True)
+    monkeypatch.setattr(fleet_client, "fetch_sessions", lambda **_: [_other_session(dirty_paths=["src/a.py"])])
+    _make_dirty(tmp_target, "src/a.py")
+    assert briefing.brief(target=tmp_target, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["interactive_sessions"]["published"] is True
+    assert payload["overlap_warnings"][0]["paths"] == ["src/a.py"]
+
+
+def test_work_brief_fetch_failure_records_error_without_warnings(tmp_target, monkeypatch, capsys):
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-1")
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr(fleet_client, "publish_session", lambda snap: fleet_client.SessionWriteResult(ok=True))
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: True)
+
+    def boom(**_kwargs):
+        raise fleet_client.FleetClientError("hub unreachable")
+
+    monkeypatch.setattr(fleet_client, "fetch_sessions", boom)
+    _make_dirty(tmp_target, "src/a.py")
+    assert briefing.brief(target=tmp_target, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["interactive_sessions"]["published"] is True
+    assert payload["interactive_sessions"]["error"]
+    assert payload["overlap_warnings"] == []
+
+
+def test_work_brief_text_prints_at_most_three_warnings_and_eight_paths(tmp_target, monkeypatch, capsys):
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-1")
+    monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:3774")
+    monkeypatch.setattr(fleet_client, "publish_session", lambda snap: fleet_client.SessionWriteResult(ok=True))
+    monkeypatch.setattr(fleet_client, "upsert_session", lambda snap: True)
+    rows = []
+    for index in range(5):
+        row = _other_session(dirty_paths=["src/a.py", f"src/extra-{index}.py"])
+        row["session_id"] = f"sess-{index}"
+        row["dirty_paths"] = [f"src/p{n}.py" for n in range(12)]
+        row["dirty_paths"][0] = "src/a.py"
+        rows.append(row)
+    monkeypatch.setattr(fleet_client, "fetch_sessions", lambda **_: rows)
+    _make_dirty(tmp_target, "src/a.py")
+    for index in range(12):
+        (tmp_target / f"src/p{index}.py").write_text("x\n", encoding="utf-8")
+    assert briefing.brief(target=tmp_target, json_output=False) == 0
+    out = capsys.readouterr().out
+    warning_lines = [line for line in out.splitlines() if line.startswith("overlap:")]
+    assert len(warning_lines) <= 3
+    for line in warning_lines:
+        path_count = line.count("src/")
+        assert path_count <= 8
+    payload_rc = briefing.brief(target=tmp_target, json_output=True)
+    assert payload_rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["overlap_warnings"]) == 5
+
+
+def test_work_brief_json_includes_bounded_publish_failure_reason(tmp_target, monkeypatch, capsys):
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-1")
+
+    def unpublished(snapshot):
+        from brigade.fleet_client import SessionWriteResult
+
+        del snapshot
+        return SessionWriteResult(ok=False, reason="hub_unconfigured")
+
+    monkeypatch.setattr(fleet_client, "publish_session", unpublished)
+    monkeypatch.setattr(fleet_client, "upsert_session", unpublished)
+    _make_dirty(tmp_target, "src/a.py")
+    assert briefing.brief(target=tmp_target, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["interactive_sessions"]["published"] is False
+    reason = payload["interactive_sessions"].get("status") or payload["interactive_sessions"].get("error")
+    assert reason == "hub_unconfigured"
+    blob = json.dumps(payload["interactive_sessions"])
+    assert "Bearer" not in blob
+    assert "hub_unconfigured" in blob


### PR DESCRIPTION
## Summary

- publish TTL-bound interactive session presence for Claude Code, Cursor, and Codex/T3 through Fleet Hub
- group worktrees by repository identity and warn when active sessions report the same dirty path
- add the `brigade fleet sessions` view and an interactive-session panel in Command Deck without consuming run or station capacity
- isolate Jules credentials in Cloud Tracker tests so fleet-host verification does not depend on live provider inventory

Closes #1261.

## Safety boundaries

- Hub records bounded path names, never file contents or diffs
- session publication is best effort and does not enter the durable fleet spool
- session rows remain separate from runs, claims, cloud leases, and capacity calculations
- stale sessions expire through the Hub TTL when a harness cannot publish `session.ended`

## Verification

- focused feature suite: `20260829-180855-work-verify-dbfb8c`
- presence-hook regression: `20260829-185133-work-verify-413eee`
- hook, dashboard, and CLI suite: `20260829-185157-work-verify-442524`
- fleet-sync isolation: `20260829-182438-work-verify-d8d4a5`
- isolated full-gate failures after the 3,600-second full-gate timeout: `20260829-195709-work-verify-85a7f2`
- final affected-file suite: `20260829-201355-work-verify-1ffee5`
- packaged in-house history scan: `20260829-201659-work-verify-e6dd20`

The single full `./scripts/verify` run reached 90% before the required 3,600-second limit. Its 3 observed failures were isolated: the Kimi harness test passed unchanged, and the 2 Cloud Tracker tests passed after their provider fixture was changed to hide a live Jules credential. Per repository policy, the full gate was not retried.
