### PR TITLE
feat(care): make managed schedules configurable

### DIFF
--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -5,8 +5,8 @@ of the recipes below into your own crontab, user timer, or CI job after
 `brigade init` wires the target, or explicitly opt in with
 `brigade care install --target .`. With the default `auto` backend it installs
 systemd user timers on Linux or launchd agents on macOS and reports an
-unsupported scheduler elsewhere. The public CLI does not install crontab
-entries. Use the manual crontab recipes on this page when cron is your trigger.
+unsupported scheduler elsewhere. Use the manual crontab recipes on this page
+when cron is your trigger.
 Every registration is namespaced by a hash of the absolute target path, so
 status and uninstall operate only on that target. Uninstalling a missing
 registration is a clear no-op. Brigade still does not own a daemon or
@@ -32,6 +32,7 @@ brigade memory care init --with-runbooks --target .
 brigade extras on   # runbook + center report are extras-gated
 brigade care install --target .
 brigade care install --target . --entry handoff-ingest --entry care-scan
+brigade care install --target . --entry care-scan --schedule 'care-scan=*-*-* 07:15:00'
 brigade care status --target . --entry care-scan
 # brigade care uninstall --target . --entry handoff-ingest
 # brigade care uninstall --target .
@@ -49,6 +50,23 @@ receipt; nightly ops calls
 inside a `# BEGIN BRIGADE CARE ... hash:...` managed block so status can detect
 drift and uninstall can remove only Brigade's span.
 
+`--schedule JOB_ID=VALUE` is repeatable and applies only to entries selected by
+`--entry` (or to entries in the default set). Its value uses the selected
+scheduler's syntax: `OnCalendar` syntax for systemd and the supported cron
+subset for launchd and Task Scheduler. A later `care install` reads the
+schedule from an existing managed systemd unit or launchd plist and keeps it
+unless that entry gets another explicit `--schedule` value.
+The schedule is stored in the registration itself, not in a separate Brigade
+preferences file.
+
+For systemd, `care status --json` reports both `managed_calendar`, read from
+Brigade's timer file, and `effective_calendar`, read from
+`systemctl --user show ... TimersCalendar` after systemd resolves drop-ins. A
+different effective value sets `schedule_diverged`. If `evidence-crawl` shares
+an effective calendar with the known `brigadeclaw-daily-report` timer, status
+adds a `miseledger-calendar-collision` warning. The warning is advisory and
+does not disable either timer.
+
 To install one job without the rest of that set, pass `--entry JOB_ID`
 (repeatable). The five maintainer memory jobs from the care-managed inventory
 are `handoff-ingest`, `care-scan`, `memory-refresh`, `evidence-crawl`, and
@@ -57,7 +75,7 @@ operator-approved runbook at `.brigade/memory-care/runbooks/<job-id>.json`; if
 that file is missing, install writes nothing and says why. Omitting `--entry`
 still installs the atomic five-recipe set above. Status and uninstall take the
 same selector, and namespaced backends still key registrations by
-`(target identity, job_id)`. Per-job installs use systemd or launchd. The
+`(target identity, job_id)`. Per-job installs support systemd and launchd. The
 crontab examples below remain operator-owned manual recipes.
 
 Related docs: [memory care](memory-care.md), [scanner registry](scanner-registry.md), [operator center](operator-center.md), [agents guide](agents-guide.md), [execution model](execution-model.md).

--- a/src/brigade/care_cmd.py
+++ b/src/brigade/care_cmd.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from . import managed_block, memory_cmd, runbook_cmd
+from . import care_schedules, managed_block, memory_cmd, runbook_cmd
 
 CARE_KIND = "CARE"
 CARE_MARKER_VERSION = 1
@@ -30,7 +30,6 @@ CARE_MARKER_STYLE = managed_block.MARKER_STYLE_HASH
 DEFAULT_BACKEND = "auto"
 SUPPORTED_BACKENDS = ("auto", "crontab", "systemd", "launchd", "schtasks")
 SCHTASKS_BACKEND = "schtasks"
-SCHTASKS_WEEKDAYS = ("SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT")
 # /NP (S4U) requires elevation: a non-admin `schtasks /Create /RU user /NP`
 # prompts for a password and exits 1. /IT runs while the user is logged on
 # and works without elevation — the intended zero-setup default. Care tasks
