### PR TITLE
fix(grokbot): bind doctor queue identity

### DIFF
--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -177,6 +177,11 @@ def load_feed_hub_token() -> str | None:
     return _read_descriptor_safe_token_file(Path(path_text))
 
 
+def load_hub_token_file(path: Path) -> str:
+    """Load one configured Fleet Hub listener token from a safe file."""
+    return _read_descriptor_safe_token_file(path)
+
+
 def _read_descriptor_safe_token_file(path: Path) -> str:
     """Read one owner-private token through a no-follow descriptor."""
     no_follow = getattr(os, "O_NOFOLLOW", None)

--- a/src/brigade/grokbot_ops.py
+++ b/src/brigade/grokbot_ops.py
@@ -187,9 +187,19 @@ def doctor(target: Path, instance: str, *, timeout: int = DEFAULT_TIMEOUT_SECOND
     record("permissions", bool(writable))
 
     try:
-        grokbot_jobs.status(target)
+        hub_token_file = config.get("hub_token_file")
+        if hub_token_file is None:
+            grokbot_jobs.status(target)
+        else:
+            if not isinstance(hub_token_file, str):
+                raise grokbot_mcp.ConfigurationError("invalid")
+            from . import fleet_client_grokbot
+
+            hub_token = grokbot_mcp.load_hub_token_file(Path(hub_token_file))
+            with fleet_client_grokbot.listener_identity(hub_token):
+                grokbot_jobs.status(target)
         record("queue", True)
-    except (grokbot_jobs.GrokbotJobError, ValueError, OSError):
+    except (grokbot_jobs.GrokbotJobError, grokbot_mcp.ConfigurationError, ValueError, OSError):
         record("queue", False)
 
     record("endpoint", _health_check(config, bearer, timeout))

--- a/tests/test_grokbot_ops.py
+++ b/tests/test_grokbot_ops.py
@@ -314,6 +314,73 @@ def test_doctor_reports_sanitized_checks_without_private_content(tmp_path: Path,
     assert "PRIVATE_INSTRUCTIONS_MUST_NOT_LEAK" not in combined
 
 
+@pytest.mark.parametrize("instance", ("operator", "repository-scout", "implementation-worker"))
+def test_doctor_uses_configured_listener_actor_for_hub_queue_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, instance: str
+):
+    from brigade import fleet_client_grokbot
+
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    token = f"{instance}-listener-token"
+    token_file = tmp_path / f"{instance}.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    assert _setup(tmp_path, instance, ["--hub-token-file", str(token_file)]) == 0
+
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "status",
+        lambda _target: seen.append(fleet_client_grokbot.current_listener_token()) or {"jobs": []},
+    )
+
+    checks = grokbot_ops.doctor(tmp_path, instance)
+
+    assert {check["check"]: check["status"] for check in checks}["queue"] == "ok"
+    assert seen == [token]
+
+
+def test_doctor_keeps_host_identity_without_configured_listener_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from brigade import fleet_client_grokbot
+
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    assert _setup(tmp_path, "operator") == 0
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "status",
+        lambda _target: seen.append(fleet_client_grokbot.current_listener_token()) or {"jobs": []},
+    )
+
+    checks = grokbot_ops.doctor(tmp_path, "operator")
+
+    assert {check["check"]: check["status"] for check in checks}["queue"] == "ok"
+    assert seen == [None]
+
+
+def test_doctor_refuses_changed_unsafe_listener_token_file_without_secret_or_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    token = SECRET
+    token_file = tmp_path / "listener.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    assert _setup(tmp_path, "operator", ["--hub-token-file", str(token_file)]) == 0
+    token_file.chmod(0o640)
+    status_calls: list[object] = []
+    monkeypatch.setattr(grokbot_jobs, "status", lambda _target: status_calls.append(object()) or {"jobs": []})
+
+    checks = grokbot_ops.doctor(tmp_path, "operator")
+
+    statuses = {check["check"]: check["status"] for check in checks}
+    assert statuses["config"] == "fail"
+    assert "queue" not in statuses
+    assert status_calls == []
+    assert token not in json.dumps(checks)
+    assert str(token_file) not in json.dumps(checks)
+
+
 def test_doctor_fails_cleanly_on_missing_config(tmp_path: Path, capsys):
     assert cli.main(["run", "cloud", "grokbot", "doctor", "--target", str(tmp_path), "--instance", "operator"]) == 1
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

- bind each queue-role doctor probe to its configured Fleet Hub listener actor
- preserve the host identity when no listener token reference is configured
- reuse the bounded, no-follow token reader and fail closed without exposing paths or values

## Verification

- `20260830-224333-work-verify-d927c8`: 220 passed, 4 optional-extra skips
- `20260830-224418-work-verify-cfa75b`: live repository-scout doctor passed against the queue target
- `20260830-230112-work-verify-083537`: focused follow-up and content-guard verification passed
- `20260830-224443-work-verify-20d1a1`: the single local full gate passed static checks and reached 6% of pytest before its 900-second receipt timeout, with no stderr or test failure; exact-head GitHub CI is the terminal full gate
- independent OpenAI gpt-5.6-sol review found zero unresolved Critical or Important findings

Refs #1255