### PR TITLE
fix(fleet): stop applying the hub 'none' reasoning placeholder as a pin

### DIFF
--- a/src/brigade/aboyeur_model_policy.py
+++ b/src/brigade/aboyeur_model_policy.py
@@ -80,14 +80,25 @@ _NO_REASONING_SENTINEL = "none"
 
 
 def _effective_reasoning(aboyeur: Any, cli_ref: str, policy_reasoning: str) -> str | None:
-    """Hub reasoning is a required column: ``"none"`` is its placeholder, and only
-    some adapters accept a pin at all. Either case leaves the launch spec unpinned;
-    the admission receipt still carries the Hub's exact value."""
-    if policy_reasoning.strip().lower() == _NO_REASONING_SENTINEL:
+    """Hub reasoning is a required column: ``"none"`` is its placeholder, a blank
+    string pins nothing, and only some adapters accept a pin at all. Each case
+    leaves the launch spec unpinned; the admission receipt still carries the Hub's
+    exact value, so the decision records whether the pin was applied."""
+    if not _is_reasoning_pin(policy_reasoning):
         return None
     if not aboyeur.agents.supports_reasoning(cli_ref):
         return None
     return policy_reasoning
+
+
+def _is_reasoning_pin(policy_reasoning: str) -> bool:
+    stripped = policy_reasoning.strip()
+    return bool(stripped) and stripped.lower() != _NO_REASONING_SENTINEL
+
+
+def _reasoning_pin_unsupported(aboyeur: Any, cli_ref: str, policy_reasoning: str) -> bool:
+    """True when a real Hub pin was dropped because the bound adapter takes none."""
+    return _is_reasoning_pin(policy_reasoning) and not aboyeur.agents.supports_reasoning(cli_ref)
 
 
 def _cli_from_binding(aboyeur: Any, instance_id: str) -> str | None:
