### PR TITLE
fix(grokbot): let feed actors list their queue under hub authority

### DIFF
--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -1405,6 +1405,14 @@ def _print_reconcile_result(result: dict) -> None:
         print(f"job {job['job_id']} state={job['state']}")
 
 
+_DOCTOR_NON_FAILING_STATUSES = frozenset({"ok", "skipped"})
+
+
+def _doctor_exit_code(checks: list[dict[str, str]]) -> int:
+    """Fail only on statuses outside the explicit non-failing allowlist."""
+    return 0 if all(check["status"] in _DOCTOR_NON_FAILING_STATUSES for check in checks) else 1
+
+
 def _dispatch_grokbot_pack(args, target: Path) -> int:
     """Preview-first connector-pack lifecycle without printing secret values."""
     from .. import grokbot_mcp, grokbot_ops, grokbot_packs
@@ -1449,7 +1457,7 @@ def _dispatch_grokbot_pack(args, target: Path) -> int:
             else:
                 for check in checks:
                     print(f"{check['check']}: {check['status']}")
-            return 1 if any(check["status"] != "ok" for check in checks) else 0
+            return _doctor_exit_code(checks)
         elif command == "canary":
             result = grokbot_packs.canary(target, args.pack_id)
             if args.json:
@@ -1575,11 +1583,9 @@ def _dispatch_grokbot_ops(args, target: Path) -> int:
 
         if command == "doctor":
             checks = grokbot_ops.doctor(target, instance)
-            failed = False
             for check in checks:
                 print(f"{check['check']}: {check['status']}")
-                failed = failed or check["status"] == "fail"
-            return 1 if failed else 0
+            return _doctor_exit_code(checks)
 
         if command == "canary":
             result = grokbot_ops.canary(target, instance)

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -9,7 +9,7 @@ import os
 import stat
 import sys
 from pathlib import Path
-from typing import Any, ContextManager
+from typing import Any, ContextManager, NamedTuple
 
 _PROMPT_FILE_MAX_BYTES = 64 * 1024
 _LAUNCH_LABEL_MAX = 120
@@ -1176,7 +1176,7 @@ def _dispatch_grokbot_feed(args, target: Path) -> int:
 
     try:
         if args.apply:
-            with _feed_hub_identity(target):
+            with _feed_hub_identity(target).context:
                 result = grokbot_feed.apply(target, args.manifest, limit=args.limit)
         else:
             result = grokbot_feed.preflight(target, args.manifest, limit=args.limit)
@@ -1208,25 +1208,35 @@ def _print_feed_result(result: dict) -> None:
         print(f"job {job['job_id']} state={job['state']}")
 
 
-def _feed_hub_identity(target: Path) -> ContextManager[None]:
+class _FeedIdentity(NamedTuple):
+    """The bound feed context plus the actor kind it speaks as, when bound."""
+
+    context: ContextManager[None]
+    actor_kind: str | None
+
+
+def _feed_hub_identity(target: Path) -> _FeedIdentity:
     """Bind the dedicated feed actor for Hub mutations, with no fallback."""
     from .. import fleet_client_grokbot, grokbot_jobs, grokbot_mcp
 
     if not grokbot_jobs.hub_authority(target):
-        return nullcontext()
+        return _FeedIdentity(nullcontext(), None)
     token = grokbot_mcp.load_feed_hub_token()
     if token is None:
         raise grokbot_mcp.ConfigurationError("invalid")
-    return fleet_client_grokbot.listener_identity(token)
+    return _FeedIdentity(fleet_client_grokbot.listener_identity(token), "feed")
 
 
 def _dispatch_grokbot_scout_feed(args, target: Path) -> int:
     """Preview or enqueue one approved scout without exposing policy content."""
     from .. import grokbot_mcp, grokbot_scout_feed
 
+    actor_kind: str | None = None
     try:
         if args.apply:
-            with _feed_hub_identity(target):
+            identity = _feed_hub_identity(target)
+            actor_kind = identity.actor_kind
+            with identity.context:
                 result = grokbot_scout_feed.apply(target, args.policy)
         else:
             result = grokbot_scout_feed.preflight(target, args.policy)
