### PR TITLE
fix(grokbot): bind direct queue actor identity

### DIFF
--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import nullcontext
 import json
 import os
 import stat
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, ContextManager
 
 _PROMPT_FILE_MAX_BYTES = 64 * 1024
 _LAUNCH_LABEL_MAX = 120
@@ -1118,36 +1119,43 @@ def _dispatch_grokbot(args, target: Path) -> int:
             raise
         return 0
     try:
-        if command == "enqueue":
-            result = grokbot_jobs.enqueue(target, _read_json_object(args.spec, "--spec"), args.idempotency_key)
-        elif command == "claim":
-            result = grokbot_jobs.claim(target, args.job_id, args.bot_id, args.lease_id, args.lease_seconds)
-        elif command == "renew":
-            result = grokbot_jobs.renew(target, args.job_id, args.bot_id, args.lease_id, args.lease_seconds)
-        elif command == "start":
-            result = grokbot_jobs.transition(target, args.job_id, args.bot_id, args.lease_id, "running")
-        elif command == "complete":
-            result = grokbot_jobs.transition(
-                target,
-                args.job_id,
-                args.bot_id,
-                args.lease_id,
-                "completed",
-                artifact=_read_json_object(args.artifact, "--artifact"),
-            )
-        elif command == "fail":
-            result = grokbot_jobs.transition(target, args.job_id, args.bot_id, args.lease_id, "failed")
-        elif command == "cancel":
-            result = grokbot_jobs.cancel(target, args.job_id)
-        elif command == "ack-cancel":
-            result = grokbot_jobs.acknowledge_cancel(target, args.job_id, args.bot_id, args.lease_id)
-        elif command == "expire":
-            result = grokbot_jobs.expire(target, args.job_id)
-        elif command == "status":
-            result = grokbot_jobs.status(target, args.job_id)
-        else:  # argparse makes this unreachable.
-            print(f"error: unknown Grok Bot command: {command}", file=sys.stderr)
-            return 2
+        token = grokbot_mcp.load_direct_queue_listener_token()
+        identity: ContextManager[None] = nullcontext()
+        if token is not None:
+            from .. import fleet_client_grokbot
+
+            identity = fleet_client_grokbot.listener_identity(token)
+        with identity:
+            if command == "enqueue":
+                result = grokbot_jobs.enqueue(target, _read_json_object(args.spec, "--spec"), args.idempotency_key)
+            elif command == "claim":
+                result = grokbot_jobs.claim(target, args.job_id, args.bot_id, args.lease_id, args.lease_seconds)
+            elif command == "renew":
+                result = grokbot_jobs.renew(target, args.job_id, args.bot_id, args.lease_id, args.lease_seconds)
+            elif command == "start":
+                result = grokbot_jobs.transition(target, args.job_id, args.bot_id, args.lease_id, "running")
+            elif command == "complete":
+                result = grokbot_jobs.transition(
+                    target,
+                    args.job_id,
+                    args.bot_id,
+                    args.lease_id,
+                    "completed",
+                    artifact=_read_json_object(args.artifact, "--artifact"),
+                )
+            elif command == "fail":
+                result = grokbot_jobs.transition(target, args.job_id, args.bot_id, args.lease_id, "failed")
+            elif command == "cancel":
+                result = grokbot_jobs.cancel(target, args.job_id)
+            elif command == "ack-cancel":
+                result = grokbot_jobs.acknowledge_cancel(target, args.job_id, args.bot_id, args.lease_id)
+            elif command == "expire":
+                result = grokbot_jobs.expire(target, args.job_id)
+            elif command == "status":
+                result = grokbot_jobs.status(target, args.job_id)
+            else:  # argparse makes this unreachable.
+                print(f"error: unknown Grok Bot command: {command}", file=sys.stderr)
+                return 2
     except grokbot_jobs.GrokbotJobError as exc:
         print(f"error: {exc.reason}", file=sys.stderr)
         return 2

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -31,6 +31,8 @@ _FLEET_HOLDER_DOMAIN = b"brigade.grokbot.fleet-holder"
 _FLEET_SESSION_DOMAIN = b"brigade.grokbot.fleet-session"
 _FLEET_BEST_EFFORT = frozenset({"no-hub", "no-identity", "hub-unavailable"})
 ENVIRONMENT_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,127}$")