@@ -437,12 +448,16 @@ def _resolve_versioned(
                 else:
                     outcome = "enabled"
                     detail = "exact seat/provider/model/reasoning/binding entry is enabled"
+                    effective_reasoning = _effective_reasoning(aboyeur, resolved_cli, policy_reasoning)
+                    decision["reasoning_applied"] = effective_reasoning is not None
+                    if _reasoning_pin_unsupported(aboyeur, resolved_cli, policy_reasoning):
+                        detail = f"{detail}; reasoning pin not supported by {resolved_cli}"
                     keep_env = _local_cli_matches_hub_binding(aboyeur, agent, binding)
                     kept_agents[seat] = replace(
                         agent,
                         cli=resolved_cli,
                         model=policy_model,
-                        reasoning=_effective_reasoning(aboyeur, resolved_cli, policy_reasoning),
+                        reasoning=effective_reasoning,
                         command=None,
                         env=agent.env if keep_env else None,
                     )

--- a/src/brigade/aboyeur_model_policy.py
+++ b/src/brigade/aboyeur_model_policy.py
@@ -76,6 +76,20 @@ def _permanent_floor(provider: object, model: object) -> str | None:
     return fleet_model_roster.retired_reason(provider, model)
 
 
+_NO_REASONING_SENTINEL = "none"
+
+
+def _effective_reasoning(aboyeur: Any, cli_ref: str, policy_reasoning: str) -> str | None:
+    """Hub reasoning is a required column: ``"none"`` is its placeholder, and only
+    some adapters accept a pin at all. Either case leaves the launch spec unpinned;
+    the admission receipt still carries the Hub's exact value."""
+    if policy_reasoning.strip().lower() == _NO_REASONING_SENTINEL:
+        return None
+    if not aboyeur.agents.supports_reasoning(cli_ref):
+        return None
+    return policy_reasoning
+
+
 def _cli_from_binding(aboyeur: Any, instance_id: str) -> str | None:
     """Map a Hub Brigade binding onto a known adapter key."""
     if aboyeur.agents.is_known(instance_id):
@@ -428,7 +442,7 @@ def _resolve_versioned(
                         agent,
                         cli=resolved_cli,
                         model=policy_model,
-                        reasoning=policy_reasoning,
+                        reasoning=_effective_reasoning(aboyeur, resolved_cli, policy_reasoning),
                         command=None,
                         env=agent.env if keep_env else None,
                     )

--- a/src/brigade/fleet_model_admission.py
+++ b/src/brigade/fleet_model_admission.py
@@ -1248,7 +1248,7 @@ def _empty_binding_remediation(seat: Mapping[str, Any], roster: Mapping[str, Any
     model = seat.get("model") or "model"
     return (
         f"brigade fleet models set {provider} {model} {name} --enable "
-        f"--reasoning <reasoning> --brigade-cli <cli> --t3-instance-id <id> "
+        f"--reasoning <reasoning|none> --brigade-cli <cli> --t3-instance-id <id> "
         f"--expect-revision {revision}"
     )
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2283,3 +2283,9 @@ def test_missing_cloudflare_ai_gateway_env_vars_empty_string_counts_as_missing()
             "CLOUDFLARE_GATEWAY_ID": "fake-gateway-id-for-test",
         }
     ) == ["CLOUDFLARE_ACCOUNT_ID"]
+
+
+def test_build_argv_rejects_reasoning_pin_for_claude():
+    with pytest.raises(ValueError) as excinfo:
+        agents.build_argv("claude", "hi", read_only=True, reasoning="high")
+    assert "does not support reasoning pins (supported: codex, grok, opencode, pi)" in str(excinfo.value)

--- a/tests/test_fleet_model_admission.py
+++ b/tests/test_fleet_model_admission.py
@@ -366,6 +366,9 @@ def test_admitted_none_reasoning_is_not_applied_as_a_pin():
     assert resolution.roster.agents["chef"].reasoning is None
     admission = next(item for item in resolution.receipt["admissions"] if item["seat"] == "chef")
     assert admission["reasoning"] == "none"
+    decision = next(item for item in resolution.receipt["decisions"] if item["seat"] == "chef")
+    assert decision["reasoning_applied"] is False
+    assert decision["detail"] == "exact seat/provider/model/reasoning/binding entry is enabled"
 
 
 def test_admitted_reasoning_is_dropped_for_adapters_without_reasoning_support():
@@ -380,6 +383,12 @@ def test_admitted_reasoning_is_dropped_for_adapters_without_reasoning_support():
     assert resolution.roster.agents["chef"].reasoning is None
     decision = next(item for item in resolution.receipt["decisions"] if item["seat"] == "chef")
     assert decision["outcome"] == "enabled"
+    assert decision["reasoning_applied"] is False
+    assert decision["detail"] == (
+        "exact seat/provider/model/reasoning/binding entry is enabled; reasoning pin not supported by claude"
+    )
+    admission = next(item for item in resolution.receipt["admissions"] if item["seat"] == "chef")
+    assert admission["reasoning"] == "high"
 
 
 def _reasoning_adapter_roster() -> Roster:
@@ -403,6 +412,30 @@ def test_admitted_reasoning_is_preserved_for_reasoning_adapters():
 
     assert resolution.error is None
     assert resolution.roster.agents["coder"].reasoning == "high"
+    decision = next(item for item in resolution.receipt["decisions"] if item["seat"] == "coder")
+    assert decision["reasoning_applied"] is True
+    assert decision["detail"] == "exact seat/provider/model/reasoning/binding entry is enabled"
+    admission = next(item for item in resolution.receipt["admissions"] if item["seat"] == "coder")
+    assert admission["reasoning"] == "high"
+
+
+def test_admitted_blank_reasoning_is_not_applied_as_a_pin():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _reasoning_adapter_roster(),
+        worker="coder",
+        snapshot=_versioned_snapshot(
+            _versioned_seat("coder", "openai", "gpt-5.6-terra", reasoning="   ", instance_id="codex"),
+        ),
+    )
+
+    assert resolution.error is None
+    assert resolution.roster.agents["coder"].reasoning is None
+    decision = next(item for item in resolution.receipt["decisions"] if item["seat"] == "coder")
+    assert decision["outcome"] == "enabled"
+    assert decision["reasoning_applied"] is False
+    assert decision["detail"] == "exact seat/provider/model/reasoning/binding entry is enabled"
+    admission = next(item for item in resolution.receipt["admissions"] if item["seat"] == "coder")
+    assert admission["reasoning"] == "   "
 
 
 def test_admitted_none_reasoning_is_dropped_for_reasoning_adapters_too():

--- a/tests/test_fleet_model_admission.py
+++ b/tests/test_fleet_model_admission.py
@@ -354,6 +354,72 @@ def test_versioned_snapshot_fails_closed_without_exact_reasoning_and_binding():
     assert "cursor_grok" in resolution.error
 
 
