### PR TITLE
fix(run): bind Grok continuation sessions

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -61,6 +61,7 @@ _GROK_RESULT_SCHEMA = json.dumps(
     },
     separators=(",", ":"),
 )
+_GROK_SESSION_RESERVED_ARGUMENTS = ("--resume", "--session-id")
 
 
 @dataclass(frozen=True)
@@ -702,6 +703,7 @@ def build_argv(
     reasoning: str | None = None,
     cwd: Path | None = None,
     resume_session_id: str | None = None,
+    session_binding_id: str | None = None,
     oracle_browser_engine: bool = False,
 ) -> List[str]:
     if resume_session_id is not None:
@@ -711,6 +713,15 @@ def build_argv(
             raise ValueError("grok exact-session continuation requires read-only dispatch")
         if not resume_session_id.strip():
             raise ValueError("grok exact-session continuation requires a session id")
+    if session_binding_id is not None:
+        if cli_ref != "grok":
+            raise ValueError("Grok session binding supports grok only")
+        if not (read_only or sandbox == "read-only"):
+            raise ValueError("Grok session binding requires read-only dispatch")
+        if not session_binding_id.strip():
+            raise ValueError("Grok session binding requires a session id")
+        if resume_session_id is not None and resume_session_id != session_binding_id:
+            raise ValueError("Grok continuation must bind the resumed session id")
 
     if cli_ref.startswith(_OLLAMA_PREFIX):
         ollama_model = cli_ref[len(_OLLAMA_PREFIX) :]
@@ -737,6 +748,8 @@ def build_argv(
         argv = [argv[0], "--engine", "browser", *argv[1:]]
     if resume_session_id is not None:
         argv = [argv[0], "--resume", resume_session_id, *argv[1:]]
+    elif session_binding_id is not None:
+        argv = [argv[0], "--session-id", session_binding_id, *argv[1:]]
     if model is not None:
         argv = _with_model(cli_ref, argv, model)
     if reasoning is not None:
@@ -746,6 +759,17 @@ def build_argv(
 
 def detect(cli_ref: str, command: tuple[str, ...] | None = None) -> bool:
     return resolve_agent_executable(cli_ref, command=command).runnable
+
+
+def _reserved_grok_session_argument(command: tuple[str, ...] | None) -> str | None:
+    if command is None:
+        return None
+    for token in command[1:]:
+        if token == "--" or any(
+            token == flag or token.startswith(f"{flag}=") for flag in _GROK_SESSION_RESERVED_ARGUMENTS
+        ):
+            return token
+    return None
 
 
 def _accepts_keyword(function: Callable[..., object], name: str) -> bool:
@@ -1009,6 +1033,7 @@ def run_agent(
     env: dict[str, str] | None = None,
     command: tuple[str, ...] | None = None,
     resume_session_id: str | None = None,
+    session_binding_id: str | None = None,
     process_registry: proc.ProcessRegistry | None = None,
     cloud_safe_mode: bool = False,
 ) -> AgentResult:
@@ -1062,6 +1087,19 @@ def run_agent(
             requested_model=model,
             reasoning=reasoning,
         )
+
+    if session_binding_id is not None:
+        reserved_argument = _reserved_grok_session_argument(command)
+        if reserved_argument is not None:
+            return AgentResult(
+                text="",
+                ok=False,
+                detail=f"reserved Grok session argument is not allowed with session binding: {reserved_argument}",
+                failure_phase="dispatch",
+                failure_kind="invalid-dispatch-args",
+                requested_model=model,
+                reasoning=reasoning,
+            )
 
     if cli_ref.startswith(_CODEX_CLOUD_PREFIX):
         env_token = cli_ref[len(_CODEX_CLOUD_PREFIX) :]
@@ -1152,6 +1190,7 @@ def run_agent(
             reasoning=reasoning,
             cwd=cwd,
             resume_session_id=resume_session_id,
+            session_binding_id=session_binding_id,
             oracle_browser_engine=oracle_browser_engine,
         )
     except UnsupportedSandboxError as exc:
@@ -1291,6 +1330,22 @@ def run_agent(
     safe_structured_error = _scrub_env_override_values(structured_error, resolved_overrides, resolved_secret_targets)[
         :200
     ]
+    if structured_grok and session_binding_id is not None and grok_session_id != session_binding_id:
+        return AgentResult(
+            text="",
+            ok=False,
+            detail="grok result session id did not match the launcher-owned dispatch binding",
+            failure_phase="output-validation",
+            failure_kind="grok-session-unbound",
+            stdout=safe_stdout,
+            stderr=safe_stderr,
+            exit_code=result.code,
+            timed_out=result.code == 124,
+            requested_model=model,
+            reasoning=reasoning,
+            stop_reason=grok_stop_reason,
+            request_id=grok_request_id,
+        )
     if result.code != 0:
         oracle_auth = _oracle_auth_detail(cli_ref, safe_stdout, safe_stderr)
         provider_preflight = oracle_auth or _provider_preflight_detail(cli_ref, safe_stdout, safe_stderr)

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -7,6 +7,7 @@ import os
 import secrets
 import sys
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -515,10 +516,15 @@ def dispatch(
         accepts_cloud_safe_mode = accepts_var_keyword or any(
             parameter.name == "cloud_safe_mode" for parameter in parameters
         )
+        accepts_session_binding = accepts_var_keyword or any(
+            parameter.name == "session_binding_id" for parameter in parameters
+        )
         if not accepts_registry:
             kwargs.pop("process_registry", None)
         if not accepts_cloud_safe_mode:
             kwargs.pop("cloud_safe_mode", None)
+        if not accepts_session_binding:
+            kwargs.pop("session_binding_id", None)
         if orchestrator_run_id is not None:
             # Real agents.run_agent accepts env=; legacy fixed-signature test
             # doubles do not. Mirror the process_registry gate so BRIGADE_RUN_ID
@@ -624,6 +630,16 @@ def dispatch(
             cli_ref = selected_agent.cli
             seat_process_registry = process_registry.for_seat(selected_agent.name)
             cloud_dispatch_kwargs = {"cloud_safe_mode": selected_agent.cloud_safe_mode}
+            session_binding_id = (
+                resume_session_id or str(uuid.uuid4())
+                if (
+                    direct
+                    and effective_read_only
+                    and selected_agent.cli == "grok"
+                    and selected_agent.transport == "direct"
+                )
+                else None
+            )
             if selected_agent.transport == "acpx":
                 from . import acpx_adapter
 
@@ -655,6 +671,7 @@ def dispatch(
                     env=dict(selected_agent.env) if selected_agent.env is not None else None,
                     **direct_command_kwargs(selected_agent),
                     resume_session_id=resume_session_id,
+                    session_binding_id=session_binding_id,
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                 )
@@ -679,6 +696,7 @@ def dispatch(
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
                     **env_kwargs,
+                    session_binding_id=session_binding_id,
                 )
             if selected_agent.cli == "codex" and appserver is not None:
                 approval_prompt = (
@@ -738,6 +756,7 @@ def dispatch(
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
+                    session_binding_id=session_binding_id,
                 )
             if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is None:
                 return run_direct_agent(
@@ -750,6 +769,7 @@ def dispatch(
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
+                    session_binding_id=session_binding_id,
                 )
             if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is None:
                 return run_direct_agent(
@@ -762,6 +782,7 @@ def dispatch(
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
+                    session_binding_id=session_binding_id,
                 )
             if sandbox is None and selected_agent.model is None and selected_agent.reasoning is not None:
                 return run_direct_agent(
@@ -774,6 +795,7 @@ def dispatch(
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
+                    session_binding_id=session_binding_id,
                 )
             if sandbox is not None and selected_agent.model is not None and selected_agent.reasoning is None:
                 return run_direct_agent(
@@ -787,6 +809,7 @@ def dispatch(
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
+                    session_binding_id=session_binding_id,
                 )
             if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is not None:
                 return run_direct_agent(
@@ -800,6 +823,7 @@ def dispatch(
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
+                    session_binding_id=session_binding_id,
                 )
             if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is not None:
                 return run_direct_agent(
@@ -813,6 +837,7 @@ def dispatch(
                     process_registry=seat_process_registry,
                     **cloud_dispatch_kwargs,
                     **direct_command_kwargs(selected_agent),
+                    session_binding_id=session_binding_id,
                 )
             assert sandbox is not None
             assert selected_agent.model is not None
@@ -829,6 +854,7 @@ def dispatch(
                 process_registry=seat_process_registry,
                 **cloud_dispatch_kwargs,
                 **direct_command_kwargs(selected_agent),
+                session_binding_id=session_binding_id,
             )
 
         def invoke(

--- a/src/brigade/worker_failure.py
+++ b/src/brigade/worker_failure.py
@@ -184,6 +184,7 @@ LEGACY_FAILURE_KIND_MAP: dict[str, FailureClass] = {
     "env-ref-missing": FailureClass.CONFIGURATION_INVALID,
     "grok-fallback-missing": FailureClass.CONFIGURATION_INVALID,
     "grok-session-missing": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "grok-session-unbound": FailureClass.OUTPUT_CONTRACT_VIOLATION,
     "invalid-dispatch-args": FailureClass.CONFIGURATION_INVALID,
     "invalid-session-continuation": FailureClass.CONFIGURATION_INVALID,
     "malformed-final-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -15,6 +15,7 @@ from brigade import context_eval
 from brigade import evidence_brief
 from brigade import proc
 from brigade import provenance
+from brigade import run_transport
 from brigade import runguard
 from brigade.roster import Agent, Roster
 from tests import thread_sync
@@ -198,13 +199,16 @@ def _grok_roster(*, fallback=False):
     )
 
 
+_GROK_SESSION_ID = "019f0000-0000-7000-8000-000000000001"
+
+
 def _grok_envelope(answer, *, valid=True, stop_reason="EndTurn"):
     structured = {"kind": "answer", "answer": answer}
     return json.dumps(
         {
             "text": json.dumps(structured),
             "stopReason": stop_reason,
-            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "sessionId": _GROK_SESSION_ID,
             "requestId": "00000000-0000-4000-8000-000000000001",
             "structuredOutput": structured if valid else None,
             "structuredOutputError": None if valid else "model did not produce structured output",
@@ -217,9 +221,19 @@ def _stub_grok_process(monkeypatch, *results):
     outputs = iter(results)
     calls = []
 
+    monkeypatch.setattr(run_transport.uuid, "uuid4", lambda: _GROK_SESSION_ID)
+
     def fake_run(argv, **kwargs):
         if argv and Path(argv[0]).name == "grok":
             calls.append(argv)
+            if len(calls) == 1:
+                assert "--session-id" in argv
+                assert argv[argv.index("--session-id") + 1] == _GROK_SESSION_ID
+                assert "--resume" not in argv
+            else:
+                assert "--resume" in argv
+                assert argv[argv.index("--resume") + 1] == _GROK_SESSION_ID
+                assert "--session-id" not in argv
             return next(outputs)
         return real_run(argv, **kwargs)
 
@@ -2107,8 +2121,7 @@ def test_run_direct_grok_progress_only_output_fails_with_honest_artifacts(monkey
         "Reviewing the README.md and tools/brigade.md diffs against Brigade 0.22.0. "
         "Gathering the git diffs and current file content first."
     )
-    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
-    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
+    _stub_grok_process(monkeypatch, agents.proc.Result(0, output + "\n", ""))
     output_dir = tmp_path / "run"
 
     rc = run_aboyeur_guarded(
@@ -2124,22 +2137,18 @@ def test_run_direct_grok_progress_only_output_fails_with_honest_artifacts(monkey
     assert rc == 2
     run_payload = json.loads((output_dir / "run.json").read_text())
     assert run_payload["status"] == "failed"
-    assert run_payload["error"] == (
-        "grok invalid-final result did not include the session id required for exact continuation"
-    )
+    assert run_payload["error"] == "grok result session id did not match the launcher-owned dispatch binding"
     assert run_payload["suspected_noop"] is False
     worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
     assert worker["ok"] is False
-    assert worker["detail"] == (
-        "grok invalid-final result did not include the session id required for exact continuation"
-    )
-    assert worker["failure_kind"] == "grok-session-missing"
+    assert worker["detail"] == "grok result session id did not match the launcher-owned dispatch binding"
+    assert worker["failure_kind"] == "grok-session-unbound"
     assert worker["exit_code"] == 0
     assert len(worker["attempts"]) == 1
-    assert worker["attempts"][0]["failure_kind"] == "malformed-final-output"
+    assert worker["attempts"][0]["failure_kind"] == "grok-session-unbound"
     assert worker["attempts"][0]["selected"] is False
     assert (output_dir / worker["stdout_log"]).read_text() == output + "\n"
-    assert (output_dir / "final.txt").read_text().strip() == output
+    assert (output_dir / "final.txt").read_text().strip() == ""
 
 
 def test_run_direct_grok_structured_final_succeeds_with_honest_artifacts(monkeypatch, tmp_path):
@@ -2149,13 +2158,12 @@ def test_run_direct_grok_structured_final_succeeds_with_honest_artifacts(monkeyp
         {
             "text": json.dumps(structured),
             "stopReason": "EndTurn",
-            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "sessionId": _GROK_SESSION_ID,
             "requestId": "00000000-0000-4000-8000-000000000001",
             "structuredOutput": structured,
         }
     )
-    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
-    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+    _stub_grok_process(monkeypatch, agents.proc.Result(0, stdout + "\n", ""))
     output_dir = tmp_path / "run"
 
     rc = run_aboyeur_guarded(
@@ -2403,13 +2411,12 @@ def test_run_defers_success_until_worktree_artifact_collection(monkeypatch, tmp_
         {
             "text": json.dumps(structured),
             "stopReason": "EndTurn",
-            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "sessionId": _GROK_SESSION_ID,
             "requestId": "00000000-0000-4000-8000-000000000001",
             "structuredOutput": structured,
         }
     )
-    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
-    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+    _stub_grok_process(monkeypatch, agents.proc.Result(0, stdout + "\n", ""))
     output_dir = tmp_path / "run"
 
     rc = run_aboyeur_guarded(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1197,13 +1197,19 @@ def test_run_agent_classifies_silent_adapter_exit(monkeypatch, cli_ref):
     assert result.exit_code == 0
 
 
-def _grok_json_output(answer: str, *, structured: bool = True, stop_reason: str = "EndTurn") -> str:
+def _grok_json_output(
+    answer: str,
+    *,
+    structured: bool = True,
+    stop_reason: str = "EndTurn",
+    session_id: str = "019f0000-0000-7000-8000-000000000001",
+) -> str:
     result = {"kind": "answer", "answer": answer}
     return json.dumps(
         {
             "text": json.dumps(result),
             "stopReason": stop_reason,
-            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "sessionId": session_id,
             "requestId": "00000000-0000-4000-8000-000000000001",
             "structuredOutput": result if structured else None,
             "structuredOutputError": None if structured else "model did not produce structured output",
@@ -1361,16 +1367,90 @@ def test_run_agent_resumes_exact_grok_session_with_original_settings(monkeypatch
         model="grok-4.5",
         reasoning="high",
         resume_session_id=session_id,
+        session_binding_id=session_id,
     )
 
     assert result.ok is True
     assert seen["argv"].count("--resume") == 1
     assert seen["argv"][seen["argv"].index("--resume") + 1] == session_id
+    assert "--session-id" not in seen["argv"]
     assert seen["argv"][seen["argv"].index("-p") + 1] == "Return the final answer now."
     assert seen["argv"][seen["argv"].index("-m") + 1] == "grok-4.5"
     assert seen["argv"][seen["argv"].index("--reasoning-effort") + 1] == "high"
     assert seen["kwargs"]["timeout"] == 47
     assert seen["kwargs"]["cwd"] == tmp_path
+
+
+def test_run_agent_binds_initial_grok_session_to_launcher_id(monkeypatch):
+    session_id = "A"
+    seen = {}
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        return agents.proc.Result(0, _grok_json_output("No actionable findings.", session_id=session_id), "")
+
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    result = agents.run_agent(
+        "grok",
+        "review it",
+        read_only=True,
+        model="grok-4.5",
+        session_binding_id=session_id,
+    )
+
+    assert result.ok is True
+    assert result.session_id == session_id
+    assert seen["argv"][seen["argv"].index("--session-id") + 1] == session_id
+    assert "--resume" not in seen["argv"]
+
+
+@pytest.mark.parametrize("returned_session_id", ["FOREIGN", None])
+def test_run_agent_rejects_unbound_grok_result_session(monkeypatch, returned_session_id):
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(
+            0,
+            _grok_json_output("FOREIGN_SESSION_CONTENT", session_id=returned_session_id),
+            "",
+        ),
+    )
+
+    result = agents.run_agent(
+        "grok",
+        "review it",
+        read_only=True,
+        model="grok-4.5",
+        session_binding_id="A",
+    )
+
+    assert result.ok is False
+    assert result.text == ""
+    assert result.session_id is None
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "grok-session-unbound"
+
+
+@pytest.mark.parametrize("token", ["--resume", "--resume=A", "--session-id", "--session-id=A", "--"])
+def test_run_agent_rejects_reserved_custom_grok_session_argument_before_launch(monkeypatch, token):
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda *args, **kwargs: pytest.fail("process must not launch"))
+
+    result = agents.run_agent(
+        "grok",
+        "review it",
+        read_only=True,
+        command=("fake-grok", token),
+        session_binding_id="A",
+    )
+
+    assert result.ok is False
+    assert result.failure_phase == "dispatch"
+    assert result.failure_kind == "invalid-dispatch-args"
+    assert "reserved Grok session argument" in result.detail
 
 
 def test_run_agent_keeps_permission_mode_prompt_separate_from_grok_flags(monkeypatch):

--- a/tests/test_run_transport_recovery.py
+++ b/tests/test_run_transport_recovery.py
@@ -1,5 +1,7 @@
 from dataclasses import replace
 
+import pytest
+
 from brigade import acpx_adapter, agents, message_envelope, run_transport
 from brigade.roster import Agent, Roster
 from brigade.run_receipts import worker_payload, write_worker_logs
@@ -158,6 +160,19 @@ def _successful_final(text="No actionable findings.") -> agents.AgentResult:
     )
 
 
+def _unbound_session(*, session_id: str | None) -> agents.AgentResult:
+    return agents.AgentResult(
+        text="",
+        ok=False,
+        detail="grok result session id did not match the launcher-owned dispatch binding",
+        exit_code=0,
+        requested_model="grok-4.5",
+        failure_phase="output-validation",
+        failure_kind="grok-session-unbound",
+        session_id=session_id,
+    )
+
+
 def _dispatch_recovery(
     monkeypatch,
     tmp_path,
@@ -225,6 +240,7 @@ def test_direct_grok_continuation_reuses_exact_session_and_settings(monkeypatch,
     _, continuation_prompt, continuation_kwargs = direct_calls[1]
     assert "Return the final answer now" in continuation_prompt
     assert continuation_kwargs["resume_session_id"] == "019f0000-0000-7000-8000-000000000001"
+    assert continuation_kwargs["session_binding_id"] == "019f0000-0000-7000-8000-000000000001"
     assert continuation_kwargs["timeout"] == 31
     assert continuation_kwargs["cwd"] == tmp_path
     assert continuation_kwargs["read_only"] is True
@@ -233,6 +249,34 @@ def test_direct_grok_continuation_reuses_exact_session_and_settings(monkeypatch,
     assert continuation_kwargs["reasoning"] == "high"
     assert [attempt.kind for attempt in result.attempts] == ["initial", "continuation"]
     assert [attempt.selected for attempt in result.attempts] == [False, True]
+
+
+def test_direct_grok_initial_dispatch_uses_launcher_owned_session_uuid(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_transport.uuid, "uuid4", lambda: "A")
+
+    result, direct_calls, fallback_calls = _dispatch_recovery(monkeypatch, tmp_path, [_successful_final()])
+
+    assert result.ok is True
+    assert fallback_calls == []
+    assert direct_calls[0][2]["session_binding_id"] == "A"
+
+
+@pytest.mark.parametrize("session_id", ["FOREIGN", None])
+def test_direct_grok_unbound_session_does_not_resume_or_fallback(monkeypatch, tmp_path, session_id):
+    fallback = replace(_successful_final("Fallback must not launch."), transport="acpx", stop_reason="end_turn")
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_unbound_session(session_id=session_id)],
+        fallback_result=fallback,
+    )
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "grok-session-unbound"
+    assert len(direct_calls) == 1
+    assert fallback_calls == []
+    assert [attempt.kind for attempt in result.attempts] == ["initial"]
 
 
 def test_direct_grok_fallback_recovers_after_two_invalid_finals(monkeypatch, tmp_path):

--- a/tests/test_worker_failure.py
+++ b/tests/test_worker_failure.py
@@ -45,6 +45,7 @@ EXPECTED_LEGACY_CLASSIFICATIONS = {
     "env-ref-missing": FailureClass.CONFIGURATION_INVALID,
     "grok-fallback-missing": FailureClass.CONFIGURATION_INVALID,
     "grok-session-missing": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "grok-session-unbound": FailureClass.OUTPUT_CONTRACT_VIOLATION,
     "invalid-dispatch-args": FailureClass.CONFIGURATION_INVALID,
     "invalid-session-continuation": FailureClass.CONFIGURATION_INVALID,
     "malformed-final-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,


### PR DESCRIPTION
## Summary

- Mint a launcher UUID for each direct, read-only Grok dispatch and require it in the result.
- Refuse caller-supplied Grok session controls while a binding is active.
- Fail unbound output without continuation or fallback, and classify it as an output contract violation.

## Verification

- `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_agents.py","tests/test_run_transport_recovery.py","tests/test_worker_failure.py","tests/test_aboyeur.py"]' --capture brigade-work`\n- `GOFLAGS=-buildvcs=false brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_evidence_cmd.py::test_crawl_plan_printed_commands_exec_on_bundled_engine","tests/test_evidence_cmd.py::test_crawl_plan_memory_command_execs_when_namespace_declared","tests/test_evidence_cmd.py::test_issue_1024_mutation_memory_on_clean_workspace_fails_on_bundled_engine"]' --capture brigade-work`\n- Full local gate was run once. Its remaining evidence-engine tests failed only because Go could not stamp VCS state in this checkout; the focused rerun with `GOFLAGS=-buildvcs=false` passed.