### PR TITLE
test(windows): cover native inbox lock deadline

### DIFF
--- a/scripts/windows-native-acceptance.ps1
+++ b/scripts/windows-native-acceptance.ps1
@@ -837,6 +837,71 @@ else:
         & $brigadePython $inboxProbeScript $inboxProbeRoot
         if ($LASTEXITCODE -ne 0) { throw "import inbox Windows probe failed" }
 
+        Write-Step "inbox lock msvcrt contention deadline"
+        $inboxLockProbeRoot = Join-Path $acceptRoot "inbox-lock-probe"
+        New-Item -ItemType Directory -Force -Path $inboxLockProbeRoot | Out-Null
+        $inboxLockProbeScript = Join-Path $acceptRoot "inbox_lock_contention_probe.py"
+        @'
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from brigade.work_cmd import inbox_lock
+
+target = Path(sys.argv[1]).resolve()
+probe_root = Path(sys.argv[2]).resolve()
+probe_root.mkdir(parents=True, exist_ok=True)
+(target / ".brigade" / "work" / "imports").mkdir(parents=True, exist_ok=True)
+ready = probe_root / "holder-ready"
+holder = probe_root / "holder.py"
+holder.write_text(
+    "from pathlib import Path\n"
+    "import sys\n"
+    "import time\n"
+    "from brigade.work_cmd import inbox_lock\n"
+    "target = Path(sys.argv[1])\n"
+    "ready = Path(sys.argv[2])\n"
+    "with inbox_lock.inbox_writer_lock(target, deadline_seconds=10):\n"
+    "    ready.write_text('ready', encoding='utf-8')\n"
+    "    time.sleep(10)\n",
+    encoding="utf-8",
+)
+
+holder_process = subprocess.Popen([sys.executable, str(holder), str(target), str(ready)])
+try:
+    wait_deadline = time.monotonic() + 5
+    while not ready.exists():
+        if holder_process.poll() is not None:
+            raise SystemExit(f"native lock holder exited early: {holder_process.returncode}")
+        if time.monotonic() >= wait_deadline:
+            raise SystemExit("native lock holder did not become ready")
+        time.sleep(0.02)
+
+    if inbox_lock.msvcrt is None:
+        raise SystemExit("msvcrt is unavailable in native Windows acceptance")
+    if inbox_lock.fcntl is not None:
+        raise SystemExit("fcntl unexpectedly available in native Windows acceptance")
+
+    started = time.monotonic()
+    try:
+        with inbox_lock.inbox_writer_lock(target, deadline_seconds=0.5):
+            raise SystemExit("inbox writer lock did not time out behind native holder")
+    except inbox_lock.InboxLockTimeout:
+        elapsed = time.monotonic() - started
+        if elapsed < 0.35 or elapsed > 2:
+            raise SystemExit(f"native LK_NBLCK acquisition exceeded deadline bound: {elapsed:.3f}s")
+finally:
+    holder_process.terminate()
+    try:
+        holder_process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        holder_process.kill()
+        holder_process.wait(timeout=10)
+'@ | Set-Content -Path $inboxLockProbeScript -Encoding UTF8
+        & $brigadePython $inboxLockProbeScript $workRepo $inboxLockProbeRoot
+        if ($LASTEXITCODE -ne 0) { throw "native msvcrt inbox lock contention probe failed" }
+
         # import-issues reads .brigade/memory-care/decay/refresh-queue.json.
         # operator quickstart / init create the decay directory, not the queue;
         # scan is the producer (same order as the daily-care-pass runbook).

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -516,6 +516,16 @@ def test_ci_windows_native_acceptance_script_covers_required_flow():
     assert "#requires -Version 5.1" in text
 
 
+def test_ci_windows_native_acceptance_script_proves_msvcrt_lock_deadline_contention():
+    """Native Windows acceptance must exercise the actual LK_NBLCK timeout path (#1215)."""
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+
+    assert 'Write-Step "inbox lock msvcrt contention deadline"' in text
+    assert "msvcrt is unavailable in native Windows acceptance" in text
+    assert "inbox writer lock did not time out behind native holder" in text
+    assert "native LK_NBLCK acquisition exceeded deadline bound" in text
+
+
 def test_windows_native_acceptance_schtasks_missing_task_query_does_not_fail_the_job():
     """After /Delete, schtasks /Query exits 1 with
     'ERROR: The system cannot find the file specified'. That names the


### PR DESCRIPTION
Implements finding 5 from #1215 only.\n\nAdds a Windows-native acceptance probe that holds the inbox writer lock in a child process, confirms the msvcrt backend, and checks LK_NBLCK contention reaches InboxLockTimeout within the bounded deadline.\n\nVerification:\n- Windows native acceptance through Brigade: 20260830-185825-work-verify-b1c6f9, passed.\n- Targeted pytest through Brigade: 20260830-185505-work-verify-2bd7fe, passed.\n- Full gate through Brigade: 20260830-190109-work-verify-ec2777, blocked by existing Windows mypy errors for POSIX-only os and signal attributes before tests.