### PR TITLE
fix(grokbot): bind backup reporter selectors

### DIFF
--- a/docs/phase-grokbot-backup-reporter-selectors-plan.md
+++ b/docs/phase-grokbot-backup-reporter-selectors-plan.md
@@ -1,0 +1,28 @@
+# Grok Bot Backup Reporter Selector Plan
+
+## Problem
+
+Backup observations choose a public target alias or operation ID, but the adapter invokes each reporter with only its fixed runtime arguments. The shipped reporters require a selector on every call, so observations fail even when direct reporter execution succeeds.
+
+## Decision
+
+Append one validated selector pair at the fixed-command execution boundary:
+
+- target status and restore readiness: `--target-alias <canonical registry alias>`
+- operation status: `--operation-id <validated operation ID>`
+
+The executable, working directory, environment, timeout, output bound, and configured arguments stay fixed. Execution continues to use an argument vector without a shell.
+
+## Rejected alternatives
+
+- Add selectors to runtime configuration. Selectors vary per request and would make a fixed runtime command select one resource permanently.
+- Let reporter scripts infer a target or operation. That makes observations ambiguous and breaks the public request-to-reporter binding.
+- Accept arbitrary selector text. Public identifiers already have a closed 64-character grammar and must be validated before they enter the process argument vector.
+
+## Acceptance
+
+- Target observation invokes the configured reporter with its fixed arguments followed by `--target-alias` and the canonical selected alias.
+- Restore-readiness observation uses the same target selector contract.
+- Operation observation validates its identifier and appends `--operation-id` with the exact validated value.
+- Invalid or oversized identifiers fail before the reporter runner is called.
+- Existing timeout, output, executable, and no-shell boundaries remain unchanged.

--- a/src/brigade/grokbot_backup/adapters.py
+++ b/src/brigade/grokbot_backup/adapters.py
@@ -150,6 +150,7 @@ class BackupObservers:
             self.runtime["reporters"][target["reporter_id"]],
             target["timeout_ms"],
             parse_raw_target_observation,
+            ("--target-alias", target["alias"]),
         )
 
     def observe_restore_readiness(self, alias: str) -> dict[str, Any]:
@@ -161,14 +162,17 @@ class BackupObservers:
             self.runtime["reporters"][reporter_id],
             target["timeout_ms"],
             parse_raw_restore_readiness,
+            ("--target-alias", target["alias"]),
         )
 
-    def observe_operation(self, _operation_id: str) -> dict[str, Any]:
+    def observe_operation(self, operation_id: str) -> dict[str, Any]:
+        validated = parse_identifier(operation_id)
         timeout_ms = self.registry.targets[0]["timeout_ms"] if self.registry.targets else 12_000
         return self._observe(
             self.runtime["reporters"]["backup-operation-status-v1"],
             timeout_ms,
             parse_raw_operation,
+            ("--operation-id", validated),
         )
 
     def _observe(
@@ -176,19 +180,20 @@ class BackupObservers:
         command: Mapping[str, Any] | None,
         timeout_ms: int,
         parser: Callable[[object], dict[str, Any]],
+        selector: tuple[str, str],
     ) -> dict[str, Any]:
         if command is None:
             raise BackupError("invalid_request", "Backup observation request is invalid")
-        stdout = self.limiter.run(lambda: self._run_reporter(command, timeout_ms))
+        stdout = self.limiter.run(lambda: self._run_reporter(command, timeout_ms, selector))
         return {"raw": parser(_parse_json(stdout)), "receipt_ref": self.create_receipt_ref()}
 
