### PR TITLE
fix(fleet): classify grokbot enqueue replays

### DIFF
--- a/src/brigade/fleet_hub_grokbot.py
+++ b/src/brigade/fleet_hub_grokbot.py
@@ -915,7 +915,10 @@ def _replay_operation(conn: sqlite3.Connection, request: dict[str, Any]) -> tupl
         return None, True
     if row[4] not in (None, request["queue_owner_node_id"]):
         return None, True
-    return json.loads(row[1]), False
+    payload = json.loads(row[1])
+    if request["action"] == "enqueue" and payload.get("enqueued") is True:
+        payload["idempotent"] = True
+    return payload, False
 
 
 def _store_operation(conn: sqlite3.Connection, request: dict[str, Any], payload: dict[str, Any]) -> None:

--- a/tests/test_fleet_cloud.py
+++ b/tests/test_fleet_cloud.py
@@ -887,10 +887,29 @@ def test_grokbot_hub_is_authoritative_for_enqueue_claim_renew_and_replay(conn):
     _enroll_actors(conn)
     first = fleet_hub_grokbot.handle_grokbot(conn, _grokbot_enqueue(), caller_node=FEED_NODE)
     assert first[0] == 200 and first[1]["idempotent"] is False
+    before = conn.execute(
+        "SELECT state, item_revision, sequence FROM grokbot_jobs WHERE job_id=?", (first[1]["job"]["job_id"],)
+    ).fetchone()
+    event_count = conn.execute("SELECT COUNT(*) FROM events WHERE harness='grokbot'").fetchone()[0]
+    job_count = conn.execute("SELECT COUNT(*) FROM grokbot_jobs").fetchone()[0]
     same_op = fleet_hub_grokbot.handle_grokbot(conn, _grokbot_enqueue(), caller_node=FEED_NODE)
     assert same_op[0] == 200
-    assert same_op[1]["job"]["item_revision"] == first[1]["job"]["item_revision"] == 1
-    assert same_op[1]["job"]["sequence"] == first[1]["job"]["sequence"] == 1
+    assert same_op[1]["idempotent"] is True
+    assert same_op[1]["job"] == first[1]["job"]
+    assert (
+        conn.execute(
+            "SELECT state, item_revision, sequence FROM grokbot_jobs WHERE job_id=?", (first[1]["job"]["job_id"],)
+        ).fetchone()
+        == before
+    )
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE harness='grokbot'").fetchone()[0] == event_count
+    assert conn.execute("SELECT COUNT(*) FROM grokbot_jobs").fetchone()[0] == job_count
+    mismatch = fleet_hub_grokbot.handle_grokbot(
+        conn,
+        {**_grokbot_enqueue(), "label": "different label"},
+        caller_node=FEED_NODE,
+    )
+    assert mismatch == (409, {"enqueued": False, "error": "operation-mismatch"})
     replay = fleet_hub_grokbot.handle_grokbot(
         conn, _grokbot_enqueue(operation_id="op-enqueue-retry"), caller_node=FEED_NODE
     )

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, fleet_client_grokbot, grokbot_feed, grokbot_jobs
+from brigade import cli, fleet_client_grokbot, fleet_hub, fleet_hub_grokbot, grokbot_feed, grokbot_jobs
 
 
 SECRET_INSTRUCTIONS = "SECRET_INSTRUCTION_DO_NOT_PRINT"
@@ -281,6 +281,68 @@ def test_apply_repeated_run_skips_known_and_creates_next_unknown(tmp_path: Path)
     assert result["jobs"][1]["job_id"] != first_id
     assert len(_job_files(tmp_path)) == 2
     _assert_redacted(result)
+
+
+def test_apply_hub_replay_is_skipped_without_duplicate_job_or_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    feed_node = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    connection = fleet_hub.init_db(tmp_path / "fleet.db")
+    try:
+        status, payload = fleet_hub_grokbot.handle_grokbot(
+            connection,
+            {
+                "action": "enroll-actor",
+                "enroll_node_id": feed_node,
+                "queue_owner_node_id": feed_node,
+                "queue_id": "grokbot-feed-test",
+                "actor_kind": "feed",
+                "enabled": True,
+            },
+            caller_node=None,
+        )
+        assert (status, payload) == (200, {"enrolled": True, "node_id": feed_node})
+
+        def enqueue(**fields: object) -> fleet_client_grokbot.GrokbotHubDecision:
+            status, payload = fleet_hub_grokbot.handle_grokbot(
+                connection,
+                {"action": "enqueue", **fields},
+                caller_node=feed_node,
+            )
+            return fleet_client_grokbot.GrokbotHubDecision(
+                granted=status == 200 and payload.get("enqueued") is True,
+                reason=payload.get("error", "") if isinstance(payload, dict) else "invalid-response",
+                job=payload.get("job") if isinstance(payload, dict) else None,
+                idempotent=payload.get("idempotent") is True if isinstance(payload, dict) else False,
+            )
+
+        monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+        monkeypatch.setattr(fleet_client_grokbot, "enqueue", enqueue)
+        manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+        first = grokbot_feed.apply(tmp_path, manifest)
+        job_id = first["jobs"][0]["job_id"]
+        before = connection.execute(
+            "SELECT state, item_revision, sequence FROM grokbot_jobs WHERE job_id=?", (job_id,)
+        ).fetchone()
+        event_count = connection.execute("SELECT COUNT(*) FROM events WHERE harness='grokbot'").fetchone()[0]
+
+        second = grokbot_feed.apply(tmp_path, manifest)
+
+        assert first["created"] == 1
+        assert first["skipped"] == 0
+        assert second["known"] == 0
+        assert second["created"] == 0
+        assert second["skipped"] == 1
+        assert second["jobs"] == [{"job_id": job_id, "state": "queued", "idempotent": True}]
+        assert (
+            connection.execute(
+                "SELECT state, item_revision, sequence FROM grokbot_jobs WHERE job_id=?", (job_id,)
+            ).fetchone()
+            == before
+        )
+        assert connection.execute("SELECT COUNT(*) FROM grokbot_jobs").fetchone()[0] == 1
+        assert connection.execute("SELECT COUNT(*) FROM events WHERE harness='grokbot'").fetchone()[0] == event_count
+    finally:
+        connection.close()
 
 
 def test_apply_invalid_later_entry_prevents_all_writes(tmp_path: Path):


### PR DESCRIPTION
## Summary

- mark exact successful Grok Bot enqueue operation replays as idempotent
- preserve stored job state, revision, sequence, and event count
- lock Hub and feed replay behavior with mismatch and duplicate regressions

## Verification

- focused Hub/feed gate: `20260830-225450-work-verify-193e21`
- full gate: `20260830-235626-work-verify-1c8d25` ran 10,969 passing tests and failed only the unrelated timeout-latch timing test
- isolated timeout-latch test: `20260831-003051-work-verify-f2ebae` passed
