### PR TITLE
fix(evidence-ledger): hash native imports before incremental skip

### DIFF
--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -1840,13 +1840,10 @@ func nativeFastPathOptions(db *sql.DB, name string, opts sources.Options) (sourc
 	if len(manifest) == 0 {
 		return opts, nil
 	}
-	opts.Scan = func(p string, size int64, mtime string) (sources.ScanDecision, error) {
+	opts.Scan = func(p string, size int64, _ string) (sources.ScanDecision, error) {
 		prior, ok := manifest[p]
 		if !ok || prior.Size != size {
 			return sources.ScanDecision{}, nil
-		}
-		if prior.MTime == mtime {
-			return sources.ScanDecision{Skip: true}, nil
 		}
 		hash, err := sources.FileHash(p)
 		if err != nil {

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -1391,6 +1391,37 @@ func TestNativeImportFastPathReparsesSameSizeChangedFile(t *testing.T) {
 	}
 }
 
+func TestNativeImportFastPathReparsesSameSizeChangedFileWithRestoredMTime(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	writeCodexFixture(t, path, "alpha")
+	first := runJSON(t, "import", "codex", path, "--json")
+	if first["files_parsed"].(float64) != 1 || first["files_skipped"].(float64) != 0 {
+		t.Fatalf("first import counters = %v", first)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeCodexFixture(t, path, "bravo")
+	if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+	second := runJSON(t, "import", "codex", path, "--json")
+	if second["files_parsed"].(float64) != 1 || second["files_skipped"].(float64) != 0 {
+		t.Fatalf("restored-mtime changed file should be reparsed: %v", second)
+	}
+	if second["inserted_items"].(float64) == 0 {
+		t.Fatalf("restored-mtime changed file imported no new item: %v", second)
+	}
+	search := runJSON(t, "search", "bravo", "--source", "codex", "--json")
+	if len(search["results"].([]any)) == 0 {
+		t.Fatalf("restored-mtime changed file record missing from search: %v", search)
+	}
+}
+
 func TestNativeImportDryRunDoesNotWriteSourceScans(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -441,7 +441,7 @@ type ScanRecord struct {
 }
 
 // LoadSourceScans returns the manifest for a source kind keyed by file path,
-// so an incremental import can skip files whose size and mtime are unchanged.
+// so an incremental import can compare each file with its prior content identity.
 func LoadSourceScans(db *sql.DB, sourceKind string) (map[string]ScanRecord, error) {
 	rows, err := db.Query(`select path, size, mtime, content_hash from source_scans where source_kind = ?`, sourceKind)
 	if err != nil {

--- a/engines/evidence-ledger/internal/sources/source.go
+++ b/engines/evidence-ledger/internal/sources/source.go
@@ -56,8 +56,8 @@ type FileScan struct {
 	Records     int    `json:"records_generated"`
 	Warnings    int    `json:"warnings"`
 	// Skipped is true when an incremental import recognized the file as
-	// unchanged and did not read or hash it. ContentHash stays empty in that
-	// case so callers know not to overwrite the manifest's good hash.
+	// unchanged and avoided parsing it. ContentHash is populated when the skip
+	// was verified by hashing, and stays empty for legacy metadata-only callers.
 	Skipped bool `json:"skipped,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- hash same-size native source files before an incremental skip decision
- parse equal-length rewrites even when their original timestamp is restored
- correct manifest comments that described metadata as content identity

## Verification

- RED receipt `20260830-014656-work-verify-949cfe`: the restored-timestamp regression failed with `files_parsed=0`, `files_skipped=1`, and `inserted_items=0`
- focused receipt `20260830-015204-work-verify-80eed0`: `go -C engines/evidence-ledger test ./internal/app -run '^TestNativeImportFastPath' -count=1` exited 0
- independent read-only review found no Critical or Important findings

The local full gate receipt `20260830-015215-work-verify-4aa12e` failed after 10,634 tests passed because a temporary shared virtualenv resolved the base checkout instead of this worktree. The two failures were `ModuleNotFoundError: No module named 'brigade.aboyeur_artifacts'` and `AttributeError: module 'brigade.proc' has no attribute 'spawn_detached'`; both surfaces exist in this worktree and are unrelated to the Go diff. The shared virtualenv link was removed. Head-SHA CI is the full gate for this PR.

Closes #1316
