### PR TITLE
fix(grokbot): accept exact Obsidian missing-file envelope

### DIFF
--- a/docs/phase-grokbot-obsidian-missing-file-plan.md
+++ b/docs/phase-grokbot-obsidian-missing-file-plan.md
@@ -1,0 +1,32 @@
+# Grok Bot Obsidian Missing-File Plan
+
+## Problem
+
+Obsidian Local REST API MCP reports an absent `vault_read` path as an MCP error envelope. `NativeMcpPort` rejects every error envelope before its existing exact missing-file comparison, so create-note work cannot prove that its target is absent.
+
+## Decision
+
+Recognize one closed missing-file envelope inside `_read_vault_file` before generic result parsing:
+
+- the top-level object has only `isError` and `content`
+- `isError` is exactly `true`
+- `content` has one block
+- the block has only `type` and `text`
+- `type` is `text`
+- `text` is within the existing MCP output byte limit
+- `text` equals `File not found: <normalized requested path>`
+
+Every other error envelope remains a `protocol_error`. `_tool_text` keeps rejecting `isError` results for all other adapter operations.
+
+## Rejected alternatives
+
+- Accept any error text containing `File not found`. This could bind one requested path to a different missing path or accept extra untrusted content.
+- Relax `_tool_text` globally. Other tools do not use a missing-file sentinel and must keep failing closed on MCP errors.
+- Treat any `isError` response as absence. Authentication, transport, plugin, and protocol failures must not authorize create behavior.
+
+## Acceptance
+
+- The exact live missing-file envelope returns `None` for the exact normalized requested path.
+- A different path, extra top-level key, extra content block, extra block key, non-text block, other error message, non-string text, or oversized text raises `protocol_error`.
+- The native call uses the normalized requested path.
+- Existing success parsing, sanitization, output limits, and strict error handling stay unchanged.

--- a/src/brigade/grokbot_obsidian/adapters.py
+++ b/src/brigade/grokbot_obsidian/adapters.py
@@ -197,6 +197,29 @@ def _tool_text(result: object) -> str:
     return text
 
 
+def _file_not_found_text(path: str) -> str:
+    return f"File not found: {path}"
+
+
+def _closed_missing_file_envelope(result: object, path: str) -> bool:
+    if not isinstance(result, dict) or set(result) != {"isError", "content"}:
+        return False
+    if result.get("isError") is not True:
+        return False
+    content = result.get("content")
+    if not isinstance(content, list) or len(content) != 1:
+        return False
+    block = content[0]
+    if not isinstance(block, dict) or set(block) != {"type", "text"}:
+        return False
+    if block.get("type") != "text":
+        return False
+    text = block.get("text")
+    if not isinstance(text, str) or utf8_byte_length(text) > MAX_OUTPUT_BYTES:
+        return False
+    return text == _file_not_found_text(path)
+
+
 def _etag(value: object) -> str:
     if not isinstance(value, str) or not REVISION_TOKEN_RE.fullmatch(value):
         _protocol()
@@ -244,16 +267,17 @@ class NativeMcpPort:
             if exc.code == "unavailable":
                 raise
             raise
+        if _closed_missing_file_envelope(raw, path):
+            return None
+        if isinstance(raw, dict) and raw.get("isError") is True:
+            _protocol()
         if raw is None:
             return None
         if isinstance(raw, dict) and raw.get("missing") is True:
             return None
         if isinstance(raw, dict) and "content" in raw and "tags" not in raw and raw.get("type") == "text":
-            try:
-                text = _tool_text(raw)
-            except ObsidianError:
-                return None
-            if text == f"File not found: {path}":
+            text = _tool_text(raw)
+            if text == _file_not_found_text(path):
                 return None
             try:
                 raw = json.loads(text)

--- a/tests/test_grokbot_obsidian_adapters.py
+++ b/tests/test_grokbot_obsidian_adapters.py
@@ -10,6 +10,7 @@ import pytest
 
 from brigade.grokbot_obsidian.adapters import (
     ENV_ALLOWLIST,
+    MAX_OUTPUT_BYTES,
     NATIVE_MCP_TOOLS,
     ExcalidrawAdapter,
     NativeMcpPort,
@@ -17,6 +18,7 @@ from brigade.grokbot_obsidian.adapters import (
     assert_safe_excalidraw_scene,
 )
 from brigade.grokbot_obsidian.contracts import ObsidianError
+from brigade.grokbot_obsidian.path_policy import normalize_vault_path
 
 
 class ScriptedClient:
@@ -507,6 +509,120 @@ def test_copy_and_move_use_path_destination_and_forbid_overwrite():
             },
         ),
     ]
