### PR TITLE
fix(grokbot): bind feed service actor identity

### DIFF
--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -162,8 +162,8 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_grokbot_enroll.add_argument(
         "--role",
         required=True,
-        choices=("operator", "repository-scout", "implementation-worker"),
-        help="Fixed listener actor kind. Worker kinds also receive the matching queue role.",
+        choices=("feed", "control", "operator", "repository-scout", "implementation-worker"),
+        help="Fixed Grok Bot actor kind. Worker kinds also receive the matching queue role.",
     )
     p_grokbot_enroll.add_argument("--json", action="store_true", help="Emit safe enrollment metadata as JSON.")
     p_grokbot_enroll.set_defaults(func=_dispatch_grokbot_enroll_actor)

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -1172,13 +1172,17 @@ def _dispatch_grokbot(args, target: Path) -> int:
 
 def _dispatch_grokbot_feed(args, target: Path) -> int:
     """Validate or apply an approved feed without printing private task context."""
-    from .. import grokbot_feed
+    from .. import grokbot_feed, grokbot_mcp
 
     try:
         if args.apply:
-            result = grokbot_feed.apply(target, args.manifest, limit=args.limit)
+            with _feed_hub_identity(target):
+                result = grokbot_feed.apply(target, args.manifest, limit=args.limit)
         else:
             result = grokbot_feed.preflight(target, args.manifest, limit=args.limit)
+    except grokbot_mcp.ConfigurationError:
+        print("error: Grok Bot feed configuration is invalid", file=sys.stderr)
+        return 2
     except grokbot_feed.FeedError as exc:
         if exc.reason == "queue-error" and exc.index is not None:
             print(f"error: queue-error index={exc.index}", file=sys.stderr)
@@ -1204,15 +1208,31 @@ def _print_feed_result(result: dict) -> None:
         print(f"job {job['job_id']} state={job['state']}")
 
 
+def _feed_hub_identity(target: Path) -> ContextManager[None]:
+    """Bind the dedicated feed actor for Hub mutations, with no fallback."""
+    from .. import fleet_client_grokbot, grokbot_jobs, grokbot_mcp
+
+    if not grokbot_jobs.hub_authority(target):
+        return nullcontext()
+    token = grokbot_mcp.load_feed_hub_token()
+    if token is None:
+        raise grokbot_mcp.ConfigurationError("invalid")
+    return fleet_client_grokbot.listener_identity(token)
+
+
 def _dispatch_grokbot_scout_feed(args, target: Path) -> int:
     """Preview or enqueue one approved scout without exposing policy content."""
-    from .. import grokbot_scout_feed
+    from .. import grokbot_mcp, grokbot_scout_feed
 
     try:
         if args.apply:
-            result = grokbot_scout_feed.apply(target, args.policy)
+            with _feed_hub_identity(target):
+                result = grokbot_scout_feed.apply(target, args.policy)
         else:
             result = grokbot_scout_feed.preflight(target, args.policy)
+    except grokbot_mcp.ConfigurationError:
+        print("error: Grok Bot feed configuration is invalid", file=sys.stderr)
+        return 2
     except grokbot_scout_feed.ScoutFeedError as exc:
         print(f"error: {exc.reason}", file=sys.stderr)
         return 2
@@ -1237,6 +1257,9 @@ def _print_scout_feed_result(result: dict) -> None:
 
 def _dispatch_grokbot_reconcile(args, target: Path) -> int:
     """Preview or draft canonical-owner handoffs without printing report text."""
+    # Reconciliation reads completed report bytes and writes the owner inbox.
+    # The control actor has only enqueue/whoami authority, so it cannot safely
+    # stand in for this local canonical-owner path.
     from .. import grokbot_reconcile
 
     try:

--- a/src/brigade/fleet_client_grokbot.py
+++ b/src/brigade/fleet_client_grokbot.py
@@ -66,7 +66,7 @@ _OK_KEYS = {
     "ack-cancel": "acknowledged",
 }
 _LISTENER_TOKEN: ContextVar[str | None] = ContextVar("grokbot_listener_token", default=None)