@@ -1234,7 +1244,9 @@ def _dispatch_grokbot_scout_feed(args, target: Path) -> int:
         print("error: Grok Bot feed configuration is invalid", file=sys.stderr)
         return 2
     except grokbot_scout_feed.ScoutFeedError as exc:
-        print(f"error: {exc.reason}", file=sys.stderr)
+        if exc.action is not None and exc.actor_kind is None:
+            exc.actor_kind = actor_kind
+        print(f"error: {exc.public_detail()}", file=sys.stderr)
         return 2
 
     if args.json:
@@ -1566,7 +1578,7 @@ def _dispatch_grokbot_ops(args, target: Path) -> int:
             failed = False
             for check in checks:
                 print(f"{check['check']}: {check['status']}")
-                failed = failed or check["status"] != "ok"
+                failed = failed or check["status"] == "fail"
             return 1 if failed else 0
 
         if command == "canary":

--- a/src/brigade/fleet_hub_grokbot.py
+++ b/src/brigade/fleet_hub_grokbot.py
@@ -38,6 +38,7 @@ HUB_STATES = WORK_STATES | TERMINAL_STATES
 CREATE_ACTIONS = frozenset({"enqueue"})
 OPERATOR_ACTIONS = frozenset({"list", "status", "whoami", "cancel", "expire", "report-metadata"})
 WORKER_ACTIONS = frozenset({"list", "status", "whoami", "claim", "start", "renew", "complete", "fail", "ack-cancel"})
+FEED_ACTIONS = frozenset({"enqueue", "list", "whoami"})
 ADMIN_ACTIONS = frozenset({"enroll-actor"})
 IDENTITY_ACTIONS = frozenset({"whoami"})
 ACTIONS = CREATE_ACTIONS | OPERATOR_ACTIONS | WORKER_ACTIONS | ADMIN_ACTIONS | IDENTITY_ACTIONS