+
+
+def test_vault_read_exact_missing_file_envelope_returns_none():
+    requested = "01 - Projects/missing-note.md"
+    normalized = normalize_vault_path(requested)
+    client = ScriptedClient(
+        {
+            "vault_read": {
+                "isError": True,
+                "content": [{"type": "text", "text": f"File not found: {normalized}"}],
+            }
+        }
+    )
+    port = NativeMcpPort(client)
+    assert port.read(requested) is None
+    assert client.calls == [("vault_read", {"path": normalized})]
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        {
+            "isError": True,
+            "content": [{"type": "text", "text": "File not found: 01 - Projects/other.md"}],
+        },
+        {
+            "isError": True,
+            "content": [{"type": "text", "text": "File not found: 01 - Projects/missing-note.md"}],
+            "extra": True,
+        },
+        {
+            "isError": True,
+            "content": [
+                {"type": "text", "text": "File not found: 01 - Projects/missing-note.md"},
+                {"type": "text", "text": "extra"},
+            ],
+        },
+        {
+            "isError": True,
+            "content": [
+                {
+                    "type": "text",
+                    "text": "File not found: 01 - Projects/missing-note.md",
+                    "extra": True,
+                }
+            ],
+        },
+        {
+            "isError": True,
+            "content": [{"type": "image", "text": "File not found: 01 - Projects/missing-note.md"}],
+        },
+        {"isError": True, "content": [{"type": "text", "text": "Permission denied"}]},
+        {"isError": True, "content": [{"type": "text", "text": 1}]},
+        {"isError": True, "content": [{"type": "text", "text": "x" * (MAX_OUTPUT_BYTES + 1)}]},
+        {"isError": True, "missing": True},
+        {
+            "isError": 1,
+            "content": [{"type": "text", "text": "File not found: 01 - Projects/missing-note.md"}],
+        },
+        {"isError": True, "content": []},
+    ],
+    ids=[
+        "different_path",
+        "extra_top_level_keys",
+        "extra_content_blocks",
+        "extra_block_keys",
+        "non_text_block",
+        "other_error_message",
+        "non_string_text",
+        "text_over_max_output_bytes",
+        "is_error_true_and_missing_true",
+        "is_error_integer_1",
+        "empty_is_error_content",
+    ],
+)
+def test_vault_read_inexact_error_envelope_is_protocol_error(envelope: dict[str, object]):
+    requested = "01 - Projects/missing-note.md"
+    client = ScriptedClient({"vault_read": envelope})
+    port = NativeMcpPort(client)
+    with pytest.raises(ObsidianError) as caught:
+        port.read(requested)
+    assert caught.value.code == "protocol_error"
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        {"type": "text", "content": []},
+        {
+            "type": "text",
+            "content": [{"type": "image", "text": "File not found: 01 - Projects/missing-note.md"}],
+        },
+        {"type": "text", "content": [{"type": "text", "text": 1}]},
+        {
+            "type": "text",
+            "content": [{"type": "text", "text": "x" * (MAX_OUTPUT_BYTES + 1)}],
+        },
+    ],
+    ids=[
+        "empty_content",
+        "non_text_content",
+        "non_string_text",
+        "oversized_text",
+    ],
+)
+def test_vault_read_malformed_legacy_type_text_wrapper_is_protocol_error(
+    envelope: dict[str, object],
+):
+    requested = "01 - Projects/missing-note.md"
+    client = ScriptedClient({"vault_read": envelope})
+    port = NativeMcpPort(client)
+    with pytest.raises(ObsidianError) as caught:
+        port.read(requested)
+    assert caught.value.code == "protocol_error"
 
 
 def test_excalidraw_embed_is_a_staged_heading_patch(tmp_path: Path):


### PR DESCRIPTION
## Summary

- recognize only the exact Local REST MCP missing-file error envelope for the exact requested vault path
- keep every other `isError` result as `protocol_error`
- stop malformed legacy text wrappers from being misclassified as file absence
- leave `_tool_text` strict for every other native MCP caller

## Verification

- initial RED: `20260830-122848-work-verify-7e2974`
- review-repair RED: `20260830-124240-work-verify-2b9f41`
- focused GREEN after review repair: `20260830-124525-work-verify-e8849f` (`70 passed`)
- live read-only probe: `20260830-123947-work-verify-d0c3b2` observed the exact two-key error envelope and exact path binding without capturing credentials or vault content
- independent Opus review: no Critical findings and implementation marked ready. Both Important review notes were resolved before commit.
- full Brigade verification: bounded after 1,000 seconds with pytest still active and no failure output. It was terminated once and not restarted. GitHub required checks are the terminal full gate.

Refs #1255