+def test_admitted_none_reasoning_is_not_applied_as_a_pin():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster(),
+        snapshot=_versioned_snapshot(
+            _versioned_seat("chef", "anthropic", "opus-5", reasoning="none", instance_id="claude"),
+        ),
+    )
+
+    assert resolution.error is None
+    assert resolution.roster.agents["chef"].reasoning is None
+    admission = next(item for item in resolution.receipt["admissions"] if item["seat"] == "chef")
+    assert admission["reasoning"] == "none"
+
+
+def test_admitted_reasoning_is_dropped_for_adapters_without_reasoning_support():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster(),
+        snapshot=_versioned_snapshot(
+            _versioned_seat("chef", "anthropic", "opus-5", reasoning="high", instance_id="claude"),
+        ),
+    )
+
+    assert resolution.error is None
+    assert resolution.roster.agents["chef"].reasoning is None
+    decision = next(item for item in resolution.receipt["decisions"] if item["seat"] == "chef")
+    assert decision["outcome"] == "enabled"
+
+
+def _reasoning_adapter_roster() -> Roster:
+    return Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan", model="opus-5"),
+            "coder": Agent("coder", "codex", "code", model="gpt-5.6-terra"),
+        },
+    )
+
+
+def test_admitted_reasoning_is_preserved_for_reasoning_adapters():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _reasoning_adapter_roster(),
+        worker="coder",
+        snapshot=_versioned_snapshot(
+            _versioned_seat("coder", "openai", "gpt-5.6-terra", reasoning="high", instance_id="codex"),
+        ),
+    )
+
+    assert resolution.error is None
+    assert resolution.roster.agents["coder"].reasoning == "high"
+
+
+def test_admitted_none_reasoning_is_dropped_for_reasoning_adapters_too():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _reasoning_adapter_roster(),
+        worker="coder",
+        snapshot=_versioned_snapshot(
+            _versioned_seat("coder", "openai", "gpt-5.6-terra", reasoning="none", instance_id="codex"),
+        ),
+    )
+
+    assert resolution.error is None
+    assert resolution.roster.agents["coder"].reasoning is None
+    admission = next(item for item in resolution.receipt["admissions"] if item["seat"] == "coder")
+    assert admission["reasoning"] == "none"
+
+
 def test_unconfigured_hub_preserves_local_roster_behavior():
     resolution = aboyeur.resolve_fleet_model_policy(
         _roster(),
@@ -568,7 +634,9 @@ def test_brigade_run_without_injected_snapshot_dispatches_hub_approved_seat(tmp_
             == 0
         )
 
-        assert dispatched == [{"cli": "cursor", "model": "cursor-grok-4.6-high-fast", "reasoning": "high"}]
+        # cursor-agent has no reasoning flag: the Hub pin stays in the admission
+        # receipt below, but the launch spec drops it instead of failing dispatch.
+        assert dispatched == [{"cli": "cursor", "model": "cursor-grok-4.6-high-fast", "reasoning": None}]
         assert acquired == [("cursor_grok", "cursor", "cursor-grok-4.6-high-fast")]
         policy = json.loads((output_dir / "model-policy.json").read_text())
         run = json.loads((output_dir / "run.json").read_text())
@@ -891,6 +959,69 @@ def test_direct_worker_runs_with_only_its_authoritative_policy_seat(monkeypatch,
     assert "coder" not in effective["agents"]
     assert "reviewer" not in effective["agents"]
     assert invocations == ["cursor"]
+
+
+def test_direct_worker_claude_seat_dispatches_under_none_reasoning_admission(monkeypatch, tmp_path):
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan", model="opus-5"),
+            "claude_standby": Agent("claude_standby", "claude", "code", model="opus"),
+        },
+    )
+    snapshot = _versioned_snapshot(
+        _versioned_seat("claude_standby", "anthropic", "opus", reasoning="none", instance_id="claude"),
+        expires_at="2099-08-30T14:15:00Z",
+    )
+    monkeypatch.setattr(fleet_client, "load_model_policy_snapshot", lambda: snapshot)
+    _mock_exact_runtime_admission(monkeypatch, snapshot)
+    monkeypatch.setattr(
+        fleet_client,
+        "acquire_model_lease",
+        lambda *args, **kwargs: fleet_client.ModelLeaseDecision(True, "ok", "direct-lease", "direct-holder"),
+    )
+    monkeypatch.setattr(
+        fleet_client,
+        "release_model_lease",
+        lambda lease_id, *, holder: fleet_client.ModelLeaseDecision(True, "ok", lease_id, holder),
+    )
+    launched: list[list[str]] = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        launched.append(
+            agents.build_argv(
+                cli_ref,
+                prompt,
+                read_only=True,
+                model=kwargs.get("model"),
+                reasoning=kwargs.get("reasoning"),
+            )
+        )
+        return agents.AgentResult(text="implemented", ok=True)
+
+    monkeypatch.setattr(agents, "run_agent", fake_run_agent)
+    output_dir = tmp_path / "run"
+
+    assert (
+        run_aboyeur_guarded(
+            "implement it",
+            roster,
+            worker="claude_standby",
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    assert launched, "worker seat never dispatched"
+    argv = launched[0]
+    assert not any(
+        token in ("--reasoning", "--reasoning-effort", "--thinking", "--variant") or "model_reasoning_effort" in token
+        for token in argv
+    )
+    effective = json.loads((output_dir / "roster.json").read_text())
+    assert effective["agents"]["claude_standby"]["reasoning"] is None
 
 
 def test_orchestrated_run_leases_only_planner_worker_and_synthesis_seats(monkeypatch, tmp_path):

--- a/tests/test_run_transport.py
+++ b/tests/test_run_transport.py
@@ -804,7 +804,10 @@ def test_dispatch_receives_hub_approved_model_reasoning_and_binding(monkeypatch,
     agent = resolution.roster.agents["chef"]
     assert agent.cli == "claude"
     assert agent.model == "opus-5"
-    assert agent.reasoning == "high"
+    # claude has no reasoning flag, so the hub-approved reasoning is dropped at
+    # the policy layer; flow-through for reasoning adapters is covered in
+    # tests/test_fleet_model_admission.py.
+    assert agent.reasoning is None
     calls: list[dict[str, object]] = []
 
     def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
@@ -823,7 +826,7 @@ def test_dispatch_receives_hub_approved_model_reasoning_and_binding(monkeypatch,
         output_dir=tmp_path,
     )
     assert results[0].ok is True
-    assert calls == [{"cli": "claude", "model": "opus-5", "reasoning": "high"}]
+    assert calls == [{"cli": "claude", "model": "opus-5", "reasoning": None}]
 
 
 def test_dispatch_does_not_run_when_versioned_custom_command_or_model_override_is_denied(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #1346. Every seat whose hub master-roster row carried `reasoning = "none"` (the schema's required placeholder, and the default when `brigade fleet models set` runs without `--reasoning`) failed dispatch when its CLI has no reasoning flag:

```
error: worker failed: 'claude' does not support reasoning pins (supported: codex, grok, opencode, pi)
```

`resolve_fleet_model_policy` copied the admitted reasoning verbatim onto the launch spec with no sentinel handling and no `supports_reasoning()` check. That killed direct `--worker` dispatch, chef planning, and seat health for every claude seat, and left a latent bug for reasoning-capable seats where `"none"` became a real pin (`-c model_reasoning_effort="none"`).

## Fix

`_effective_reasoning()` in `aboyeur_model_policy.py`, applied at the `replace(...)` site: drop the pin when the value is the `"none"` sentinel (checked first, applies to every adapter) or when the resolved CLI is not a reasoning adapter (backstop). The admission receipt keeps the hub's exact value for provenance; only the launch spec is unpinned. `_with_reasoning` still raises on unsupported adapters, and the hub column stays `NOT NULL` - both are load-bearing and unchanged. The empty-binding remediation hint now reads `--reasoning <reasoning|none>`.

## Tests

- `test_admitted_none_reasoning_is_not_applied_as_a_pin` (receipt keeps `"none"`, launch spec drops it)
- `test_admitted_reasoning_is_dropped_for_adapters_without_reasoning_support`
- `test_admitted_reasoning_is_preserved_for_reasoning_adapters` (no over-strip)
- `test_admitted_none_reasoning_is_dropped_for_reasoning_adapters_too` (the latent codex case)
- `test_build_argv_rejects_reasoning_pin_for_claude` (locks the adapter invariant)

## Verification

`brigade work verify run` receipt `20260831-233832-work-verify-c8c97a`: `./scripts/verify-focused tests/test_fleet_model_admission.py tests/test_agents.py` completed, exit 0, 268 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reasoning settings for versioned Fleet Hub policies.
  * Unsupported adapters no longer receive reasoning options during launch.
  * The `none` reasoning value is now accepted and correctly omitted from agent launch settings.
  * Admission records continue to preserve the original reasoning selection for auditing.
  * Reasoning-capable adapters retain supported reasoning pins during dispatch.

* **Tests**
  * Expanded coverage for supported and unsupported adapter reasoning behavior.
  * Added validation for dispatches using `none` reasoning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->