@@ -149,8 +150,8 @@ LEASE_SECONDS_MAX = 3600
 DEFAULT_LEASE_SECONDS = 300
 _CLOUD_HOLDER_DOMAIN = b"brigade.grokbot.cloud-holder"
 _ACTOR_KIND_ACTIONS = {
-    "feed": frozenset({"enqueue", "whoami"}),
-    "control": frozenset({"enqueue", "whoami"}),
+    "feed": FEED_ACTIONS,
+    "control": FEED_ACTIONS,
     "operator": OPERATOR_ACTIONS,
     "implementation-worker": WORKER_ACTIONS,
     "repository-scout": WORKER_ACTIONS,

--- a/src/brigade/grokbot_job_validation.py
+++ b/src/brigade/grokbot_job_validation.py
@@ -22,8 +22,9 @@ ARTIFACT_KINDS = frozenset({"draft-pr", "branch", "report"})
 class GrokbotJobError(ValueError):
     """A rejected Grok Bot job request with a stable machine-readable reason."""
 
-    def __init__(self, reason: str):
+    def __init__(self, reason: str, *, action: str | None = None):
         self.reason = reason
+        self.action = action
         super().__init__(reason)
 
 

--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -1660,7 +1660,7 @@ def _hub_jobs(*, role: str | None = None, include_all: bool = False) -> list[dic
 
     decision = fleet_client_grokbot.list_jobs(role=role, include_all=include_all)
     if not decision.granted or decision.jobs is None:
-        raise GrokbotJobError(decision.reason)
+        raise GrokbotJobError(decision.reason, action="list")
     return [_hub_projection_job(job) for job in decision.jobs]
 
 
@@ -1804,7 +1804,7 @@ def _require_hub(action: str, job_id: str | None = None, **fields: Any) -> Any:
     operation = getattr(fleet_client_grokbot, action)
     decision = operation(job_id, **fields) if job_id is not None else operation(**fields)
     if not decision.granted:
-        raise GrokbotJobError(decision.reason)
+        raise GrokbotJobError(decision.reason, action=action)
     return decision
 
 

--- a/src/brigade/grokbot_ops.py
+++ b/src/brigade/grokbot_ops.py
@@ -202,8 +202,42 @@ def doctor(target: Path, instance: str, *, timeout: int = DEFAULT_TIMEOUT_SECOND
     except (grokbot_jobs.GrokbotJobError, grokbot_mcp.ConfigurationError, ValueError, OSError):
         record("queue", False)
 
+    feed_authority = _feed_authority_check(target)
+    if feed_authority is not None:
+        checks.append(feed_authority)
+
     record("endpoint", _health_check(config, bearer, timeout))
     return checks
+
+
+def _feed_authority_check(target: Path) -> dict[str, str] | None:
+    """Prove read-only that the feed actor holds the reads scout-feed --apply needs.
+
+    Only ``whoami`` and ``list`` are issued. A doctor never enqueues.
+    """
+    from . import fleet_client_grokbot
+
+    if not grokbot_jobs.hub_authority(target):
+        return None
+    try:
+        token = grokbot_mcp.load_feed_hub_token()
+    except (grokbot_mcp.ConfigurationError, OSError, ValueError):
+        return {"check": "feed-authority", "status": "fail"}
+    if token is None:
+        return {"check": "feed-authority", "status": "skipped"}
+    try:
+        with fleet_client_grokbot.listener_identity(token):
+            identity = fleet_client_grokbot.whoami()
+            listing = fleet_client_grokbot.list_jobs(role="repository-scout", include_all=True)
+    except (grokbot_mcp.ConfigurationError, OSError, ValueError):
+        return {"check": "feed-authority", "status": "fail"}
+    ok = (
+        identity.granted
+        and isinstance(identity.job, dict)
+        and identity.job.get("actor_kind") in {"feed", "control"}
+        and listing.granted
+    )
+    return {"check": "feed-authority", "status": "ok" if ok else "fail"}
 
 
 def canary(target: Path, instance: str, *, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> dict[str, Any]:

--- a/src/brigade/grokbot_scout_feed.py
+++ b/src/brigade/grokbot_scout_feed.py
@@ -33,9 +33,31 @@ POLICY_KEYS = frozenset(
 class ScoutFeedError(ValueError):
     """A rejected scout policy or discovery request with a stable reason."""
 
-    def __init__(self, reason: str):
+    def __init__(self, reason: str, *, action: str | None = None, actor_kind: str | None = None):
         self.reason = reason
+        self.action = action
+        self.actor_kind = actor_kind
         super().__init__(reason)
+
+    def public_detail(self) -> str:
+        """Stable, path-free, credential-free diagnostic for CLI stderr."""
+        parts = [self.reason]
+        if self.action:
+            parts.append(f"action={self.action}")
+        if self.actor_kind:
+            parts.append(f"actor={self.actor_kind}")
+        return " ".join(parts)
+
+
+def _queue_error(exc: grokbot_jobs.GrokbotJobError) -> ScoutFeedError:
+    """Translate a queue failure, surfacing only hub-bounded refusal reasons.
+
+    A refused hub action carries a reason the Fleet Hub client already bounded,
+    so it is safe to name. Private local storage reasons stay redacted.
+    """
+    if exc.action is None:
+        return ScoutFeedError("queue-error")
+    return ScoutFeedError(exc.reason, action=exc.action)
 
 
 def preflight(target: Path, policy_path: Path, *, now: datetime | None = None) -> dict[str, object]:
@@ -45,7 +67,7 @@ def preflight(target: Path, policy_path: Path, *, now: datetime | None = None) -
     try:
         return _selection(target, policy, numbers, _resolve_now(now))
     except grokbot_jobs.GrokbotJobError as exc:
-        raise ScoutFeedError("queue-error") from exc
+        raise _queue_error(exc) from exc
 
 
 def apply(target: Path, policy_path: Path, *, now: datetime | None = None) -> dict[str, object]:
@@ -72,7 +94,7 @@ def apply(target: Path, policy_path: Path, *, now: datetime | None = None) -> di
             now=instant,
         )
     except grokbot_jobs.GrokbotJobError as exc:
-        raise ScoutFeedError("queue-error") from exc
+        raise _queue_error(exc) from exc
     if admission["reason"] != "created":
         return {
             **selection,

--- a/tests/test_fleet_cloud.py
+++ b/tests/test_fleet_cloud.py
@@ -891,6 +891,22 @@ def _holder_body(
     return body
 
 
+def _forbidden_action_body(action: str, job_id: str, *, prefix: str) -> dict[str, object]:
+    """Build a schema-valid body so refusals come from authorization, not validation."""
+    if action == "report-metadata":
+        return {"action": action, "job_id": job_id}
+    if action == "claim":
+        return _claim_body(job_id, operation_id=f"{prefix}-{action}")
+    if action == "complete":
+        return _holder_body("complete", job_id, revision=1, generation=1, operation_id=f"{prefix}-{action}")
+    return {
+        "action": action,
+        "job_id": job_id,
+        "expected_item_revision": 1,
+        "operation_id": f"{prefix}-{action}",
+    }
+
+
 def _refuse_cross_actor(conn, body: dict[str, object], caller_node: str) -> None:
     from brigade import fleet_hub_grokbot
 
@@ -1102,25 +1118,95 @@ def test_grokbot_actor_policy_isolates_node_queue_and_role(conn):
         fleet_hub_grokbot.handle_grokbot(
             conn, _claim_body(scout["job_id"], operation_id="op-wrong-role"), caller_node=WORKER_NODE
         )
-    with pytest.raises(fleet_hub.FleetHubForbidden):
-        fleet_hub_grokbot.handle_grokbot(conn, {"action": "list"}, caller_node=FEED_NODE)
+    feed_listed = fleet_hub_grokbot.handle_grokbot(conn, {"action": "list"}, caller_node=FEED_NODE)
+    assert feed_listed[0] == 200
+    assert {item["job_id"] for item in feed_listed[1]["jobs"]} == {job["job_id"], scout["job_id"]}
+    assert {item["queue_id"] for item in feed_listed[1]["jobs"]} == {QUEUE_ID}
     with pytest.raises(fleet_hub.FleetHubForbidden):
         fleet_hub_grokbot.handle_grokbot(
             conn, {"action": "claim", **_claim_body(job["job_id"])}, caller_node=OPERATOR_NODE
         )
 
 
-def test_grokbot_control_actor_is_enqueue_only_administrative_readiness(conn):
+def test_grokbot_control_actor_lists_only_its_own_queue(conn):
     from brigade import fleet_hub_grokbot
 
     _enroll_actors(conn)
     _enroll_actor(conn, CONTROL_NODE, kind="control", queue_id=QUEUE_ID)
+    _enroll_actor(conn, OTHER_FEED, kind="feed", queue_id=OTHER_QUEUE)
+    mine = fleet_hub_grokbot.handle_grokbot(conn, _grokbot_enqueue(), caller_node=FEED_NODE)[1]["job"]
+    theirs = fleet_hub_grokbot.handle_grokbot(
+        conn,
+        _grokbot_enqueue("grokbot-" + "c" * 24, "c" * 64, operation_id="op-enq-other"),
+        caller_node=OTHER_FEED,
+    )[1]["job"]
 
     status, payload = fleet_hub_grokbot.handle_grokbot(conn, {"action": "whoami"}, caller_node=CONTROL_NODE)
     assert status == 200
     assert payload == {"actor_kind": "control", "role": None}
+    listed = fleet_hub_grokbot.handle_grokbot(conn, {"action": "list"}, caller_node=CONTROL_NODE)
+    assert listed[0] == 200
+    assert [item["job_id"] for item in listed[1]["jobs"]] == [mine["job_id"]]
+    assert theirs["job_id"] not in {item["job_id"] for item in listed[1]["jobs"]}
+    for action in ("claim", "cancel", "expire", "complete", "report-metadata"):
+        with pytest.raises(fleet_hub.FleetHubForbidden):
+            fleet_hub_grokbot.handle_grokbot(
+                conn,
+                _forbidden_action_body(action, mine["job_id"], prefix="op-control"),
+                caller_node=CONTROL_NODE,
+            )
+
+
+def test_grokbot_feed_actor_list_is_scoped_to_its_own_queue(conn):
+    from brigade import fleet_hub_grokbot
+
+    _enroll_actors(conn)
+    _enroll_actor(conn, OTHER_FEED, kind="feed", queue_id=OTHER_QUEUE)
+    mine = fleet_hub_grokbot.handle_grokbot(conn, _grokbot_enqueue(), caller_node=FEED_NODE)[1]["job"]
+    theirs = fleet_hub_grokbot.handle_grokbot(
+        conn,
+        _grokbot_enqueue("grokbot-" + "c" * 24, "c" * 64, operation_id="op-enq-other"),
+        caller_node=OTHER_FEED,
+    )[1]["job"]
+
+    listed = fleet_hub_grokbot.handle_grokbot(conn, {"action": "list"}, caller_node=FEED_NODE)
+
+    assert listed[0] == 200
+    assert [item["job_id"] for item in listed[1]["jobs"]] == [mine["job_id"]]
+    assert theirs["job_id"] not in {item["job_id"] for item in listed[1]["jobs"]}
+    for item in listed[1]["jobs"]:
+        assert set(item) <= set(fleet_hub_grokbot.SAFE_JOB_FIELDS)
+        assert "idempotency_key_hash" not in item
+        assert "lease_token_digest" not in item
+
+
+@pytest.mark.parametrize("action", ("cancel", "expire", "claim", "complete", "report-metadata"))
+def test_grokbot_feed_actor_still_cannot_mutate_or_read_reports(conn, action):
+    from brigade import fleet_hub_grokbot
+
+    _enroll_actors(conn)
+    job = fleet_hub_grokbot.handle_grokbot(conn, _grokbot_enqueue(), caller_node=FEED_NODE)[1]["job"]
+
     with pytest.raises(fleet_hub.FleetHubForbidden):
-        fleet_hub_grokbot.handle_grokbot(conn, {"action": "list"}, caller_node=CONTROL_NODE)
+        fleet_hub_grokbot.handle_grokbot(
+            conn,
+            _forbidden_action_body(action, job["job_id"], prefix="op-feed"),
+            caller_node=FEED_NODE,
+        )
+
+
+def test_grokbot_feed_actor_list_needs_no_reenrollment(conn):
+    from brigade import fleet_hub_grokbot
+
+    _enroll_actors(conn)
+    enrollments = conn.execute("SELECT COUNT(*) FROM grokbot_actor_policy WHERE node_id = ?", (FEED_NODE,)).fetchone()
+    job = fleet_hub_grokbot.handle_grokbot(conn, _grokbot_enqueue(), caller_node=FEED_NODE)[1]["job"]
+
+    listed = fleet_hub_grokbot.handle_grokbot(conn, {"action": "list"}, caller_node=FEED_NODE)
+
+    assert listed[0] == 200
+    assert [item["job_id"] for item in listed[1]["jobs"]] == [job["job_id"]]
+    assert enrollments[0] == 1
 
 
 def test_grokbot_operation_replay_and_revision_fencing(conn):
@@ -1314,7 +1400,8 @@ def test_grokbot_http_get_is_removed_and_admin_cannot_list_unscoped(tmp_path):
         status, payload = _request(hub, "POST", "/grokbot", token=ADMIN_TOKEN, body={"action": "list"})
         assert status == 403
         status, payload = _request(hub, "POST", "/grokbot", token=feed_token, body={"action": "list"})
-        assert status == 403
+        assert status == 200
+        assert {job["queue_id"] for job in payload["jobs"]} == {QUEUE_ID}
 
 
 def test_grokbot_hub_projection_is_deck_only_and_terminal_jobs_release_capacity(conn):

--- a/tests/test_grokbot_ops.py
+++ b/tests/test_grokbot_ops.py
@@ -476,7 +476,7 @@ def test_doctor_feed_authority_probe_issues_no_mutating_hub_action(tmp_path: Pat
 
 @pytest.mark.parametrize(
     ("feed_status", "exit_code"),
-    (("skipped", 0), ("ok", 0), ("fail", 1)),
+    (("skipped", 0), ("ok", 0), ("fail", 1), ("unrecognized", 1)),
 )
 def test_doctor_command_treats_a_skipped_feed_authority_probe_as_non_failing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys, feed_status: str, exit_code: int

--- a/tests/test_grokbot_ops.py
+++ b/tests/test_grokbot_ops.py
@@ -381,6 +381,115 @@ def test_doctor_refuses_changed_unsafe_listener_token_file_without_secret_or_pat
     assert str(token_file) not in json.dumps(checks)
 
 
+def _feed_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    token = "feed-listener-token"
+    token_file = tmp_path / "feed.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.setenv("BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE", str(token_file))
+    return token
+
+
+def _stub_hub(monkeypatch: pytest.MonkeyPatch, *, actor_kind: str = "feed", list_granted: bool = True) -> list[str]:
+    from brigade import fleet_client_grokbot
+
+    actions: list[str] = []
+
+    def whoami(**_fields: object):
+        actions.append("whoami")
+        return fleet_client_grokbot.GrokbotHubDecision(True, "ok", job={"actor_kind": actor_kind, "role": None})
+
+    def list_jobs(**_fields: object):
+        actions.append("list")
+        if not list_granted:
+            return fleet_client_grokbot.GrokbotHubDecision(False, "auth-failed")
+        return fleet_client_grokbot.GrokbotHubDecision(True, "ok", jobs=[])
+
+    monkeypatch.setattr(fleet_client_grokbot, "whoami", whoami)
+    monkeypatch.setattr(fleet_client_grokbot, "list_jobs", list_jobs)
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    monkeypatch.setattr(grokbot_jobs, "status", lambda _target: {"jobs": []})
+    return actions
+
+
+def test_doctor_reports_feed_authority_ok_when_feed_can_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    assert _setup(tmp_path, "operator") == 0
+    token = _feed_token(tmp_path, monkeypatch)
+    _stub_hub(monkeypatch)
+
+    checks = grokbot_ops.doctor(tmp_path, "operator")
+
+    assert {check["check"]: check["status"] for check in checks}["feed-authority"] == "ok"
+    assert token not in json.dumps(checks)
+
+
+def test_doctor_reports_feed_authority_fail_when_feed_list_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    assert _setup(tmp_path, "operator") == 0
+    _feed_token(tmp_path, monkeypatch)
+    _stub_hub(monkeypatch, list_granted=False)
+
+    checks = grokbot_ops.doctor(tmp_path, "operator")
+
+    assert {check["check"]: check["status"] for check in checks}["feed-authority"] == "fail"
+
+
+def test_doctor_skips_feed_authority_without_a_configured_feed_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    monkeypatch.delenv("BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE", raising=False)
+    assert _setup(tmp_path, "operator") == 0
+    actions = _stub_hub(monkeypatch)
+
+    checks = grokbot_ops.doctor(tmp_path, "operator")
+
+    assert {check["check"]: check["status"] for check in checks}["feed-authority"] == "skipped"
+    assert actions == []
+
+
+def test_doctor_omits_feed_authority_without_hub_authority(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    assert _setup(tmp_path, "operator") == 0
+    _feed_token(tmp_path, monkeypatch)
+    actions = _stub_hub(monkeypatch)
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: False)
+
+    checks = grokbot_ops.doctor(tmp_path, "operator")
+
+    assert "feed-authority" not in {check["check"] for check in checks}
+    assert actions == []
+
+
+def test_doctor_feed_authority_probe_issues_no_mutating_hub_action(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from brigade import fleet_hub_grokbot
+
+    monkeypatch.setenv("TEST_GROKBOT_BEARER", SECRET)
+    assert _setup(tmp_path, "operator") == 0
+    _feed_token(tmp_path, monkeypatch)
+    actions = _stub_hub(monkeypatch)
+
+    grokbot_ops.doctor(tmp_path, "operator")
+
+    assert set(actions) == {"whoami", "list"}
+    assert not set(actions) & fleet_hub_grokbot.MUTATING_ACTIONS
+
+
+@pytest.mark.parametrize(
+    ("feed_status", "exit_code"),
+    (("skipped", 0), ("ok", 0), ("fail", 1)),
+)
+def test_doctor_command_treats_a_skipped_feed_authority_probe_as_non_failing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys, feed_status: str, exit_code: int
+):
+    checks = [{"check": "queue", "status": "ok"}, {"check": "feed-authority", "status": feed_status}]
+    monkeypatch.setattr(grokbot_ops, "doctor", lambda *_args, **_kwargs: checks)
+
+    argv = ["run", "cloud", "grokbot", "doctor", "--target", str(tmp_path), "--instance", "operator"]
+
+    assert cli.main(argv) == exit_code
+    assert f"feed-authority: {feed_status}" in capsys.readouterr().out
+
+
 def test_doctor_fails_cleanly_on_missing_config(tmp_path: Path, capsys):
     assert cli.main(["run", "cloud", "grokbot", "doctor", "--target", str(tmp_path), "--instance", "operator"]) == 1
     captured = capsys.readouterr()

--- a/tests/test_grokbot_packs.py
+++ b/tests/test_grokbot_packs.py
@@ -1463,3 +1463,17 @@ def test_first_party_pack_units_use_shared_listener_recovery_policy(tmp_path: Pa
     grokbot_packs.apply_setup(tmp_path, "operator", bearer_env="TEST_GROKBOT_BEARER")
     unit = grokbot_packs.render_install_service(tmp_path, "operator")
     assert_listener_recovery_policy(unit)
+
+
+@pytest.mark.parametrize(
+    ("feed_status", "exit_code"),
+    (("skipped", 0), ("ok", 0), ("fail", 1), ("unrecognized", 1)),
+)
+def test_pack_doctor_cli_fails_only_on_non_allowlisted_statuses(
+    tmp_path: Path, monkeypatch, capsys, feed_status: str, exit_code: int
+):
+    checks = [{"check": "queue", "status": "ok"}, {"check": "feed-authority", "status": feed_status}]
+    monkeypatch.setattr(grokbot_packs, "doctor", lambda *_args, **_kwargs: checks)
+
+    assert cli.main(_pack_argv(tmp_path, "doctor", "--id", "repository-scout")) == exit_code
+    assert f"feed-authority: {feed_status}" in capsys.readouterr().out

--- a/tests/test_grokbot_scout_feed.py
+++ b/tests/test_grokbot_scout_feed.py
@@ -390,6 +390,36 @@ def test_apply_translates_enqueue_errors_at_the_public_boundary(tmp_path: Path, 
         grokbot_scout_feed.apply(tmp_path, policy, now=NOW)
 
 
+def test_apply_surfaces_the_refused_hub_action_and_actor_kind(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    policy = _write_policy(tmp_path / "policy.json", _policy())
+    _gh_numbers(monkeypatch, [7])
+    monkeypatch.setattr(
+        grokbot_scout_feed.grokbot_jobs,
+        "enqueue_repository_scout",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            grokbot_scout_feed.grokbot_jobs.GrokbotJobError("auth-failed", action="list")
+        ),
+    )
+
+    with pytest.raises(grokbot_scout_feed.ScoutFeedError) as raised:
+        grokbot_scout_feed.apply(tmp_path, policy, now=NOW)
+
+    assert raised.value.reason == "auth-failed"
+    assert raised.value.action == "list"
+    assert raised.value.actor_kind is None
+    assert raised.value.public_detail() == "auth-failed action=list"
+
+
+def test_scout_feed_error_keeps_stable_reasons_for_non_hub_failures():
+    for reason in ("malformed-policy", "gh-unavailable", "unsafe-policy"):
+        error = grokbot_scout_feed.ScoutFeedError(reason)
+        assert error.reason == reason
+        assert error.action is None
+        assert error.actor_kind is None
+        assert error.public_detail() == reason
+        assert "action=" not in error.public_detail()
+
+
 def test_preflight_rejects_symlinked_policy_without_queue_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     real = _write_policy(tmp_path / "real-policy.json", _policy())
     policy = tmp_path / "policy.json"
@@ -534,6 +564,33 @@ def test_cli_scout_feed_apply_binds_dedicated_feed_identity(tmp_path: Path, monk
     assert _run_scout_feed(tmp_path, policy, "--apply") == 0
     assert seen == [token]
     assert token not in capsys.readouterr().out
+
+
+def test_cli_scout_feed_prints_refused_action_without_paths_or_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+):
+    token = "dedicated-scout-feed-token"
+    token_file = tmp_path / "feed.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.setenv("BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    _gh_numbers(monkeypatch, [7])
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "enqueue_repository_scout",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(grokbot_jobs.GrokbotJobError("auth-failed", action="list")),
+    )
+    policy = _write_policy(tmp_path / "policy.json", _policy())
+
+    assert _run_scout_feed(tmp_path, policy, "--apply") == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "error: auth-failed action=list actor=feed\n"
+    assert "/" not in captured.err
+    assert "policy.json" not in captured.err
+    assert token not in captured.err
 
 
 def test_cli_scout_feed_text_reports_no_work_without_private_policy_context(


### PR DESCRIPTION
## Summary

Fixes #1343. Under hub authority, `scout-feed --apply` was structurally dead: `_enqueue_scout_via_hub` reads the hub queue first (`list`) for its daily-limit and active-scout rails, and no enrolled actor kind held both `list` and `enqueue`. The refusal was then flattened to `queue-error` (a storage-shaped message for an authorization refusal), and doctor reported green throughout because no check exercised the feed actor's hub authority.

Note the investigation corrected one detail of the issue: `_selection`'s local `_queue_snapshot` is pure descriptor-relative file I/O and never touches the hub; the refused `list` comes from the hub-side rails inside `_enqueue_scout_via_hub`. Under hub authority those hub rails are the real ones, so dropping the read was never an option.

## Fix

1. **Hub grant**: `FEED_ACTIONS = {enqueue, list, whoami}` for `feed` and `control`. The hub's `list` handler already pins `queue_id` for every caller and projects only `SAFE_JOB_FIELDS` (no `idempotency_key_hash`, no `lease_token_digest`), so no scope widens. The grant is retroactive - authorization reads actor kind at request time - and needs no re-enrollment. Deploy direction: roll the hub first; an old hub still refuses `list` from new clients.
2. **Error surfacing**: `GrokbotJobError` and `ScoutFeedError` gain an optional `action`; the CLI prints `error: auth-failed action=list actor=feed`. Only hub-bounded refusal reasons are named; local storage failures keep the redacted `queue-error` form, and nothing path- or token-shaped reaches stderr.
3. **Doctor**: a read-only `feed-authority` check (whoami + list, never enqueue) runs when hub authority is active; `ok`/`fail`/`skipped`, where `skipped` (no feed token configured) does not fail the doctor exit. This catches exactly the #1343 class: healthy token, right identity, refused read.

## Deliberate contract change

Two hub tests asserting feed/control `list` refusals now assert queue-scoped success. The forbidden-action surface is re-asserted: feed and control still cannot `claim`, `cancel`, `expire`, `complete`, or `report-metadata`, and a feed `list` is proven scoped to its own queue with a `SAFE_JOB_FIELDS`-subset projection.

## Verification

`brigade work verify run` receipt `20260831-235828-work-verify-69a528`: `./scripts/verify-focused tests/test_fleet_cloud.py tests/test_grokbot_scout_feed.py tests/test_grokbot_ops.py` completed, exit 0, 174 passed. An earlier neighbour-suite regression pass also completed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)