-GROKBOT_LISTENER_ACTORS = frozenset({"operator", "implementation-worker", "repository-scout"})
+GROKBOT_LISTENER_ACTORS = frozenset({"feed", "control", "operator", "implementation-worker", "repository-scout"})
 GROKBOT_WORKER_ROLES = frozenset({"implementation-worker", "repository-scout"})
 _BOUNDED_REFUSAL_REASONS = frozenset(
     {

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -33,6 +33,7 @@ _FLEET_BEST_EFFORT = frozenset({"no-hub", "no-identity", "hub-unavailable"})
 ENVIRONMENT_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,127}$")
 _DIRECT_QUEUE_HUB_TOKEN_FILE_ENV = "BRIGADE_GROKBOT_HUB_TOKEN_FILE"
 _DIRECT_QUEUE_HUB_TOKEN_MAX_BYTES = 4098
+_FEED_HUB_TOKEN_FILE_ENV = "BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE"
 
 OPERATOR_TOOLS = frozenset(
     {
@@ -165,9 +166,22 @@ def load_direct_queue_listener_token() -> str | None:
     path_text = os.environ.get(_DIRECT_QUEUE_HUB_TOKEN_FILE_ENV)
     if path_text is None:
         return None
-    path = Path(path_text)
+    return _read_descriptor_safe_token_file(Path(path_text))
+
+
+def load_feed_hub_token() -> str | None:
+    """Load the feed actor's dedicated Fleet Hub token without fallback."""
+    path_text = os.environ.get(_FEED_HUB_TOKEN_FILE_ENV)
+    if path_text is None:
+        return None
+    return _read_descriptor_safe_token_file(Path(path_text))
+
+
+def _read_descriptor_safe_token_file(path: Path) -> str:
+    """Read one owner-private token through a no-follow descriptor."""
     no_follow = getattr(os, "O_NOFOLLOW", None)
-    if not path.is_absolute() or not isinstance(no_follow, int) or no_follow == 0:
+    owner = getattr(os, "getuid", None)
+    if not path.is_absolute() or not isinstance(no_follow, int) or no_follow == 0 or not callable(owner):
         raise ConfigurationError("invalid")
 
     descriptor: int | None = None
@@ -179,6 +193,7 @@ def load_direct_queue_listener_token() -> str | None:
         info = os.fstat(descriptor)
         if (
             not stat.S_ISREG(info.st_mode)
+            or info.st_uid != owner()
             or stat.S_IMODE(info.st_mode) & 0o077
             or info.st_size > _DIRECT_QUEUE_HUB_TOKEN_MAX_BYTES
         ):
@@ -197,7 +212,7 @@ def load_direct_queue_listener_token() -> str | None:
         return _validate_bearer(data.decode("utf-8").rstrip("\r\n"))
     except ConfigurationError:
         raise
-    except (OSError, UnicodeDecodeError):
+    except (OSError, UnicodeDecodeError, ValueError):
         raise ConfigurationError("invalid") from None
     finally:
         if descriptor is not None:

--- a/tests/test_fleet_cloud.py
+++ b/tests/test_fleet_cloud.py
@@ -756,6 +756,7 @@ OTHER_WORKER = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
 OPERATOR_NODE = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
 SCOUT_NODE = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
 OTHER_FEED = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+CONTROL_NODE = "12121212-1212-4212-8212-121212121212"
 QUEUE_ID = "grokbot-queue-main"
 OTHER_QUEUE = "grokbot-queue-other"
 
@@ -1061,6 +1062,19 @@ def test_grokbot_actor_policy_isolates_node_queue_and_role(conn):
         fleet_hub_grokbot.handle_grokbot(
             conn, {"action": "claim", **_claim_body(job["job_id"])}, caller_node=OPERATOR_NODE
         )
+
+
+def test_grokbot_control_actor_is_enqueue_only_administrative_readiness(conn):
+    from brigade import fleet_hub_grokbot
+
+    _enroll_actors(conn)
+    _enroll_actor(conn, CONTROL_NODE, kind="control", queue_id=QUEUE_ID)
+
+    status, payload = fleet_hub_grokbot.handle_grokbot(conn, {"action": "whoami"}, caller_node=CONTROL_NODE)
+    assert status == 200
+    assert payload == {"actor_kind": "control", "role": None}
+    with pytest.raises(fleet_hub.FleetHubForbidden):
+        fleet_hub_grokbot.handle_grokbot(conn, {"action": "list"}, caller_node=CONTROL_NODE)
 
 
 def test_grokbot_operation_replay_and_revision_fencing(conn):

--- a/tests/test_fleet_nodes.py
+++ b/tests/test_fleet_nodes.py
@@ -513,6 +513,45 @@ class TestNodesCli:
             conn.close()
         assert policy == (NODE_A, NODE_A, "grokbot-queue-main", "repository-scout", "repository-scout", 1)
 
+    @pytest.mark.parametrize("actor_kind", ("feed", "control"))
+    def test_grokbot_enroll_actor_cli_accepts_service_actor_kinds(self, monkeypatch, capsys, actor_kind):
+        from brigade import cli
+
+        calls: list[dict[str, str]] = []
+        monkeypatch.setattr(
+            fleet_client_grokbot,
+            "enroll_actor",
+            lambda **kwargs: calls.append(kwargs) or {"enrolled": True, "node_id": NODE_A},
+        )
+
+        assert (
+            cli.main(
+                [
+                    "fleet",
+                    "grokbot",
+                    "enroll-actor",
+                    NODE_A,
+                    "--queue-owner-node-id",
+                    NODE_A,
+                    "--queue-id",
+                    "grokbot-queue-main",
+                    "--role",
+                    actor_kind,
+                    "--json",
+                ]
+            )
+            == 0
+        )
+        assert json.loads(capsys.readouterr().out) == {"enrolled": True, "node_id": NODE_A}
+        assert calls == [
+            {
+                "node_id": NODE_A,
+                "queue_owner_node_id": NODE_A,
+                "queue_id": "grokbot-queue-main",
+                "actor_kind": actor_kind,
+            }
+        ]
+
     def test_add_list_revoke_round_trip(self, hub, capsys):
         from brigade import cli
 

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, grokbot_feed, grokbot_jobs
+from brigade import cli, fleet_client_grokbot, grokbot_feed, grokbot_jobs
 
 
 SECRET_INSTRUCTIONS = "SECRET_INSTRUCTION_DO_NOT_PRINT"
@@ -426,6 +426,84 @@ def test_cli_feed_defaults_to_validation_only(tmp_path: Path, capsys):
     assert SECRET_VERIFY not in captured.out
     assert SECRET_OWNERSHIP not in captured.out
     assert not _queue_root(tmp_path).exists()
+
+
+def test_cli_feed_preview_needs_no_feed_identity_or_hub_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "enqueue",
+        lambda *_args, **_kwargs: pytest.fail("preview must not enqueue through the hub"),
+    )
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest)) == 0
+    assert "valid=1" in capsys.readouterr().out
+
+
+def test_cli_feed_apply_binds_dedicated_feed_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):
+    token = "dedicated-feed-token"
+    token_file = tmp_path / "feed.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.setenv("BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "enqueue",
+        lambda *_args, **_kwargs: (
+            seen.append(fleet_client_grokbot.current_listener_token())
+            or {"job_id": "grokbot-" + "a" * 24, "state": "queued", "idempotent": False}
+        ),
+    )
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply") == 0
+    assert seen == [token]
+    assert token not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("kind", ("missing", "relative", "symlink", "directory", "unsafe-mode"))
+def test_cli_feed_apply_rejects_unsafe_dedicated_identity_before_enqueue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys, kind: str
+):
+    token = "dedicated-feed-token-must-not-leak"
+    configured_path = tmp_path / "feed.hub-token"
+    if kind == "missing":
+        configured_text = str(configured_path)
+    elif kind == "relative":
+        configured_text = "feed.hub-token"
+    elif kind == "symlink":
+        target = tmp_path / "real.hub-token"
+        target.write_text(token + "\n", encoding="utf-8")
+        target.chmod(0o600)
+        configured_path.symlink_to(target)
+        configured_text = str(configured_path)
+    elif kind == "directory":
+        configured_path.mkdir()
+        configured_text = str(configured_path)
+    else:
+        configured_path.write_text(token + "\n", encoding="utf-8")
+        configured_path.chmod(0o640)
+        configured_text = str(configured_path)
+    monkeypatch.setenv("BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE", configured_text)
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    hub_calls: list[object] = []
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "enqueue",
+        lambda *_args, **_kwargs: hub_calls.append(object()) or pytest.fail("unsafe feed token must block enqueue"),
+    )
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply") == 2
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err
+    assert hub_calls == []
+    assert rendered == "error: Grok Bot feed configuration is invalid\n"
+    assert token not in rendered
+    assert configured_text not in rendered
 
 
 def test_cli_feed_apply_limit_1_then_repeats_to_the_next_unknown(tmp_path: Path, capsys):