+_DIRECT_QUEUE_HUB_TOKEN_FILE_ENV = "BRIGADE_GROKBOT_HUB_TOKEN_FILE"
+_DIRECT_QUEUE_HUB_TOKEN_MAX_BYTES = 4098
 
 OPERATOR_TOOLS = frozenset(
     {
@@ -150,12 +152,59 @@ def load_hub_token(*, instance: str) -> str | None:
     """
     names = (
         f"BRIGADE_GROKBOT_{instance.replace('-', '_').upper()}_HUB_TOKEN_FILE",
-        "BRIGADE_GROKBOT_HUB_TOKEN_FILE",
+        _DIRECT_QUEUE_HUB_TOKEN_FILE_ENV,
     )
     path_text = next((os.environ.get(name) for name in names if os.environ.get(name)), None)
     if path_text is None:
         return None
     return _read_mode600_secret(Path(path_text))
+
+
+def load_direct_queue_listener_token() -> str | None:
+    """Load only the generic direct-queue listener token from a safe file."""
+    path_text = os.environ.get(_DIRECT_QUEUE_HUB_TOKEN_FILE_ENV)
+    if path_text is None:
+        return None
+    path = Path(path_text)
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    if not path.is_absolute() or not isinstance(no_follow, int) or no_follow == 0:
+        raise ConfigurationError("invalid")
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | no_follow | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0),
+        )
+        info = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or stat.S_IMODE(info.st_mode) & 0o077
+            or info.st_size > _DIRECT_QUEUE_HUB_TOKEN_MAX_BYTES
+        ):
+            raise ConfigurationError("invalid")
+        chunks: list[bytes] = []
+        remaining = _DIRECT_QUEUE_HUB_TOKEN_MAX_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > _DIRECT_QUEUE_HUB_TOKEN_MAX_BYTES:
+            raise ConfigurationError("invalid")
+        return _validate_bearer(data.decode("utf-8").rstrip("\r\n"))
+    except ConfigurationError:
+        raise
+    except (OSError, UnicodeDecodeError):
+        raise ConfigurationError("invalid") from None
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                raise ConfigurationError("invalid") from None
 
 
 def _read_mode600_secret(path: Path) -> str:

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import grokbot_jobs
+from brigade import fleet_client_grokbot, grokbot_jobs
 from brigade import cli
 
 
@@ -696,6 +696,95 @@ def test_corrupted_idempotency_record_fails_closed(tmp_path: Path):
 
 def _run_grokbot(target: Path, *command: str) -> int:
     return cli.main(["run", "cloud", "grokbot", *command, "--target", str(target)])
+
+
+def test_cli_queue_lifecycle_uses_generic_listener_identity_file(tmp_path: Path, monkeypatch, capsys):
+    token = "direct-queue-listener-token"
+    token_file = tmp_path / "listener.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.setenv("BRIGADE_GROKBOT_HUB_TOKEN_FILE", str(token_file))
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "status",
+        lambda *_args, **_kwargs: seen.append(fleet_client_grokbot.current_listener_token()) or {"jobs": []},
+    )
+
+    assert _run_grokbot(tmp_path, "status", "--json") == 0
+    assert json.loads(capsys.readouterr().out) == {"jobs": []}
+    assert seen == [token]
+
+
+def test_cli_queue_lifecycle_keeps_host_identity_without_generic_listener_file(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.delenv("BRIGADE_GROKBOT_HUB_TOKEN_FILE", raising=False)
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "status",
+        lambda *_args, **_kwargs: seen.append(fleet_client_grokbot.current_listener_token()) or {"jobs": []},
+    )
+
+    assert _run_grokbot(tmp_path, "status", "--json") == 0
+    assert json.loads(capsys.readouterr().out) == {"jobs": []}
+    assert seen == [None]
+
+
+@pytest.mark.parametrize("kind", ("relative", "symlink", "directory", "unsafe-mode"))
+def test_cli_queue_lifecycle_rejects_unsafe_generic_listener_file_before_hub_call(
+    tmp_path: Path, monkeypatch, capsys, kind: str
+):
+    token = "direct-queue-token-must-not-leak"
+    configured_path = tmp_path / "listener.hub-token"
+    if kind == "relative":
+        configured_text = "listener.hub-token"
+    elif kind == "symlink":
+        target = tmp_path / "real.hub-token"
+        target.write_text(token + "\n", encoding="utf-8")
+        target.chmod(0o600)
+        configured_path.symlink_to(target)
+        configured_text = str(configured_path)
+    elif kind == "directory":
+        configured_path.mkdir()
+        configured_text = str(configured_path)
+    else:
+        configured_path.write_text(token + "\n", encoding="utf-8")
+        configured_path.chmod(0o640)
+        configured_text = str(configured_path)
+    monkeypatch.setenv("BRIGADE_GROKBOT_HUB_TOKEN_FILE", configured_text)
+    hub_calls: list[object] = []
+    monkeypatch.setattr(grokbot_jobs, "status", lambda *_args, **_kwargs: hub_calls.append(object()) or {"jobs": []})
+
+    assert _run_grokbot(tmp_path, "status") == 2
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err
+    assert hub_calls == []
+    assert token not in rendered
+    assert configured_text not in rendered
+
+
+def test_cli_generic_listener_identity_does_not_override_hub_role_policy(tmp_path: Path, monkeypatch, capsys):
+    token = "role-checked-listener-token"
+    token_file = tmp_path / "listener.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.setenv("BRIGADE_GROKBOT_HUB_TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "list_jobs",
+        lambda **_kwargs: (
+            seen.append(fleet_client_grokbot.current_listener_token())
+            or fleet_client_grokbot.GrokbotHubDecision(False, "role-forbidden")
+        ),
+    )
+
+    assert _run_grokbot(tmp_path, "status") == 2
+    captured = capsys.readouterr()
+    assert seen == [token]
+    assert captured.out == ""
+    assert captured.err.strip() == "error: role-forbidden"
 
 
 def test_cli_grokbot_lifecycle_commands_keep_private_content_out_of_output(tmp_path: Path, capsys):


### PR DESCRIPTION
## Summary

- bind direct Grok Bot queue lifecycle commands to a dedicated listener identity when the generic token-file reference is present
- load that credential through a bounded no-follow descriptor and reject unsafe paths before Hub access
- preserve ordinary host identity and every non-lifecycle Grok Bot command path

## Verification

- focused: `./scripts/verify-focused tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py`
  - 173 passed, 4 optional-extra skips
  - receipt `20260830-203320-work-verify-334ffe`
- full: `./scripts/verify`
  - exit 0
  - receipt `20260830-203344-work-verify-1b6a23`
