### PR TITLE
fix(grokbot): bootstrap listener hub credentials

### DIFF
--- a/src/brigade/grokbot_ops.py
+++ b/src/brigade/grokbot_ops.py
@@ -114,7 +114,8 @@ def save_config(
     if hub_token_file is not None:
         payload["hub_token_file"] = _validated_hub_token_file(hub_token_file)
     _validate_config(payload)
-    grokbot_jobs.status(target)
+    with grokbot_jobs._storage_paths(target):
+        pass
     path = config_path(target, instance)
     try:
         _write_text_nofollow_atomic(path, json.dumps(payload, indent=2, sort_keys=True) + "\n", mode=0o600)

--- a/tests/test_grokbot_ops.py
+++ b/tests/test_grokbot_ops.py
@@ -207,6 +207,23 @@ def test_setup_stores_hub_token_file_reference_and_renders_role_environment(tmp_
         )
 
 
+def test_setup_with_hub_authority_does_not_require_queue_status(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    hub_token = tmp_path / "listener.hub-token"
+    hub_token.write_text("hub-node-token-value\n", encoding="utf-8")
+    hub_token.chmod(0o600)
+    grokbot_jobs.admit_hub_authority(tmp_path)
+
+    def fail_status(_target: Path) -> None:
+        raise grokbot_jobs.GrokbotJobError("hub-authentication-failed")
+
+    monkeypatch.setattr(grokbot_jobs, "status", fail_status)
+
+    assert _setup(tmp_path, "implementation-worker", ["--hub-token-file", str(hub_token)]) == 0
+    config = grokbot_ops.load_config(tmp_path, "implementation-worker")
+    assert config["hub_token_file"] == str(hub_token)
+
+
 def test_operator_setup_renders_its_own_hub_actor_token_reference(tmp_path: Path, monkeypatch, capsys):
     monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
     hub_token = tmp_path / "operator.hub-token"


### PR DESCRIPTION
## Summary

- persist validated Grok Bot listener configuration without a Hub queue status call
- retain safe local queue storage initialization
- keep doctor queue diagnostics unchanged
- cover Hub-authoritative setup when the host identity cannot read the queue

## Verification

- `20260830-191333-work-verify-de09d6`: full `./scripts/verify`, exit 0
- `20260830-194826-work-verify-b85300`: focused Grok Bot and incoming CI workflow tests, exit 0