@@ -352,39 +351,7 @@ def _schtasks_schedule_flags(schedule: str) -> str:
     06:15 template — that fallback is what silently mis-scheduled 4 of 5
     default care entries (#1021).
     """
-    fields = schedule.split()
-    if len(fields) != 5:
-        raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
-    minute, hour, day, month, weekday = fields
-    if hour == day == month == weekday == "*" and minute.startswith("*/"):
-        try:
-            every = int(minute[2:])
-        except ValueError as exc:
-            raise ValueError(f"unsupported care schedule for schtasks: {schedule}") from exc
-        if every <= 0:
-            raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
-        return f"/SC MINUTE /MO {every}"
-    try:
-        minute_i = int(minute)
-        hour_i = int(hour)
-    except ValueError as exc:
-        raise ValueError(f"unsupported care schedule for schtasks: {schedule}") from exc
-    if not (0 <= minute_i <= 59 and 0 <= hour_i <= 23):
-        raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
-    start = f"{hour_i:02d}:{minute_i:02d}"
-    if day == month == weekday == "*":
-        return f"/SC DAILY /ST {start}"
-    if day == month == "*" and weekday != "*":
-        try:
-            weekday_i = int(weekday)
-        except ValueError as exc:
-            raise ValueError(f"unsupported care schedule for schtasks: {schedule}") from exc
-        if weekday_i == 7:
-            weekday_i = 0
-        if weekday_i < 0 or weekday_i > 6:
-            raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
-        return f"/SC WEEKLY /D {SCHTASKS_WEEKDAYS[weekday_i]} /ST {start}"
-    raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
+    return care_schedules.schtasks_schedule_flags(schedule)
 
 
 def _schtasks_task_run(entry: CareEntry, *, workspace: Path) -> str:
@@ -1022,21 +989,6 @@ def _launchd_dir(home: Path | None = None) -> Path:
     return (home if home is not None else Path.home()) / "Library" / "LaunchAgents"
 
 
-def _launchd_interval_seconds(schedule: str) -> int | None:
-    fields = schedule.split()
-    if len(fields) != 5:
-        return None
-    minute, hour, day, month, weekday = fields
-    if hour == day == month == weekday == "*" and minute.startswith("*/"):
-        try:
-            every = int(minute[2:])
-        except ValueError:
-            return None
-        if every > 0:
-            return every * 60
-    return None
-
-
 def _launchd_plists(
     *,
     workspace: Path,
@@ -1067,7 +1019,7 @@ def _launchd_plists(
         # launchd supports interval timers directly; calendar recipes use their
         # documented local hour/minute (weekly additionally pins Monday).
         # launchd Weekday uses the same numbering as cron (0/7=Sunday, 1=Monday).
-        interval = _launchd_interval_seconds(entry.schedule)
+        interval = care_schedules.launchd_interval_seconds(entry.schedule)
         if interval is not None:
             payload["StartInterval"] = interval
         else:
@@ -1208,6 +1160,7 @@ def install(
     json_output: bool = False,
     home: Path | None = None,
     entry_ids: list[str] | None = None,
+    schedule_specs: list[str] | None = None,
 ) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
@@ -1239,6 +1192,27 @@ def install(
         elif backend == "launchd":
             installed = _installed_launchd_entries(target=target, home=home)
             entries, adopted = _adopt_installed_aliases(entries, installed)
+
+    previous_crontab = None
+    if backend == "crontab":
+        current_crontab, read_error = _read_crontab()
+        if not read_error:
+            parsed = managed_block.parse_blocks(current_crontab, kind=CARE_KIND, style=CARE_MARKER_STYLE)
+            previous_crontab = parsed.body if parsed.status == "ok" else None
+    try:
+        entries = care_schedules.install_schedule_overrides(
+            entries,
+            schedule_specs=schedule_specs,
+            backend=backend,
+            known_ids=_catalog_by_id(),
+            systemd_unit_dir=_systemd_user_dir(home),
+            launchd_directory=_launchd_dir(home),
+            identity=_target_identity(target),
+            crontab_body=previous_crontab,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
     if _uses_schtasks(backend):
         return _windows_install(workspace=target, entries=entries, json_output=json_output, dry_run=dry_run)
@@ -1426,6 +1400,7 @@ def _systemd_unit_bodies(
         timer_name = f"brigade-care-{identity}-{entry.entry_id}.timer"
         assert entry.kind == "runbook" and entry.runbook_rel is not None
         exec_start = _systemd_exec_start_runbook(entry.runbook_rel)
+        calendar_lines = [f"OnCalendar={value}" for value in entry.on_calendar.splitlines() if value.strip()]
         service_body = "\n".join(
             [
                 "[Unit]",
@@ -1444,7 +1419,7 @@ def _systemd_unit_bodies(
                 f"Description={entry.description} timer",
                 "",
                 "[Timer]",
-                f"OnCalendar={entry.on_calendar}",
+                *calendar_lines,
                 "Persistent=true",
                 "",
                 "[Install]",
@@ -1803,7 +1778,30 @@ def _systemd_backend_status(
         if name.endswith(".timer"):
             timer_enabled.append(_systemd_timer_is_enabled(unit_dir=unit_dir, timer_name=name))
             results[-1]["enabled"] = timer_enabled[-1]
+            managed_calendar = care_schedules.systemd_managed_calendar(existing_text)
+            if path.is_file():
+                effective_calendar, inspection_error = care_schedules.effective_systemd_calendar(name)
+            else:
+                effective_calendar, inspection_error = None, None
+            results[-1].update(
+                {
+                    "managed_calendar": managed_calendar,
+                    "effective_calendar": effective_calendar,
+                    "schedule_diverged": bool(
+                        managed_calendar and effective_calendar and managed_calendar != effective_calendar
+                    ),
+                }
+            )
+            if inspection_error:
+                results[-1]["schedule_inspection_error"] = inspection_error
         unit_statuses.append(public_status)
+    timer_calendars = {
+        name.removeprefix(f"brigade-care-{_target_identity(target)}-").removesuffix(".timer"): result.get(
+            "effective_calendar"
+        )
+        for result in results
+        if (name := str(result["name"])).endswith(".timer")
+    }
     return {
         "backend": "systemd",
         "status": _aggregate_systemd_status(unit_statuses),
@@ -1812,6 +1810,7 @@ def _systemd_backend_status(
         "error": None,
         "unit_dir": str(unit_dir),
         "units": results,
+        "schedule_warnings": care_schedules.miseledger_schedule_warnings(timer_calendars),
     }
 
 

--- a/src/brigade/care_schedules.py
+++ b/src/brigade/care_schedules.py
@@ -1,0 +1,325 @@
+"""Backend-specific schedule parsing and systemd calendar inspection for care."""
+
+from __future__ import annotations
+
+import plistlib
+import re
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHTASKS_WEEKDAYS = ("SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT")
+_CRON_FIELD = re.compile(r"^[0-9*/,-]+$")
+_KNOWN_MISELEDGER_TIMERS = {"brigadeclaw-daily-report": "brigadeclaw-daily-report.timer"}
+_SYSTEMD_ON_CALENDAR = re.compile(
+    r"(?:^|[\s{])OnCalendar=(?P<calendar>.*?)(?=\s*;\s*[A-Za-z_][A-Za-z0-9_]*=|\s*})",
+    re.DOTALL,
+)
+
+
+def schtasks_schedule_flags(schedule: str) -> str:
+    """Map the supported cron subset to Task Scheduler flags."""
+    fields = schedule.split()
+    if len(fields) != 5:
+        raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
+    minute, hour, day, month, weekday = fields
+    if hour == day == month == weekday == "*" and minute.startswith("*/"):
+        try:
+            every = int(minute[2:])
+        except ValueError as exc:
+            raise ValueError(f"unsupported care schedule for schtasks: {schedule}") from exc
+        if every <= 0:
+            raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
+        return f"/SC MINUTE /MO {every}"
+    try:
+        minute_i = int(minute)
+        hour_i = int(hour)
+    except ValueError as exc:
+        raise ValueError(f"unsupported care schedule for schtasks: {schedule}") from exc
+    if not (0 <= minute_i <= 59 and 0 <= hour_i <= 23):
+        raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
+    start = f"{hour_i:02d}:{minute_i:02d}"
+    if day == month == weekday == "*":
+        return f"/SC DAILY /ST {start}"
+    if day == month == "*" and weekday != "*":
+        try:
+            weekday_i = int(weekday)
+        except ValueError as exc:
+            raise ValueError(f"unsupported care schedule for schtasks: {schedule}") from exc
+        if weekday_i == 7:
+            weekday_i = 0
+        if weekday_i < 0 or weekday_i > 6:
+            raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
+        return f"/SC WEEKLY /D {SCHTASKS_WEEKDAYS[weekday_i]} /ST {start}"
+    raise ValueError(f"unsupported care schedule for schtasks: {schedule}")
+
+
+def launchd_interval_seconds(schedule: str) -> int | None:
+    fields = schedule.split()
+    if len(fields) != 5:
+        return None
+    minute, hour, day, month, weekday = fields
+    if hour == day == month == weekday == "*" and minute.startswith("*/"):
+        try:
+            every = int(minute[2:])
+        except ValueError:
+            return None
+        if every > 0:
+            return every * 60
+    return None
+
+
+def _validate_cron(schedule: str) -> None:
+    fields = schedule.split()
+    if len(fields) != 5 or any(not _CRON_FIELD.fullmatch(field) for field in fields):
+        raise ValueError(f"invalid care cron schedule: {schedule}")
+    for field, low, high in zip(fields, (0, 0, 1, 1, 0), (59, 23, 31, 12, 7), strict=True):
+        for part in field.split(","):
+            base, slash, step = part.partition("/")
+            if slash and (not step.isdigit() or int(step) <= 0):
+                raise ValueError(f"invalid care cron schedule: {schedule}")
+            bounds = base.split("-", 1)
+            if base == "*":
+                continue
+            if not all(value.isdigit() and low <= int(value) <= high for value in bounds):
+                raise ValueError(f"invalid care cron schedule: {schedule}")
+            if len(bounds) == 2 and int(bounds[0]) > int(bounds[1]):
+                raise ValueError(f"invalid care cron schedule: {schedule}")
+
+
+def _validate_launchd(schedule: str) -> None:
+    if launchd_interval_seconds(schedule) is not None:
+        return
+    fields = schedule.split()
+    if len(fields) != 5:
+        raise ValueError(f"unsupported care schedule for launchd: {schedule}")
+    minute, hour, day, month, weekday = fields
+    try:
+        minute_i, hour_i = int(minute), int(hour)
+        weekday_i = None if weekday == "*" else int(weekday)
+    except ValueError as exc:
+        raise ValueError(f"unsupported care schedule for launchd: {schedule}") from exc
+    if day != "*" or month != "*" or not (0 <= minute_i <= 59 and 0 <= hour_i <= 23):
+        raise ValueError(f"unsupported care schedule for launchd: {schedule}")
+    if weekday_i is not None and not 0 <= weekday_i <= 7:
+        raise ValueError(f"unsupported care schedule for launchd: {schedule}")
+
+
+def _validate_systemd(calendar: str) -> None:
+    try:
+        result = subprocess.run(
+            ["systemd-analyze", "calendar", calendar],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError("cannot validate systemd calendar: systemd-analyze command not found") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError("cannot validate systemd calendar: systemd-analyze timed out") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "invalid calendar").strip()
+        raise ValueError(f"invalid systemd calendar: {detail}")
+
+
+def validate_schedule(backend: str, value: str) -> None:
+    """Reject a schedule that the selected scheduler cannot represent."""
+    if not value.strip():
+        raise ValueError("care schedule must not be empty")
+    if backend == "systemd":
+        _validate_systemd(value)
+    elif backend == "launchd":
+        _validate_launchd(value)
+    elif backend == "schtasks":
+        schtasks_schedule_flags(value)
+    elif backend == "crontab":
+        _validate_cron(value)
+
+
+def parse_schedule_specs(
+    specs: list[str] | None,
+    *,
+    selected_ids: Iterable[str],
+    known_ids: Iterable[str],
+    backend: str,
+) -> dict[str, str]:
+    selected = set(selected_ids)
+    known = set(known_ids)
+    parsed: dict[str, str] = {}
+    for raw in specs or []:
+        entry_id, sep, value = raw.partition("=")
+        entry_id, value = entry_id.strip(), value.strip()
+        if not sep or not entry_id:
+            raise ValueError("care --schedule must use JOB_ID=VALUE")
+        if entry_id not in known:
+            raise ValueError(f"unknown care entry in --schedule: {entry_id}")
+        if entry_id not in selected:
+            raise ValueError(f"care --schedule requires selected entry: {entry_id}")
+        if entry_id in parsed:
+            raise ValueError(f"duplicate care schedule for entry: {entry_id}")
+        validate_schedule(backend, value)
+        parsed[entry_id] = value
+    return parsed
+
+
+def apply_schedule_overrides(entries: tuple[Any, ...], overrides: dict[str, str], *, backend: str) -> tuple[Any, ...]:
+    field = "on_calendar" if backend == "systemd" else "schedule"
+    return tuple(replace(entry, **{field: overrides.get(entry.entry_id, getattr(entry, field))}) for entry in entries)
+
+
+def install_schedule_overrides(
+    entries: tuple[Any, ...],
+    *,
+    schedule_specs: list[str] | None,
+    backend: str,
+    known_ids: Iterable[str],
+    systemd_unit_dir: Path | None = None,
+    launchd_directory: Path | None = None,
+    identity: str | None = None,
+    crontab_body: str | None = None,
+) -> tuple[Any, ...]:
+    """Apply requested schedules and readable managed schedules before rendering.
+
+    Task Scheduler is a printed-plan backend, so it has no installed schedule
+    to read. An unreadable crontab deliberately falls back to its normal install
+    path, which reports the read failure before any scheduler write.
+    """
+    overrides = parse_schedule_specs(
+        schedule_specs, selected_ids=(entry.entry_id for entry in entries), known_ids=known_ids, backend=backend
+    )
+    persisted: dict[str, str] = {}
+    if identity and backend == "systemd" and systemd_unit_dir is not None:
+        persisted = persisted_systemd_schedules(entries, unit_dir=systemd_unit_dir, identity=identity)
+    elif identity and backend == "launchd" and launchd_directory is not None:
+        persisted = persisted_launchd_schedules(entries, directory=launchd_directory, identity=identity)
+    elif backend == "crontab" and crontab_body is not None:
+        persisted = persisted_crontab_schedules(entries, crontab_body)
+    persisted.update(overrides)
+    return apply_schedule_overrides(entries, persisted, backend=backend)
+
+
+def systemd_managed_calendar(text: str) -> str | None:
+    return _canonical_systemd_calendars(systemd_managed_calendars(text))
+
+
+def systemd_managed_calendars(text: str) -> tuple[str, ...]:
+    in_timer = False
+    calendars: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_timer = stripped == "[Timer]"
+            continue
+        if in_timer and stripped.startswith("OnCalendar="):
+            value = stripped.split("=", 1)[1].strip()
+            if value:
+                calendars.append(" ".join(value.split()))
+    return tuple(calendars)
+
+
+def persisted_systemd_schedules(entries: tuple[Any, ...], *, unit_dir: Path, identity: str) -> dict[str, str]:
+    schedules: dict[str, str] = {}
+    for entry in entries:
+        path = unit_dir / f"brigade-care-{identity}-{entry.entry_id}.timer"
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            calendars = systemd_managed_calendars(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        if calendars:
+            schedules[entry.entry_id] = "\n".join(calendars)
+    return schedules
+
+
+def persisted_launchd_schedules(entries: tuple[Any, ...], *, directory: Path, identity: str) -> dict[str, str]:
+    schedules: dict[str, str] = {}
+    for entry in entries:
+        path = directory / f"dev.brigade.care.{identity}.{entry.entry_id}.plist"
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            payload = plistlib.loads(path.read_bytes())
+        except (OSError, ValueError, plistlib.InvalidFileException):
+            continue
+        interval = payload.get("StartInterval")
+        if isinstance(interval, int) and interval > 0 and interval % 60 == 0:
+            schedules[entry.entry_id] = f"*/{interval // 60} * * * *"
+            continue
+        calendar = payload.get("StartCalendarInterval")
+        if not isinstance(calendar, dict):
+            continue
+        minute, hour = calendar.get("Minute"), calendar.get("Hour")
+        weekday = calendar.get("Weekday", "*")
+        if isinstance(minute, int) and isinstance(hour, int) and isinstance(weekday, int | str):
+            schedules[entry.entry_id] = f"{minute} {hour} * * {weekday}"
+    return schedules
+
+
+def persisted_crontab_schedules(entries: tuple[Any, ...], body: str) -> dict[str, str]:
+    schedules: dict[str, str] = {}
+    for line in body.splitlines():
+        fields = line.split(maxsplit=5)
+        if len(fields) != 6:
+            continue
+        cron = " ".join(fields[:5])
+        for entry in entries:
+            if entry.runbook_rel and entry.runbook_rel in fields[5]:
+                schedules[entry.entry_id] = cron
+    return schedules
+
+
+def effective_systemd_calendar(timer_name: str) -> tuple[str | None, str | None]:
+    """Read the resolved timer calendar, which includes systemd drop-ins."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "--user", "show", timer_name, "--property=TimersCalendar", "--value"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        return None, "systemctl command not found"
+    except subprocess.TimeoutExpired:
+        return None, "systemctl --user show timed out"
+    if result.returncode != 0:
+        return None, (result.stderr or result.stdout or f"systemctl exited {result.returncode}").strip()
+    output = (result.stdout or "").strip()
+    if not output:
+        return None, "systemd returned no timer calendar"
+    calendar = _canonical_systemd_calendars(match.group("calendar") for match in _SYSTEMD_ON_CALENDAR.finditer(output))
+    if calendar:
+        return calendar, None
+    if "OnCalendar=" in output:
+        return None, "systemd returned malformed timer calendar"
+    return None, "systemd returned no timer calendar"
+
+
+def _canonical_systemd_calendars(calendars: Iterable[str]) -> str | None:
+    values = [" ".join(calendar.split()) for calendar in calendars]
+    return "; ".join(value for value in values if value) or None
+
+
+def miseledger_schedule_warnings(timer_calendars: dict[str, str | None]) -> list[dict[str, Any]]:
+    """Report known same-host writers that systemd schedules on one calendar."""
+    calendars = {entry_id: value for entry_id, value in timer_calendars.items() if value}
+    if "evidence-crawl" in calendars:
+        for entry_id, timer_name in _KNOWN_MISELEDGER_TIMERS.items():
+            value, _ = effective_systemd_calendar(timer_name)
+            if value:
+                calendars[entry_id] = value
+    grouped: dict[str, list[str]] = {}
+    for entry_id, calendar_set in calendars.items():
+        for calendar in calendar_set.split("; "):
+            grouped.setdefault(calendar, []).append(entry_id)
+    return [
+        {"kind": "miseledger-calendar-collision", "calendar": calendar, "entries": entry_ids}
+        for calendar, entry_ids in sorted(grouped.items())
+        if len(entry_ids) > 1
+    ]

--- a/src/brigade/cli/care.py
+++ b/src/brigade/cli/care.py
@@ -41,6 +41,13 @@ def register(sub: argparse._SubParsersAction) -> None:
         metavar="JOB_ID",
         help="Install one named care entry. Repeatable. Default: the atomic scheduled-care set.",
     )
