### PR TITLE
feat(cloud): report provider health honestly

### DIFF
--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -123,14 +123,12 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
 
     p_setup = cloud_sub.add_parser("setup", help="Write local Codex Cloud environment configuration (no live task).")
     p_setup.add_argument("--target", type=Path, default=Path("."))
-    p_setup.add_argument(
-        "--provider", required=True, choices=("codex-cloud", "cursor-cloud", "grokbot-cloud", "claude-cloud", "jules")
-    )
+    p_setup.add_argument("--provider", required=True, choices=("codex-cloud",))
     setup_src = p_setup.add_mutually_exclusive_group(required=True)
     setup_src.add_argument("--env-var", help="Name of the environment variable holding the Codex Cloud env id.")
     setup_src.add_argument("--env-id", help="Store a Codex Cloud env id locally. Prefer --env-var.")
 
-    p_doctor = cloud_sub.add_parser("doctor", help="Check Codex Cloud seat configuration without submitting a task.")
+    p_doctor = cloud_sub.add_parser("doctor", help="Check one cloud provider without submitting a task.")
     p_doctor.add_argument("--target", type=Path, default=Path("."))
     p_doctor.add_argument(
         "--provider", required=True, choices=("codex-cloud", "cursor-cloud", "grokbot-cloud", "claude-cloud", "jules")
@@ -139,10 +137,10 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
     p_doctor.add_argument(
         "--selector",
         default="configured",
-        help="Codex Cloud environment selector to validate (configured, $VAR, or literal id).",
+        help="Codex Cloud environment selector to validate (Codex Cloud only).",
     )
 
-    p_canary = cloud_sub.add_parser("canary", help="Bounded Codex Cloud inventory check. Never exec or apply.")
+    p_canary = cloud_sub.add_parser("canary", help="Bounded cloud inventory check. Never exec or apply.")
     p_canary.add_argument("--target", type=Path, default=Path("."))
     p_canary.add_argument(
         "--provider", required=True, choices=("codex-cloud", "cursor-cloud", "grokbot-cloud", "claude-cloud", "jules")
@@ -151,7 +149,7 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
     p_canary.add_argument(
         "--selector",
         default="configured",
-        help="Codex Cloud environment selector to validate (configured, $VAR, or literal id).",
+        help="Codex Cloud environment selector to validate (Codex Cloud only).",
     )
 
     p_grokbot = cloud_sub.add_parser("grokbot", help="Manage the private local Grok Bot job queue.")
@@ -510,7 +508,7 @@ def dispatch(args) -> int:
     if command == "grokbot":
         return _dispatch_grokbot(args, target)
     if command in {"setup", "doctor", "canary"}:
-        return _dispatch_codex_cloud_ops(args, target)
+        return _dispatch_cloud_ops(args, target)
 
     from .. import cloud_tracker
 
@@ -565,7 +563,9 @@ def dispatch(args) -> int:
     if command == "sync":
         from .. import fleet_client
 
-        provider_tasks, github, cursor_wired = cloud_tracker.observe_providers(target)
+        observations, github = cloud_tracker.observe_provider_details(target)
+        provider_tasks = cloud_tracker._legacy_provider_tasks(observations)  # noqa: SLF001 - compatibility projection
+        cursor_wired = observations["cursor-cloud"].configured
         hub_leases: list[dict[str, Any]] = []
         try:
             snapshot = fleet_client.fetch_cloud()
@@ -580,6 +580,7 @@ def dispatch(args) -> int:
             provider_tasks=provider_tasks,
             github=github,
             cursor_wired=cursor_wired,
+            provider_observations=observations,
             hub_leases=hub_leases,
         )
         if args.json:
@@ -601,12 +602,15 @@ def dispatch(args) -> int:
             except ValueError as exc:
                 print(f"error: {exc}", file=sys.stderr)
                 return 2
-        provider_tasks, github, cursor_wired = cloud_tracker.observe_providers(target)
+        observations, github = cloud_tracker.observe_provider_details(target)
+        provider_tasks = cloud_tracker._legacy_provider_tasks(observations)  # noqa: SLF001 - compatibility projection
+        cursor_wired = observations["cursor-cloud"].configured
         payload = cloud_tracker.status_payload(
             target,
             provider_tasks=provider_tasks,
             github=github,
             cursor_wired=cursor_wired,
+            provider_observations=observations,
         )
         if args.json:
             print(json.dumps(payload, indent=2, sort_keys=True))
@@ -626,12 +630,15 @@ def dispatch(args) -> int:
         return 0
 
     if command == "sweep":
-        provider_tasks, github, cursor_wired = cloud_tracker.observe_providers(target)
+        observations, github = cloud_tracker.observe_provider_details(target)
+        provider_tasks = cloud_tracker._legacy_provider_tasks(observations)  # noqa: SLF001 - compatibility projection
+        cursor_wired = observations["cursor-cloud"].configured
         status = cloud_tracker.status_payload(
             target,
             provider_tasks=provider_tasks,
             github=github,
             cursor_wired=cursor_wired,
+            provider_observations=observations,
         )
         report = cloud_tracker.sweep(target, status=status)
         if args.json:
@@ -644,7 +651,9 @@ def dispatch(args) -> int:
         return 0
 
     if command == "compact":
-        provider_tasks, github, cursor_wired = cloud_tracker.observe_providers(target)
+        observations, github = cloud_tracker.observe_provider_details(target)
+        provider_tasks = cloud_tracker._legacy_provider_tasks(observations)  # noqa: SLF001 - compatibility projection
+        cursor_wired = observations["cursor-cloud"].configured
         try:
             report = cloud_tracker.compact_registry(
                 target,
@@ -845,15 +854,15 @@ def _emit_launch_payload(payload: dict[str, Any], *, as_json: bool, exit_code: i
     return exit_code
 
 
-def _dispatch_codex_cloud_ops(args, target: Path) -> int:
-    """Setup, doctor, and inventory canary for a Codex Cloud run seat."""
-    from .. import codex_cloud
+def _dispatch_cloud_ops(args, target: Path) -> int:
+    """Route setup, doctor, and canary to their bounded provider operation."""
+    from .. import cloud_tracker, codex_cloud
 
-    if getattr(args, "provider", None) != "codex-cloud":
-        print("error: setup, doctor, and canary currently support --provider codex-cloud", file=sys.stderr)
-        return 2
     command = args.run_cloud_command
     if command == "setup":
+        if getattr(args, "provider", None) != "codex-cloud":
+            print("error: setup supports --provider codex-cloud only", file=sys.stderr)
+            return 2
         try:
             if args.env_var:
                 codex_cloud.save_environment_config(target, environment_id_env=args.env_var)
@@ -864,7 +873,7 @@ def _dispatch_codex_cloud_ops(args, target: Path) -> int:
             return 2
         print("codex-cloud config saved")
         return 0
-    if command == "doctor":
+    if command == "doctor" and args.provider == "codex-cloud":
         result = codex_cloud.doctor(target, selector=args.selector)
         if args.json:
             print(json.dumps(result, indent=2, sort_keys=True))
@@ -873,7 +882,7 @@ def _dispatch_codex_cloud_ops(args, target: Path) -> int:
             print(f"environment_configured: {'yes' if result['environment_configured'] else 'no'}")
             print(f"selector: {result.get('selector', args.selector)}")
         return 0 if result["ok"] else 1
-    if command == "canary":
+    if command == "canary" and args.provider == "codex-cloud":
         result = codex_cloud.canary(target, selector=args.selector)
         if args.json:
             print(json.dumps(result, indent=2, sort_keys=True))
@@ -886,8 +895,79 @@ def _dispatch_codex_cloud_ops(args, target: Path) -> int:
             print(f"task_count: {result['task_count']}")
             print("apply: no")
         return 0 if result["ok"] else 1
-    print(f"error: unknown cloud command: {command}", file=sys.stderr)
-    return 2
+    if command not in {"doctor", "canary"}:
+        print(f"error: unknown cloud command: {command}", file=sys.stderr)
+        return 2
+
+    observation = cloud_tracker.observe_provider(args.provider, target)
+    provider_result: dict[str, Any] = {
+        "ok": observation.configured and observation.reachable and observation.reason is None,
+        "provider": args.provider,
+        "configured": observation.configured,
+        "reachable": observation.reachable,
+        "reason": observation.reason,
+    }
+    if command == "canary":
+        tasks = observation.tasks
+        if args.provider == "grokbot-cloud" and provider_result["ok"]:
+            from .. import fleet_client_grokbot
+
+            decision = fleet_client_grokbot.list_jobs(include_all=False)
+            if not decision.granted or decision.jobs is None:
+                health_reason = _grokbot_health_reason(decision.reason)
+                provider_result.update(
+                    {
+                        "ok": False,
+                        "reachable": health_reason
+                        not in {
+                            "unconfigured",
+                            "actor-not-enrolled",
+                            "auth-failure",
+                            "transport-failure",
+                        },
+                        "reason": health_reason,
+                    }
+                )
+                tasks = {}
+            else:
+                tasks = {
+                    str(job.get("job_id")): {
+                        "job_id": str(job.get("job_id")),
+                        "state": str(job.get("state")),
+                        "role": job.get("role"),
+                    }
+                    for job in decision.jobs[:20]
+                    if isinstance(job, dict)
+                    and isinstance(job.get("job_id"), str)
+                    and cloud_tracker.is_active_state(job.get("state"))
+                }
+        provider_result["tasks"] = list(tasks.values())[:20]
+        provider_result["task_count"] = len(provider_result["tasks"])
+        provider_result["apply"] = False
+    if args.json:
+        print(json.dumps(provider_result, indent=2, sort_keys=True))
+    else:
+        print(f"{args.provider} {command}: {'ok' if provider_result['ok'] else 'fail'}")
+        print(f"configured: {'yes' if provider_result['configured'] else 'no'}")
+        print(f"reachable: {'yes' if provider_result['reachable'] else 'no'}")
+        if provider_result["reason"]:
+            print(f"reason: {provider_result['reason']}")
+        if command == "canary":
+            print(f"task_count: {provider_result['task_count']}")
+            print("apply: no")
+    return 0 if provider_result["ok"] else 1
+
+
+def _grokbot_health_reason(reason: str) -> str:
+    if reason == "no-hub":
+        return "unconfigured"
+    if reason == "no-identity":
+        return "actor-not-enrolled"
+    if reason == "hub-unavailable":
+        return "transport-failure"
+    if reason == "auth-failed":
+        return "auth-failure"
+    return reason
 
 
 def _dispatch_grokbot(args, target: Path) -> int:

--- a/src/brigade/cloud_tracker.py
+++ b/src/brigade/cloud_tracker.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 import subprocess
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -45,6 +46,16 @@ CLASSIFICATIONS = (
     "orphaned",
     "needs-investigation",
 )
+
+
+@dataclass(frozen=True)
+class ProviderObservation:
+    """Bounded, sanitized health and inventory evidence for one provider."""
+
+    configured: bool
+    reachable: bool
+    reason: str | None
+    tasks: dict[str, dict[str, Any]]
 
 
 def _root(target: Path) -> Path:
@@ -319,11 +330,15 @@ def _classify_entry(
     stale_ready_hours: int,
     now: datetime,
     cursor_wired: bool,
+    provider_observations: dict[str, ProviderObservation] | None = None,
 ) -> dict[str, Any]:
     provider = str(entry.get("provider") or "")
     task_id = entry.get("task_id")
     branch = entry.get("branch") if isinstance(entry.get("branch"), str) else None
-    provider_info = provider_tasks.get(str(task_id)) if task_id else None
+    observation = provider_observations.get(provider) if provider_observations else None
+    provider_info = observation.tasks.get(str(task_id)) if observation and task_id else None
+    if provider_info is None:
+        provider_info = provider_tasks.get(str(task_id)) if task_id else None
     provider_state = None
     ready_at = None
     if isinstance(provider_info, dict):
@@ -341,7 +356,7 @@ def _classify_entry(
     evidence: dict[str, Any] = {
         "registry": {"id": entry.get("id"), "source": entry.get("source"), "dispatched_at": entry.get("dispatched_at")},
         "provider": {
-            "wired": provider != "cursor-cloud" or cursor_wired,
+            "wired": observation.configured if observation else provider != "cursor-cloud" or cursor_wired,
             "state": provider_state,
             "task_id": task_id,
         },
@@ -351,9 +366,17 @@ def _classify_entry(
             "prs": prs,
         },
     }
+    if observation is not None:
+        evidence["provider"].update(
+            {
+                "configured": observation.configured,
+                "reachable": observation.reachable,
+                "reason": observation.reason,
+            }
+        )
 
     classification = "pending"
-    if provider == "cursor-cloud" and not cursor_wired:
+    if provider == "cursor-cloud" and not (observation.configured if observation else cursor_wired):
         evidence["provider"] = "unwired"
         if branch_exists and (provider_state in FAILED_STATES or not task_id):
             classification = "orphaned"
@@ -594,6 +617,7 @@ def status_payload(
     provider_tasks: dict[str, Any] | None = None,
     github: dict[str, Any] | None = None,
     cursor_wired: bool = False,
+    provider_observations: dict[str, ProviderObservation] | None = None,
 ) -> dict[str, Any]:
     from . import grokbot_jobs
 
@@ -605,6 +629,7 @@ def status_payload(
     provider_tasks = provider_tasks if isinstance(provider_tasks, dict) else {}
     github = github if isinstance(github, dict) else {"branches": [], "prs": []}
     jules_wired = jules_cloud_wired()
+    provider_observations = provider_observations if isinstance(provider_observations, dict) else None
 
     entries = [
         _classify_entry(
@@ -614,6 +639,7 @@ def status_payload(
             stale_ready_hours=stale_ready_hours,
             now=observed,
             cursor_wired=cursor_wired,
+            provider_observations=provider_observations,
         )
         for entry in registry["entries"]
     ]
@@ -634,35 +660,56 @@ def status_payload(
         )
     )
 
+    sources: dict[str, dict[str, Any]] = {
+        "codex-cloud": {"wired": True, "authority": "best-effort"},
+        "cursor-cloud": {
+            "wired": bool(cursor_wired),
+            "authority": "best-effort" if cursor_wired else "unwired",
+            "detail": None if cursor_wired else "no API key; cursor cloud left unwired",
+        },
+        "claude-cloud": {
+            "wired": False,
+            "authority": "disabled-by-policy",
+            "detail": "local/background sessions are not cloud discovery; claude cloud remains untracked/disabled until a structured bindable provider surface exists",
+        },
+        "jules": {
+            "wired": jules_wired,
+            "authority": "alpha REST" if jules_wired else "unwired",
+            "detail": None if jules_wired else "JULES_API_KEY not set",
+        },
+        "grokbot-cloud": {
+            "wired": True,
+            "authority": "hub" if grokbot_jobs.hub_authority(target) else "local-queue",
+            **({"degraded": True, "detail": "hub unavailable"} if grokbot_degraded else {}),
+        },
+        "github": {"wired": True, "authority": "ground-truth"},
+    }
+    if provider_observations:
+        for provider, observation in provider_observations.items():
+            source = sources.get(provider)
+            if source is None:
+                continue
+            source.update(
+                {
+                    "wired": observation.configured,
+                    "configured": observation.configured,
+                    "reachable": observation.reachable,
+                    "reason": observation.reason,
+                }
+            )
+            if provider == "claude-cloud":
+                source["detail"] = "disabled-by-policy"
+            elif observation.reason is not None:
+                source["detail"] = observation.reason
+            elif "detail" in source:
+                source["detail"] = None
+
     return {
         "schema": STATUS_SCHEMA,
         "target": str(target.expanduser().resolve()),
         "observed_at": _now_iso(observed),
         "stale_ready_hours": stale_ready_hours,
-        "sources": {
-            "codex-cloud": {"wired": True, "authority": "best-effort"},
-            "cursor-cloud": {
-                "wired": bool(cursor_wired),
-                "authority": "best-effort" if cursor_wired else "unwired",
-                "detail": None if cursor_wired else "no API key; cursor cloud left unwired",
-            },
-            "claude-cloud": {
-                "wired": False,
-                "authority": "disabled-by-policy",
-                "detail": "local/background sessions are not cloud discovery; claude cloud remains untracked/disabled until a structured bindable provider surface exists",
-            },
-            "jules": {
-                "wired": jules_wired,
-                "authority": "alpha REST" if jules_wired else "unwired",
-                "detail": None if jules_wired else "JULES_API_KEY not set",
-            },
-            "grokbot-cloud": {
-                "wired": True,
-                "authority": "hub" if grokbot_jobs.hub_authority(target) else "local-queue",
-                **({"degraded": True, "detail": "hub unavailable"} if grokbot_degraded else {}),
-            },
-            "github": {"wired": True, "authority": "ground-truth"},
-        },
+        "sources": sources,
         "entries": entries,
         "counts": {
             classification: sum(1 for row in entries if row.get("classification") == classification)
@@ -678,6 +725,7 @@ def sync_payload(
     provider_tasks: dict[str, Any] | None = None,
     github: dict[str, Any] | None = None,
     cursor_wired: bool = False,
+    provider_observations: dict[str, ProviderObservation] | None = None,
     hub_leases: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Reconcile registry observations with hub leases without secrets.
@@ -699,6 +747,7 @@ def sync_payload(
         provider_tasks=provider_tasks,
         github=github,
         cursor_wired=cursor_wired,
+        provider_observations=provider_observations,
     )
     hub_leases = hub_leases if isinstance(hub_leases, list) else []
 
@@ -1027,36 +1076,48 @@ def _parse_codex_cloud_list(stdout: str) -> dict[str, Any]:
     return tasks
 
 
-def observe_codex_cloud_tasks(target: Path) -> dict[str, Any]:
+def _codex_cloud_observation(target: Path) -> ProviderObservation:
     from . import codex_cloud
 
     try:
         inventory = codex_cloud.list_tasks(cwd=target)
     except Exception:  # noqa: BLE001 - observation must stay bounded
-        inventory = codex_cloud.ListTasksResult([])
-    if inventory.tasks:
-        return {
-            row["id"]: {"state": row.get("state"), "ready_at": None}
-            for row in inventory.tasks
-            if isinstance(row.get("id"), str)
-        }
+        return ProviderObservation(True, False, "transport-failure", {})
+    tasks = {
+        row["id"]: {"state": row.get("state"), "ready_at": None}
+        for row in inventory.tasks
+        if isinstance(row.get("id"), str)
+    }
+    if not tasks:
+        # Preserve the established bounded positive-evidence fallback for
+        # registered tasks. Failure or absence never implies a terminal state.
+        registry = load_registry(target)
+        for entry in registry["entries"]:
+            task_id = entry.get("task_id")
+            if not isinstance(task_id, str) or entry.get("provider") != "codex-cloud":
+                continue
+            scode, sout, serr = _run_text(["codex", "cloud", "status", task_id], cwd=target)
+            blob = (sout + "\n" + serr).strip()
+            if scode != 0 and not blob:
+                continue
+            state = codex_cloud._scan_status(blob)  # noqa: SLF001 - shared status scanner
+            if state is not None:
+                tasks[task_id] = {"state": state, "ready_at": None}
+    if not inventory.ok:
+        reason = inventory.reason or "provider-error"
+        if reason in {"provider-missing", "provider-unavailable"}:
+            return ProviderObservation(False, False, reason, tasks)
+        if reason == "provider-timeout":
+            return ProviderObservation(True, False, "transport-failure", tasks)
+        if reason == "auth-failure":
+            return ProviderObservation(True, False, reason, tasks)
+        return ProviderObservation(True, True, reason, tasks)
+    return ProviderObservation(True, True, None, tasks)
 
-    # Empty or unavailable structured inventory is not terminal evidence. Fall
-    # back to status reads only for task ids already present in the local
-    # registry, and never infer completion from absence.
-    registry = load_registry(target)
-    tasks: dict[str, Any] = {}
-    for entry in registry["entries"]:
-        task_id = entry.get("task_id")
-        if not isinstance(task_id, str) or entry.get("provider") != "codex-cloud":
-            continue
-        scode, sout, serr = _run_text(["codex", "cloud", "status", task_id], cwd=target)
-        blob = (sout + "\n" + serr).strip()
-        if scode != 0 and not blob:
-            continue
-        state = codex_cloud._scan_status(blob)  # noqa: SLF001 - shared status scanner
-        tasks[task_id] = {"state": state, "ready_at": None}
-    return tasks
+
+def observe_codex_cloud_tasks(target: Path) -> dict[str, Any]:
+    """Compatibility wrapper returning only Codex Cloud inventory rows."""
+    return _codex_cloud_observation(target).tasks
 
 
 def observe_github(target: Path) -> dict[str, Any]:
@@ -1147,7 +1208,16 @@ def _cursor_api_key() -> str | None:
     return None
 
 
-def observe_cursor_cloud_tasks(target: Path) -> dict[str, Any]:
+def _provider_error_observation(error: BaseException) -> ProviderObservation:
+    reason = getattr(error, "reason", None)
+    if reason == "auth-failure":
+        return ProviderObservation(True, False, "auth-failure", {})
+    if reason == "transport-failure" or isinstance(error, (OSError, TimeoutError)):
+        return ProviderObservation(True, False, "transport-failure", {})
+    return ProviderObservation(True, True, "provider-error", {})
+
+
+def _cursor_cloud_observation(target: Path) -> ProviderObservation:
     """Fetch sanitized Cursor Cloud inventory when an API key is present.
 
     Provider API failures are bounded: the tracker stays available and no
@@ -1155,13 +1225,13 @@ def observe_cursor_cloud_tasks(target: Path) -> dict[str, Any]:
     """
     api_key = _cursor_api_key()
     if not api_key:
-        return {}
+        return ProviderObservation(False, False, "unconfigured", {})
     try:
         from . import cursor_cloud
 
         agents = cursor_cloud.list_agents(api_key, max_pages=2, max_items=100, include_usage=True)
-    except Exception:  # noqa: BLE001 - observation must stay bounded
-        return {}
+    except Exception as exc:  # noqa: BLE001 - observation must stay bounded
+        return _provider_error_observation(exc)
     tasks: dict[str, Any] = {}
     for agent in agents:
         if not isinstance(agent, dict):
@@ -1186,7 +1256,12 @@ def observe_cursor_cloud_tasks(target: Path) -> dict[str, Any]:
         if usage:
             row["usage"] = usage
         tasks[agent_id] = row
-    return tasks
+    return ProviderObservation(True, True, None, tasks)
+
+
+def observe_cursor_cloud_tasks(target: Path) -> dict[str, Any]:
+    """Compatibility wrapper returning only Cursor Cloud inventory rows."""
+    return _cursor_cloud_observation(target).tasks
 
 
 def jules_cloud_wired() -> bool:
@@ -1204,7 +1279,7 @@ def _jules_api_key() -> str | None:
     return value or None
 
 
-def observe_jules_cloud_tasks(target: Path) -> dict[str, Any]:
+def _jules_cloud_observation(target: Path) -> ProviderObservation:
     """Fetch sanitized Jules Cloud inventory when an API key is present.
 
     Provider API failures are bounded: the tracker stays available and no
@@ -1215,13 +1290,13 @@ def observe_jules_cloud_tasks(target: Path) -> dict[str, Any]:
     """
     api_key = _jules_api_key()
     if not api_key:
-        return {}
+        return ProviderObservation(False, False, "unconfigured", {})
     try:
         from . import jules_cloud
 
         sessions = jules_cloud.list_sessions(api_key, max_pages=2, max_items=100)
-    except Exception:  # noqa: BLE001 - observation must stay bounded
-        return {}
+    except Exception as exc:  # noqa: BLE001 - observation must stay bounded
+        return _provider_error_observation(exc)
     tasks: dict[str, Any] = {}
     for session in sessions:
         if not isinstance(session, dict):
@@ -1230,26 +1305,71 @@ def observe_jules_cloud_tasks(target: Path) -> dict[str, Any]:
         if not isinstance(session_id, str):
             continue
         tasks[session_id] = {"state": normalize_provider_state(session.get("state"))}
+    return ProviderObservation(True, True, None, tasks)
+
+
+def observe_jules_cloud_tasks(target: Path) -> dict[str, Any]:
+    """Compatibility wrapper returning only Jules Cloud inventory rows."""
+    return _jules_cloud_observation(target).tasks
+
+
+def _grokbot_cloud_observation() -> ProviderObservation:
+    from . import fleet_client_grokbot
+
+    try:
+        decision = fleet_client_grokbot.whoami()
+    except Exception:  # noqa: BLE001 - provider health must stay bounded
+        return ProviderObservation(True, False, "transport-failure", {})
+    if decision.granted:
+        return ProviderObservation(True, True, None, {})
+    if decision.reason == "no-hub":
+        return ProviderObservation(False, False, "unconfigured", {})
+    if decision.reason == "no-identity":
+        return ProviderObservation(True, False, "actor-not-enrolled", {})
+    if decision.reason == "auth-failed":
+        return ProviderObservation(True, False, "auth-failure", {})
+    if decision.reason == "hub-unavailable":
+        return ProviderObservation(True, False, "transport-failure", {})
+    return ProviderObservation(True, True, decision.reason, {})
+
+
+def observe_provider(provider: str, target: Path) -> ProviderObservation:
+    """Observe exactly one provider without exposing credentials or bodies."""
+    if provider == "codex-cloud":
+        return _codex_cloud_observation(target)
+    if provider == "cursor-cloud":
+        return _cursor_cloud_observation(target)
+    if provider == "jules":
+        return _jules_cloud_observation(target)
+    if provider == "grokbot-cloud":
+        return _grokbot_cloud_observation()
+    if provider == "claude-cloud":
+        return ProviderObservation(False, False, "disabled-by-policy", {})
+    return ProviderObservation(False, False, "unsupported-provider", {})
+
+
+def observe_provider_details(target: Path, **_kwargs: Any) -> tuple[dict[str, ProviderObservation], dict[str, Any]]:
+    """Return per-provider health so failed empty inventories stay visible."""
+    observations: dict[str, ProviderObservation] = {}
+    for provider in TRACKER_PROVIDERS:
+        try:
+            observations[provider] = observe_provider(provider, target)
+        except Exception:  # noqa: BLE001 - observation must stay bounded
+            observations[provider] = ProviderObservation(True, False, "transport-failure", {})
+    return observations, observe_github(target)
+
+
+def _legacy_provider_tasks(observations: dict[str, ProviderObservation]) -> dict[str, Any]:
+    tasks: dict[str, Any] = {}
+    for provider in ("codex-cloud", "cursor-cloud", "jules"):
+        tasks.update(observations.get(provider, ProviderObservation(False, False, None, {})).tasks)
     return tasks
 
 
 def observe_providers(target: Path, **_kwargs: Any) -> tuple[dict[str, Any], dict[str, Any], bool]:
-    provider_tasks: dict[str, Any] = {}
-    try:
-        provider_tasks.update(observe_codex_cloud_tasks(target))
-    except Exception:  # noqa: BLE001 - observation must stay bounded
-        pass
-    if cursor_cloud_wired():
-        try:
-            provider_tasks.update(observe_cursor_cloud_tasks(target))
-        except Exception:  # noqa: BLE001 - observation must stay bounded
-            pass
-    if jules_cloud_wired():
-        try:
-            provider_tasks.update(observe_jules_cloud_tasks(target))
-        except Exception:  # noqa: BLE001 - observation must stay bounded
-            pass
-    return provider_tasks, observe_github(target), cursor_cloud_wired()
+    """Compatibility wrapper for callers that only accept a flattened inventory."""
+    observations, github = observe_provider_details(target)
+    return _legacy_provider_tasks(observations), github, observations["cursor-cloud"].configured
 
 
 def center_activity_records(

--- a/src/brigade/cursor_cloud.py
+++ b/src/brigade/cursor_cloud.py
@@ -34,6 +34,10 @@ _TERMINAL_STATES = frozenset({"finished", "error", "cancelled", "expired"})
 class CursorCloudError(RuntimeError):
     """Raised on Cursor Cloud failures; message carries no secrets or bodies."""
 
+    def __init__(self, message: str, *, reason: str = "provider-error") -> None:
+        super().__init__(message)
+        self.reason = reason
+
 
 @dataclass(frozen=True)
 class LaunchResult:
@@ -132,9 +136,10 @@ def _call(opener, request: urllib.request.Request, deadline: float) -> dict[str,
         raise
     except urllib.error.HTTPError as exc:
         # Sanitize: never re-read or include the response body.
-        raise CursorCloudError("Cursor Cloud request failed") from exc
-    except urllib.error.URLError as exc:
-        raise CursorCloudError("Cursor Cloud request failed") from exc
+        reason = "auth-failure" if exc.code in (401, 403) else "provider-error"
+        raise CursorCloudError("Cursor Cloud request failed", reason=reason) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise CursorCloudError("Cursor Cloud request failed", reason="transport-failure") from exc
     except Exception as exc:
         raise CursorCloudError("Cursor Cloud request failed") from exc
 

--- a/src/brigade/jules_cloud.py
+++ b/src/brigade/jules_cloud.py
@@ -58,6 +58,10 @@ _ACTIVE_STATES = frozenset(
 class JulesCloudError(RuntimeError):
     """Raised on Jules Cloud failures; message carries no secrets or bodies."""
 
+    def __init__(self, message: str, *, reason: str = "provider-error") -> None:
+        super().__init__(message)
+        self.reason = reason
+
 
 @dataclass(frozen=True)
 class LaunchResult:
@@ -414,9 +418,10 @@ def _call(
         raise
     except urllib.error.HTTPError as exc:
         # Sanitize: never re-read or include the response body.
-        raise JulesCloudError("Jules Cloud request failed") from exc
-    except urllib.error.URLError as exc:
-        raise JulesCloudError("Jules Cloud request failed") from exc
+        reason = "auth-failure" if exc.code in (401, 403) else "provider-error"
+        raise JulesCloudError("Jules Cloud request failed", reason=reason) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise JulesCloudError("Jules Cloud request failed", reason="transport-failure") from exc
     except Exception as exc:
         raise JulesCloudError("Jules Cloud request failed") from exc
 

--- a/tests/test_cloud_tracker.py
+++ b/tests/test_cloud_tracker.py
@@ -776,10 +776,20 @@ def test_sync_command_exists_and_is_non_mutating(tmp_path: Path, capsys, monkeyp
         prompt_hash="sha256:bb",
         dispatched_at=_iso(NOW),
     )
+    observations = {
+        provider: cloud_tracker.ProviderObservation(False, False, "unconfigured", {})
+        for provider in cloud_tracker.TRACKER_PROVIDERS
+    }
+    observations["codex-cloud"] = cloud_tracker.ProviderObservation(
+        True,
+        True,
+        None,
+        {"task-sync": {"state": "running"}},
+    )
     monkeypatch.setattr(
         cloud_tracker,
-        "observe_providers",
-        lambda target, **k: ({"task-sync": {"state": "running"}}, {"branches": [], "prs": []}, False),
+        "observe_provider_details",
+        lambda target, **k: (observations, {"branches": [], "prs": []}),
     )
     rc = cli.main(["run", "cloud", "sync", "--target", str(tmp_path), "--json"])
     assert rc == 0
@@ -989,6 +999,113 @@ def test_observe_providers_does_not_call_claude_local_inventory(monkeypatch, tmp
     tasks, _github, _cursor_wired = cloud_tracker.observe_providers(tmp_path)
     assert tasks == {}
     assert called == []
+
+
+def test_observe_provider_details_keeps_unconfigured_and_failed_inventory_distinct(monkeypatch, tmp_path: Path):
+    """An empty inventory is healthy only when the provider answered it."""
+    from brigade import fleet_client_grokbot
+
+    _isolate_hosted_providers(monkeypatch)
+    monkeypatch.setenv("CURSOR_API_KEY", "fake-cursor-key")
+    monkeypatch.setenv("JULES_API_KEY", "fake-jules-key")
+    monkeypatch.setattr(
+        cursor_cloud,
+        "list_agents",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("network unavailable")),
+    )
+    monkeypatch.setattr(jules_cloud, "list_sessions", lambda *a, **k: [])
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "whoami",
+        lambda **k: fleet_client_grokbot.GrokbotHubDecision(False, "no-identity"),
+    )
+
+    observations, _github = cloud_tracker.observe_provider_details(tmp_path)
+
+    assert observations["cursor-cloud"].configured is True
+    assert observations["cursor-cloud"].reachable is False
+    assert observations["cursor-cloud"].reason == "transport-failure"
+    assert observations["cursor-cloud"].tasks == {}
+    assert observations["jules"].configured is True
+    assert observations["jules"].reachable is True
+    assert observations["jules"].reason is None
+    assert observations["jules"].tasks == {}
+    assert observations["grokbot-cloud"].configured is True
+    assert observations["grokbot-cloud"].reachable is False
+    assert observations["grokbot-cloud"].reason == "actor-not-enrolled"
+    assert observations["claude-cloud"].reason == "disabled-by-policy"
+
+    payload = cloud_tracker.status_payload(
+        tmp_path,
+        provider_observations=observations,
+        github={"branches": [], "prs": []},
+    )
+    assert payload["sources"]["cursor-cloud"]["reachable"] is False
+    assert payload["sources"]["jules"]["reachable"] is True
+    assert payload["sources"]["claude-cloud"]["reason"] == "disabled-by-policy"
+
+
+def test_provider_auth_failures_are_configured_but_not_reachable(monkeypatch, tmp_path: Path):
+    from brigade import fleet_client_grokbot
+
+    _isolate_hosted_providers(monkeypatch)
+    monkeypatch.setenv("CURSOR_API_KEY", "fake-cursor-key")
+    monkeypatch.setattr(
+        cursor_cloud,
+        "list_agents",
+        lambda *a, **k: (_ for _ in ()).throw(cursor_cloud.CursorCloudError("sanitized", reason="auth-failure")),
+    )
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "whoami",
+        lambda **k: fleet_client_grokbot.GrokbotHubDecision(False, "auth-failed"),
+    )
+
+    cursor = cloud_tracker.observe_provider("cursor-cloud", tmp_path)
+    grokbot = cloud_tracker.observe_provider("grokbot-cloud", tmp_path)
+
+    assert (cursor.configured, cursor.reachable, cursor.reason) == (
+        True,
+        False,
+        "auth-failure",
+    )
+    assert (grokbot.configured, grokbot.reachable, grokbot.reason) == (
+        True,
+        False,
+        "auth-failure",
+    )
+
+
+def test_codex_failed_inventory_keeps_health_and_bounded_status_evidence(monkeypatch, tmp_path: Path):
+    from brigade import codex_cloud
+
+    cloud_tracker.register(
+        tmp_path,
+        provider="codex-cloud",
+        task_id="task_registered01",
+        label="registered",
+        prompt_hash=_prompt_hash("x"),
+        dispatched_at=_iso(NOW),
+    )
+    monkeypatch.setattr(
+        codex_cloud,
+        "list_tasks",
+        lambda **kwargs: codex_cloud.ListTasksResult([], ok=False, reason="auth-failure"),
+    )
+    monkeypatch.setattr(
+        cloud_tracker,
+        "_run_text",
+        lambda *args, **kwargs: (0, "[COMPLETED] registered", ""),
+    )
+
+    observation = cloud_tracker.observe_provider("codex-cloud", tmp_path)
+
+    assert (observation.configured, observation.reachable, observation.reason) == (
+        True,
+        False,
+        "auth-failure",
+    )
+    assert observation.tasks == {"task_registered01": {"state": "completed", "ready_at": None}}
 
 
 def test_local_claude_session_cannot_make_claude_cloud_registry_row_active(monkeypatch, tmp_path: Path):
@@ -2502,10 +2619,20 @@ class _JulesLaunchOpener:
 def test_cli_run_cloud_compact_json_contract(tmp_path: Path, capsys, monkeypatch):
     ids = _seed_mixed_registry(tmp_path)
     provider_tasks, github = _mixed_provider_and_github()
+    observations = {
+        provider: cloud_tracker.ProviderObservation(False, False, "unconfigured", {})
+        for provider in cloud_tracker.TRACKER_PROVIDERS
+    }
+    observations["codex-cloud"] = cloud_tracker.ProviderObservation(
+        True,
+        True,
+        None,
+        provider_tasks,
+    )
     monkeypatch.setattr(
         cloud_tracker,
-        "observe_providers",
-        lambda target, **kwargs: (provider_tasks, github, False),
+        "observe_provider_details",
+        lambda target, **kwargs: (observations, github),
     )
     rc = cli.main(
         [

--- a/tests/test_codex_cloud.py
+++ b/tests/test_codex_cloud.py
@@ -4,7 +4,17 @@ from pathlib import Path
 
 import pytest
 
-from brigade import agents, cli, cloud_tracker, codex_cloud, fleet_client, proc
+from brigade import (
+    agents,
+    cli,
+    cloud_tracker,
+    codex_cloud,
+    cursor_cloud,
+    fleet_client,
+    fleet_client_grokbot,
+    jules_cloud,
+    proc,
+)
 
 
 def test_codex_cloud_ref_is_known_and_maps_to_codex():
@@ -1449,3 +1459,95 @@ class TestCodexCloudCli:
         assert all(argv[2] == "list" for argv in codex_calls)
         assert codex_calls
         assert not any(argv[2] in {"exec", "apply"} for argv in calls)
+
+    def test_cloud_doctor_and_canary_route_to_supported_provider_adapters(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setenv("CURSOR_API_KEY", "cursor-key")
+        monkeypatch.setenv("JULES_API_KEY", "jules-key")
+        monkeypatch.setattr(cursor_cloud, "list_agents", lambda *a, **k: [])
+        monkeypatch.setattr(jules_cloud, "list_sessions", lambda *a, **k: [{"id": "sess-1", "state": "running"}])
+        whoami_calls = []
+        monkeypatch.setattr(
+            fleet_client_grokbot,
+            "whoami",
+            lambda **k: whoami_calls.append(k) or fleet_client_grokbot.GrokbotHubDecision(True, "ok"),
+        )
+        monkeypatch.setattr(
+            fleet_client_grokbot,
+            "list_jobs",
+            lambda **k: fleet_client_grokbot.GrokbotHubDecision(
+                True,
+                "ok",
+                jobs=[
+                    {"job_id": "grokbot-active", "state": "running", "role": "implementation-worker"},
+                    {"job_id": "grokbot-done", "state": "completed", "role": "implementation-worker"},
+                ],
+            ),
+        )
+
+        assert (
+            cli.main(["run", "cloud", "doctor", "--provider", "cursor-cloud", "--target", str(tmp_path), "--json"]) == 0
+        )
+        assert json.loads(capsys.readouterr().out)["provider"] == "cursor-cloud"
+        assert cli.main(["run", "cloud", "canary", "--provider", "jules", "--target", str(tmp_path), "--json"]) == 0
+        assert json.loads(capsys.readouterr().out)["task_count"] == 1
+        assert (
+            cli.main(["run", "cloud", "doctor", "--provider", "grokbot-cloud", "--target", str(tmp_path), "--json"])
+            == 0
+        )
+        assert whoami_calls
+        capsys.readouterr()
+        assert (
+            cli.main(["run", "cloud", "canary", "--provider", "grokbot-cloud", "--target", str(tmp_path), "--json"])
+            == 0
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["tasks"] == [{"job_id": "grokbot-active", "role": "implementation-worker", "state": "running"}]
+        assert (
+            cli.main(["run", "cloud", "doctor", "--provider", "claude-cloud", "--target", str(tmp_path), "--json"]) == 1
+        )
+        assert json.loads(capsys.readouterr().out)["reason"] == "disabled-by-policy"
+        with pytest.raises(SystemExit) as rejected_setup:
+            cli.main(
+                ["run", "cloud", "setup", "--provider", "cursor-cloud", "--target", str(tmp_path), "--env-id", "env-1"]
+            )
+        assert rejected_setup.value.code == 2
+
+    def test_claude_cloud_doctor_is_static_disabled_policy(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(
+            cursor_cloud,
+            "list_agents",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("cursor must not run")),
+        )
+        monkeypatch.setattr(
+            jules_cloud,
+            "list_sessions",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("jules must not run")),
+        )
+        monkeypatch.setattr(
+            fleet_client_grokbot,
+            "whoami",
+            lambda **k: (_ for _ in ()).throw(AssertionError("grokbot must not run")),
+        )
+        monkeypatch.setattr(
+            codex_cloud,
+            "list_tasks",
+            lambda **k: (_ for _ in ()).throw(AssertionError("codex must not run")),
+        )
+
+        assert (
+            cli.main(
+                [
+                    "run",
+                    "cloud",
+                    "doctor",
+                    "--provider",
+                    "claude-cloud",
+                    "--target",
+                    str(tmp_path),
+                    "--json",
+                ]
+            )
+            == 1
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["reason"] == "disabled-by-policy"


### PR DESCRIPTION
## Summary

- make `run cloud doctor` and `canary` provider-aware for Codex Cloud, Cursor Cloud, Jules, Grok Bot, and policy-disabled Claude Cloud
- preserve configured, reachable, and bounded failure reasons instead of treating failed empty inventories as healthy
- keep positive terminal evidence fallbacks bounded to registered tasks and keep secrets out of Hub and registry payloads
- narrow `run cloud setup` to the Codex-only setup surface it actually implements

## Verification

- `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_aboyeur.py::test_artifact_helper_imports_before_aboyeur_facade","tests/test_run_detach.py::test_spawn_detached_child_survives_parent_session_exit","tests/test_cloud_tracker.py","tests/test_codex_cloud.py","tests/test_cursor_cloud.py","tests/test_jules_cloud.py","tests/test_grokbot_jobs.py"]' --capture brigade-work`
  - passed, receipt `20260830-174004-work-verify-00a4bf`
- one full `./scripts/verify` run passed 10,929 tests and coverage, but its two subprocess tests resolved Brigade from a shared symlinked venv tied to another checkout and failed on modules absent from that checkout. After replacing the symlink with an isolated editable venv, both exact selectors passed in the focused receipt above. Full receipt: `20260830-170347-work-verify-d2614f`.
