### PR TITLE
fix(agents): parse grok 1.0.13 finals in both dispatch modes

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -61,6 +61,10 @@ _GROK_RESULT_SCHEMA = json.dumps(
     },
     separators=(",", ":"),
 )
+# grok <=1.0.12 emitted "EndTurn"; 1.0.13 emits "end_turn". Accept both rather
+# than pinning one CLI build. Keep this an explicit set: normalizing by case and
+# underscore would silently admit "endturn", "END_TURN", and future tokens.
+_GROK_SUCCESS_STOP_REASONS = frozenset({"EndTurn", "end_turn"})
 _GROK_SESSION_RESERVED_ARGUMENTS = ("--resume", "--session-id")
 
 
@@ -280,7 +284,7 @@ def _grok_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | No
     # before dispatch. Keep this base shape stable for argv construction callers.
     if read_only or sandbox == "read-only":
         return ["grok", "-p", prompt, "--permission-mode", "plan"]
-    return ["grok", "-p", prompt, "--always-approve"]
+    return ["grok", "-p", prompt, "--always-approve", "--output-format", "json"]
 
 
 def _amp_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
@@ -386,10 +390,20 @@ def direct_cursor_read_only_limitation(model: str | None) -> str | None:
     return None
 
 
-def _parse_grok_final_output(stdout: str) -> _GrokFinal:
-    """Extract a schema-constrained final answer from Grok's JSON envelope."""
+def _parse_grok_final_output(stdout: str, *, schema_required: bool = True) -> _GrokFinal:
+    """Extract a final answer from Grok's JSON envelope.
+
+    Read-only dispatch pins ``--json-schema`` and requires ``structuredOutput``
+    to match it exactly. Write mode only asks for ``--output-format json``, so
+    the final answer is the envelope's ``text`` and ``structuredOutput`` is
+    absent; the stop reason and structured-error guards still apply.
+    """
     base_error = "grok exited 0 without a structured final response"
     raw = stdout.strip()
+    if not schema_required and not raw:
+        # A silent exit is not an envelope problem. Leave it to run_agent's
+        # empty-output classifier so the trust/permissions hint survives.
+        return _GrokFinal(text="", error="")
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
@@ -419,6 +433,34 @@ def _parse_grok_final_output(stdout: str) -> _GrokFinal:
         if isinstance(nested, dict) and isinstance(nested.get("answer"), str):
             fallback = nested["answer"].strip()
 
+    successful_stop = stop_reason in _GROK_SUCCESS_STOP_REASONS
+    if not schema_required:
+        if not successful_stop or structured_error_present:
+            detail = f"{base_error} ({'; '.join(diagnostic_parts)})" if diagnostic_parts else base_error
+            return _GrokFinal(
+                text=fallback,
+                error=detail,
+                diagnostic=(structured_output_error if isinstance(structured_output_error, str) else ""),
+                session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
+                request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
+                stop_reason=stop_reason if isinstance(stop_reason, str) else None,
+            )
+        if not isinstance(display_text, str) or not display_text.strip():
+            return _GrokFinal(
+                text=fallback,
+                error=base_error,
+                session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
+                request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
+                stop_reason=stop_reason if isinstance(stop_reason, str) else None,
+            )
+        return _GrokFinal(
+            text=display_text.strip(),
+            error="",
+            session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
+            request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
+            stop_reason=stop_reason if isinstance(stop_reason, str) else None,
+        )
+
     structured = payload.get("structuredOutput")
     answer = structured.get("answer") if isinstance(structured, dict) else None
     exact_shape = (
@@ -430,7 +472,6 @@ def _parse_grok_final_output(stdout: str) -> _GrokFinal:
     )
     if not exact_shape and not structured_error_present:
         diagnostic_parts.append("structured output did not match expected schema")
-    successful_stop = stop_reason == "EndTurn"
     no_structured_error = not structured_error_present
     if not successful_stop or not no_structured_error or not exact_shape:
         detail = f"{base_error} ({'; '.join(diagnostic_parts)})" if diagnostic_parts else base_error
@@ -1221,7 +1262,10 @@ def run_agent(
             requested_model=model,
             reasoning=reasoning,
         )
