### PR TITLE
feat(grokbot): add operations relay pack

### DIFF
--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -272,7 +272,9 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
             "cerebro-memory",
             "fleet-steward",
             "backup-steward",
+            "n8n-operator",
             "obsidian-operator",
+            "operations-relay",
             "wazuh-triage",
             "n8n-operator",
         ),
@@ -419,6 +421,13 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
     pack_upstream_key.add_argument(
         "--upstream-key-env",
         help="Name of the environment variable holding the upstream key. Required for obsidian-operator.",
+    )
+    p_pack_setup.add_argument(
+        "--owner",
+        type=Path,
+        default=None,
+        dest="owner_workspace",
+        help="Absolute owner workspace. Required for operations-relay.",
     )
     p_pack_setup.add_argument("--apply", action="store_true", help="Write local config. Default is preview only.")
 
@@ -964,6 +973,13 @@ def _dispatch_grokbot(args, target: Path) -> int:
 
                     n8n_config, n8n_tools = build_n8n_listener(target, **listener_kwargs)
                     run_n8n_listener(n8n_config, n8n_tools)
+                elif args.pack == "operations-relay":
+                    from .. import grokbot_operations_relay
+
+                    operations_config, operations_tools = grokbot_operations_relay.build_listener_from_target(
+                        target, **listener_kwargs
+                    )
+                    grokbot_operations_relay.run_listener(operations_config, operations_tools)
                 else:
                     cerebro_config, cerebro_tools = grokbot_cerebro.build_listener_from_target(
                         target, **listener_kwargs
@@ -993,6 +1009,7 @@ def _dispatch_grokbot(args, target: Path) -> int:
                 grokbot_fleet,
                 grokbot_n8n,
                 grokbot_obsidian,
+                grokbot_operations_relay,
                 grokbot_packs,
                 grokbot_wazuh,
             )
@@ -1005,6 +1022,7 @@ def _dispatch_grokbot(args, target: Path) -> int:
                     grokbot_fleet.FleetError,
                     grokbot_n8n.N8nError,
                     grokbot_obsidian.ObsidianError,
+                    grokbot_operations_relay.OperationsRelayError,
                     grokbot_packs.PackError,
                     grokbot_wazuh.WazuhError,
                 ),
@@ -1288,6 +1306,7 @@ def _dispatch_grokbot_pack(args, target: Path) -> int:
                 "upstream_url": getattr(args, "upstream_url", None),
                 "upstream_key_env": getattr(args, "upstream_key_env", None),
                 "upstream_key_file": getattr(args, "upstream_key_file", None),