+    p_install.add_argument(
+        "--schedule",
+        dest="schedule_specs",
+        action="append",
+        metavar="JOB_ID=VALUE",
+        help="Override one selected entry's schedule. Repeatable.",
+    )
 
     p_status = care_sub.add_parser(
         "status",
@@ -99,6 +106,7 @@ def dispatch(args) -> int:
             adopt=args.adopt,
             json_output=args.json,
             entry_ids=args.entry_ids,
+            schedule_specs=args.schedule_specs,
         )
     if args.care_command == "status":
         return care_cmd.status(

--- a/tests/test_care_cmd.py
+++ b/tests/test_care_cmd.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import care_cmd, cli, managed_block, memory_cmd
+from brigade import care_cmd, care_schedules, cli, managed_block, memory_cmd
 
 
 def test_care_registration_identity_is_stable_and_target_specific(tmp_path):
@@ -1361,6 +1361,303 @@ def test_care_cli_dispatch_passes_entry(monkeypatch, tmp_path):
     assert seen["status"]["entry_ids"] == ["care-scan"]
     assert cli.main(["care", "uninstall", "--target", str(tmp_path), "--entry", "handoff-ingest"]) == 0
     assert seen["uninstall"]["entry_ids"] == ["handoff-ingest"]
+
+
+def test_care_cli_dispatch_passes_schedule_specs(monkeypatch, tmp_path):
+    seen: dict[str, dict] = {}
+
+    def fake_install(**kwargs):
+        seen["install"] = kwargs
+        return 0
+
+    monkeypatch.setattr("brigade.care_cmd.install", fake_install)
+
+    assert (
+        cli.main(
+            [
+                "care",
+                "install",
+                "--target",
+                str(tmp_path),
+                "--entry",
+                "care-scan",
+                "--schedule",
+                "care-scan=*-*-* 07:15:00",
+            ]
+        )
+        == 0
+    )
+    assert seen["install"]["schedule_specs"] == ["care-scan=*-*-* 07:15:00"]
+
+
+@pytest.mark.parametrize("command", ["install", "status", "uninstall"])
+def test_care_cli_does_not_expose_internal_crontab_backend(command, tmp_path):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["care", command, "--target", str(tmp_path), "--backend", "crontab"])
+
+    assert exc_info.value.code == 2
+
+
+def test_care_systemd_custom_schedule_is_installed(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert (
+        care_cmd.install(
+            target=target,
+            backend="systemd",
+            home=home,
+            entry_ids=["care-scan"],
+            schedule_specs=["care-scan=*-*-* 07:15:00"],
+        )
+        == 0
+    )
+    timer = _unit_path(home, target, "care-scan", ".timer")
+    assert "OnCalendar=*-*-* 07:15:00" in timer.read_text(encoding="utf-8")
+
+
+def test_care_systemd_install_preserves_local_schedule_on_upgrade(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert (
+        care_cmd.install(
+            target=target,
+            backend="systemd",
+            home=home,
+            entry_ids=["care-scan"],
+            schedule_specs=["care-scan=*-*-* 07:15:00"],
+        )
+        == 0
+    )
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    timer = _unit_path(home, target, "care-scan", ".timer")
+    assert "OnCalendar=*-*-* 07:15:00" in timer.read_text(encoding="utf-8")
+
+
+def test_care_systemd_install_preserves_multiple_calendars_as_separate_directives(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    timer = _unit_path(home, target, "care-scan", ".timer")
+    parsed = managed_block.parse_blocks(
+        timer.read_text(encoding="utf-8"),
+        kind=care_cmd.CARE_KIND,
+        style=care_cmd.CARE_MARKER_STYLE,
+    )
+    assert parsed.status == "ok"
+    multi_calendar_body = parsed.body.replace(
+        "OnCalendar=*-*-* 06:15:00",
+        "OnCalendar=*-*-* 06:15:00\nOnCalendar=Mon *-*-* 09:00:00",
+    )
+    timer.write_text(
+        managed_block.render_block(
+            multi_calendar_body,
+            kind=care_cmd.CARE_KIND,
+            profile="systemd",
+            style=care_cmd.CARE_MARKER_STYLE,
+        ),
+        encoding="utf-8",
+    )
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    timer_text = timer.read_text(encoding="utf-8")
+    assert timer_text.count("OnCalendar=") == 2
+    assert "OnCalendar=*-*-* 06:15:00\nOnCalendar=Mon *-*-* 09:00:00" in timer_text
+    assert "OnCalendar=*-*-* 06:15:00; Mon *-*-* 09:00:00" not in timer_text
+
+
+def test_care_systemd_status_reports_drop_in_calendar_divergence(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(
+        care_schedules,
+        "effective_systemd_calendar",
+        lambda timer_name: ("*-*-* 07:15:00", None),
+    )
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    capsys.readouterr()
+    assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    timer = next(unit for unit in payload["units"] if unit["name"].endswith("care-scan.timer"))
+    assert timer["managed_calendar"] == "*-*-* 06:15:00"
+    assert timer["effective_calendar"] == "*-*-* 07:15:00"
+    assert timer["schedule_diverged"] is True
+
+
+def test_effective_systemd_calendar_extracts_on_calendar_from_structured_output(monkeypatch):
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="{ OnCalendar=*-*-* 08:00:00 ; next_elapse=Sun 2026-08-30 08:00:00 EDT }\n",
+        stderr="",
+    )
+    monkeypatch.setattr(care_schedules.subprocess, "run", lambda *args, **kwargs: result)
+
+    assert care_schedules.effective_systemd_calendar("brigade-care-test.timer") == ("*-*-* 08:00:00", None)
+
+
+def test_effective_systemd_calendar_canonicalizes_multiple_structured_entries(monkeypatch):
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=(
+            "{ OnCalendar=*-*-* 08:00:00 ; next_elapse=Sun 2026-08-30 08:00:00 EDT }\n"
+            "{ OnCalendar=Mon *-*-* 09:00:00 ; next_elapse=Mon 2026-08-31 09:00:00 EDT }\n"
+        ),
+        stderr="",
+    )
+    monkeypatch.setattr(care_schedules.subprocess, "run", lambda *args, **kwargs: result)
+
+    assert care_schedules.effective_systemd_calendar("brigade-care-test.timer") == (
+        "*-*-* 08:00:00; Mon *-*-* 09:00:00",
+        None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("stdout", "error"),
+    [
+        ("", "systemd returned no timer calendar"),
+        ("{ OnCalendar= ; next_elapse=Sun 2026-08-30 08:00:00 EDT }", "systemd returned malformed timer calendar"),
+    ],
+)
+def test_effective_systemd_calendar_reports_bounded_parse_errors(monkeypatch, stdout, error):
+    result = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+    monkeypatch.setattr(care_schedules.subprocess, "run", lambda *args, **kwargs: result)
+
+    assert care_schedules.effective_systemd_calendar("brigade-care-test.timer") == (None, error)
+
+
+def test_care_systemd_status_warns_on_known_miseledger_schedule_collision(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    _write_operator_runbook(target, "evidence-crawl.json", "evidence-crawl")
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+
+    def fake_systemctl(args, **kwargs):
+        timer_name = args[3]
+        assert args[:3] == ["systemctl", "--user", "show"]
+        assert args[4:] == ["--property=TimersCalendar", "--value"]
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout="{ OnCalendar=*-*-* 08:00:00 ; next_elapse=Sun 2026-08-30 08:00:00 EDT }\n",
+            stderr="" if timer_name else "unreachable",
+        )
+
+    monkeypatch.setattr(care_schedules.subprocess, "run", fake_systemctl)
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["evidence-crawl"]) == 0
+    capsys.readouterr()
+    assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schedule_warnings"] == [
+        {
+            "calendar": "*-*-* 08:00:00",
+            "entries": ["evidence-crawl", "brigadeclaw-daily-report"],
+            "kind": "miseledger-calendar-collision",
+        }
+    ]
+
+
+def test_miseledger_collision_matches_one_calendar_from_a_multi_calendar_timer(monkeypatch):
+    monkeypatch.setattr(
+        care_schedules,
+        "effective_systemd_calendar",
+        lambda timer_name: ("*-*-* 08:00:00", None),
+    )
+
+    assert care_schedules.miseledger_schedule_warnings({"evidence-crawl": "*-*-* 08:00:00; Mon *-*-* 09:00:00"}) == [
+        {
+            "kind": "miseledger-calendar-collision",
+            "calendar": "*-*-* 08:00:00",
+            "entries": ["evidence-crawl", "brigadeclaw-daily-report"],
+        }
+    ]
+
+
+def test_care_systemd_status_keeps_default_managed_calendar(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(
+        care_schedules,
+        "effective_systemd_calendar",
+        lambda timer_name: ("*-*-* 06:15:00", None),
+    )
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    capsys.readouterr()
+    assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    timer = next(unit for unit in payload["units"] if unit["name"].endswith("care-scan.timer"))
+    assert timer["managed_calendar"] == "*-*-* 06:15:00"
+    assert timer["effective_calendar"] == "*-*-* 06:15:00"
+    assert timer["schedule_diverged"] is False
+
+
+@pytest.mark.parametrize(
+    ("backend", "schedule"),
+    [
+        ("crontab", "15 6 * * *"),
+        ("launchd", "0 7 * * 1"),
+        ("launchd", "*/30 * * * *"),
+        ("schtasks", "*/30 * * * *"),
+    ],
+)
+def test_care_schedule_subsets_validate_without_platform_commands(backend, schedule):
+    care_schedules.validate_schedule(backend, schedule)
+
+
+@pytest.mark.parametrize(
+    ("backend", "schedule"),
+    [
+        ("crontab", "99 6 * * *"),
+        ("launchd", "0 7 1 * *"),
+        ("schtasks", "0 0 1 * *"),
+    ],
+)
+def test_care_schedule_subsets_reject_unsupported_values(backend, schedule):
+    with pytest.raises(ValueError):
+        care_schedules.validate_schedule(backend, schedule)
+
+
+def test_care_systemd_status_keeps_calendar_inspection_failure(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    target = tmp_path / "ws"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_schedules, "effective_systemd_calendar", lambda timer_name: (None, "no user bus"))
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, entry_ids=["care-scan"]) == 0
+    capsys.readouterr()
+    assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    timer = next(unit for unit in payload["units"] if unit["name"].endswith("care-scan.timer"))
+    assert timer["managed_calendar"] == "*-*-* 06:15:00"
+    assert timer["effective_calendar"] is None
+    assert timer["schedule_diverged"] is False
+    assert timer["schedule_inspection_error"] == "no user bus"
 
 
 def _write_runbook_receipt(


### PR DESCRIPTION
## Summary

- add repeatable per-entry `--schedule` overrides and preserve managed systemd and launchd choices across reinstall
- report managed and effective systemd calendars after parsing structured `TimersCalendar` records
- warn when known MiseLedger writers share an individual calendar, including multi-calendar timers

## Verification

- `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_care_cmd.py"]' --capture brigade-work` (`87 passed, 3 skipped`)
- `brigade work verify run --target . --argv-json '["./scripts/verify"]' --timeout 3600 --capture brigade-work` (`10660 passed, 11 skipped, 68 subtests passed`)

Closes #1248