-    structured_grok = cli_ref == "grok" and (read_only or sandbox == "read-only")
+    # Both modes emit a JSON envelope, but only read-only constrains the model
+    # to the {kind, answer} schema; write mode must stay free to use tools.
+    grok_envelope = cli_ref == "grok"
+    structured_grok = grok_envelope and (read_only or sandbox == "read-only")
     if structured_grok:
         if argv[-2:] != ["--permission-mode", "plan"]:
             return AgentResult(
@@ -1318,8 +1362,8 @@ def run_agent(
     grok_session_id = None
     grok_request_id = None
     grok_stop_reason = None
-    if structured_grok:
-        grok_final = _parse_grok_final_output(result.stdout)
+    if grok_envelope:
+        grok_final = _parse_grok_final_output(result.stdout, schema_required=structured_grok)
         text = grok_final.text
         structured_error = grok_final.error
         structured_diagnostic = grok_final.diagnostic

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -65,6 +65,13 @@ _GROK_RESULT_SCHEMA = json.dumps(
 # than pinning one CLI build. Keep this an explicit set: normalizing by case and
 # underscore would silently admit "endturn", "END_TURN", and future tokens.
 _GROK_SUCCESS_STOP_REASONS = frozenset({"EndTurn", "end_turn"})
+# Write mode only asks for --output-format json, so stdout that does not parse
+# as an envelope is almost always CLI version skew, not a malformed final.
+# Name the envelope so the operator does not read it as a model failure.
+_GROK_MISSING_ENVELOPE_ERROR = (
+    "grok did not emit an --output-format json envelope; check the grok CLI version "
+    "(need a build that supports --output-format json)"
+)
 _GROK_SESSION_RESERVED_ARGUMENTS = ("--resume", "--session-id")
 
 
@@ -390,6 +397,20 @@ def direct_cursor_read_only_limitation(model: str | None) -> str | None:
     return None
 
 
+def _grok_write_final_text(display_text: object, raw: str) -> str:
+    """Write mode's single definition of the final answer.
+
+    The envelope's ``text`` is the answer whenever it is present, on the success
+    path and on every error path alike. Raw stdout only stands in when ``text``
+    is absent or empty, so a run stays diagnosable without a second extraction
+    rule. Unwrapping a nested ``{"kind": "answer"}`` payload belongs to the
+    schema-constrained read-only path, which asks for that shape.
+    """
+    if isinstance(display_text, str) and display_text.strip():
+        return display_text.strip()
+    return raw
+
+
 def _parse_grok_final_output(stdout: str, *, schema_required: bool = True) -> _GrokFinal:
     """Extract a final answer from Grok's JSON envelope.
 
@@ -404,12 +425,16 @@ def _parse_grok_final_output(stdout: str, *, schema_required: bool = True) -> _G
         # A silent exit is not an envelope problem. Leave it to run_agent's
         # empty-output classifier so the trust/permissions hint survives.
         return _GrokFinal(text="", error="")
+    # Read-only dispatch pins --json-schema, so a non-envelope there really is a
+    # missing structured final. Write mode keeps result.text as the raw stdout
+    # either way so the run stays diagnosable.
+    missing_envelope = base_error if schema_required else _GROK_MISSING_ENVELOPE_ERROR
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
-        return _GrokFinal(text=raw, error=base_error)
+        return _GrokFinal(text=raw, error=missing_envelope)
     if not isinstance(payload, dict):
-        return _GrokFinal(text=raw, error=base_error)
+        return _GrokFinal(text=raw, error=missing_envelope)
 
     diagnostic_parts: list[str] = []
     stop_reason = payload.get("stopReason")
@@ -424,21 +449,13 @@ def _parse_grok_final_output(stdout: str, *, schema_required: bool = True) -> _G
             diagnostic_parts.append("structuredOutputError was present")
 
     display_text = payload.get("text")
-    fallback = display_text.strip() if isinstance(display_text, str) else raw
-    if isinstance(display_text, str):
-        try:
-            nested = json.loads(display_text)
-        except json.JSONDecodeError:
-            nested = None
-        if isinstance(nested, dict) and isinstance(nested.get("answer"), str):
-            fallback = nested["answer"].strip()
-
     successful_stop = stop_reason in _GROK_SUCCESS_STOP_REASONS
     if not schema_required:
+        final_text = _grok_write_final_text(display_text, raw)
         if not successful_stop or structured_error_present:
             detail = f"{base_error} ({'; '.join(diagnostic_parts)})" if diagnostic_parts else base_error
             return _GrokFinal(
-                text=fallback,
+                text=final_text,
                 error=detail,
                 diagnostic=(structured_output_error if isinstance(structured_output_error, str) else ""),
                 session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
@@ -447,19 +464,28 @@ def _parse_grok_final_output(stdout: str, *, schema_required: bool = True) -> _G
             )
         if not isinstance(display_text, str) or not display_text.strip():
             return _GrokFinal(
-                text=fallback,
+                text=final_text,
                 error=base_error,
                 session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
                 request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
                 stop_reason=stop_reason if isinstance(stop_reason, str) else None,
             )
         return _GrokFinal(
-            text=display_text.strip(),
+            text=final_text,
             error="",
             session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
             request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
             stop_reason=stop_reason if isinstance(stop_reason, str) else None,
         )
+
+    fallback = display_text.strip() if isinstance(display_text, str) else raw
+    if isinstance(display_text, str):
+        try:
+            nested = json.loads(display_text)
+        except json.JSONDecodeError:
+            nested = None
+        if isinstance(nested, dict) and isinstance(nested.get("answer"), str):
+            fallback = nested["answer"].strip()
 
     structured = payload.get("structuredOutput")
     answer = structured.get("answer") if isinstance(structured, dict) else None

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -2151,13 +2151,15 @@ def test_run_direct_grok_progress_only_output_fails_with_honest_artifacts(monkey
     assert (output_dir / "final.txt").read_text().strip() == ""
 
 
-def test_run_direct_grok_structured_final_succeeds_with_honest_artifacts(monkeypatch, tmp_path):
+# grok <=1.0.12 emitted "EndTurn"; 1.0.13 emits "end_turn" (#1345).
+@pytest.mark.parametrize("stop_reason", ["EndTurn", "end_turn"])
+def test_run_direct_grok_structured_final_succeeds_with_honest_artifacts(monkeypatch, tmp_path, stop_reason):
     answer = "No actionable findings."
     structured = {"kind": "answer", "answer": answer}
     stdout = json.dumps(
         {
             "text": json.dumps(structured),
-            "stopReason": "EndTurn",
+            "stopReason": stop_reason,
             "sessionId": _GROK_SESSION_ID,
             "requestId": "00000000-0000-4000-8000-000000000001",
             "structuredOutput": structured,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -40,7 +40,14 @@ def test_build_argv_for_known_clis():
     assert agents.build_argv("kimi", "hi") == ["kimi", "-p", "hi"]
     assert agents.build_argv("adal", "hi") == ["adal", "-q", "hi"]
     assert agents.build_argv("openhands", "hi") == ["openhands", "--headless", "-t", "hi"]
-    assert agents.build_argv("grok", "hi") == ["grok", "-p", "hi", "--always-approve"]
+    assert agents.build_argv("grok", "hi") == [
+        "grok",
+        "-p",
+        "hi",
+        "--always-approve",
+        "--output-format",
+        "json",
+    ]
     assert agents.build_argv("amp", "hi") == ["amp", "-x", "hi"]
     assert agents.build_argv("crush", "hi") == ["crush", "run", "hi"]
     assert agents.build_argv("ollama:llama3.3", "hi") == ["ollama", "run", "llama3.3", "hi"]
@@ -1009,7 +1016,10 @@ def test_run_agent_maps_codex_stdin_hang_banner(monkeypatch):
         ("codex", ["codex", "exec", "-c", 'model_reasoning_effort="xhigh"', "-"]),
         ("opencode", ["opencode", "run", "--variant", "xhigh", "hi"]),
         ("pi", ["pi", "--thinking", "xhigh", "-p", "hi"]),
-        ("grok", ["grok", "--reasoning-effort", "xhigh", "-p", "hi", "--always-approve"]),
+        (
+            "grok",
+            ["grok", "--reasoning-effort", "xhigh", "-p", "hi", "--always-approve", "--output-format", "json"],
+        ),
     ],
 )
 def test_build_argv_applies_reasoning(cli_ref, expected):
@@ -1215,6 +1225,99 @@ def _grok_json_output(
             "structuredOutputError": None if structured else "model did not produce structured output",
         }
     )
+
+
+def _grok_write_envelope(
+    text: str,
+    *,
+    stop_reason: str = "end_turn",
+    session_id: str = "019f0000-0000-7000-8000-000000000001",
+) -> str:
+    """Write-mode grok envelope: --output-format json without a --json-schema."""
+    return json.dumps(
+        {
+            "text": text,
+            "stopReason": stop_reason,
+            "sessionId": session_id,
+            "requestId": "00000000-0000-4000-8000-000000000001",
+        }
+    )
+
+
+def test_run_agent_accepts_grok_snake_case_end_turn_stop_reason(monkeypatch):
+    stdout = _grok_json_output("PONG", stop_reason="end_turn")
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "reply with PONG", read_only=True, model="grok-4.5")
+
+    assert result.ok is True
+    assert result.text == "PONG"
+    assert result.stop_reason == "end_turn"
+
+
+@pytest.mark.parametrize("stop_reason", ["Cancelled", "endturn", "END_TURN", "end turn"])
+def test_run_agent_still_rejects_unknown_grok_stop_reasons(monkeypatch, stop_reason):
+    stdout = _grok_json_output("No actionable findings.", stop_reason=stop_reason)
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "malformed-final-output"
+    assert result.stop_reason == stop_reason
+
+
+def test_run_agent_accepts_grok_write_mode_envelope_text(monkeypatch):
+    answer = "Implemented the requested change."
+    stdout = _grok_write_envelope(answer)
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "implement it", read_only=False, model="grok-4.5")
+
+    assert result.ok is True
+    assert result.text == answer
+    assert result.stop_reason == "end_turn"
+    assert result.session_id == "019f0000-0000-7000-8000-000000000001"
+    assert result.request_id == "00000000-0000-4000-8000-000000000001"
+
+
+def test_run_agent_write_mode_does_not_request_a_json_schema(monkeypatch):
+    stdout = _grok_write_envelope("Implemented the requested change.")
+    seen = {}
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        return agents.proc.Result(0, stdout + "\n", "")
+
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    result = agents.run_agent("grok", "implement it", read_only=False, model="grok-4.5")
+
+    assert result.ok is True
+    assert seen["argv"][-2:] == ["--output-format", "json"]
+    assert "--json-schema" not in seen["argv"]
+    assert "--sandbox" not in seen["argv"]
+    assert "--permission-mode" not in seen["argv"]
+
+
+def test_run_agent_rejects_grok_write_mode_progress_without_end_turn(monkeypatch):
+    stdout = _grok_write_envelope("Gathering the diffs first.", stop_reason="max_turns")
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "implement it", read_only=False, model="grok-4.5")
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "malformed-final-output"
+    assert result.detail == "grok exited 0 without a structured final response (stopReason=max_turns)"
+    assert result.text == "Gathering the diffs first."
+    assert result.stop_reason == "max_turns"
 
 
 def test_run_agent_rejects_grok_progress_without_structured_final_output(monkeypatch):
@@ -1477,15 +1580,21 @@ def test_run_agent_keeps_permission_mode_prompt_separate_from_grok_flags(monkeyp
     ]
 
 
-def test_run_agent_keeps_writable_grok_plain_output(monkeypatch):
+def test_run_agent_rejects_writable_grok_plain_output(monkeypatch):
+    # An older grok build that ignores --output-format json emits bare text.
+    # Surface that as a diagnosable failure, not a silent pass.
     output = "Implemented the requested change."
     monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
     monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
 
     result = agents.run_agent("grok", "implement it", read_only=False, model="grok-4.5")
 
-    assert result.ok is True
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "malformed-final-output"
+    assert result.detail == "grok exited 0 without a structured final response"
     assert result.text == output
+    assert result.stdout == output + "\n"
 
 
 def test_run_agent_reports_invalid_internal_grok_read_only_argv(monkeypatch):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1582,7 +1582,8 @@ def test_run_agent_keeps_permission_mode_prompt_separate_from_grok_flags(monkeyp
 
 def test_run_agent_rejects_writable_grok_plain_output(monkeypatch):
     # An older grok build that ignores --output-format json emits bare text.
-    # Surface that as a diagnosable failure, not a silent pass.
+    # Surface that as a diagnosable failure naming the envelope, not a silent
+    # pass and not the generic "no structured final response" detail.
     output = "Implemented the requested change."
     monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
     monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
@@ -1592,9 +1593,43 @@ def test_run_agent_rejects_writable_grok_plain_output(monkeypatch):
     assert result.ok is False
     assert result.failure_phase == "output-validation"
     assert result.failure_kind == "malformed-final-output"
-    assert result.detail == "grok exited 0 without a structured final response"
+    assert result.detail == (
+        "grok did not emit an --output-format json envelope; check the grok CLI version "
+        "(need a build that supports --output-format json)"
+    )
     assert result.text == output
     assert result.stdout == output + "\n"
+
+
+def test_run_agent_read_only_plain_output_keeps_generic_final_detail(monkeypatch):
+    # Read-only dispatch pins --json-schema, so bare text there is a missing
+    # structured final, not CLI version skew. Keep the original detail.
+    output = "Implemented the requested change."
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "malformed-final-output"
+    assert result.detail == "grok exited 0 without a structured final response"
+    assert result.text == output
+
+
+@pytest.mark.parametrize("stop_reason", ["end_turn", "max_turns"])
+def test_run_agent_grok_write_mode_uses_one_final_answer_rule(monkeypatch, stop_reason):
+    # Success and failure paths share one extraction rule: the answer is the
+    # envelope's "text", never a re-parse of a JSON-looking payload inside it.
+    nested = json.dumps({"kind": "answer", "answer": "unwrapped"})
+    stdout = _grok_write_envelope(nested, stop_reason=stop_reason)
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "implement it", read_only=False, model="grok-4.5")
+
+    assert result.ok is (stop_reason == "end_turn")
+    assert result.text == nested
 
 
 def test_run_agent_reports_invalid_internal_grok_read_only_argv(monkeypatch):

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -19,6 +19,8 @@ def test_pins_model_for_grok():
         "-p",
         "P",
         "--always-approve",
+        "--output-format",
+        "json",
     ]
     read_only = agents.build_argv("grok", "P", read_only=True, model="grok-composer-2.5-fast")
     assert read_only == [

--- a/tests/test_run_transport_recovery.py
+++ b/tests/test_run_transport_recovery.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import replace
 
 import pytest
@@ -217,6 +218,35 @@ def _dispatch_recovery(
 
 def test_direct_grok_first_attempt_success_is_selected(monkeypatch, tmp_path):
     result, direct_calls, fallback_calls = _dispatch_recovery(monkeypatch, tmp_path, [_successful_final()])
+
+    assert result.ok is True
+    assert result.text == "No actionable findings."
+    assert len(direct_calls) == 1
+    assert fallback_calls == []
+    assert [attempt.kind for attempt in result.attempts] == ["initial"]
+    assert [attempt.selected for attempt in result.attempts] == [True]
+
+
+def test_grok_continuation_is_not_triggered_for_end_turn_finals(monkeypatch, tmp_path):
+    # #1345: grok 1.0.13 reports snake_case "end_turn". Run the real adapter so
+    # the transport sees exactly what the parser produces, not a hand-built result.
+    structured = {"kind": "answer", "answer": "No actionable findings."}
+    stdout = json.dumps(
+        {
+            "text": json.dumps(structured),
+            "stopReason": "end_turn",
+            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "requestId": "00000000-0000-4000-8000-000000000001",
+            "structuredOutput": structured,
+            "structuredOutputError": None,
+        }
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+    direct_final = agents.run_agent("grok", "Review the diff.", read_only=True, model="grok-4.5")
+    assert direct_final.ok is True
+
+    result, direct_calls, fallback_calls = _dispatch_recovery(monkeypatch, tmp_path, [direct_final])
 
     assert result.ok is True
     assert result.text == "No actionable findings."


### PR DESCRIPTION
## Summary

Fixes #1345. Two independent defects kept `cli = "grok"` seats from ever completing a dispatch on grok 1.0.13:

1. **Read-only**: the envelope was fine - `structuredOutput` matched the pinned schema exactly - but the success check compared `stopReason` against the exact string `EndTurn`, and 1.0.13 emits `end_turn`. One failed comparison cascaded into the continuation attempt and then `grok-fallback-missing`.
2. **Write mode**: the argv never requested JSON output, so bare text hit the `_progress_only` heuristic and failed as "progress or intent without a final result" with the correct answer present in stdout.

## Fix

- `_GROK_SUCCESS_STOP_REASONS = frozenset({"EndTurn", "end_turn"})` - an explicit two-member set, deliberately not a case/underscore normalizer, so `endturn`, `END_TURN`, and future tokens stay rejected.
- Write-mode argv gains `--output-format json`.
- `_parse_grok_final_output` gains `schema_required`: read-only keeps the exact `{kind, answer}` contract; write mode takes the envelope's `text` under the same stop-reason and structured-error guards. Write mode does not get the `--json-schema` pin (it must stay free to use tools).
- Bare-text write stdout now yields `malformed-final-output` with the raw text preserved - older grok builds fail diagnosably instead of passing unvalidated. Grok write mode net-gains strictness; `validate_final_output`, `result_integrity`, `invalid_final_fallback`, and every non-grok adapter are untouched.

## Tests

Snake-case acceptance (the regression that would have caught #1345), unknown/normalized stop-reason rejection, write-mode envelope text extraction, write-mode argv shape, `max_turns` rejection, bare-text diagnostic, no-continuation-on-`end_turn` (transport recovery), and both stop-reason casings parametrized through the aboyeur fixtures.

## Verification

`brigade work verify run` receipt `20260831-234715-work-verify-402d29`: `./scripts/verify-focused tests/test_agents.py tests/test_run_transport_recovery.py tests/test_aboyeur.py` completed, exit 0, 481 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)