+                "owner_workspace": getattr(args, "owner_workspace", None),
             }
             result = (
                 grokbot_packs.apply_setup(target, args.pack_id, **setup_kwargs)

--- a/src/brigade/grokbot_operations_relay.py
+++ b/src/brigade/grokbot_operations_relay.py
@@ -1,0 +1,682 @@
+"""First-party operations-relay connector: submit one finding, read delivery state."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from . import grokbot_findings, grokbot_findings_relay, grokbot_mcp, grokbot_ops
+
+PACK_ID = "operations-relay"
+DEFAULT_BIND = "127.0.0.1:8777"
+SERVICE_NAME = "grokbot-operations-relay"
+TOOLS = frozenset({"automation_finding_status", "submit_automation_finding"})
+SUBMIT_KEYS = grokbot_findings.REQUIRED_ENTRY_KEYS
+STATUS_KEYS = frozenset({"producer", "finding_id", "revision"})
+FORBIDDEN_TOOL_KEYS = frozenset(
+    {
+        "argv",
+        "bearer",
+        "command",
+        "credential",
+        "cwd",
+        "dest",
+        "destination",
+        "executable",
+        "file",
+        "http",
+        "https",
+        "memory",
+        "owner",
+        "password",
+        "path",
+        "secret",
+        "target",
+        "token",
+        "url",
+    }
+)
+ERROR_MESSAGES = {
+    "invalid_request": "Tool input failed validation",
+    "unavailable": "Operations relay is unavailable",
+}
+MAX_REQUEST_BYTES = 16_384
+PUBLIC_RESULT_LIMIT = 131_072
+_TOOL_DESCRIPTIONS = {
+    "submit_automation_finding": "Submit one automation finding for owner review",
+    "automation_finding_status": "Read opaque delivery state for one finding",
+}
+FINDINGS_VALIDATION = frozenset(
+    {
+        "digest-mismatch",
+        "invalid-body",
+        "invalid-content-digest",
+        "invalid-entry",
+        "invalid-finding-id",
+        "invalid-observed-at",
+        "invalid-producer",
+        "invalid-revision",
+        "invalid-severity",
+        "invalid-source-digest",
+        "invalid-source-ref",
+        "invalid-title",
+    }
+)
+
+
+class OperationsRelayError(ValueError):
+    """Stable public operations-relay failure. Messages never include paths or secrets."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        self.code = reason
+        self.message = ERROR_MESSAGES[reason]
+        super().__init__(self.message)
+
+    def public_error(self) -> dict[str, dict[str, str]]:
+        return {"error": {"code": self.reason, "message": ERROR_MESSAGES[self.reason]}}
+
+    def __repr__(self) -> str:
+        return f"OperationsRelayError({self.reason!r})"
+
+
+@dataclass(frozen=True)
+class OperationsRelayListenerConfig:
+    target: Path
+    bind_host: str
+    bind_port: int
+    allowed_hosts: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
+    bearer: str
+    owner_workspace: str
+
+    def __repr__(self) -> str:
+        return f"OperationsRelayListenerConfig(bind_host={self.bind_host!r}, bind_port={self.bind_port})"
+
+
+def validate_owner_workspace(owner: object) -> str:
+    if not isinstance(owner, (str, Path)) or (isinstance(owner, str) and not owner):
+        raise OperationsRelayError("invalid_request")
+    path = Path(owner)
+    if not path.is_absolute() or "\x00" in str(path):
+        raise OperationsRelayError("invalid_request")
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise OperationsRelayError("invalid_request") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise OperationsRelayError("invalid_request")
+    if stat.S_IMODE(info.st_mode) != 0o700:
+        raise OperationsRelayError("invalid_request")
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        raise OperationsRelayError("invalid_request")
+    try:
+        validated = grokbot_findings._validate_owner(path)
+    except grokbot_findings.FindingsError as exc:
+        raise OperationsRelayError("invalid_request") from exc
+    return str(validated)
+
+
+def parse_submit_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) & FORBIDDEN_TOOL_KEYS:
+        raise OperationsRelayError("invalid_request")
+    if set(raw) != SUBMIT_KEYS:
+        raise OperationsRelayError("invalid_request")
+    try:
+        return grokbot_findings._validate_entry(raw, index=0)
+    except grokbot_findings.FindingsError as exc:
+        raise OperationsRelayError("invalid_request") from exc
+
+
+def parse_status_input(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict) or set(raw) & FORBIDDEN_TOOL_KEYS:
+        raise OperationsRelayError("invalid_request")
+    if set(raw) != STATUS_KEYS:
+        raise OperationsRelayError("invalid_request")
+    try:
+        return {
+            "producer": grokbot_findings._bounded_identifier(raw["producer"], reason="invalid-producer", index=0),
+            "finding_id": grokbot_findings._bounded_identifier(raw["finding_id"], reason="invalid-finding-id", index=0),
+            "revision": grokbot_findings._bounded_identifier(raw["revision"], reason="invalid-revision", index=0),
+        }
+    except grokbot_findings.FindingsError as exc:
+        raise OperationsRelayError("invalid_request") from exc
+
+
+class OperationsRelayTools:
+    """Closed public operations-relay tool surface."""
+
+    def __init__(
+        self,
+        *,
+        target: Path,
+        owner: Path,
+        now: Callable[[], datetime] | None = None,
+        secrets: list[str] | None = None,
+    ):
+        self.target = Path(target)
+        self.owner = Path(owner)
+        self.now = now or (lambda: datetime.now(timezone.utc))
+        self.secrets = list(secrets or [])
+
+    @classmethod
+    def placeholder(cls, config: OperationsRelayListenerConfig) -> "OperationsRelayTools":
+        return cls(target=config.target, owner=Path(config.owner_workspace))
+
+    def inventory(self) -> list[str]:
+        return sorted(TOOLS)
+
+    def call_tool(self, name: str, arguments: object) -> dict[str, Any]:
+        handlers = {
+            "submit_automation_finding": self.submit_automation_finding,
+            "automation_finding_status": self.automation_finding_status,
+        }
+        if name not in handlers:
+            raise OperationsRelayError("invalid_request")
+        result = handlers[name](arguments)
+        encoded = json.dumps(result, separators=(",", ":"))
+        if len(encoded.encode("utf-8")) > PUBLIC_RESULT_LIMIT:
+            raise OperationsRelayError("unavailable")
+        return result
+
+    def submit_automation_finding(self, raw: object) -> dict[str, Any]:
+        entry = parse_submit_input(raw)
+        handle = grokbot_findings.identity_digest(entry["producer"], entry["finding_id"], entry["revision"])
+        try:
+            delivered = grokbot_findings_relay.relay_apply(
+                [entry],
+                self.target,
+                self.owner,
+                limit=1,
+                now=self.now(),
+            )
+        except grokbot_findings.FindingsError as exc:
+            if exc.reason in FINDINGS_VALIDATION:
+                raise OperationsRelayError("invalid_request") from exc
+            raise OperationsRelayError("unavailable") from exc
+        return {
+            "handle": handle,
+            "created": delivered["created"],
+            "known": delivered["known"],
+            "reported": delivered["reported"],
+            "pending": delivered["pending"],
+            "state": _delivery_state(self.target, handle),
+        }
+
+    def automation_finding_status(self, raw: object) -> dict[str, Any]:
+        parsed = parse_status_input(raw)
+        handle = grokbot_findings.identity_digest(parsed["producer"], parsed["finding_id"], parsed["revision"])
+        return {"handle": handle, "state": _delivery_state(self.target, handle)}
+
+
+class OperationsRelayAdapter:
+    def __init__(self, config: OperationsRelayListenerConfig, tools: OperationsRelayTools):
+        self.config = config
+        self.tools = tools
+
+    def authorized(self, authorization: str | None) -> bool:
+        if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
+            return False
+        bearer = authorization[7:]
+        if not bearer.isascii():
+            return False
+        try:
+            return hmac.compare_digest(bearer, self.config.bearer)
+        except ValueError:
+            return False
+
+    def health_payload(self) -> dict[str, object]:
+        return {"ok": True, "service": SERVICE_NAME}
+
+    def tool_inventory(self) -> list[dict[str, str]]:
+        return [{"name": name, "description": _TOOL_DESCRIPTIONS[name]} for name in sorted(TOOLS)]
+
+    def call_tool(self, name: str, arguments: object) -> dict[str, Any]:
+        try:
+            return self.tools.call_tool(name, arguments)
+        except OperationsRelayError as exc:
+            return exc.public_error()
+
+
+def doctor(target: Path, *, timeout: int | None = None) -> list[dict[str, str]]:
+    from . import grokbot_packs
+
+    checks: list[dict[str, str]] = []
+
+    def record(name: str, ok: bool) -> None:
+        checks.append({"check": name, "status": "ok" if ok else "fail"})
+
+    try:
+        from mcp.server import MCPServer  # noqa: F401
+
+        record("dependency", True)
+    except ImportError:
+        record("dependency", False)
+    try:
+        config, bearer = _load_runtime(target)
+        record("config", True)
+    except (
+        OperationsRelayError,
+        grokbot_packs.PackError,
+        grokbot_mcp.ConfigurationError,
+        OSError,
+        ValueError,
+        KeyError,
+    ):
+        record("config", False)
+        return checks
+    parent = grokbot_packs.instance_config_path(target, PACK_ID).parent
+    record("permissions", os.access(parent, os.W_OK) if parent.is_dir() else False)
+    record("endpoint", _health_check(config, bearer, timeout or grokbot_ops.DEFAULT_TIMEOUT_SECONDS))
+    return checks
+
+
+def canary(target: Path, *, timeout: int | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"ok": False, "pack_id": PACK_ID}
+    try:
+        config, bearer = _load_runtime(target)
+    except Exception:
+        result["reason"] = "config"
+        return result
+    wait = timeout or grokbot_ops.DEFAULT_TIMEOUT_SECONDS
+    base = f"http://{grokbot_ops._connect_host(config.bind_host)}:{config.bind_port}"
+    health = grokbot_ops._request_json(f"{base}/health", bearer, wait, method="GET")
+    anonymous_status = grokbot_ops._anonymous_health_status(f"{base}/health", wait)
+    tools_response = grokbot_ops._tools_list(base, bearer, wait)
+    if health is None or health.get("ok") is not True or health.get("service") != SERVICE_NAME:
+        result["reason"] = "health"
+        return result
+    if anonymous_status not in {401, 403}:
+        result["reason"] = "auth"
+        return result
+    if tools_response is None:
+        result["reason"] = "inventory-unreachable"
+        return result
+    names = {tool.get("name") for tool in tools_response if isinstance(tool, dict)}
+    if names != set(TOOLS):
+        result["reason"] = "inventory-mismatch"
+        return result
+    result.update(
+        {
+            "ok": True,
+            "health": health,
+            "auth_rejected_without_bearer": True,
+            "tools": sorted(TOOLS),
+        }
+    )
+    return result
+
+
+def render_unit(target: Path, *, python: str | None = None) -> str:
+    instance = _load_validated_instance(target)
+    reference = instance["bearer"]
+    bind = instance["bind"]
+    args = [
+        python or sys.executable,
+        "-m",
+        "brigade",
+        "run",
+        "cloud",
+        "grokbot",
+        "serve",
+        "--pack",
+        PACK_ID,
+        "--target",
+        str(target),
+        "--bind",
+        bind,
+    ]
+    for host in instance.get("allowed_hosts", []):
+        args += ["--allow-host", host]
+    for origin in instance.get("allowed_origins", []):
+        args += ["--allow-origin", origin]
+    if reference["kind"] == "file":
+        args += ["--bearer-file", reference["path"]]
+    elif reference["kind"] == "env":
+        args += ["--bearer-env", reference["name"]]
+    exec_start = " ".join(grokbot_ops._systemd_quote(argument) for argument in args)
+    writable = " ".join(
+        grokbot_ops._systemd_quote(path)
+        for path in (
+            str((Path(target) / grokbot_ops.QUEUE_STATE_DIR).resolve()),
+            instance["owner_workspace"],
+        )
+    )
+    return (
+        "# Generated by brigade run cloud grokbot pack install-service.\n"
+        f"# Unit: {grokbot_ops.unit_name(PACK_ID)}\n"
+        "[Unit]\n"
+        "Description=Brigade Grok Bot MCP listener (operations-relay)\n"
+        "After=network.target\n\n"
+        "[Service]\n"
+        "Type=simple\n"
+        f"ExecStart={exec_start}\n"
+        "Restart=on-failure\n"
+        "NoNewPrivileges=yes\n"
+        "PrivateTmp=yes\n"
+        "ProtectSystem=strict\n"
+        "ProtectHome=read-only\n\n"
+        f"ReadWritePaths={writable}\n\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+def write_unit(target: Path, out_dir: Path, *, force: bool = False, python: str | None = None) -> Path:
+    rendered = render_unit(target, python=python)
+    path = out_dir / grokbot_ops.unit_name(PACK_ID)
+    try:
+        existing = grokbot_ops._read_regular_text(path)
+    except FileNotFoundError:
+        existing = None
+    except OSError as exc:
+        if not force or not grokbot_ops._path_is_symlink(path):
+            raise grokbot_ops.ServiceRenderError(f"refusing unsafe unit path: {path.name}") from exc
+        existing = None
+    if existing == rendered:
+        return path
+    if existing is not None and not force:
+        raise grokbot_ops.ServiceRenderError(f"refusing to overwrite existing unit: {path.name}")
+    try:
+        grokbot_ops._write_text_nofollow_atomic(
+            path,
+            rendered,
+            mode=0o644,
+            replace_symlink=force,
+            replace=force or existing is not None,
+        )
+    except OSError as exc:
+        raise grokbot_ops.ServiceRenderError(f"refusing unsafe unit path: {path.name}") from exc
+    return path
+
+
+def build_app(config: OperationsRelayListenerConfig, tools: OperationsRelayTools) -> Callable[..., Any]:
+    MCPServer, JSONResponse, _, TransportSecuritySettings = grokbot_mcp._load_mcp()
+    adapter = OperationsRelayAdapter(config, tools)
+    server = MCPServer(SERVICE_NAME, version="1")
+
+    @server.custom_route("/health", methods=["GET"])
+    async def health(_: Any) -> Any:
+        return JSONResponse(adapter.health_payload())
+
+    _register_tools(server, adapter)
+    allowed_hosts = list(dict.fromkeys((*grokbot_mcp.SDK_LOOPBACK_ALLOWED_HOSTS, *config.allowed_hosts)))
+    if not grokbot_mcp._is_loopback(config.bind_host):
+        allowed_hosts = list(config.allowed_hosts)
+    app = server.streamable_http_app(
+        json_response=True,
+        stateless_http=True,
+        max_request_body_size=MAX_REQUEST_BYTES,
+        host=config.bind_host,
+        transport_security=TransportSecuritySettings(
+            allowed_hosts=allowed_hosts,
+            allowed_origins=list(config.allowed_origins),
+        ),
+    )
+    return _OperationsRelayGateASGI(app, _OperationsRelayRequestGate(config), adapter)
+
+
+def run_listener(config: OperationsRelayListenerConfig, tools: OperationsRelayTools) -> None:
+    grokbot_mcp._load_mcp()
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise grokbot_mcp.OptionalDependencyError() from exc
+    uvicorn.run(
+        build_app(config, tools), host=config.bind_host, port=config.bind_port, access_log=False, log_level="warning"
+    )
+
+
+def build_listener_from_target(
+    target: Path,
+    *,
+    bind: str | None,
+    allowed_hosts: list[str],
+    allowed_origins: list[str],
+    bearer_file: Path | None,
+    bearer_env: str | None,
+) -> tuple[OperationsRelayListenerConfig, OperationsRelayTools]:
+    from . import grokbot_packs
+
+    instance = grokbot_packs._load_instance_config(target, PACK_ID)
+    chosen_bind = bind or instance["bind"]
+    host, port = grokbot_packs._parse_default_bind(chosen_bind)
+    owner = validate_owner_workspace(str(instance["owner_workspace"]))
+    bearer = _require_isolated_bearer(grokbot_mcp.load_bearer(bearer_file=bearer_file, bearer_env=bearer_env))
+    config = OperationsRelayListenerConfig(
+        target=target.expanduser().resolve(),
+        bind_host=host,
+        bind_port=port,
+        allowed_hosts=tuple(allowed_hosts),
+        allowed_origins=tuple(allowed_origins),
+        bearer=bearer,
+        owner_workspace=owner,
+    )
+    return config, OperationsRelayTools(
+        target=config.target,
+        owner=Path(owner),
+        secrets=[bearer, owner],
+    )
+
+
+def _delivery_state(target: Path, handle: str) -> str:
+    try:
+        for record in grokbot_findings_relay._read_outbox_records(target):
+            if record.get("relay_id") == handle and record.get("status") in grokbot_findings_relay.OUTBOX_STATUSES:
+                return str(record["status"])
+        if _marker_exists(target, handle):
+            return "delivered"
+    except grokbot_findings.FindingsError:
+        return "unknown"
+    return "unknown"
+
+
+def _marker_exists(target: Path, handle: str) -> bool:
+    directory = grokbot_findings._open_findings_readonly(target)
+    try:
+        if directory is None:
+            return False
+        location: int | Path = directory.descriptor if directory.descriptor is not None else directory.path
+        try:
+            names = os.listdir(location)
+        except OSError:
+            return False
+        return f"{handle}.json" in names
+    finally:
+        if directory is not None and directory.descriptor is not None:
+            os.close(directory.descriptor)
+
+
+def _load_validated_instance(target: Path) -> dict[str, Any]:
+    from . import grokbot_packs
+
+    payload = grokbot_packs._load_instance_config(target, PACK_ID)
+    owner = validate_owner_workspace(str(payload["owner_workspace"]))
+    grokbot_packs._parse_default_bind(str(payload["bind"]))
+    grokbot_packs._validate_bearer_reference(payload["bearer"])
+    validated = dict(payload)
+    validated["owner_workspace"] = owner
+    return validated
+
+
+def _environment_invalid() -> None:
+    raise OperationsRelayError("invalid_request")
+
+
+def _require_isolated_bearer(bearer: str) -> str:
+    if len(bearer) < 32:
+        _environment_invalid()
+    dispatch_token = os.environ.get("GROKBOT_DISPATCH_TOKEN")
+    if dispatch_token is not None and bearer == dispatch_token:
+        _environment_invalid()
+    return bearer
+
+
+def _resolve_bearer(reference: Mapping[str, str]) -> str:
+    return _require_isolated_bearer(grokbot_ops._resolve_bearer(dict(reference)))
+
+
+def _load_runtime(target: Path) -> tuple[OperationsRelayListenerConfig, str]:
+    payload = _load_validated_instance(target)
+    from . import grokbot_packs
+
+    host, port = grokbot_packs._parse_default_bind(str(payload["bind"]))
+    bearer = _resolve_bearer(payload["bearer"])
+    config = OperationsRelayListenerConfig(
+        target=target,
+        bind_host=host,
+        bind_port=port,
+        allowed_hosts=tuple(payload["allowed_hosts"]),
+        allowed_origins=tuple(payload["allowed_origins"]),
+        bearer=bearer,
+        owner_workspace=payload["owner_workspace"],
+    )
+    return config, bearer
+
+
+def _register_tools(server: Any, adapter: OperationsRelayAdapter) -> None:
+    def submit_automation_finding(
+        producer: str,
+        finding_id: str,
+        revision: str,
+        observed_at: str,
+        severity: str,
+        title: str,
+        body: str,
+        source_ref: str,
+        source_digest: str,
+        content_digest: str,
+    ) -> dict[str, Any]:
+        return adapter.call_tool(
+            "submit_automation_finding",
+            {
+                "producer": producer,
+                "finding_id": finding_id,
+                "revision": revision,
+                "observed_at": observed_at,
+                "severity": severity,
+                "title": title,
+                "body": body,
+                "source_ref": source_ref,
+                "source_digest": source_digest,
+                "content_digest": content_digest,
+            },
+        )
+
+    def automation_finding_status(producer: str, finding_id: str, revision: str) -> dict[str, Any]:
+        return adapter.call_tool(
+            "automation_finding_status",
+            {"producer": producer, "finding_id": finding_id, "revision": revision},
+        )
+
+    for name, handler in (
+        ("submit_automation_finding", submit_automation_finding),
+        ("automation_finding_status", automation_finding_status),
+    ):
+        handler.__name__ = name
+        handler.__doc__ = _TOOL_DESCRIPTIONS[name]
+        server.tool(name=name, description=_TOOL_DESCRIPTIONS[name])(handler)
+
+
+class _OperationsRelayRequestGate:
+    def __init__(self, config: OperationsRelayListenerConfig, *, max_request_bytes: int = MAX_REQUEST_BYTES):
+        self.config = config
+        self.max_request_bytes = max_request_bytes
+        self._adapter = OperationsRelayAdapter(config, OperationsRelayTools.placeholder(config))
+
+    def reject_reason(self, headers: Mapping[str, str], body_size: int) -> str | None:
+        if body_size < 0 or body_size > self.max_request_bytes:
+            return "too-large"
+        host = headers.get("host", "").split(":", 1)[0].casefold()
+        if grokbot_mcp._is_loopback(self.config.bind_host) and host in {"localhost", "127.0.0.1", "::1", ""}:
+            pass
+        elif host not in {entry.casefold().split(":", 1)[0] for entry in self.config.allowed_hosts}:
+            return "forbidden"
+        origin = headers.get("origin")
+        if origin is not None and origin not in self.config.allowed_origins:
+            return "forbidden"
+        if not self._adapter.authorized(headers.get("authorization")):
+            return "unauthorized"
+        return None
+
+
+class _OperationsRelayGateASGI:
+    def __init__(
+        self,
+        app: Callable[..., Any],
+        gate: _OperationsRelayRequestGate,
+        adapter: OperationsRelayAdapter,
+    ):
+        self.app = app
+        self.gate = gate
+        self.adapter = adapter
+
+    async def __call__(self, scope: dict[str, Any], receive: Callable[..., Any], send: Callable[..., Any]) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = {key.decode("latin-1").casefold(): value.decode("latin-1") for key, value in scope.get("headers", [])}
+        content_length = headers.get("content-length")
+        if content_length is not None and (
+            not content_length.isdecimal() or int(content_length) > self.gate.max_request_bytes
+        ):
+            await grokbot_mcp._reject_http(send, 413, "Request body is too large")
+            return
+        reason = self.gate.reject_reason(headers, 0)
+        if reason is not None:
+            await grokbot_mcp._reject_http(
+                send,
+                401 if reason == "unauthorized" else 403,
+                "Unauthorized" if reason == "unauthorized" else "Forbidden",
+            )
+            return
+        body, messages, too_large = await grokbot_mcp._read_bounded_body(receive, self.gate.max_request_bytes)
+        if too_large:
+            await grokbot_mcp._reject_http(send, 413, "Request body is too large")
+            return
+        if scope.get("path") == "/mcp" and _invalid_tool_request(body):
+            await grokbot_mcp._reject_tool(send, body)
+            return
+        await self.app(scope, grokbot_mcp._replay_messages(messages, receive), send)
+
+
+def _invalid_tool_request(body: bytes) -> bool:
+    try:
+        request = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(request, dict) or request.get("method") != "tools/call":
+        return False
+    params = request.get("params")
+    if not isinstance(params, dict):
+        return True
+    name = params.get("name")
+    if name not in TOOLS:
+        return True
+    arguments = params.get("arguments")
+    parser = {
+        "submit_automation_finding": parse_submit_input,
+        "automation_finding_status": parse_status_input,
+    }[name]
+    try:
+        parser(arguments if arguments is not None else {})
+    except OperationsRelayError:
+        return True
+    return False
+
+
+def _health_check(config: OperationsRelayListenerConfig, bearer: str, timeout: int) -> bool:
+    payload = grokbot_ops._request_json(
+        f"http://{grokbot_ops._connect_host(config.bind_host)}:{config.bind_port}/health",
+        bearer,
+        timeout,
+        method="GET",
+    )
+    return payload is not None and payload.get("ok") is True and payload.get("service") == SERVICE_NAME

--- a/src/brigade/grokbot_packs.py
+++ b/src/brigade/grokbot_packs.py
@@ -23,6 +23,7 @@ from . import (
     grokbot_mcp,
     grokbot_n8n,
     grokbot_obsidian,
+    grokbot_operations_relay,
     grokbot_ops,
     grokbot_wazuh,
 )
@@ -54,11 +55,13 @@ CONNECTOR_DEFAULT_BINDS = {
     "fleet-steward": "127.0.0.1:8771",
     "n8n-operator": "127.0.0.1:8775",
     "obsidian-operator": "127.0.0.1:8773",
+    "operations-relay": "127.0.0.1:8777",
     "wazuh-triage": "127.0.0.1:8774",
 }
 STEWARD_PACK_IDS = frozenset({"backup-steward", "fleet-steward", "wazuh-triage"})
 OBSIDIAN_PACK_ID = "obsidian-operator"
 N8N_PACK_ID = "n8n-operator"
+OPERATIONS_RELAY_PACK_ID = "operations-relay"
 FLEET_INSTANCE_KEYS = INSTANCE_KEYS | frozenset(
     {
         "runtime_path",
@@ -85,6 +88,7 @@ N8N_INSTANCE_KEYS = INSTANCE_KEYS | frozenset(
         "approval_dir",
     }
 )
+OPERATIONS_RELAY_INSTANCE_KEYS = INSTANCE_KEYS | frozenset({"owner_workspace"})
 CONNECTOR_INSTANCE_KEYS = INSTANCE_KEYS | frozenset({"cli_executable", "workdir"})
 VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 PACK_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
@@ -124,6 +128,8 @@ def _connector_tools(pack_id: str) -> frozenset[str]:
         return grokbot_obsidian.TOOLS
     if pack_id == N8N_PACK_ID:
         return grokbot_n8n.TOOLS
+    if pack_id == OPERATIONS_RELAY_PACK_ID:
+        return grokbot_operations_relay.TOOLS
     if pack_id == "wazuh-triage":
         return grokbot_wazuh.TOOLS
     return frozenset()
@@ -215,6 +221,7 @@ def preview_setup(
     upstream_key_env: str | None = None,
     upstream_key_file: Path | None = None,
     upstream_key: dict[str, Any] | None = None,
+    owner_workspace: str | Path | None = None,
 ) -> dict[str, Any]:
     return _setup(
         target,
@@ -238,6 +245,7 @@ def preview_setup(
         upstream_key_env=upstream_key_env,
         upstream_key_file=upstream_key_file,
         upstream_key=upstream_key,
+        owner_workspace=owner_workspace,
     )
 
 
@@ -263,6 +271,7 @@ def apply_setup(
     upstream_key_env: str | None = None,
     upstream_key_file: Path | None = None,
     upstream_key: dict[str, Any] | None = None,
+    owner_workspace: str | Path | None = None,
 ) -> dict[str, Any]:
     return _setup(
         target,
@@ -286,6 +295,7 @@ def apply_setup(
         upstream_key_env=upstream_key_env,
         upstream_key_file=upstream_key_file,
         upstream_key=upstream_key,
+        owner_workspace=owner_workspace,
     )
 
 
@@ -303,6 +313,8 @@ def doctor(target: Path, pack_id: str, *, service_result: bool = False) -> list[
         checks = grokbot_wazuh.doctor(target)
     elif pack["id"] == N8N_PACK_ID:
         checks = grokbot_n8n.doctor(target)
+    elif pack["id"] == OPERATIONS_RELAY_PACK_ID:
+        checks = grokbot_operations_relay.doctor(target)
     else:
         checks = grokbot_cerebro.doctor(target)
     if service_result:
@@ -324,6 +336,8 @@ def canary(target: Path, pack_id: str) -> dict[str, Any]:
         return grokbot_wazuh.canary(target)
     if pack["id"] == N8N_PACK_ID:
         return grokbot_n8n.canary(target)
+    if pack["id"] == OPERATIONS_RELAY_PACK_ID:
+        return grokbot_operations_relay.canary(target)
     return grokbot_cerebro.canary(target)
 
 
@@ -343,6 +357,8 @@ def render_install_service(target: Path, pack_id: str) -> str:
             return grokbot_wazuh.render_unit(target, python=sys.executable)
         if pack["id"] == N8N_PACK_ID:
             return grokbot_n8n.render_unit(target, python=sys.executable)
+        if pack["id"] == OPERATIONS_RELAY_PACK_ID:
+            return grokbot_operations_relay.render_unit(target, python=sys.executable)
         return grokbot_cerebro.render_unit(target, python=sys.executable)
     except PackError:
         raise
@@ -357,6 +373,7 @@ def render_install_service(target: Path, pack_id: str) -> str:
                 grokbot_fleet.FleetError,
                 grokbot_n8n.N8nError,
                 grokbot_obsidian.ObsidianError,
+                grokbot_operations_relay.OperationsRelayError,
                 grokbot_wazuh.WazuhError,
             ),
         ):
@@ -386,6 +403,8 @@ def apply_install_service(
             path = grokbot_wazuh.write_unit(target, out_dir, force=force)
         elif pack["id"] == N8N_PACK_ID:
             path = grokbot_n8n.write_unit(target, out_dir, force=force)
+        elif pack["id"] == OPERATIONS_RELAY_PACK_ID:
+            path = grokbot_operations_relay.write_unit(target, out_dir, force=force)
         else:
             path = grokbot_cerebro.write_unit(target, out_dir, force=force)
     except PackError:
@@ -401,6 +420,7 @@ def apply_install_service(
                 grokbot_fleet.FleetError,
                 grokbot_n8n.N8nError,
                 grokbot_obsidian.ObsidianError,
+                grokbot_operations_relay.OperationsRelayError,
                 grokbot_wazuh.WazuhError,
             ),
         ):
@@ -448,6 +468,7 @@ def _setup(
     upstream_key_env: str | None = None,
     upstream_key_file: Path | None = None,
     upstream_key: dict[str, Any] | None = None,
+    owner_workspace: str | Path | None = None,
 ) -> dict[str, Any]:
     pack = show_pack(pack_id)
     reference = _bearer_reference(bearer_env=bearer_env, bearer_file=bearer_file, bearer=bearer)
@@ -472,6 +493,7 @@ def _setup(
         if (
             cli_executable is not None
             or workdir is not None
+            or owner_workspace is not None
             or any(path is not None for path in fleet_paths)
             or any(path is not None for path in obsidian_paths)
             or any(field is not None for field in upstream_fields)
@@ -481,13 +503,14 @@ def _setup(
         if (
             cli_executable is not None
             or workdir is not None
+            or owner_workspace is not None
             or any(path is not None for path in obsidian_paths)
             or any(field is not None for field in upstream_fields)
         ):
             raise PackError("unexpected-key")
         payload.update(_steward_path_references(pack["id"], runtime_path, ledger_path, action_state_path, approval_dir))
     elif pack["id"] == OBSIDIAN_PACK_ID:
-        if cli_executable is not None or workdir is not None or ledger_path is not None:
+        if cli_executable is not None or workdir is not None or ledger_path is not None or owner_workspace is not None:
             raise PackError("unexpected-key")
         payload.update(
             _obsidian_path_references(runtime_path, action_state_path, approval_dir, staging_dir, excalidraw_bin)
@@ -498,14 +521,26 @@ def _setup(
             cli_executable is not None
             or workdir is not None
             or ledger_path is not None
+            or owner_workspace is not None
             or any(path is not None for path in obsidian_paths)
             or any(field is not None for field in upstream_fields)
         ):
             raise PackError("unexpected-key")
         payload.update(_n8n_path_references(runtime_path, action_state_path, approval_dir))
+    elif pack["id"] == OPERATIONS_RELAY_PACK_ID:
+        if (
+            cli_executable is not None
+            or workdir is not None
+            or any(path is not None for path in fleet_paths)
+            or any(path is not None for path in obsidian_paths)
+            or any(field is not None for field in upstream_fields)
+        ):
+            raise PackError("unexpected-key")
+        payload["owner_workspace"] = _operations_relay_owner_reference(owner_workspace)
     else:
         if (
-            any(path is not None for path in fleet_paths)
+            owner_workspace is not None
+            or any(path is not None for path in fleet_paths)
             or any(path is not None for path in obsidian_paths)
             or any(field is not None for field in upstream_fields)
         ):
@@ -889,7 +924,9 @@ def _validate_instance_config(payload: Mapping[str, Any], pack_id: str) -> dict[
     if not isinstance(route, str) or not PUBLIC_ROUTE_RE.fullmatch(route):
         raise PackError("unexpected-key")
     _validate_bearer_reference(payload.get("bearer"))
-    if pack["id"] == OBSIDIAN_PACK_ID:
+    if pack["id"] == OPERATIONS_RELAY_PACK_ID:
+        _operations_relay_owner_reference(payload.get("owner_workspace"))
+    elif pack["id"] == OBSIDIAN_PACK_ID:
         _obsidian_path_references(
             payload.get("runtime_path"),
             payload.get("action_state_path"),
@@ -963,11 +1000,22 @@ def _instance_keys(pack: Mapping[str, Any]) -> frozenset[str]:
         return INSTANCE_KEYS
     if pack["id"] == OBSIDIAN_PACK_ID:
         return OBSIDIAN_INSTANCE_KEYS
+    if pack["id"] == OPERATIONS_RELAY_PACK_ID:
+        return OPERATIONS_RELAY_INSTANCE_KEYS
     if pack["id"] == N8N_PACK_ID:
         return N8N_INSTANCE_KEYS
     if pack["id"] in STEWARD_PACK_IDS:
         return FLEET_INSTANCE_KEYS
     return CONNECTOR_INSTANCE_KEYS
+
+
+def _operations_relay_owner_reference(owner_workspace: object) -> str:
+    if owner_workspace is None:
+        raise PackError("missing-path-reference")
+    try:
+        return grokbot_operations_relay.validate_owner_workspace(owner_workspace)
+    except grokbot_operations_relay.OperationsRelayError as exc:
+        raise PackError("unsafe-path") from exc
 
 
 def _obsidian_upstream_references(

--- a/tests/test_grokbot_operations_relay.py
+++ b/tests/test_grokbot_operations_relay.py
@@ -1,0 +1,545 @@
+# content-guard: allow bearer-token file
+"""First-party operations-relay connector pack: closed submit/status tools."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, fleet_client, grokbot_findings, grokbot_ops, grokbot_packs
+from brigade import grokbot_operations_relay as operations_relay
+
+SECRET = "not-a-real-token-value-32chars!!"
+SHORT_BEARER = "short-token"
+SHARED_DISPATCH_BEARER = "shared-dispatch-bearer-32chars!!"
+PRIVATE_TITLE = "PRIVATE_OPS_TITLE_TOKEN"
+PRIVATE_BODY = (
+    "Bearer ghp_exampleNotARealToken0000000000000001\n"
+    "ssh root@192.0.2.10\n"
+    "command: curl http://example.invalid/secret\n"
+    "credential: hunter2-example\n"
+    "path: /etc/shadow\n"
+)
+NOW = datetime(2026, 8, 30, 11, 0, tzinfo=timezone.utc)
+PACK_ID = "operations-relay"
+TOOLS = ("automation_finding_status", "submit_automation_finding")
+FORBIDDEN_PUBLIC = {
+    "title",
+    "body",
+    "address",
+    "command",
+    "credential",
+    "payload",
+    "token",
+    "password",
+    "secret",
+    "producer",
+    "finding_id",
+    "source_ref",
+    "source_digest",
+    "events",
+    "findings",
+    "revision",
+    "path",
+    "url",
+}
+LEAK_TOKENS = (
+    SECRET,
+    PRIVATE_TITLE,
+    "ghp_exampleNotARealToken0000000000000001",
+    "192.0.2.10",
+    "http://example.invalid/secret",
+    "hunter2-example",
+    "/etc/shadow",
+)
+
+
+def _reject(reason: str):
+    return pytest.raises(grokbot_packs.PackError, match=reason)
+
+
+def _owner(path: Path) -> Path:
+    path.mkdir(mode=0o700)
+    os.chmod(path, 0o700)
+    return path
+
+
+def _entry(
+    *,
+    producer: str = "n8n",
+    finding_id: str = "workflow-stale",
+    revision: str = "1",
+    title: str = PRIVATE_TITLE,
+    body: str = PRIVATE_BODY,
+    source_ref: str = "n8n:workflow-stale",
+    severity: str = "high",
+) -> dict[str, str]:
+    return {
+        "producer": producer,
+        "finding_id": finding_id,
+        "revision": revision,
+        "observed_at": "2026-08-30T11:00:00Z",
+        "severity": severity,
+        "title": title,
+        "body": body,
+        "source_ref": source_ref,
+        "source_digest": grokbot_findings.content_digest("source", body),
+        "content_digest": grokbot_findings.content_digest(title, body),
+    }
+
+
+def _handle(entry: dict[str, str]) -> str:
+    return grokbot_findings.identity_digest(entry["producer"], entry["finding_id"], entry["revision"])
+
+
+def _public_keys(value: object) -> set[str]:
+    keys: set[str] = set()
+    if isinstance(value, dict):
+        keys.update(value)
+        for item in value.values():
+            keys.update(_public_keys(item))
+    elif isinstance(value, list):
+        for item in value:
+            keys.update(_public_keys(item))
+    return keys
+
+
+def _assert_opaque(text: str) -> None:
+    for token in LEAK_TOKENS:
+        assert token not in text
+
+
+def _assert_opaque_result(result: dict[str, object]) -> None:
+    assert FORBIDDEN_PUBLIC.isdisjoint(_public_keys(result))
+    _assert_opaque(json.dumps(result, sort_keys=True))
+
+
+def _isolate_home(tmp_path: Path, monkeypatch) -> Path:
+    home = tmp_path / "home"
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    monkeypatch.delenv("BRIGADE_FLEET_HUB_URL", raising=False)
+    monkeypatch.delenv("BRIGADE_FLEET_TOKEN", raising=False)
+    return home
+
+
+def _capture_events(monkeypatch) -> list[dict[str, object]]:
+    captured: list[dict[str, object]] = []
+
+    def _capture(event: dict[str, object], **_kwargs: object) -> bool:
+        captured.append(copy.deepcopy(event))
+        return True
+
+    monkeypatch.setattr(fleet_client, "report_event", _capture)
+    return captured
+
+
+def _tools(tmp_path: Path, monkeypatch) -> tuple[operations_relay.OperationsRelayTools, Path, Path]:
+    _isolate_home(tmp_path, monkeypatch)
+    queue = tmp_path / "queue"
+    owner = tmp_path / "owner"
+    queue.mkdir()
+    owner.mkdir()
+    tools = operations_relay.OperationsRelayTools(target=queue, owner=owner, now=lambda: NOW)
+    return tools, queue, owner
+
+
+def test_operations_relay_pack_is_closed_on_8777_with_exact_inventory():
+    pack = grokbot_packs.show_pack(PACK_ID)
+    assert pack["kind"] == "connector"
+    assert pack["instance"] == PACK_ID
+    assert pack["default_bind"] == "127.0.0.1:8777"
+    assert pack["public_route"] == ""
+    assert pack["tools"] == list(TOOLS)
+    assert set(operations_relay.TOOLS) == set(TOOLS)
+    with _reject("unknown-pack"):
+        grokbot_packs.show_pack("operations")
+    binds = {pack["id"]: pack["default_bind"] for pack in grokbot_packs.list_packs()}
+    assert binds[PACK_ID] == "127.0.0.1:8777"
+    ports = {grokbot_packs._parse_default_bind(bind)[1] for bind in binds.values()}
+    assert len(ports) == len(binds)
+
+
+def test_setup_preview_apply_and_rejects_foreign_keys(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    owner = _owner(tmp_path / "owner")
+    preview = grokbot_packs.preview_setup(
+        tmp_path,
+        PACK_ID,
+        bearer_env="TEST_GROKBOT_BEARER",
+        owner_workspace=owner,
+    )
+    assert preview["apply"] is False
+    assert preview["bind"] == "127.0.0.1:8777"
+    dumped = json.dumps(preview)
+    assert str(owner) not in dumped
+    assert SECRET not in dumped
+    assert not grokbot_packs.instance_config_path(tmp_path, PACK_ID).exists()
+    assert not grokbot_ops.config_path(tmp_path, PACK_ID).exists()
+
+    applied = grokbot_packs.apply_setup(
+        tmp_path,
+        PACK_ID,
+        bearer_env="TEST_GROKBOT_BEARER",
+        owner_workspace=owner,
+    )
+    pack_path = grokbot_packs.instance_config_path(tmp_path, PACK_ID)
+    assert applied["apply"] is True
+    assert pack_path.is_file()
+    assert pack_path.stat().st_mode & 0o777 == 0o600
+    assert not grokbot_ops.config_path(tmp_path, PACK_ID).exists()
+    config = json.loads(pack_path.read_text(encoding="utf-8"))
+    assert set(config) == grokbot_packs.OPERATIONS_RELAY_INSTANCE_KEYS
+    assert SECRET not in json.dumps(config)
+    assert "cli_executable" not in config
+    assert config["owner_workspace"] == str(owner)
+    assert config["bearer"] == {"kind": "env", "name": "TEST_GROKBOT_BEARER"}
+
+    with _reject("unexpected-key"):
+        grokbot_packs.apply_setup(
+            tmp_path,
+            PACK_ID,
+            bearer_env="TEST_GROKBOT_BEARER",
+            owner_workspace=owner,
+            cli_executable=tmp_path / "bin",
+        )
+    with _reject("unexpected-key"):
+        grokbot_packs.apply_setup(
+            tmp_path,
+            "operator",
+            bearer_env="TEST_GROKBOT_BEARER",
+            owner_workspace=owner,
+        )
+    with _reject("missing-path-reference"):
+        grokbot_packs.preview_setup(tmp_path, PACK_ID, bearer_env="TEST_GROKBOT_BEARER")
+
+
+def test_setup_rejects_insecure_owner_and_sanitizes_errors(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    owner = tmp_path / "owner"
+    owner.mkdir(mode=0o755)
+    os.chmod(owner, 0o755)
+    with _reject("unsafe-path") as caught:
+        grokbot_packs.apply_setup(
+            tmp_path,
+            PACK_ID,
+            bearer_env="TEST_GROKBOT_BEARER",
+            owner_workspace=owner,
+        )
+    assert SECRET not in str(caught.value)
+    assert SECRET not in caught.value.reason
+    assert str(owner) not in str(caught.value)
+    assert str(owner) not in caught.value.reason
+    assert not grokbot_packs.instance_config_path(tmp_path, PACK_ID).exists()
+
+    linked = tmp_path / "linked-owner"
+    linked.symlink_to(owner, target_is_directory=True)
+    with _reject("unsafe-path") as linked_caught:
+        grokbot_packs.apply_setup(
+            tmp_path,
+            PACK_ID,
+            bearer_env="TEST_GROKBOT_BEARER",
+            owner_workspace=linked,
+        )
+    assert str(linked) not in str(linked_caught.value)
+    assert SECRET not in str(linked_caught.value)
+
+
+def _setup_pack(tmp_path: Path, monkeypatch, bearer: str, env_name: str = "TEST_GROKBOT_BEARER") -> Path:
+    monkeypatch.setenv(env_name, bearer)
+    owner = _owner(tmp_path / "owner")
+    grokbot_packs.apply_setup(
+        tmp_path,
+        PACK_ID,
+        bearer_env=env_name,
+        owner_workspace=owner,
+    )
+    return owner
+
+
+def _assert_isolated_bearer_rejection(caught, *secrets: str) -> None:
+    assert caught.value.reason == "invalid_request"
+    text = str(caught.value)
+    for secret in (SECRET, *secrets):
+        assert secret not in text
+        assert secret not in caught.value.reason
+        assert secret not in caught.value.message
+
+
+def test_lifecycle_rejects_short_bearer(tmp_path: Path, monkeypatch):
+    owner = _setup_pack(tmp_path, monkeypatch, SHORT_BEARER)
+    with pytest.raises(operations_relay.OperationsRelayError) as resolved:
+        operations_relay._resolve_bearer({"kind": "env", "name": "TEST_GROKBOT_BEARER"})
+    _assert_isolated_bearer_rejection(resolved, SHORT_BEARER)
+    with pytest.raises(operations_relay.OperationsRelayError) as served:
+        operations_relay.build_listener_from_target(
+            tmp_path,
+            bind=None,
+            allowed_hosts=[],
+            allowed_origins=[],
+            bearer_file=None,
+            bearer_env="TEST_GROKBOT_BEARER",
+        )
+    _assert_isolated_bearer_rejection(served, SHORT_BEARER)
+    checks = operations_relay.doctor(tmp_path)
+    canary = operations_relay.canary(tmp_path)
+    sanitized = json.dumps({"checks": checks, "canary": canary, "owner": str(owner)})
+    assert any(check["check"] == "config" and check["status"] == "fail" for check in checks)
+    assert canary["ok"] is False
+    assert canary["reason"] == "config"
+    assert SHORT_BEARER not in sanitized
+    assert SECRET not in sanitized
+
+
+def test_lifecycle_rejects_shared_dispatch_bearer(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("GROKBOT_DISPATCH_TOKEN", SHARED_DISPATCH_BEARER)
+    owner = _setup_pack(tmp_path, monkeypatch, SHARED_DISPATCH_BEARER)
+    with pytest.raises(operations_relay.OperationsRelayError) as resolved:
+        operations_relay._resolve_bearer({"kind": "env", "name": "TEST_GROKBOT_BEARER"})
+    _assert_isolated_bearer_rejection(resolved, SHARED_DISPATCH_BEARER)
+    with pytest.raises(operations_relay.OperationsRelayError) as served:
+        operations_relay.build_listener_from_target(
+            tmp_path,
+            bind=None,
+            allowed_hosts=[],
+            allowed_origins=[],
+            bearer_file=None,
+            bearer_env="TEST_GROKBOT_BEARER",
+        )
+    _assert_isolated_bearer_rejection(served, SHARED_DISPATCH_BEARER)
+    checks = operations_relay.doctor(tmp_path)
+    canary = operations_relay.canary(tmp_path)
+    sanitized = json.dumps({"checks": checks, "canary": canary})
+    assert any(check["check"] == "config" and check["status"] == "fail" for check in checks)
+    assert canary["ok"] is False
+    assert canary["reason"] == "config"
+    assert SHARED_DISPATCH_BEARER not in sanitized
+    assert str(owner) not in sanitized
+
+
+def test_auth_gate_and_inventory():
+    config = operations_relay.OperationsRelayListenerConfig(
+        target=Path("/tmp/operations-relay-target"),
+        bind_host="127.0.0.1",
+        bind_port=8777,
+        allowed_hosts=(),
+        allowed_origins=(),
+        bearer=SECRET,
+        owner_workspace="/tmp/operations-relay-owner",
+    )
+    gate = operations_relay._OperationsRelayRequestGate(config)
+    assert gate.reject_reason({"host": "127.0.0.1", "authorization": f"Bearer {SECRET}"}, 0) is None
+    assert gate.reject_reason({"host": "127.0.0.1"}, 0) == "unauthorized"
+    assert gate.reject_reason({"host": "127.0.0.1", "authorization": "Bearer wrong-token"}, 0) == "unauthorized"
+    adapter = operations_relay.OperationsRelayAdapter(config, operations_relay.OperationsRelayTools.placeholder(config))
+    assert adapter.authorized(f"Bearer {SECRET}") is True
+    assert adapter.authorized("Bearer wrong-token") is False
+    assert adapter.authorized(None) is False
+    names = {tool["name"] for tool in adapter.tool_inventory()}
+    assert names == set(TOOLS)
+    assert operations_relay.OperationsRelayTools.placeholder(config).inventory() == list(TOOLS)
+
+
+def test_submit_rejects_secrets_paths_commands_urls_and_unexpected_keys(tmp_path: Path, monkeypatch):
+    tools, queue, owner = _tools(tmp_path, monkeypatch)
+    entry = _entry()
+    rejected = [
+        {**entry, "path": "/etc/passwd"},
+        {**entry, "command": "curl http://example.invalid"},
+        {**entry, "url": "https://example.invalid/hook"},
+        {**entry, "credential": "hunter2-example"},
+        {**entry, "token": SECRET},
+        {**entry, "owner": str(owner)},
+        {"schema": grokbot_findings.FINDINGS_SCHEMA, "entries": [entry]},
+        {key: value for key, value in entry.items() if key != "title"},
+        {**entry, "producer": "https://example.invalid"},
+        {**entry, "finding_id": "/var/run/secret"},
+        {**entry, "revision": "rm -rf /"},
+    ]
+    for payload in rejected:
+        with pytest.raises(operations_relay.OperationsRelayError) as caught:
+            tools.call_tool("submit_automation_finding", payload)
+        assert caught.value.reason == "invalid_request"
+        assert SECRET not in str(caught.value)
+        assert PRIVATE_TITLE not in str(caught.value)
+        assert str(owner) not in str(caught.value)
+        assert str(queue) not in str(caught.value)
+    with pytest.raises(operations_relay.OperationsRelayError) as unknown:
+        tools.call_tool("hidden_tool", entry)
+    assert unknown.value.reason == "invalid_request"
+    assert not (owner / "memory" / "handoff-inbox").exists()
+
+
+def test_first_delivery_writes_one_draft_and_one_fleet_report(tmp_path: Path, monkeypatch):
+    _isolate_home(tmp_path, monkeypatch)
+    captured = _capture_events(monkeypatch)
+    tools, queue, owner = _tools(tmp_path, monkeypatch)
+    entry = _entry()
+
+    result = tools.call_tool("submit_automation_finding", entry)
+
+    assert result["handle"] == _handle(entry)
+    assert result["created"] == 1
+    assert result["reported"] == 1
+    assert result["pending"] == 0
+    assert result["state"] == "reported"
+    _assert_opaque_result(result)
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 1
+    assert PRIVATE_TITLE in drafts[0].read_text(encoding="utf-8")
+    assert len(captured) == 1
+    assert captured[0]["run_id"] == result["handle"]
+    assert captured[0]["seat"] == "findings-relay"
+    assert set(captured[0]) == {"run_id", "seat", "harness", "state", "ts", "sequence", "digest"}
+    _assert_opaque(json.dumps(captured[0], sort_keys=True))
+
+
+def test_replay_is_idempotent(tmp_path: Path, monkeypatch):
+    _isolate_home(tmp_path, monkeypatch)
+    captured = _capture_events(monkeypatch)
+    tools, _queue, owner = _tools(tmp_path, monkeypatch)
+    entry = _entry()
+
+    first = tools.call_tool("submit_automation_finding", entry)
+    second = tools.call_tool("submit_automation_finding", entry)
+
+    assert first["handle"] == second["handle"] == _handle(entry)
+    assert first["created"] == 1
+    assert second["created"] == 0
+    assert second["known"] == 1
+    assert second["state"] == "reported"
+    _assert_opaque_result(second)
+    drafts = list((owner / "memory" / "handoff-inbox").glob("*.md"))
+    assert len(drafts) == 1
+    assert len(captured) == 1
+
+
+def test_status_returns_digest_and_state_without_entry_content(tmp_path: Path, monkeypatch):
+    _isolate_home(tmp_path, monkeypatch)
+    _capture_events(monkeypatch)
+    tools, _queue, owner = _tools(tmp_path, monkeypatch)
+    entry = _entry()
+    missing = tools.call_tool(
+        "automation_finding_status",
+        {"producer": entry["producer"], "finding_id": entry["finding_id"], "revision": entry["revision"]},
+    )
+    assert missing["handle"] == _handle(entry)
+    assert missing["state"] == "unknown"
+    _assert_opaque_result(missing)
+
+    tools.call_tool("submit_automation_finding", entry)
+    status = tools.call_tool(
+        "automation_finding_status",
+        {"producer": entry["producer"], "finding_id": entry["finding_id"], "revision": entry["revision"]},
+    )
+    assert status["handle"] == _handle(entry)
+    assert status["state"] == "reported"
+    _assert_opaque_result(status)
+    with pytest.raises(operations_relay.OperationsRelayError):
+        tools.call_tool(
+            "automation_finding_status",
+            {
+                "producer": entry["producer"],
+                "finding_id": entry["finding_id"],
+                "revision": entry["revision"],
+                "path": str(owner),
+            },
+        )
+
+
+def test_status_degrades_when_findings_storage_is_unsafe(tmp_path: Path, monkeypatch):
+    tools, _queue, _owner = _tools(tmp_path, monkeypatch)
+    entry = _entry()
+
+    def unsafe(_target: Path):
+        raise grokbot_findings.FindingsError("unsafe-storage")
+
+    monkeypatch.setattr(grokbot_findings, "_open_findings_readonly", unsafe)
+    result = tools.call_tool(
+        "automation_finding_status",
+        {"producer": entry["producer"], "finding_id": entry["finding_id"], "revision": entry["revision"]},
+    )
+    assert result == {"handle": _handle(entry), "state": "unknown"}
+    _assert_opaque_result(result)
+
+
+def test_doctor_canary_unit_and_cli_hide_secrets(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    owner = _owner(tmp_path / "owner")
+    grokbot_packs.apply_setup(
+        tmp_path,
+        PACK_ID,
+        bearer_env="TEST_GROKBOT_BEARER",
+        owner_workspace=owner,
+    )
+    checks = grokbot_packs.doctor(tmp_path, PACK_ID)
+    canary = grokbot_packs.canary(tmp_path, PACK_ID)
+    unit = grokbot_packs.render_install_service(tmp_path, PACK_ID)
+    sanitized = json.dumps({"checks": checks, "canary": canary})
+    assert SECRET not in sanitized
+    assert str(owner) not in sanitized
+    assert all(set(check) == {"check", "status"} for check in checks)
+    assert canary["ok"] is False
+    assert SECRET not in unit
+    assert "--pack" in unit
+    assert PACK_ID in unit
+    assert "127.0.0.1:8777" in unit
+    assert "NoNewPrivileges=yes" in unit
+    unit_dir = tmp_path / "units"
+    installed = grokbot_packs.apply_install_service(tmp_path, PACK_ID, out_dir=unit_dir)
+    assert installed["unit"] == grokbot_ops.unit_name(PACK_ID)
+
+    assert cli.main(["run", "cloud", "grokbot", "pack", "list", "--target", str(tmp_path), "--json"]) == 0
+    listed = json.loads(capsys.readouterr().out)
+    assert any(pack["id"] == PACK_ID for pack in listed["packs"])
+    assert (
+        cli.main(
+            [
+                "run",
+                "cloud",
+                "grokbot",
+                "pack",
+                "setup",
+                "--target",
+                str(tmp_path),
+                "--id",
+                PACK_ID,
+                "--bearer-env",
+                "TEST_GROKBOT_BEARER",
+                "--owner",
+                str(owner),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["apply"] is False
+    assert SECRET not in json.dumps(preview)
+    assert str(owner) not in json.dumps(preview)
+
+    relay_owner = _owner(tmp_path / "relay-owner")
+    assert (
+        cli.main(
+            [
+                "run",
+                "cloud",
+                "grokbot",
+                "pack",
+                "relay-setup",
+                "--target",
+                str(tmp_path),
+                "--owner",
+                str(relay_owner),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    relay_preview = json.loads(capsys.readouterr().out)
+    assert relay_preview["apply"] is False
+    assert SECRET not in json.dumps(relay_preview)

--- a/tests/test_grokbot_packs.py
+++ b/tests/test_grokbot_packs.py
@@ -21,6 +21,7 @@ PACK_IDS = (
     "implementation-worker",
     "n8n-operator",
     "obsidian-operator",
+    "operations-relay",
     "operator",
     "repository-scout",
     "wazuh-triage",
@@ -71,6 +72,10 @@ N8N_TOOLS = (
     "n8n_overview",
     "n8n_propose_action",
     "n8n_workflow_status",
+)
+OPERATIONS_RELAY_TOOLS = (
+    "automation_finding_status",
+    "submit_automation_finding",
 )
 
 
@@ -145,6 +150,11 @@ def test_registry_is_closed_deterministic_and_exact_key_validated():
             assert pack["kind"] == "connector"
             assert shown["tools"] == list(N8N_TOOLS)
             assert shown["default_bind"] == "127.0.0.1:8775"
+            assert shown["public_route"] == ""
+        elif pack["id"] == "operations-relay":
+            assert pack["kind"] == "connector"
+            assert shown["tools"] == list(OPERATIONS_RELAY_TOOLS)
+            assert shown["default_bind"] == "127.0.0.1:8777"
             assert shown["public_route"] == ""
         else:
             assert pack["kind"] == "connector"
@@ -230,6 +240,8 @@ def test_first_party_queue_packs_keep_isolated_ports_tools_and_credentials():
     assert grokbot_mcp.parse_bind(packs["obsidian-operator"]["default_bind"])[1] == 8773
     assert grokbot_mcp.parse_bind(packs["wazuh-triage"]["default_bind"])[1] == 8774
     assert grokbot_mcp.parse_bind(packs["n8n-operator"]["default_bind"])[1] == 8775
+    assert grokbot_mcp.parse_bind(packs["operations-relay"]["default_bind"])[1] == 8777
+    assert packs["operations-relay"]["default_bind"] == "127.0.0.1:8777"
     assert packs["operator"]["tools"] == _queue_tools("operator")
     assert packs["repository-scout"]["tools"] == _queue_tools("repository-scout")
     assert packs["implementation-worker"]["tools"] == _queue_tools("implementation-worker")


### PR DESCRIPTION
## Summary
- add the bundled operations-relay Grok Bot connector with two closed tools
- validate a bounded finding and route it through the existing first-party relay
- enforce bearer isolation and replay-safe owner-review delivery

## Verification
- Green focused receipt 20260830-121246-work-verify-99af50: 56 passed
- Green wider receipt 20260830-121450-work-verify-81fd50: operations relay, pack registry, findings relay, and MCP suites
- Green rebased focused receipt 20260830-125242-work-verify-001f5f
- Independent contract review findings were repaired and regression-tested
- Full local suite hit the existing repository-wide timeout while pytest was active. GitHub CI is the terminal full gate.

Refs #1255