-    def _run_reporter(self, command: Mapping[str, Any], timeout_ms: int) -> str:
+    def _run_reporter(self, command: Mapping[str, Any], timeout_ms: int, selector: tuple[str, str]) -> str:
         executable = command["executable"]
         _assert_absolute_executable(executable)
         result = run_exec(
             ExecRequest(
                 file=executable,
-                args=tuple(command["args"]),
+                args=tuple(command["args"]) + selector,
                 cwd=WORKING_DIRECTORY,
                 timeout_ms=timeout_ms,
                 max_buffer_bytes=EXEC_DEFAULT_OUTPUT_BYTES,

--- a/tests/test_grokbot_backup_adapters.py
+++ b/tests/test_grokbot_backup_adapters.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
 import pytest
 
-from brigade.grokbot_backup.adapters import BackupObservers
+from brigade.grokbot_backup.adapters import WORKING_DIRECTORY, BackupObservers
 from brigade.grokbot_backup.contracts import BackupError
-from brigade.grokbot_backup.exec import ExecRequest, PrivateExecResult, run_exec
+from brigade.grokbot_backup.exec import EXEC_DEFAULT_OUTPUT_BYTES, ExecRequest, PrivateExecResult, run_exec
 from brigade.grokbot_backup.normalize import classify_backup_lock, normalize_target_observation, sanitize_backup_detail
 from brigade.grokbot_backup.runtime_config import parse_backup_private_runtime, project_backup_registry
 from tests.test_grokbot_backup_runtime import _runtime
@@ -105,6 +106,153 @@ def test_adapter_rejects_malformed_json_and_keeps_errors_generic(tmp_path: Path)
         observers.observe_target("media-archive")
     assert caught.value.code == "protocol_error"
     assert "not-json" not in str(caught.value)
+
+
+def _restore_readiness(alias: str = "media-archive") -> dict[str, object]:
+    return {
+        "target_alias": alias,
+        "reporter_id": "restic-restore-readiness-v1",
+        "observed_at": "2026-08-28T00:00:00Z",
+        "readiness": "ready",
+        "last_rehearsal_at": "2026-08-27T00:00:00Z",
+        "last_rehearsal_result": "ok",
+        "evidence_freshness_seconds": 120,
+        "supported_recovery_scope": "target",
+        "detail": "ok",
+    }
+
+
+def _operation_observation(operation_id: str = "op-abc123def456") -> dict[str, object]:
+    return {
+        "operation_id": operation_id,
+        "target_alias": "media-archive",
+        "action_id": "run-backup",
+        "state": "succeeded",
+        "created_at": "2026-08-28T00:00:00Z",
+        "updated_at": "2026-08-28T00:00:00Z",
+        "summary": "ok",
+    }
+
+
+def _observers(tmp_path: Path, runner):
+    runtime_payload = _runtime(tmp_path)
+    for command in runtime_payload["reporters"].values():
+        command["args"] = ["--format", "json"]
+    runtime = parse_backup_private_runtime(runtime_payload)
+    registry = project_backup_registry(runtime)
+    observers = BackupObservers(
+        runtime=runtime,
+        registry=registry,
+        env={},
+        create_receipt_ref=lambda: "receipt-1",
+        secrets=[],
+        runner=runner,
+    )
+    return observers, runtime, registry
+
+
+def _assert_fixed_exec_bounds(request: ExecRequest, *, executable: str, timeout_ms: int) -> None:
+    assert request.file == executable
+    assert request.cwd == WORKING_DIRECTORY
+    assert request.env == {}
+    assert request.timeout_ms == timeout_ms
+    assert request.max_buffer_bytes == EXEC_DEFAULT_OUTPUT_BYTES
+    assert request.stdin is None
+    assert isinstance(request.args, tuple)
+
+
+def test_observe_target_appends_one_validated_target_alias_selector(tmp_path: Path):
+    captured: list[ExecRequest] = []
+
+    def runner(request: ExecRequest) -> PrivateExecResult:
+        captured.append(request)
+        return PrivateExecResult(stdout=json.dumps(_target_observation()))
+
+    observers, runtime, registry = _observers(tmp_path, runner)
+    target = registry.target("media-archive")
+    command = runtime["reporters"][target["reporter_id"]]
+    result = observers.observe_target("media-archive")
+    assert result["receipt_ref"] == "receipt-1"
+    assert len(captured) == 1
+    request = captured[0]
+    _assert_fixed_exec_bounds(
+        request,
+        executable=command["executable"],
+        timeout_ms=target["timeout_ms"],
+    )
+    assert request.args == (*command["args"], "--target-alias", target["alias"])
+    assert request.args[: len(command["args"])] == command["args"]
+    assert request.args[len(command["args"]) :] == ("--target-alias", target["alias"])
+
+
+def test_observe_restore_readiness_appends_one_validated_target_alias_selector(tmp_path: Path):
+    captured: list[ExecRequest] = []
+
+    def runner(request: ExecRequest) -> PrivateExecResult:
+        captured.append(request)
+        return PrivateExecResult(stdout=json.dumps(_restore_readiness()))
+
+    observers, runtime, registry = _observers(tmp_path, runner)
+    target = registry.target("media-archive")
+    command = runtime["reporters"][target["readiness_reporter_id"]]
+    result = observers.observe_restore_readiness("media-archive")
+    assert result["receipt_ref"] == "receipt-1"
+    assert len(captured) == 1
+    request = captured[0]
+    _assert_fixed_exec_bounds(
+        request,
+        executable=command["executable"],
+        timeout_ms=target["timeout_ms"],
+    )
+    assert request.args == (*command["args"], "--target-alias", target["alias"])
+    assert request.args[: len(command["args"])] == command["args"]
+    assert request.args[len(command["args"]) :] == ("--target-alias", target["alias"])
+
+
+def test_observe_operation_appends_one_validated_operation_id_selector(tmp_path: Path):
+    captured: list[ExecRequest] = []
+    operation_id = "op-abc123def456"
+
+    def runner(request: ExecRequest) -> PrivateExecResult:
+        captured.append(request)
+        return PrivateExecResult(stdout=json.dumps(_operation_observation(operation_id)))
+
+    observers, runtime, registry = _observers(tmp_path, runner)
+    command = runtime["reporters"]["backup-operation-status-v1"]
+    result = observers.observe_operation(operation_id)
+    assert result["receipt_ref"] == "receipt-1"
+    assert len(captured) == 1
+    request = captured[0]
+    _assert_fixed_exec_bounds(
+        request,
+        executable=command["executable"],
+        timeout_ms=registry.targets[0]["timeout_ms"],
+    )
+    assert request.args == (*command["args"], "--operation-id", operation_id)
+    assert request.args[: len(command["args"])] == command["args"]
+    assert request.args[len(command["args"]) :] == ("--operation-id", operation_id)
+
+
+def test_invalid_reporter_selectors_fail_before_runner(tmp_path: Path):
+    captured: list[ExecRequest] = []
+
+    def runner(request: ExecRequest) -> PrivateExecResult:
+        captured.append(request)
+        raise AssertionError("reporter runner must not run for invalid selectors")
+
+    observers, _runtime_payload, _registry = _observers(tmp_path, runner)
+    invalid = ("-leading", "a" * 65)
+    for value in invalid:
+        with pytest.raises(BackupError) as target_error:
+            observers.observe_target(value)
+        assert target_error.value.code == "not_found"
+        with pytest.raises(BackupError) as readiness_error:
+            observers.observe_restore_readiness(value)
+        assert readiness_error.value.code == "not_found"
+        with pytest.raises(BackupError) as operation_error:
+            observers.observe_operation(value)
+        assert operation_error.value.code == "invalid_request"
+    assert captured == []
 
 
 def test_exec_bounds_timeout_and_oversize_output():


### PR DESCRIPTION
## Summary

- append the canonical target alias when Backup Steward invokes target and restore-readiness reporters
- validate and append the requested operation ID for operation-status reporters
- keep configured arguments first and preserve the fixed executable, no-shell, timeout, environment, and output bounds
- reject invalid or oversized selectors before a reporter process starts

## Verification

- RED: `20260830-113901-work-verify-d55e0a` (`4 failed, 4 passed`)
- focused GREEN after review repair and rebase: `20260830-115412-work-verify-a25ae4`
- independent Opus review: no Critical findings, selector implementation marked ready
- full gate attempt: `20260830-115437-work-verify-901bec` stopped with exit 75 because another worktree owns the repo-wide verification lock. Required GitHub checks remain the merge gate.

## Scope note

The public operation-status tool currently reads its action store instead of calling `observe_operation`. This change validates the reporter method requested by the adapter contract but does not rewire the public tool path.

Refs #1255
