### PR TITLE
fix(fleet): collapse Grok Bot lifecycle truth

### DIFF
--- a/src/brigade/fleet_command_deck.py
+++ b/src/brigade/fleet_command_deck.py
@@ -324,7 +324,8 @@ def collides(target: str, live_runs: Sequence[LiveRun], claims: Mapping[str, Cla
 _LATEST_ROWS = (
     "SELECT node_id, run_id, repo, seat, harness, state, ts, received_at, repo_identity FROM ("
     "  SELECT e.*, ROW_NUMBER() OVER ("
-    "    PARTITION BY node_id, run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
+    "    PARTITION BY CASE WHEN harness = 'grokbot' THEN 'grokbot' ELSE 'node:' || node_id END, run_id "
+    "    ORDER BY sequence DESC, received_at DESC, digest DESC"
     "  ) AS rn FROM events e"
     ") WHERE rn = 1"
 )
@@ -359,7 +360,7 @@ def fetch_live_runs(conn: sqlite3.Connection, *, now: datetime, stale_after_seco
         f" ORDER BY {rank_sql}, ts DESC, node_id, run_id LIMIT {ACTIVE_LIMIT}"
     )
     rows = conn.execute(query, (*TERMINAL_STATES, cutoff, *AWAITING_STATES)).fetchall()
-    started = fetch_started_at(conn, [(row[0], row[1]) for row in rows])
+    started = fetch_started_at(conn, [(row[0], row[1], row[4]) for row in rows])
     runs: list[LiveRun] = []
     for node_id, run_id, repo, seat, harness, state, _ts, received_at, repo_identity in rows:
         age = _age_seconds(received_at, now)
@@ -380,22 +381,44 @@ def fetch_live_runs(conn: sqlite3.Connection, *, now: datetime, stale_after_seco
     return runs
 
 
-def fetch_started_at(conn: sqlite3.Connection, keys: Sequence[tuple[str, str]]) -> dict[tuple[str, str], str]:
+def fetch_started_at(
+    conn: sqlite3.Connection, runs: Sequence[tuple[str, str, str | None]]
+) -> dict[tuple[str, str], str]:
     result: dict[tuple[str, str], str] = {}
-    for start in range(0, len(keys), _START_CHUNK):
-        chunk = keys[start : start + _START_CHUNK]
+    generic_keys = [(node_id, run_id) for node_id, run_id, harness in runs if harness != "grokbot"]
+    for start in range(0, len(generic_keys), _START_CHUNK):
+        chunk = generic_keys[start : start + _START_CHUNK]
         predicate = " OR ".join("(node_id = ? AND run_id = ?)" for _ in chunk)
         params = [value for pair in chunk for value in pair]
         rows = conn.execute(
             "SELECT node_id, run_id, ts FROM ("
             "  SELECT node_id, run_id, ts, ROW_NUMBER() OVER ("
             "    PARTITION BY node_id, run_id ORDER BY sequence ASC, received_at ASC, digest ASC"
-            "  ) AS rn FROM events WHERE " + predicate + ")"
+            "  ) AS rn FROM events WHERE (" + predicate + ") AND (harness IS NULL OR harness != 'grokbot')"
+            ")"
             " WHERE rn = 1",
             params,
         ).fetchall()
         for row in rows:
             result[(row[0], row[1])] = row[2]
+
+    grokbot_keys = [(node_id, run_id) for node_id, run_id, harness in runs if harness == "grokbot"]
+    for start in range(0, len(grokbot_keys), _START_CHUNK):
+        chunk = grokbot_keys[start : start + _START_CHUNK]
+        run_ids = tuple({run_id for _node_id, run_id in chunk})
+        placeholders = ",".join("?" for _ in run_ids)
+        rows = conn.execute(
+            "SELECT run_id, ts FROM ("
+            "  SELECT run_id, ts, ROW_NUMBER() OVER ("
+            "    PARTITION BY run_id ORDER BY sequence ASC, received_at ASC, digest ASC"
+            "  ) AS rn FROM events WHERE harness = 'grokbot' AND run_id IN (" + placeholders + ")"
+            ") WHERE rn = 1",
+            run_ids,
+        ).fetchall()
+        started_by_run_id = {row[0]: row[1] for row in rows}
+        for node_id, run_id in chunk:
+            if run_id in started_by_run_id:
+                result[(node_id, run_id)] = started_by_run_id[run_id]
     return result
 
 

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -748,13 +748,30 @@ def set_run_preference(conn: sqlite3.Connection, raw: Any, *, updated_by: str | 
 
 
 def run_started_at(conn: sqlite3.Connection) -> dict[tuple[str, str], str]:
-    """Timestamp of the first observed event per (node_id, run_id), for elapsed."""
+    """Timestamp of the first observed event per dashboard run key, for elapsed."""
     rows = conn.execute(
-        "SELECT node_id, run_id, ts FROM ("
-        "  SELECT node_id, run_id, ts, ROW_NUMBER() OVER ("
+        "WITH starts AS ("
+        "  SELECT node_id, run_id, harness, ts, ROW_NUMBER() OVER ("
         "    PARTITION BY node_id, run_id ORDER BY sequence ASC, received_at ASC, digest ASC"
         "  ) AS rn FROM events"
-        ") WHERE rn = 1"
+        "), latest_grokbot AS ("
+        "  SELECT node_id, run_id FROM ("
+        "    SELECT node_id, run_id, ROW_NUMBER() OVER ("
+        "      PARTITION BY run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
+        "    ) AS rn FROM events WHERE harness = 'grokbot'"
+        "  ) WHERE rn = 1"
+        "), first_grokbot AS ("
+        "  SELECT run_id, ts FROM ("
+        "    SELECT run_id, ts, ROW_NUMBER() OVER ("
+        "      PARTITION BY run_id ORDER BY sequence ASC, received_at ASC, digest ASC"
+        "    ) AS rn FROM events WHERE harness = 'grokbot'"
+        "  ) WHERE rn = 1"
+        ") SELECT starts.node_id, starts.run_id, COALESCE(first_grokbot.ts, starts.ts)"
+        " FROM starts"
+        " LEFT JOIN latest_grokbot ON starts.harness = 'grokbot'"
+        "  AND starts.node_id = latest_grokbot.node_id AND starts.run_id = latest_grokbot.run_id"
+        " LEFT JOIN first_grokbot ON latest_grokbot.run_id = first_grokbot.run_id"
+        " WHERE starts.rn = 1"
     ).fetchall()
     return {(row[0], row[1]): row[2] for row in rows}
 

--- a/src/brigade/fleet_hub_status.py
+++ b/src/brigade/fleet_hub_status.py
@@ -49,11 +49,13 @@ def latest_status(
     active_ttl_seconds: int = ACTIVE_EVENT_TTL_SECONDS,
     stale_history_after_seconds: int = STALE_HISTORY_AFTER_SECONDS,
 ) -> list[dict[str, Any]]:
-    """Latest event per (node_id, run_id); non-terminal runs unless include_all.
+    """Latest event per run; non-terminal runs unless include_all.
 
-    Exactly one row per (node_id, run_id): ties on sequence (same sequence
-    seen with two digests) resolve to the most recently received, then the
-    larger digest, so the view never shows a run twice.
+    Normal fleet runs are keyed by ``(node_id, run_id)``. Grok Bot jobs are
+    hub-owned, so their lifecycle revisions are keyed globally by ``run_id``
+    even when the feed node and claimant differ. Ties on sequence resolve to
+    the most recently received, then the larger digest, so the view never
+    shows a run twice.
 
     History views (``include_all``) age old nonterminal rows to synthetic
     ``run.stale`` from Hub ``received_at``, keeping the recorded state in
@@ -63,7 +65,8 @@ def latest_status(
         "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, "
         "capability_fingerprint, repo_identity, received_at FROM ("
         "  SELECT e.*, ROW_NUMBER() OVER ("
-        "    PARTITION BY node_id, run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
+        "    PARTITION BY CASE WHEN harness = 'grokbot' THEN 'grokbot' ELSE 'node:' || node_id END, run_id "
+        "    ORDER BY sequence DESC, received_at DESC, digest DESC"
         "  ) AS rn FROM events e"
         ") WHERE rn = 1 ORDER BY node_id, run_id"
     ).fetchall()

--- a/tests/test_fleet_cloud.py
+++ b/tests/test_fleet_cloud.py
@@ -346,6 +346,33 @@ def test_cloud_http_routes_require_valid_auth_and_keep_dashboard_read_only(tmp_p
         assert _request(hub, "POST", "/", token=ADMIN_TOKEN, body={})[0] == 404
 
 
+def test_legacy_dashboard_start_map_uses_global_grokbot_start_for_latest_claimant(conn):
+    events = [
+        (NODE_A, "grok-run", 1, "grokbot", "external.queued", "2026-08-30T00:00:00+00:00"),
+        (NODE_B, "grok-run", 2, "grokbot", "external.running", "2026-08-30T00:10:00+00:00"),
+        (NODE_A, "shared-generic", 1, "claude", "run.started", "2026-08-30T00:20:00+00:00"),
+        (NODE_B, "shared-generic", 1, "claude", "run.started", "2026-08-30T00:30:00+00:00"),
+    ]
+    for node_id, run_id, sequence, harness, state, stamp in events:
+        conn.execute(
+            "INSERT INTO events (node_id, run_id, sequence, digest, repo, seat, harness, state, ts, received_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (node_id, run_id, sequence, f"{node_id}-{run_id}-{sequence}", "repo", "seat", harness, state, stamp, stamp),
+        )
+    conn.commit()
+
+    latest = fleet_hub.latest_status(conn, include_all=True)
+    assert [(row["node_id"], row["run_id"]) for row in latest] == [
+        (NODE_A, "shared-generic"),
+        (NODE_B, "grok-run"),
+        (NODE_B, "shared-generic"),
+    ]
+    started = fleet_hub.run_started_at(conn)
+    assert started[(NODE_B, "grok-run")] == "2026-08-30T00:00:00+00:00"
+    assert started[(NODE_A, "shared-generic")] == "2026-08-30T00:20:00+00:00"
+    assert started[(NODE_B, "shared-generic")] == "2026-08-30T00:30:00+00:00"
+
+
 def test_cloud_http_post_binds_node_token_to_lease_owner(tmp_path):
     with _hub(tmp_path) as hub:
         db = fleet_hub.open_db(hub[2])
@@ -1885,10 +1912,14 @@ def test_external_expired_is_terminal_and_releases_hub_capacity(conn):
     assert grok.used == 0
     assert grok.leases == ()
     assert fleet_hub.list_cloud_leases(conn) == []
-    live_states = {row["state"] for row in fleet_hub.latest_status(conn, include_all=False) if row["run_id"] == job_id}
-    assert "external.expired" not in live_states
-    history_states = {
-        row["state"] for row in fleet_hub.latest_status(conn, include_all=True) if row["run_id"] == job_id
-    }
-    assert "external.expired" in history_states
+    live_rows = [row for row in fleet_hub.latest_status(conn, include_all=False) if row["run_id"] == job_id]
+    assert live_rows == []
+    history_rows = [row for row in fleet_hub.latest_status(conn, include_all=True) if row["run_id"] == job_id]
+    assert [(row["node_id"], row["state"], row["sequence"]) for row in history_rows] == [
+        (WORKER_NODE, "external.expired", 3)
+    ]
+    event_count = conn.execute(
+        "SELECT COUNT(*) FROM events WHERE harness='grokbot' AND run_id=?", (job_id,)
+    ).fetchone()[0]
+    assert event_count == 3
     assert queued["job_id"] == job_id

--- a/tests/test_fleet_command_deck.py
+++ b/tests/test_fleet_command_deck.py
@@ -13,6 +13,7 @@ import pytest
 
 from brigade import fleet_command_deck as deck
 from brigade import fleet_hub
+from brigade import fleet_hub_status
 from brigade import fleet_hub_sessions
 
 NODE_A = "11111111-1111-4111-8111-111111111111"
@@ -32,6 +33,8 @@ CREATE TABLE IF NOT EXISTS events (
     ts TEXT NOT NULL,
     received_at TEXT NOT NULL,
     repo_identity TEXT,
+    exit_status INTEGER,
+    capability_fingerprint TEXT,
     PRIMARY KEY (node_id, run_id, sequence, digest)
 );
 """
@@ -52,6 +55,7 @@ def _insert(
     received_at: str | None = None,
     repo: str = "repo",
     repo_identity: str | None = None,
+    harness: str = "claude",
 ) -> None:
     stamp = ts if ts is not None else _ts(10)
     conn.execute(
@@ -64,7 +68,7 @@ def _insert(
             f"{node_id[:8]}-{run_id}-{sequence:04d}",
             repo,
             "seat",
-            "claude",
+            harness,
             state,
             stamp,
             received_at if received_at is not None else stamp,
@@ -674,6 +678,53 @@ def test_external_expired_is_terminal_and_does_not_stay_live(conn):
     )
     assert view.stations[0].busy == 1
     assert [tile.run.run_id for tile in view.stations[0].tiles] == ["live-job"]
+
+
+def test_grokbot_cross_node_revisions_use_one_global_latest_row(conn):
+    terminal_states = ("external.completed", "external.canceled", "external.expired")
+    for index, state in enumerate(terminal_states, start=1):
+        run_id = f"grok-terminal-{index}"
+        _insert(conn, NODE_A, run_id, 1, "external.queued", harness="grokbot", ts=_ts(600))
+        _insert(conn, NODE_B, run_id, 2, state, harness="grokbot", ts=_ts(60))
+
+    _insert(conn, NODE_A, "grok-running", 1, "external.queued", harness="grokbot", ts=_ts(600))
+    _insert(conn, NODE_B, "grok-running", 2, "external.running", harness="grokbot", ts=_ts(30))
+    _insert(conn, NODE_A, "shared-normal-run", 1, "run.started", ts=_ts(50))
+    _insert(conn, NODE_B, "shared-normal-run", 1, "run.started", ts=_ts(40))
+
+    live = deck.fetch_live_runs(conn, now=NOW, stale_after_seconds=1800)
+    assert [(run.node_id, run.run_id, run.state) for run in live] == [
+        (NODE_B, "grok-running", "external.running"),
+        (NODE_B, "shared-normal-run", "run.started"),
+        (NODE_A, "shared-normal-run", "run.started"),
+    ]
+    assert {(run.node_id, run.run_id): run.elapsed_seconds for run in live} == {
+        (NODE_B, "grok-running"): 600.0,
+        (NODE_B, "shared-normal-run"): 40.0,
+        (NODE_A, "shared-normal-run"): 50.0,
+    }
+    outcomes = deck.fetch_outcomes(conn, outcome_window=10)
+    assert {(run.node_id, run.run_id, run.state) for run in outcomes} == {
+        (NODE_B, "grok-terminal-1", "external.completed"),
+        (NODE_B, "grok-terminal-2", "external.canceled"),
+        (NODE_B, "grok-terminal-3", "external.expired"),
+    }
+
+    active_status = fleet_hub_status.latest_status(conn, now=NOW)
+    assert [(row["node_id"], row["run_id"]) for row in active_status] == [
+        (NODE_A, "shared-normal-run"),
+        (NODE_B, "grok-running"),
+        (NODE_B, "shared-normal-run"),
+    ]
+    all_status = fleet_hub_status.latest_status(conn, include_all=True, now=NOW)
+    assert [(row["node_id"], row["run_id"], row["state"]) for row in all_status] == [
+        (NODE_A, "shared-normal-run", "run.started"),
+        (NODE_B, "grok-running", "external.running"),
+        (NODE_B, "grok-terminal-1", "external.completed"),
+        (NODE_B, "grok-terminal-2", "external.canceled"),
+        (NODE_B, "grok-terminal-3", "external.expired"),
+        (NODE_B, "shared-normal-run", "run.started"),
+    ]
 
 
 # --- HTTP integration: hub-served Command Deck (task 2) ----------------------


### PR DESCRIPTION
## Summary

- treat Hub-owned Grok Bot lifecycle revisions as one global job stream even when enqueue and claim use different node identities
- hide completed, canceled, and expired jobs from active Fleet status while retaining one terminal history row
- preserve per-node identity for ordinary fleet runs and calculate Grok Bot elapsed time from the original enqueue event

## Live reproduction

A production job had `external.queued` on the feed node and `external.completed` on the worker node. Both status projections ranked by `(node_id, run_id)`, so the queued row remained visible as active after the authoritative job row was terminal.

## Verification

- focused gate: `20260831-121726-work-verify-215248`, 98 passed
- full gate: `20260831-121808-work-verify-921619`, 10,977 passed, 9 skipped, 82.74% coverage
- independent review sendbacks for Command Deck and legacy elapsed-time truth were applied before the full gate