--- a/tests/test_grokbot_mcp.py
+++ b/tests/test_grokbot_mcp.py
@@ -1603,6 +1603,11 @@ def _write_hub_token_file(path: Path, token: str) -> Path:
     return path
 
 
+def test_descriptor_safe_hub_token_reader_rejects_nul_path():
+    with pytest.raises(grokbot_mcp.ConfigurationError, match="^invalid$"):
+        grokbot_mcp._read_descriptor_safe_token_file(Path("/tmp/invalid\x00hub-token"))
+
+
 def test_three_listeners_use_distinct_hub_node_tokens_and_public_args_cannot_override(tmp_path: Path, monkeypatch):
     from brigade import fleet_client_grokbot
 

--- a/tests/test_grokbot_scout_feed.py
+++ b/tests/test_grokbot_scout_feed.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, grokbot_scout_feed
+from brigade import cli, fleet_client_grokbot, grokbot_jobs, grokbot_scout_feed
 
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
@@ -506,6 +506,34 @@ def test_cli_scout_feed_apply_json_creates_one_queued_job(tmp_path: Path, monkey
     assert payload["issue_number"] == 7
     assert payload["handle"]["state"] == "queued"
     assert len(list((tmp_path / ".brigade" / "cloud" / "grokbot" / "jobs").glob("*.json"))) == 1
+
+
+def test_cli_scout_feed_apply_binds_dedicated_feed_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):
+    token = "dedicated-scout-feed-token"
+    token_file = tmp_path / "feed.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.setenv("BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    _gh_numbers(monkeypatch, [7])
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "enqueue_repository_scout",
+        lambda *_args, **_kwargs: (
+            seen.append(fleet_client_grokbot.current_listener_token())
+            or {
+                "reason": "created",
+                "created_today": 1,
+                "handle": {"job_id": "grokbot-" + "a" * 24, "state": "queued", "idempotent": False},
+            }
+        ),
+    )
+    policy = _write_policy(tmp_path / "policy.json", _policy())
+
+    assert _run_scout_feed(tmp_path, policy, "--apply") == 0
+    assert seen == [token]
+    assert token not in capsys.readouterr().out
 
 
 def test_cli_scout_feed_text_reports_no_work_without_private_policy_context(


### PR DESCRIPTION
## Summary

- allow dedicated `feed` and `control` Grok Bot actor enrollment
- bind feed and scout-feed apply operations to a private feed actor token
- fail closed on missing, unsafe, or malformed token files before Hub mutation
- leave report reconciliation outside the enqueue-only control role

## Verification

- `./scripts/verify-focused tests/test_grokbot_feed.py tests/test_grokbot_scout_feed.py tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py tests/test_fleet_nodes.py tests/test_fleet_cloud.py`
- `./scripts/verify`
- full receipt: `20260830-214135-work-verify-661620`