### PR TITLE
fix(security): escape scanner summaries for terminals

### DIFF
--- a/src/brigade/work_cmd/helpers.py
+++ b/src/brigade/work_cmd/helpers.py
@@ -55,6 +55,14 @@ def _short(text: str, limit: int = 96) -> str:
     return rendered[: limit - 3].rstrip() + "..."
 
 
+def _terminal_safe_short(text: str, limit: int = 96) -> str:
+    escaped = "".join(
+        char.encode("unicode_escape").decode("ascii") if ord(char) <= 0x1F or 0x7F <= ord(char) <= 0x9F else char
+        for char in text
+    )
+    return _short(escaped, limit)
+
+
 def _count_status(count: object, label: str = "issue") -> str:
     return "ok" if count == 0 else f"{count} {label}(s)"
 

--- a/src/brigade/work_cmd/scanners.py
+++ b/src/brigade/work_cmd/scanners.py
@@ -3326,7 +3326,7 @@ def scanners_run_show(*, target: Path, run_id: str, json_output: bool = False) -
     print(f"stdout: {receipt.get('stdout_path')}")
     print(f"stderr: {receipt.get('stderr_path')}")
     if receipt.get("stdout_summary"):
-        print(f"stdout_summary: {helpers._short(str(receipt.get('stdout_summary')))}")
+        print(f"stdout_summary: {helpers._terminal_safe_short(str(receipt.get('stdout_summary')))}")
     if receipt.get("stderr_summary"):
-        print(f"stderr_summary: {helpers._short(str(receipt.get('stderr_summary')))}")
+        print(f"stderr_summary: {helpers._terminal_safe_short(str(receipt.get('stderr_summary')))}")
     return 0

--- a/tests/test_work_cmd_scanners.py
+++ b/tests/test_work_cmd_scanners.py
@@ -1354,6 +1354,44 @@ conflict_window = "03:00-03:10"
     assert "status: completed" in out
 
 
+def test_work_scanners_run_show_escapes_terminal_controls_but_json_preserves_them(tmp_path, capsys):
+    from brigade.work_cmd import scanners as scanners_mod
+
+    run_id = "hostile-summary"
+    stdout_summary = "\x1b[2Jstdout\x07\r\x7f\x9b31m"
+    stderr_summary = "\x1b]0;owned\x07stderr\r\x7f\x9b31m"
+    root = scanners_mod._open_scanner_runs_directory(tmp_path, create=True)
+    os.close(root)
+    run_path = helpers._scanner_runs_root(tmp_path) / run_id
+    run_path.mkdir()
+    _record_scanner_run_authority(tmp_path, run_id)
+    _write_json(
+        run_path / "receipt.json",
+        {
+            "run_id": run_id,
+            "scanner_id": "hostile-scanner",
+            "source": "hostile-scanner",
+            "status": "completed",
+            "stdout_summary": stdout_summary,
+            "stderr_summary": stderr_summary,
+        },
+    )
+    _bind_planted_scanner_receipt(tmp_path, run_id)
+    receipt_before = (run_path / "receipt.json").read_bytes()
+
+    assert work_cmd.scanners_run_show(target=tmp_path, run_id=run_id, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run"]["stdout_summary"] == stdout_summary
+    assert payload["run"]["stderr_summary"] == stderr_summary
+
+    assert work_cmd.scanners_run_show(target=tmp_path, run_id=run_id) == 0
+    out = capsys.readouterr().out
+    assert "stdout_summary: \\x1b[2Jstdout\\x07\\r\\x7f\\x9b31m" in out
+    assert "stderr_summary: \\x1b]0;owned\\x07stderr\\r\\x7f\\x9b31m" in out
+    assert not any(control in out for control in "\x1b\x07\r\x7f\x9b")
+    assert (run_path / "receipt.json").read_bytes() == receipt_before
+
+
 def test_work_scanners_run_refuses_risky_running_timeout_and_failure(tmp_path, capsys):
     _init_git_repo(tmp_path)
     script = tmp_path / "scanner.py"


### PR DESCRIPTION
## Summary

- Escape C0, DEL, and C1 controls at the plain scanner-summary output boundary before shortening.
- Keep persisted receipt summaries and `--json` output unchanged.
- Cover ESC, BEL, carriage return, DEL, and C1 bytes in both summary fields, including receipt-byte preservation.

## Verification

- Final focused Brigade gate: `20260830-030952-work-verify-efa0b9` completed with exit 0 for the scanner regression and module-size ratchet.
- Independent executable probe: `20260830-015633-work-verify-849757` completed with exit 0.
- Independent Codex review `df99594e.20260830-031034-84e22e30` found no findings.
- The one local serial full gate, receipt `20260830-022902-work-verify-34a3b7`, ran 10,636 tests successfully and failed only `test_allowlisted_modules_never_grow` because the first helper placement grew `scanners.py`. The final commit moves that helper to `helpers.py`. The named ratchet and security regression pass in the final focused receipt above. Per repository policy, the serial full gate was not retried.

Closes #1314
