### PR TITLE
feat(skills): add the verify-brigade verification skill and control helper

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -8,6 +8,12 @@ These are vendored, byte-identical copies. The source of truth is
 `skillet/skills/<name>/SKILL.md` (MIT). Do not edit files here. Update skillet
 and re-copy, then re-run `npx shadcn@latest build`.
 
+One exception: `skills/verify-brigade/` is written and maintained here, not
+vendored from skillet, and it is deliberately absent from `registry.json`. It
+drives this checkout's own `brigade` CLI, so it is a development skill for
+Brigade itself rather than a payload to serve to other projects. Edit it in
+place; `tests/test_verify_brigade_skill.py` is its gate.
+
 The registry mechanism follows [shadcn registries](https://ui.shadcn.com/docs/registry).
 [remocn](https://github.com/kapishdima/remocn) by kapishdima proved the same
 mechanism carries non-component payloads (Remotion video components). This

--- a/registry/skills/verify-brigade/SKILL.md
+++ b/registry/skills/verify-brigade/SKILL.md
@@ -13,10 +13,28 @@ target and read what it wrote. This skill drives it through one helper,
 Every drive happens in a temp target this skill creates. The helper enforces
 that: `--target` is accepted only when it resolves *under* `<state-root>/targets`,
 so the operator home, the Brigade checkout, and every other path are refused
-before a command runs. `--root` and `--evidence-root` get the same treatment -
-they may not resolve to, or contain, the home directory or the checkout - and
-`cleanup` removes only paths `new-target` recorded. `AGENTS.md` forbids driving
-the real workspace anyway; here it is not reachable.
+before a command runs. The state root gets the same treatment whether it comes
+from `--root` or from the default - resolved, refused if it resolves to or
+contains the home directory or the checkout, and refused if it is a symlink at
+the root or at `targets/`/`captures/`, so a link planted in a world-writable
+temp dir cannot redirect a drive. `cleanup` removes only paths `new-target`
+recorded. `AGENTS.md` forbids driving the real workspace anyway; here it is not
+reachable.
+
+What that paragraph does *not* claim:
+
+- A path under the temp base is allowed even when `$TMPDIR` sits inside the
+  home directory. `$TMPDIR` is the scratch tree by definition; the home refusal
+  is measured against everything else. The temp base itself is refused - a
+  state root there would chmod the shared scratch tree to `0700`.
+- The default evidence root is `<checkout>/.brigade/verification-evidence`,
+  which is inside the checkout. That is the one deliberate exception: it is
+  gitignored, and it sits outside the state root on purpose so `cleanup` cannot
+  reach the proof. `--evidence-root` is guarded like `--root`.
+- `grokbot-feed --manifest` is the one flag outside the target contract. It is
+  a caller-supplied path, read for validation only and never written, so an
+  operator can validate a real private feed manifest from wherever it lives.
+  Everything the drive *writes* still lands in the target or the state root.
 
 ## Launch
 
@@ -195,7 +213,8 @@ Subcommands: `doctor`, `new-target`, `init`, `doctor-target`, `work-verify`,
 
 Global flags: `--brigade "<command>"` to drive a different Brigade build (for
 example `--brigade "$(command -v python3) -m brigade"`), `--root <dir>` to
-isolate the state root when two runs go at once, `--timeout <s>` per call.
+isolate the state root when two runs go at once (a directory under `$TMPDIR`,
+not `$TMPDIR` itself), `--timeout <s>` per call.
 
 Every subcommand that writes accepts `--dry-run`, which reports the command it
 skipped and mutates nothing: `new-target`, `init`, `work-verify`,
@@ -206,8 +225,9 @@ skipped and mutates nothing: `new-target`, `init`, `work-verify`,
 
 `tests/test_verify_brigade_skill.py` runs `new-target`, `doctor-target`,
 `work-verify`, and `cleanup` in a pytest `tmp_path`, and asserts the path
-refusals and the `0600`/`0700` permissions, so CI fails if this helper stops
-working or stops guarding.
+refusals (including a symlink planted at the default state root), the
+unwritable-root JSON envelope, and the `0600`/`0700` permissions, so CI fails
+if this helper stops working or stops guarding.
 
 ## Reporting the proof
 

--- a/registry/skills/verify-brigade/SKILL.md
+++ b/registry/skills/verify-brigade/SKILL.md
@@ -10,9 +10,13 @@ CLI, and the only honest way to prove a change is to run that CLI against a
 target and read what it wrote. This skill drives it through one helper,
 `control-brigade.py`, so a proof is a rerunnable command instead of a story.
 
-Every drive happens in a temp target this skill creates. Never point any of
-these commands at the operator home or at the Brigade checkout - the helper
-refuses both, and `AGENTS.md` forbids it.
+Every drive happens in a temp target this skill creates. The helper enforces
+that: `--target` is accepted only when it resolves *under* `<state-root>/targets`,
+so the operator home, the Brigade checkout, and every other path are refused
+before a command runs. `--root` and `--evidence-root` get the same treatment -
+they may not resolve to, or contain, the home directory or the checkout - and
+`cleanup` removes only paths `new-target` recorded. `AGENTS.md` forbids driving
+the real workspace anyway; here it is not reachable.
 
 ## Launch
 
@@ -39,6 +43,19 @@ recorded the path so `cleanup` can find it later. Ready is
 ```bash
 TARGET=$(registry/skills/verify-brigade/control-brigade.py new-target \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["target"])')
+```
+
+`new-target` records the path before it runs `brigade init`, so `cleanup` can
+reclaim it even when that init fails; a failed init also removes the directory
+it made. `--dry-run` prints the two commands and creates nothing.
+
+To drive an existing directory you already made under `<state-root>/targets`
+(instead of letting `new-target` make one), `init` runs the same
+`brigade init` against it:
+
+```bash
+registry/skills/verify-brigade/control-brigade.py init --target "$TARGET" \
+  --depth workspace --harnesses claude,codex
 ```
 
 Teardown is the `cleanup` section below. Run it after every attempt, including
@@ -179,11 +196,18 @@ Subcommands: `doctor`, `new-target`, `init`, `doctor-target`, `work-verify`,
 Global flags: `--brigade "<command>"` to drive a different Brigade build (for
 example `--brigade "$(command -v python3) -m brigade"`), `--root <dir>` to
 isolate the state root when two runs go at once, `--timeout <s>` per call.
-Every mutating subcommand (`grokbot-pack-setup --apply`,
-`grokbot-pack-remove --apply`, `cleanup`) accepts `--dry-run`.
 
-`tests/test_verify_brigade_skill.py` runs `new-target`, `doctor-target`, and
-`cleanup` in a pytest `tmp_path`, so CI fails if this helper stops working.
+Every subcommand that writes accepts `--dry-run`, which reports the command it
+skipped and mutates nothing: `new-target`, `init`, `work-verify`,
+`grokbot-feed --sample`, `evidence`, `cleanup`, and
+`grokbot-pack-setup`/`grokbot-pack-remove` (there it forces preview even with
+`--apply`). The dry-run envelope carries `"dry_run": true` and a `would_run`,
+`would_remove`, or `would_copy` list.
+
+`tests/test_verify_brigade_skill.py` runs `new-target`, `doctor-target`,
+`work-verify`, and `cleanup` in a pytest `tmp_path`, and asserts the path
+refusals and the `0600`/`0700` permissions, so CI fails if this helper stops
+working or stops guarding.
 
 ## Reporting the proof
 

--- a/registry/skills/verify-brigade/SKILL.md
+++ b/registry/skills/verify-brigade/SKILL.md
@@ -24,13 +24,20 @@ reachable.
 What that paragraph does *not* claim:
 
 - A path under the temp base is allowed even when `$TMPDIR` sits inside the
-  home directory. `$TMPDIR` is the scratch tree by definition; the home refusal
-  is measured against everything else. The temp base itself is refused - a
-  state root there would chmod the shared scratch tree to `0700`.
+  home directory. That is the only carve-out, and it is exactly that narrow:
+  the home and checkout refusals run *first*, so the allowance applies only
+  when the temp base itself resolves inside the home directory and outside the
+  checkout. A `$TMPDIR` inside the checkout is still refused, and a relative
+  `$TMPDIR` is refused outright rather than resolved against the working
+  directory. The temp base itself is refused - a state root there would chmod
+  the shared scratch tree to `0700`.
 - The default evidence root is `<checkout>/.brigade/verification-evidence`,
   which is inside the checkout. That is the one deliberate exception: it is
   gitignored, and it sits outside the state root on purpose so `cleanup` cannot
-  reach the proof. `--evidence-root` is guarded like `--root`.
+  reach the proof. The default and `--evidence-root` are both guarded like
+  `--root`, symlink check included: a link planted at either is refused, not
+  followed. `--label` names the directory under that root, so it must be a
+  simple `[A-Za-z0-9._-]` name of 1-64 characters - no separators, no `..`.
 - `grokbot-feed --manifest` is the one flag outside the target contract. It is
   a caller-supplied path, read for validation only and never written, so an
   operator can validate a real private feed manifest from wherever it lives.

--- a/registry/skills/verify-brigade/SKILL.md
+++ b/registry/skills/verify-brigade/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: verify-brigade
+description: "Prove a Brigade change works by driving the real `brigade` CLI against a throwaway temp target, then capture receipts as evidence. Use when you changed anything under src/brigade/ and need proof beyond pytest - init/doctor wiring, work-verify receipts, Grok Bot connector packs, feed manifests, handoff lint. Also use before claiming a CLI behavior in a PR body, handoff, or job report."
+---
+
+# Verify Brigade
+
+Brigade has no server and no UI. The surface a user touches is the `brigade`
+CLI, and the only honest way to prove a change is to run that CLI against a
+target and read what it wrote. This skill drives it through one helper,
+`control-brigade.py`, so a proof is a rerunnable command instead of a story.
+
+Every drive happens in a temp target this skill creates. Never point any of
+these commands at the operator home or at the Brigade checkout - the helper
+refuses both, and `AGENTS.md` forbids it.
+
+## Launch
+
+There is no long-running process. "Launch" means: have a Brigade CLI, and have
+a fresh target to drive it against.
+
+```bash
+# once per checkout, if .venv/ is missing
+python -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+```
+
+Create the target:
+
+```bash
+registry/skills/verify-brigade/control-brigade.py new-target
+```
+
+That prints one JSON object. It ran `git init -q -b main` and
+`brigade init --depth workspace --harnesses claude,codex` in a new directory
+under the state root (`$TMPDIR/verify-brigade/targets/<stamp>-<rand>`), and
+recorded the path so `cleanup` can find it later. Ready is
+`"ok": true` plus the `"target"` path; export it:
+
+```bash
+TARGET=$(registry/skills/verify-brigade/control-brigade.py new-target \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["target"])')
+```
+
+Teardown is the `cleanup` section below. Run it after every attempt, including
+failed ones, so broken runs do not leave targets behind.
+
+## Doctor
+
+One read-only check that answers "is this rig worth driving?" - before blaming
+Brigade for a drive that fails:
+
+```bash
+registry/skills/verify-brigade/control-brigade.py doctor
+```
+
+It resolves the Brigade command (`--brigade`, then `$BRIGADE_BIN`, then
+`.venv/bin/brigade`, then `PATH`, then `python -m brigade`), reports its
+version, and checks git, the checkout, and a writable state root. `"ok": true`
+means drive. Anything `"fail"` means fix that first.
+
+Against a target that already exists, the equivalent question is:
+
+```bash
+registry/skills/verify-brigade/control-brigade.py doctor-target --target "$TARGET"
+```
+
+`"summary": {"failed": 0, ...}` is the success signal. `warn` counts above zero
+are normal on a fresh target - memory-care, security, and backups are not
+initialized yet.
+
+## Drive
+
+Real commands from this repo, one per mapped feature. The full map is in
+[`features/README.md`](features/README.md); drive the feature your change
+actually touched, not just the convenient one.
+
+```bash
+C=registry/skills/verify-brigade/control-brigade.py
+
+# init + doctor wiring
+$C doctor-target --target "$TARGET"
+
+# work verification receipts (returns the receipt id and status)
+$C work-verify --target "$TARGET" --capture verify-brigade
+
+# Grok Bot connector pack lifecycle (implementation-worker is the worker pack)
+$C grokbot-pack-setup  --target "$TARGET" --id implementation-worker
+$C grokbot-pack-setup  --target "$TARGET" --id implementation-worker --apply
+$C grokbot-pack-doctor --target "$TARGET" --id implementation-worker
+$C grokbot-pack-canary --target "$TARGET" --id implementation-worker
+$C grokbot-pack-remove --target "$TARGET" --id implementation-worker
+
+# feed manifest validation and queue projection
+$C grokbot-feed   --target "$TARGET" --sample
+$C grokbot-status --target "$TARGET"
+
+# handoff inbox lint
+$C handoff-lint --target "$TARGET" --content-guard
+```
+
+Read the exit code, not the prose:
+
+| exit | meaning |
+|---|---|
+| 0 | the drive ran and the observation is what a healthy rig produces |
+| 1 | the helper itself failed (no Brigade, unsafe path, bad target) |
+| 2 | usage error |
+| 3 | the drive ran fine, but the observation is a failure |
+
+Stable handles to assert on, in order of preference: the JSON keys the helper
+normalizes (`run_id`, `status`, `summary.failed`, `checks[].status`, `valid`,
+`reason`), then the receipt directory under
+`$TARGET/.brigade/work/verify-runs/<run-id>/`. Do not grep the human prose;
+it changes.
+
+## Evidence
+
+```bash
+registry/skills/verify-brigade/control-brigade.py evidence --target "$TARGET" --label <what-you-proved>
+```
+
+Writes `.brigade/verification-evidence/<stamp>-<label>/` in the checkout and
+prints the path as `evidence_dir`. It contains `captures/` (every command the
+helper ran, with argv, exit code, stdout, stderr, duration),
+`target-brigade/work/verify-runs/` (the real receipts Brigade wrote), and
+`manifest.json`. That directory is outside the state root, so `cleanup` cannot
+reach it.
+
+Proof standards for this repo:
+
+- Drive the CLI path a user runs. Do not import `brigade.*` in Python and call
+  the function; a passing unit test is not a proof that the command works.
+- Capture the action and the resulting state. A `work-verify` proof is the
+  command record **and** the receipt directory it names.
+- Verify the side effect on disk, not just stdout. `grokbot-pack-setup --apply`
+  claims it wrote `.brigade/grokbot/packs/<id>.json`; look at the file.
+- Preview modes here are genuinely non-mutating, but check rather than trust:
+  `grokbot-pack-setup` without `--apply` and `grokbot-pack-remove` without
+  `--apply` print a `writes`/`paths` list and touch nothing, and
+  `grokbot-feed` validates without enqueueing. Confirm by diffing
+  `$TARGET/.brigade/` before and after.
+- No mocks. Every command above hits the real CLI. The one boundary that is
+  genuinely absent is a running Grok Bot listener, and the skill reads its
+  absence as data rather than faking it.
+
+## Cleanup
+
+```bash
+registry/skills/verify-brigade/control-brigade.py cleanup --dry-run   # see it first
+registry/skills/verify-brigade/control-brigade.py cleanup
+```
+
+Cleanup removes only paths recorded by `new-target` and only when they sit
+under `<state-root>/targets/`; anything else is skipped with a reason. It never
+kills processes by name, and it never removes an evidence directory. Use
+`--target` to drop one target, `--keep-captures` to leave the raw command
+records in the state root.
+
+After cleanup, confirm the proof survived:
+
+```bash
+ls .brigade/verification-evidence/<stamp>-<label>/manifest.json
+```
+
+## Helpers
+
+`control-brigade.py` is the only helper. It is executable, stdlib-only, and
+prints one JSON object per call.
+
+```bash
+registry/skills/verify-brigade/control-brigade.py --help
+```
+
+Subcommands: `doctor`, `new-target`, `init`, `doctor-target`, `work-verify`,
+`grokbot-pack-setup`, `grokbot-pack-doctor`, `grokbot-pack-canary`,
+`grokbot-pack-remove`, `grokbot-feed`, `grokbot-status`, `handoff-lint`,
+`evidence`, `cleanup`.
+
+Global flags: `--brigade "<command>"` to drive a different Brigade build (for
+example `--brigade "$(command -v python3) -m brigade"`), `--root <dir>` to
+isolate the state root when two runs go at once, `--timeout <s>` per call.
+Every mutating subcommand (`grokbot-pack-setup --apply`,
+`grokbot-pack-remove --apply`, `cleanup`) accepts `--dry-run`.
+
+`tests/test_verify_brigade_skill.py` runs `new-target`, `doctor-target`, and
+`cleanup` in a pytest `tmp_path`, so CI fails if this helper stops working.
+
+## Reporting the proof
+
+Do not claim a Brigade behavior without the receipt. When a change is done,
+route the repo's own gate through Brigade once:
+
+```bash
+brigade work verify run --target . \
+  --argv-json '["./scripts/verify-focused","<pytest-selector>"]' \
+  --capture brigade-work
+```
+
+Then paste the `run_id`, the status, and the `evidence_dir` from this skill.

--- a/registry/skills/verify-brigade/control-brigade.py
+++ b/registry/skills/verify-brigade/control-brigade.py
@@ -1,0 +1,867 @@
+#!/usr/bin/env python3
+"""Drive the real Brigade CLI against a throwaway target and capture evidence.
+
+Every subcommand prints one JSON object on stdout. Exit codes:
+
+  0  the drive ran and the observation matched what a healthy rig produces
+  1  the helper itself failed (brigade not found, unsafe path, bad target)
+  2  usage error (argparse)
+  3  the drive ran fine but the observation is a failure (doctor FAILs,
+     verification did not complete)
+
+Nothing here touches the operator workspace or the Brigade checkout: targets are
+created under a state root (default $TMPDIR/verify-brigade) and only paths this
+helper recorded are ever removed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA = "verify-brigade.control.v1"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_DEPTH = "workspace"
+DEFAULT_HARNESSES = "claude,codex"
+DEFAULT_PROBE = "python3 --version"
+DEFAULT_TIMEOUT = 300
+
+# Non-secret placeholder. The pack config check only proves the reference
+# resolves; nothing authenticates with this value.
+BEARER_ENV_NAME = "VERIFY_BRIGADE_PACK_BEARER"
+BEARER_PLACEHOLDER = "not-a-real-bearer-verify-brigade"
+
+FEED_SAMPLE = {
+    "schema": "brigade.grokbot.feed.v1",
+    "approved": True,
+    "label": "verify-brigade sample feed",
+    "entries": [
+        {
+            "idempotency_key": "verify-brigade-sample-001",
+            "spec": {
+                "label": "sample implementation worker job",
+                "role": "implementation-worker",
+                "repository": "example-org/example-repo",
+                "base_ref": "main",
+                "ownership_paths": ["docs"],
+                "instructions": "Sample instructions used only for feed validation.",
+                "verification_commands": ["python3 --version"],
+                "artifact": {"kind": "branch"},
+                "timeout_seconds": 600,
+            },
+        }
+    ],
+}
+
+
+class HelperError(Exception):
+    """The helper cannot proceed; report it instead of driving anything."""
+
+
+# ---------------------------------------------------------------- primitives
+
+
+def emit(payload: dict, code: int = 0) -> int:
+    payload.setdefault("schema", SCHEMA)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return code
+
+
+def now_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def resolve_brigade(explicit: str | None) -> list[str]:
+    """Resolve the brigade command: --brigade, $BRIGADE_BIN, .venv, PATH, module."""
+    for candidate in (explicit, os.environ.get("BRIGADE_BIN")):
+        if candidate:
+            parts = shlex.split(candidate)
+            if not parts:
+                raise HelperError(f"empty brigade command: {candidate!r}")
+            return parts
+    venv = REPO_ROOT / ".venv" / "bin" / "brigade"
+    if venv.exists():
+        return [str(venv)]
+    found = shutil.which("brigade")
+    if found:
+        return [found]
+    return [sys.executable, "-m", "brigade"]
+
+
+def state_root(args: argparse.Namespace) -> Path:
+    root = Path(args.root).expanduser().resolve() if args.root else Path(tempfile.gettempdir()) / "verify-brigade"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "captures").mkdir(exist_ok=True)
+    (root / "targets").mkdir(exist_ok=True)
+    return root
+
+
+def read_state(root: Path) -> dict:
+    path = root / "state.json"
+    if not path.exists():
+        return {"schema": "verify-brigade.state.v1", "created_targets": []}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"schema": "verify-brigade.state.v1", "created_targets": []}
+    if not isinstance(loaded, dict):
+        return {"schema": "verify-brigade.state.v1", "created_targets": []}
+    loaded.setdefault("created_targets", [])
+    return loaded
+
+
+def write_state(root: Path, state: dict) -> None:
+    path = root / "state.json"
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def guard_target(path: Path) -> Path:
+    """Refuse to drive Brigade against the operator home or this checkout."""
+    resolved = Path(path).expanduser().resolve()
+    home = Path.home().resolve()
+    forbidden = {home, Path("/"), REPO_ROOT}
+    if resolved in forbidden:
+        raise HelperError(f"refusing to use {resolved} as a target (home, root, or the Brigade checkout)")
+    if resolved == REPO_ROOT or REPO_ROOT.is_relative_to(resolved):
+        raise HelperError(f"refusing to use {resolved}: it contains the Brigade checkout")
+    return resolved
+
+
+def record_capture(root: Path, name: str, record: dict) -> Path:
+    path = root / "captures" / f"{now_stamp()}-{uuid.uuid4().hex[:6]}-{name}.json"
+    path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def run(
+    argv: list[str],
+    *,
+    root: Path,
+    name: str,
+    env_extra: dict[str, str] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    """Run one command, capture it to the state root, and return the record."""
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, env=env, check=False)
+    except FileNotFoundError as exc:
+        raise HelperError(f"command not found: {argv[0]}") from exc
+    except subprocess.TimeoutExpired:
+        record = {
+            "argv": argv,
+            "name": name,
+            "returncode": None,
+            "timed_out": True,
+            "timeout_seconds": timeout,
+            "stdout": "",
+            "stderr": "",
+            "duration_seconds": round(time.monotonic() - started, 3),
+        }
+        record["capture"] = str(record_capture(root, name, record))
+        return record
+    record = {
+        "argv": argv,
+        "name": name,
+        "returncode": proc.returncode,
+        "timed_out": False,
+        "timeout_seconds": timeout,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "duration_seconds": round(time.monotonic() - started, 3),
+    }
+    try:
+        record["json"] = json.loads(proc.stdout)
+    except ValueError:
+        record["json"] = None
+    record["capture"] = str(record_capture(root, name, record))
+    return record
+
+
+def slim(record: dict) -> dict:
+    """A record small enough to print without drowning the reader."""
+    return {
+        "argv": record["argv"],
+        "returncode": record["returncode"],
+        "timed_out": record["timed_out"],
+        "duration_seconds": record["duration_seconds"],
+        "stdout_tail": record["stdout"][-800:],
+        "stderr_tail": record["stderr"][-800:],
+        "capture": record["capture"],
+    }
+
+
+def brigade_args(args: argparse.Namespace) -> list[str]:
+    return resolve_brigade(args.brigade)
+
+
+# ------------------------------------------------------------- subcommands
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """Read-only: is this rig worth driving?"""
+    root = state_root(args)
+    checks: list[dict] = []
+    brigade = brigade_args(args)
+
+    version = run(brigade + ["--version"], root=root, name="doctor-version", timeout=60)
+    checks.append(
+        {
+            "name": "brigade cli",
+            "status": "ok" if version["returncode"] == 0 else "fail",
+            "detail": (version["stdout"] or version["stderr"]).strip() or "no output",
+        }
+    )
+
+    git = shutil.which("git")
+    checks.append(
+        {
+            "name": "git",
+            "status": "ok" if git else "fail",
+            "detail": git or "git is required to create a target",
+        }
+    )
+
+    pyproject = REPO_ROOT / "pyproject.toml"
+    checks.append(
+        {
+            "name": "brigade checkout",
+            "status": "ok" if pyproject.exists() else "fail",
+            "detail": str(pyproject),
+        }
+    )
+
+    checks.append(
+        {
+            "name": "state root writable",
+            "status": "ok" if os.access(root, os.W_OK) else "fail",
+            "detail": str(root),
+        }
+    )
+
+    failed = [check for check in checks if check["status"] == "fail"]
+    return emit(
+        {
+            "action": "doctor",
+            "ok": not failed,
+            "brigade": brigade,
+            "python": sys.version.split()[0],
+            "repo_root": str(REPO_ROOT),
+            "state_root": str(root),
+            "checks": checks,
+        },
+        0 if not failed else 3,
+    )
+
+
+def cmd_new_target(args: argparse.Namespace) -> int:
+    """git init + brigade init in a fresh temp dir; print the path."""
+    root = state_root(args)
+    brigade = brigade_args(args)
+    target = Path(tempfile.mkdtemp(prefix=f"{now_stamp()}-", dir=root / "targets"))
+
+    git = shutil.which("git")
+    if not git:
+        raise HelperError("git is required to create a target")
+    git_record = run([git, "init", "-q", "-b", "main", str(target)], root=root, name="new-target-git", timeout=60)
+    if git_record["returncode"] != 0:
+        shutil.rmtree(target, ignore_errors=True)
+        return emit({"action": "new-target", "ok": False, "stage": "git-init", "git": slim(git_record)}, 1)
+
+    init_record = run(
+        brigade + ["init", "--target", str(target), "--depth", args.depth, "--harnesses", args.harnesses],
+        root=root,
+        name="new-target-init",
+        timeout=args.timeout,
+    )
+    if init_record["returncode"] != 0:
+        return emit(
+            {
+                "action": "new-target",
+                "ok": False,
+                "stage": "brigade-init",
+                "target": str(target),
+                "init": slim(init_record),
+            },
+            3,
+        )
+
+    state = read_state(root)
+    state["created_targets"] = sorted(set(state["created_targets"]) | {str(target)})
+    write_state(root, state)
+
+    return emit(
+        {
+            "action": "new-target",
+            "ok": True,
+            "target": str(target),
+            "depth": args.depth,
+            "harnesses": args.harnesses,
+            "state_root": str(root),
+            "brigade_dir": str(target / ".brigade"),
+            "git": slim(git_record),
+            "init": slim(init_record),
+        }
+    )
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    """Run `brigade init` against an existing directory you already own."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    if not target.is_dir():
+        raise HelperError(f"target is not a directory: {target}")
+    record = run(
+        brigade_args(args) + ["init", "--target", str(target), "--depth", args.depth, "--harnesses", args.harnesses],
+        root=root,
+        name="init",
+        timeout=args.timeout,
+    )
+    ok = record["returncode"] == 0
+    return emit(
+        {
+            "action": "init",
+            "ok": ok,
+            "target": str(target),
+            "depth": args.depth,
+            "harnesses": args.harnesses,
+            "init": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def cmd_doctor_target(args: argparse.Namespace) -> int:
+    """`brigade doctor --json` against the temp target. 0 failed is the signal."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    record = run(
+        brigade_args(args) + ["doctor", "--target", str(target), "--json"],
+        root=root,
+        name="doctor-target",
+        timeout=args.timeout,
+    )
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    failed = summary.get("failed")
+    ok = record["returncode"] == 0 and failed == 0
+    return emit(
+        {
+            "action": "doctor-target",
+            "ok": ok,
+            "target": str(target),
+            "ready": payload.get("ready"),
+            "owner": payload.get("owner"),
+            "depth": payload.get("depth"),
+            "harnesses": payload.get("harnesses"),
+            "summary": summary,
+            "doctor": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def cmd_work_verify(args: argparse.Namespace) -> int:
+    """Bounded `brigade work verify run` in the temp target; return receipt id."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    argv = brigade_args(args) + [
+        "work",
+        "verify",
+        "run",
+        "--target",
+        str(target),
+        "--command",
+        args.command,
+        "--timeout",
+        str(args.command_timeout),
+        "--json",
+    ]
+    if args.capture:
+        argv += ["--capture", args.capture]
+    record = run(argv, root=root, name="work-verify", timeout=args.timeout)
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    status = payload.get("status")
+    ok = record["returncode"] == 0 and status == "completed"
+    return emit(
+        {
+            "action": "work-verify",
+            "ok": ok,
+            "target": str(target),
+            "command": args.command,
+            "run_id": payload.get("run_id"),
+            "status": status,
+            "receipt_path": payload.get("path"),
+            "outcome_capture": payload.get("outcome_capture"),
+            "verify": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def pack_env(args: argparse.Namespace) -> dict[str, str]:
+    if args.bearer_env == BEARER_ENV_NAME and BEARER_ENV_NAME not in os.environ:
+        return {BEARER_ENV_NAME: BEARER_PLACEHOLDER}
+    return {}
+
+
+def cmd_pack_setup(args: argparse.Namespace) -> int:
+    """Preview (default) or apply non-secret pack instance config."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    apply = args.apply and not args.dry_run
+    argv = brigade_args(args) + [
+        "run",
+        "cloud",
+        "grokbot",
+        "pack",
+        "setup",
+        "--target",
+        str(target),
+        "--id",
+        args.id,
+        "--bearer-env",
+        args.bearer_env,
+        "--json",
+    ]
+    if apply:
+        argv.append("--apply")
+    record = run(argv, root=root, name="pack-setup", timeout=args.timeout)
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    ok = record["returncode"] == 0
+    return emit(
+        {
+            "action": "grokbot-pack-setup",
+            "ok": ok,
+            "target": str(target),
+            "pack_id": args.id,
+            "applied": bool(payload.get("apply")),
+            "dry_run": bool(args.dry_run),
+            "bind": payload.get("bind"),
+            "writes": payload.get("writes"),
+            "setup": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def cmd_pack_doctor(args: argparse.Namespace) -> int:
+    """Sanitized pack diagnostics. Without a listener, `endpoint` fails."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    record = run(
+        brigade_args(args)
+        + ["run", "cloud", "grokbot", "pack", "doctor", "--target", str(target), "--id", args.id, "--json"],
+        root=root,
+        name="pack-doctor",
+        env_extra=pack_env(args),
+        timeout=args.timeout,
+    )
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    checks = payload.get("checks") if isinstance(payload.get("checks"), list) else []
+    by_name = {check.get("check"): check.get("status") for check in checks if isinstance(check, dict)}
+    return emit(
+        {
+            "action": "grokbot-pack-doctor",
+            # The command answered with a sanitized check list. A failing
+            # endpoint check is the expected reading with no listener up.
+            "ok": bool(checks),
+            "target": str(target),
+            "pack_id": args.id,
+            "checks": checks,
+            "config_resolved": by_name.get("config") == "ok",
+            "listener_running": by_name.get("endpoint") == "ok",
+            "doctor": slim(record),
+        },
+        0 if checks else 3,
+    )
+
+
+def cmd_pack_canary(args: argparse.Namespace) -> int:
+    """Bounded non-mutating auth + inventory check against the pack listener."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    record = run(
+        brigade_args(args)
+        + ["run", "cloud", "grokbot", "pack", "canary", "--target", str(target), "--id", args.id, "--json"],
+        root=root,
+        name="pack-canary",
+        env_extra=pack_env(args),
+        timeout=args.timeout,
+    )
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    reason = payload.get("reason")
+    listener_running = bool(payload.get("ok"))
+    # `reason: health` with no listener bound is the proof the command ran:
+    # it resolved config, dialed the bind, and reported the miss.
+    understood = listener_running or reason in {"health", "config", "dependency"}
+    return emit(
+        {
+            "action": "grokbot-pack-canary",
+            "ok": understood,
+            "target": str(target),
+            "pack_id": args.id,
+            "listener_running": listener_running,
+            "reason": reason,
+            "expected_without_listener": reason == "health",
+            "canary": slim(record),
+        },
+        0 if understood else 3,
+    )
+
+
+def cmd_pack_remove(args: argparse.Namespace) -> int:
+    """Preview (default) or apply removal of pack config this run wrote."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    apply = args.apply and not args.dry_run
+    argv = brigade_args(args) + [
+        "run",
+        "cloud",
+        "grokbot",
+        "pack",
+        "remove",
+        "--target",
+        str(target),
+        "--id",
+        args.id,
+        "--json",
+    ]
+    if apply:
+        argv.append("--apply")
+    record = run(argv, root=root, name="pack-remove", timeout=args.timeout)
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    ok = record["returncode"] == 0
+    return emit(
+        {
+            "action": "grokbot-pack-remove",
+            "ok": ok,
+            "target": str(target),
+            "pack_id": args.id,
+            "applied": bool(payload.get("apply")),
+            "dry_run": bool(args.dry_run),
+            "paths": payload.get("paths"),
+            "remove": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def cmd_feed(args: argparse.Namespace) -> int:
+    """Validate an approved feed manifest. Validation only; never enqueues."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    if args.sample:
+        manifest = root / "sample-feed-manifest.json"
+        manifest.write_text(json.dumps(FEED_SAMPLE, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        manifest.chmod(0o600)
+    else:
+        if not args.manifest:
+            raise HelperError("pass --manifest PATH or --sample")
+        manifest = Path(args.manifest).expanduser().resolve()
+    record = run(
+        brigade_args(args)
+        + [
+            "run",
+            "cloud",
+            "grokbot",
+            "feed",
+            "--target",
+            str(target),
+            "--manifest",
+            str(manifest),
+            "--limit",
+            str(args.limit),
+            "--json",
+        ],
+        root=root,
+        name="feed",
+        timeout=args.timeout,
+    )
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    ok = record["returncode"] == 0
+    return emit(
+        {
+            "action": "grokbot-feed",
+            "ok": ok,
+            "target": str(target),
+            "manifest": str(manifest),
+            "sample": bool(args.sample),
+            "valid": payload.get("valid"),
+            "known": payload.get("known"),
+            "limit": payload.get("limit"),
+            "feed": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Safe Grok Bot job projections. Needs hub authority; reports why not."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    record = run(
+        brigade_args(args) + ["run", "cloud", "grokbot", "status", "--target", str(target), "--json"],
+        root=root,
+        name="grokbot-status",
+        timeout=args.timeout,
+    )
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    message = (record["stdout"] + record["stderr"]).strip()
+    reason = message.removeprefix("error:").strip() if message.startswith("error:") else None
+    ok = record["returncode"] == 0
+    return emit(
+        {
+            "action": "grokbot-status",
+            "ok": ok,
+            "target": str(target),
+            "reason": reason,
+            "jobs": payload.get("jobs"),
+            "status": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def cmd_handoff_lint(args: argparse.Namespace) -> int:
+    """Lint the handoff inbox of the temp target."""
+    root = state_root(args)
+    target = guard_target(Path(args.target))
+    argv = brigade_args(args) + ["handoff", "lint", "--target", str(target), "--json"]
+    if args.content_guard:
+        argv.append("--content-guard")
+    argv += list(args.paths)
+    record = run(argv, root=root, name="handoff-lint", timeout=args.timeout)
+    payload = record["json"] if isinstance(record["json"], dict) else {}
+    ok = record["returncode"] == 0 and payload.get("valid") is True
+    return emit(
+        {
+            "action": "handoff-lint",
+            "ok": ok,
+            "target": str(target),
+            "valid": payload.get("valid"),
+            "count": payload.get("count"),
+            "results": payload.get("results"),
+            "lint": slim(record),
+        },
+        0 if ok else 3,
+    )
+
+
+def cmd_evidence(args: argparse.Namespace) -> int:
+    """Copy captures and receipts somewhere cleanup never looks."""
+    root = state_root(args)
+    target = guard_target(Path(args.target)) if args.target else None
+    base = (
+        Path(args.evidence_root).expanduser().resolve()
+        if args.evidence_root
+        else REPO_ROOT / ".brigade" / "verification-evidence"
+    )
+    evidence = base / f"{now_stamp()}-{args.label}"
+    (evidence / "captures").mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    for capture in sorted((root / "captures").glob("*.json")):
+        destination = evidence / "captures" / capture.name
+        shutil.copy2(capture, destination)
+        copied.append(str(destination.relative_to(evidence)))
+
+    if target is not None:
+        for relative in ("work/verify-runs", "grokbot", "work/sessions"):
+            source = target / ".brigade" / relative
+            if not source.exists():
+                continue
+            destination = evidence / "target-brigade" / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source, destination, dirs_exist_ok=True)
+            copied.append(str(destination.relative_to(evidence)))
+
+    manifest = {
+        "schema": "verify-brigade.evidence.v1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "label": args.label,
+        "evidence_dir": str(evidence),
+        "state_root": str(root),
+        "target": str(target) if target else None,
+        "items": copied,
+    }
+    (evidence / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return emit({"action": "evidence", "ok": True, "evidence_dir": str(evidence), "items": copied})
+
+
+def cmd_cleanup(args: argparse.Namespace) -> int:
+    """Remove only the targets this helper created. Evidence is never touched."""
+    root = state_root(args)
+    state = read_state(root)
+    recorded = [Path(entry) for entry in state["created_targets"]]
+
+    if args.target:
+        wanted = Path(args.target).expanduser().resolve()
+        recorded = [entry for entry in recorded if entry == wanted]
+        if not recorded:
+            raise HelperError(f"{wanted} was not created by this helper; refusing to remove it")
+
+    removed: list[str] = []
+    skipped: list[dict] = []
+    for entry in recorded:
+        if not entry.is_relative_to(root / "targets"):
+            skipped.append({"path": str(entry), "reason": "outside the state root"})
+            continue
+        if not entry.exists():
+            skipped.append({"path": str(entry), "reason": "already gone"})
+            continue
+        if args.dry_run:
+            removed.append(str(entry))
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+        removed.append(str(entry))
+
+    captures = sorted((root / "captures").glob("*.json"))
+    if not args.dry_run:
+        if not args.keep_captures:
+            for capture in captures:
+                capture.unlink(missing_ok=True)
+        remaining = {entry for entry in state["created_targets"]} - set(removed)
+        state["created_targets"] = sorted(remaining)
+        write_state(root, state)
+
+    return emit(
+        {
+            "action": "cleanup",
+            "ok": True,
+            "dry_run": bool(args.dry_run),
+            "state_root": str(root),
+            "removed" if not args.dry_run else "would_remove": removed,
+            "captures_removed": 0 if (args.dry_run or args.keep_captures) else len(captures),
+            "skipped": skipped,
+            "note": "evidence directories are outside the state root and are never removed",
+        }
+    )
+
+
+# ------------------------------------------------------------------- parser
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="control-brigade.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--brigade", default=None, help="Brigade command (default: .venv/bin/brigade, then PATH).")
+    parser.add_argument("--root", default=None, help="State root for targets and captures.")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Timeout for each brigade call.")
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    sub.required = True
+
+    def add_target(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--target", required=True, help="Temp target created by new-target.")
+
+    def add_pack(command: argparse.ArgumentParser) -> None:
+        add_target(command)
+        command.add_argument("--id", required=True, help="Connector pack id, e.g. implementation-worker.")
+        command.add_argument("--bearer-env", default=BEARER_ENV_NAME, help="Env var holding the pack bearer.")
+
+    p = sub.add_parser("doctor", help="Read-only: is this rig worth driving?")
+    p.set_defaults(func=cmd_doctor)
+
+    p = sub.add_parser("new-target", help="git init + brigade init in a fresh temp dir.")
+    p.add_argument("--depth", default=DEFAULT_DEPTH, choices=["repo", "workspace"])
+    p.add_argument("--harnesses", default=DEFAULT_HARNESSES)
+    p.set_defaults(func=cmd_new_target)
+
+    p = sub.add_parser("init", help="Run brigade init against an existing directory.")
+    add_target(p)
+    p.add_argument("--depth", default=DEFAULT_DEPTH, choices=["repo", "workspace"])
+    p.add_argument("--harnesses", default=DEFAULT_HARNESSES)
+    p.set_defaults(func=cmd_init)
+
+    p = sub.add_parser("doctor-target", help="brigade doctor --json against the temp target.")
+    add_target(p)
+    p.set_defaults(func=cmd_doctor_target)
+
+    p = sub.add_parser("work-verify", help="Bounded brigade work verify run; returns receipt id and status.")
+    add_target(p)
+    p.add_argument("--command", default=DEFAULT_PROBE, help="Verification command to run in the target.")
+    p.add_argument("--capture", default=None, help="Artifact id for atomic --capture.")
+    p.add_argument("--command-timeout", type=int, default=60, help="Per-command timeout inside Brigade.")
+    p.set_defaults(func=cmd_work_verify)
+
+    p = sub.add_parser("grokbot-pack-setup", help="Preview or apply pack instance config.")
+    add_pack(p)
+    p.add_argument("--apply", action="store_true", help="Write config. Default is preview only.")
+    p.add_argument("--dry-run", action="store_true", help="Force preview even with --apply.")
+    p.set_defaults(func=cmd_pack_setup)
+
+    p = sub.add_parser("grokbot-pack-doctor", help="Sanitized pack diagnostics.")
+    add_pack(p)
+    p.set_defaults(func=cmd_pack_doctor)
+
+    p = sub.add_parser("grokbot-pack-canary", help="Bounded non-mutating pack auth and inventory check.")
+    add_pack(p)
+    p.set_defaults(func=cmd_pack_canary)
+
+    p = sub.add_parser("grokbot-pack-remove", help="Preview or apply removal of pack config.")
+    add_pack(p)
+    p.add_argument("--apply", action="store_true", help="Delete the files. Default is preview only.")
+    p.add_argument("--dry-run", action="store_true", help="Force preview even with --apply.")
+    p.set_defaults(func=cmd_pack_remove)
+
+    p = sub.add_parser("grokbot-feed", help="Validate an approved feed manifest (never enqueues).")
+    add_target(p)
+    p.add_argument("--manifest", default=None, help="Path to an approved private feed manifest.")
+    p.add_argument("--sample", action="store_true", help="Write and validate a bundled sample manifest.")
+    p.add_argument("--limit", type=int, default=1)
+    p.set_defaults(func=cmd_feed)
+
+    p = sub.add_parser("grokbot-status", help="Safe Grok Bot job projections.")
+    add_target(p)
+    p.set_defaults(func=cmd_status)
+
+    p = sub.add_parser("handoff-lint", help="Lint the handoff inbox of the temp target.")
+    add_target(p)
+    p.add_argument("--content-guard", action="store_true", help="Add the leak and injection scan.")
+    p.add_argument("paths", nargs="*", help="Explicit handoff files. Defaults to the pending inbox.")
+    p.set_defaults(func=cmd_handoff_lint)
+
+    p = sub.add_parser("evidence", help="Copy captures and receipts to a named evidence dir.")
+    p.add_argument("--target", default=None, help="Temp target whose receipts to copy.")
+    p.add_argument("--label", default="run", help="Suffix for the evidence directory name.")
+    p.add_argument("--evidence-root", default=None, help="Where evidence dirs live.")
+    p.set_defaults(func=cmd_evidence)
+
+    p = sub.add_parser("cleanup", help="Remove only the targets this helper created.")
+    p.add_argument("--target", default=None, help="Remove one recorded target instead of all of them.")
+    p.add_argument("--dry-run", action="store_true", help="Report what would be removed.")
+    p.add_argument("--keep-captures", action="store_true", help="Leave capture files in the state root.")
+    p.set_defaults(func=cmd_cleanup)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except HelperError as exc:
+        return emit({"action": args.command, "ok": False, "error": str(exc)}, 1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/registry/skills/verify-brigade/control-brigade.py
+++ b/registry/skills/verify-brigade/control-brigade.py
@@ -9,13 +9,26 @@ Every subcommand prints one JSON object on stdout. Exit codes:
   3  the drive ran fine but the observation is a failure (doctor FAILs,
      verification did not complete)
 
-Nothing here touches the operator workspace or the Brigade checkout. A target is
-accepted only when it resolves under `<state-root>/targets`, so the operator
-home, this checkout, and every path outside the state root are refused before a
-command runs. `--root` and `--evidence-root` are held to the same line: they may
-not resolve to, or under, the home directory or the checkout (the built-in
-defaults - `$TMPDIR/verify-brigade` and `<checkout>/.brigade/verification-evidence`
-- are the exceptions). Only paths this helper recorded are ever removed.
+No drive touches the operator workspace. A target is accepted only when it
+resolves under `<state-root>/targets`, so the operator home, this checkout, and
+every path outside the state root are refused before a command runs.
+
+`--root` and the default state root get the same treatment: both are resolved,
+both are refused if they resolve to or contain the home directory or the
+checkout, and neither may be a symlink at the root or at `targets/` and
+`captures/`. Anything under the temp base is allowed, including when `$TMPDIR`
+itself sits inside the home directory; the temp base itself is refused, because
+a state root there would chmod the shared scratch tree.
+
+Two deliberate exceptions to "nothing under the checkout":
+
+  * evidence. The default evidence root is `<checkout>/.brigade/verification-evidence`,
+    which is inside this checkout - gitignored, and the point is that `cleanup`
+    cannot reach it. `--evidence-root` is guarded like `--root`.
+  * `grokbot-feed --manifest`. That path is a caller's own manifest, read for
+    validation only, and is the one flag outside the target contract.
+
+Only paths this helper recorded are ever removed.
 """
 
 from __future__ import annotations
@@ -110,13 +123,21 @@ def temp_base() -> Path:
 def guard_root(raw: str, *, flag: str, extra_allowed: tuple[Path, ...] = ()) -> Path:
     """Refuse a caller-supplied root that lands in the operator home or this checkout.
 
-    The scratch tree (`$TMPDIR`) and the helper's own defaults are the allowed
-    bases; everything else is measured against the home directory and the
-    Brigade checkout, in both directions (inside it, or containing it).
+    A directory *under* the scratch tree (`$TMPDIR`), and the helper's own
+    defaults, are the allowed bases; everything else is measured against the
+    home directory and the Brigade checkout, in both directions (inside it, or
+    containing it). The temp base itself is not a state root: accepting it
+    would chmod the shared scratch tree to `0700` and scatter `targets/`,
+    `captures/`, and `state.json` across it.
     """
     resolved = Path(raw).expanduser().resolve()
-    for base in (temp_base(), *extra_allowed):
-        if resolved.is_relative_to(base):
+    base = temp_base()
+    if resolved == base:
+        raise HelperError(f"refusing {flag} {resolved}: it is the temp base itself; use a directory under it")
+    if resolved.is_relative_to(base):
+        return resolved
+    for allowed in extra_allowed:
+        if resolved.is_relative_to(allowed):
             return resolved
     for forbidden, label in ((REPO_ROOT, "the Brigade checkout"), (Path.home().resolve(), "the operator home")):
         if resolved.is_relative_to(forbidden):
@@ -126,15 +147,51 @@ def guard_root(raw: str, *, flag: str, extra_allowed: tuple[Path, ...] = ()) -> 
     return resolved
 
 
-def state_root(args: argparse.Namespace) -> Path:
-    root = guard_root(args.root, flag="--root") if args.root else temp_base() / "verify-brigade"
-    root.mkdir(parents=True, exist_ok=True)
-    root.chmod(0o700)
-    for name in ("captures", "targets"):
-        sub = root / name
-        sub.mkdir(exist_ok=True)
-        sub.chmod(0o700)
+def guard_no_symlink(path: Path, *, flag: str) -> None:
+    """Refuse a state-root path that is a symlink.
+
+    `mkdir(exist_ok=True)` follows an existing symlink, so a link planted at
+    the state root - or at one of its subdirectories - would redirect every
+    drive, and `cleanup`'s removal, wherever it points. The temp base is
+    world-writable on most hosts, which makes the *default* root as reachable
+    a plant as an explicit `--root`.
+    """
+    if path.is_symlink():
+        raise HelperError(f"refusing {flag} {path}: it is a symlink")
+
+
+def prepare_state_root(root: Path, *, flag: str) -> Path:
+    """Create the state root and its subdirectories without following a symlink."""
+    guard_no_symlink(root, flag=flag)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        # A link planted between the check and the mkdir would have been
+        # followed silently; the created path must still resolve to itself.
+        guard_no_symlink(root, flag=flag)
+        if root.resolve() != root:
+            raise HelperError(f"refusing {flag} {root}: it resolves to {root.resolve()}")
+        root.chmod(0o700)
+        for name in ("captures", "targets"):
+            sub = root / name
+            guard_no_symlink(sub, flag=f"{flag} subdirectory")
+            sub.mkdir(exist_ok=True)
+            guard_no_symlink(sub, flag=f"{flag} subdirectory")
+            if sub.resolve() != sub:
+                raise HelperError(f"refusing {flag} subdirectory {sub}: it resolves to {sub.resolve()}")
+            sub.chmod(0o700)
+    except OSError as exc:  # PermissionError included: report it, never traceback
+        raise HelperError(f"cannot prepare {flag} {root}: {exc}") from exc
     return root
+
+
+def state_root(args: argparse.Namespace) -> Path:
+    """Resolve, guard, and create the state root - default and `--root` alike."""
+    raw = args.root or str(temp_base() / "verify-brigade")
+    flag = "--root" if args.root else "the default state root"
+    # The symlink check runs on the unresolved path: `resolve()` follows a
+    # planted link, so the guard has to look before it resolves.
+    guard_no_symlink(Path(raw).expanduser(), flag=flag)
+    return prepare_state_root(guard_root(raw, flag=flag), flag=flag)
 
 
 def read_state(root: Path) -> dict:

--- a/registry/skills/verify-brigade/control-brigade.py
+++ b/registry/skills/verify-brigade/control-brigade.py
@@ -16,15 +16,20 @@ every path outside the state root are refused before a command runs.
 `--root` and the default state root get the same treatment: both are resolved,
 both are refused if they resolve to or contain the home directory or the
 checkout, and neither may be a symlink at the root or at `targets/` and
-`captures/`. Anything under the temp base is allowed, including when `$TMPDIR`
-itself sits inside the home directory; the temp base itself is refused, because
-a state root there would chmod the shared scratch tree.
+`captures/`. Those refusals run before the temp base allowance, so a `$TMPDIR`
+pointed at the home or the checkout cannot launder a path back into either; the
+one carve-out is a temp base that sits inside the home directory and outside the
+checkout. A relative `$TMPDIR` is refused outright, because it would resolve
+against the working directory. The temp base itself is refused too, because a
+state root there would chmod the shared scratch tree.
 
 Two deliberate exceptions to "nothing under the checkout":
 
   * evidence. The default evidence root is `<checkout>/.brigade/verification-evidence`,
     which is inside this checkout - gitignored, and the point is that `cleanup`
-    cannot reach it. `--evidence-root` is guarded like `--root`.
+    cannot reach it. The default and `--evidence-root` are both guarded like
+    `--root`, symlink check included, and `--label` must be a simple
+    `[A-Za-z0-9._-]` name so it cannot steer the directory anywhere.
   * `grokbot-feed --manifest`. That path is a caller's own manifest, read for
     validation only, and is the one flag outside the target contract.
 
@@ -36,6 +41,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -53,6 +59,7 @@ DEFAULT_DEPTH = "workspace"
 DEFAULT_HARNESSES = "claude,codex"
 DEFAULT_PROBE = "python3 --version"
 DEFAULT_TIMEOUT = 300
+LABEL_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,64}")
 
 # Non-secret placeholder. The pack config check only proves the reference
 # resolves; nothing authenticates with this value.
@@ -117,34 +124,61 @@ def resolve_brigade(explicit: str | None) -> list[str]:
 
 
 def temp_base() -> Path:
-    return Path(tempfile.gettempdir()).resolve()
+    """The scratch tree, which must be an absolute path.
+
+    `tempfile.gettempdir()` returns a relative `$TMPDIR` verbatim, and
+    `resolve()` would anchor it to the working directory - the Brigade checkout
+    in every documented invocation. A temp base that moves with the cwd is not
+    a temp base, so refuse it instead of measuring anything against it.
+    """
+    raw = Path(tempfile.gettempdir())
+    if not raw.is_absolute():
+        raise HelperError(f"refusing a relative temp base {raw}: $TMPDIR must be an absolute path")
+    return raw.resolve()
 
 
 def guard_root(raw: str, *, flag: str, extra_allowed: tuple[Path, ...] = ()) -> Path:
     """Refuse a caller-supplied root that lands in the operator home or this checkout.
 
-    A directory *under* the scratch tree (`$TMPDIR`), and the helper's own
-    defaults, are the allowed bases; everything else is measured against the
-    home directory and the Brigade checkout, in both directions (inside it, or
-    containing it). The temp base itself is not a state root: accepting it
-    would chmod the shared scratch tree to `0700` and scatter `targets/`,
-    `captures/`, and `state.json` across it.
+    Order matters. The home and checkout refusals run *before* the temp base
+    allowance, so a `$TMPDIR` pointed at either one cannot launder a path back
+    into them. The single carve-out is a temp base that sits inside the home
+    directory and outside the checkout: `$TMPDIR` is the scratch tree by
+    definition, so a path under it is allowed even though it is also under the
+    home. Nothing excuses the checkout. The temp base itself is not a state
+    root either: accepting it would chmod the shared scratch tree to `0700` and
+    scatter `targets/`, `captures/`, and `state.json` across it.
     """
     resolved = Path(raw).expanduser().resolve()
     base = temp_base()
+    home = Path.home().expanduser().resolve()
     if resolved == base:
         raise HelperError(f"refusing {flag} {resolved}: it is the temp base itself; use a directory under it")
-    if resolved.is_relative_to(base):
-        return resolved
     for allowed in extra_allowed:
         if resolved.is_relative_to(allowed):
             return resolved
-    for forbidden, label in ((REPO_ROOT, "the Brigade checkout"), (Path.home().resolve(), "the operator home")):
+    under_base = resolved.is_relative_to(base)
+    home_excused = under_base and base.is_relative_to(home) and not base.is_relative_to(REPO_ROOT)
+    for forbidden, label in ((REPO_ROOT, "the Brigade checkout"), (home, "the operator home")):
         if resolved.is_relative_to(forbidden):
+            if forbidden == home and home_excused:
+                continue
             raise HelperError(f"refusing {flag} {resolved}: it is inside {label}")
         if forbidden.is_relative_to(resolved):
             raise HelperError(f"refusing {flag} {resolved}: it contains {label}")
     return resolved
+
+
+def guard_label(label: str) -> str:
+    """Refuse a `--label` that is path input rather than a name.
+
+    The label becomes the last component of the evidence directory name, so a
+    label carrying a separator or `..` would place the evidence - and its
+    `mkdir(parents=True)` - anywhere the caller wants.
+    """
+    if any(bad in label for bad in ("/", "\\", "..")) or not LABEL_PATTERN.fullmatch(label):
+        raise HelperError(f"refusing --label {label!r}: use a simple [A-Za-z0-9._-] name of 1-64 characters")
+    return label
 
 
 def guard_no_symlink(path: Path, *, flag: str) -> None:
@@ -182,6 +216,33 @@ def prepare_state_root(root: Path, *, flag: str) -> Path:
     except OSError as exc:  # PermissionError included: report it, never traceback
         raise HelperError(f"cannot prepare {flag} {root}: {exc}") from exc
     return root
+
+
+def evidence_root(args: argparse.Namespace) -> Path:
+    """Resolve and guard the evidence root - default and `--evidence-root` alike.
+
+    Same treatment as the state root: the symlink check runs on the unresolved
+    path, because `resolve()` follows a link planted at
+    `<checkout>/.brigade/verification-evidence` as happily as one planted in a
+    world-writable temp dir.
+    """
+    raw = args.evidence_root or str(DEFAULT_EVIDENCE_ROOT)
+    flag = "--evidence-root" if args.evidence_root else "the default evidence root"
+    guard_no_symlink(Path(raw).expanduser(), flag=flag)
+    return guard_root(raw, flag=flag, extra_allowed=(DEFAULT_EVIDENCE_ROOT,))
+
+
+def prepare_evidence_root(base: Path, *, flag: str) -> Path:
+    """Create the evidence root without following a symlink planted mid-flight."""
+    guard_no_symlink(base, flag=flag)
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+        guard_no_symlink(base, flag=flag)
+        if base.resolve() != base:
+            raise HelperError(f"refusing {flag} {base}: it resolves to {base.resolve()}")
+    except OSError as exc:  # PermissionError included: report it, never traceback
+        raise HelperError(f"cannot prepare {flag} {base}: {exc}") from exc
+    return base
 
 
 def state_root(args: argparse.Namespace) -> Path:
@@ -835,13 +896,12 @@ def cmd_evidence(args: argparse.Namespace) -> int:
     """Copy captures and receipts somewhere cleanup never looks."""
     root = state_root(args)
     target = guard_target(Path(args.target), root) if args.target else None
-    base = (
-        guard_root(args.evidence_root, flag="--evidence-root", extra_allowed=(DEFAULT_EVIDENCE_ROOT,))
-        if args.evidence_root
-        else DEFAULT_EVIDENCE_ROOT
-    )
-    evidence = base / f"{now_stamp()}-{args.label}"
+    label = guard_label(args.label)
+    flag = "--evidence-root" if args.evidence_root else "the default evidence root"
+    base = evidence_root(args)
+    evidence = base / f"{now_stamp()}-{label}"
     if not args.dry_run:
+        prepare_evidence_root(base, flag=flag)
         (evidence / "captures").mkdir(parents=True, exist_ok=True)
 
     copied: list[str] = []
@@ -876,7 +936,7 @@ def cmd_evidence(args: argparse.Namespace) -> int:
     manifest = {
         "schema": "verify-brigade.evidence.v1",
         "created_at": datetime.now(timezone.utc).isoformat(),
-        "label": args.label,
+        "label": label,
         "evidence_dir": str(evidence),
         "state_root": str(root),
         "target": str(target) if target else None,
@@ -907,6 +967,13 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
     for entry in recorded:
         if not entry.is_relative_to(root / "targets"):
             skipped.append({"path": str(entry), "reason": "outside the state root"})
+            continue
+        # A recorded target swapped for a symlink is not the directory this
+        # helper created: `rmtree` would no-op on it (or, without
+        # `ignore_errors`, follow it), so report a skip instead of a phantom
+        # removal and leave it recorded.
+        if entry.is_symlink():
+            skipped.append({"path": str(entry), "reason": "skipped-symlink"})
             continue
         if not entry.exists():
             skipped.append({"path": str(entry), "reason": "already gone"})
@@ -1037,7 +1104,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p = sub.add_parser("evidence", help="Copy captures and receipts to a named evidence dir.")
     p.add_argument("--target", default=None, help="Temp target whose receipts to copy.")
-    p.add_argument("--label", default="run", help="Suffix for the evidence directory name.")
+    p.add_argument(
+        "--label",
+        default="run",
+        help="Suffix for the evidence directory name ([A-Za-z0-9._-], 1-64 characters).",
+    )
     p.add_argument("--evidence-root", default=None, help="Where evidence dirs live.")
     add_dry_run(p, "Report what would be copied without creating the evidence dir.")
     p.set_defaults(func=cmd_evidence)

--- a/registry/skills/verify-brigade/control-brigade.py
+++ b/registry/skills/verify-brigade/control-brigade.py
@@ -9,9 +9,13 @@ Every subcommand prints one JSON object on stdout. Exit codes:
   3  the drive ran fine but the observation is a failure (doctor FAILs,
      verification did not complete)
 
-Nothing here touches the operator workspace or the Brigade checkout: targets are
-created under a state root (default $TMPDIR/verify-brigade) and only paths this
-helper recorded are ever removed.
+Nothing here touches the operator workspace or the Brigade checkout. A target is
+accepted only when it resolves under `<state-root>/targets`, so the operator
+home, this checkout, and every path outside the state root are refused before a
+command runs. `--root` and `--evidence-root` are held to the same line: they may
+not resolve to, or under, the home directory or the checkout (the built-in
+defaults - `$TMPDIR/verify-brigade` and `<checkout>/.brigade/verification-evidence`
+- are the exceptions). Only paths this helper recorded are ever removed.
 """
 
 from __future__ import annotations
@@ -31,6 +35,7 @@ from pathlib import Path
 
 SCHEMA = "verify-brigade.control.v1"
 REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_EVIDENCE_ROOT = REPO_ROOT / ".brigade" / "verification-evidence"
 DEFAULT_DEPTH = "workspace"
 DEFAULT_HARNESSES = "claude,codex"
 DEFAULT_PROBE = "python3 --version"
@@ -98,11 +103,37 @@ def resolve_brigade(explicit: str | None) -> list[str]:
     return [sys.executable, "-m", "brigade"]
 
 
+def temp_base() -> Path:
+    return Path(tempfile.gettempdir()).resolve()
+
+
+def guard_root(raw: str, *, flag: str, extra_allowed: tuple[Path, ...] = ()) -> Path:
+    """Refuse a caller-supplied root that lands in the operator home or this checkout.
+
+    The scratch tree (`$TMPDIR`) and the helper's own defaults are the allowed
+    bases; everything else is measured against the home directory and the
+    Brigade checkout, in both directions (inside it, or containing it).
+    """
+    resolved = Path(raw).expanduser().resolve()
+    for base in (temp_base(), *extra_allowed):
+        if resolved.is_relative_to(base):
+            return resolved
+    for forbidden, label in ((REPO_ROOT, "the Brigade checkout"), (Path.home().resolve(), "the operator home")):
+        if resolved.is_relative_to(forbidden):
+            raise HelperError(f"refusing {flag} {resolved}: it is inside {label}")
+        if forbidden.is_relative_to(resolved):
+            raise HelperError(f"refusing {flag} {resolved}: it contains {label}")
+    return resolved
+
+
 def state_root(args: argparse.Namespace) -> Path:
-    root = Path(args.root).expanduser().resolve() if args.root else Path(tempfile.gettempdir()) / "verify-brigade"
+    root = guard_root(args.root, flag="--root") if args.root else temp_base() / "verify-brigade"
     root.mkdir(parents=True, exist_ok=True)
-    (root / "captures").mkdir(exist_ok=True)
-    (root / "targets").mkdir(exist_ok=True)
+    root.chmod(0o700)
+    for name in ("captures", "targets"):
+        sub = root / name
+        sub.mkdir(exist_ok=True)
+        sub.chmod(0o700)
     return root
 
 
@@ -124,24 +155,40 @@ def write_state(root: Path, state: dict) -> None:
     path = root / "state.json"
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.chmod(0o600)
     tmp.replace(path)
 
 
-def guard_target(path: Path) -> Path:
-    """Refuse to drive Brigade against the operator home or this checkout."""
+def record_target(root: Path, target: Path) -> None:
+    """Record a created target before anything else can fail on it."""
+    state = read_state(root)
+    state["created_targets"] = sorted(set(state["created_targets"]) | {str(target)})
+    write_state(root, state)
+
+
+def guard_target(path: Path, root: Path) -> Path:
+    """Accept a target only when it lives under `<state-root>/targets`.
+
+    Everything else is refused, which is what keeps a drive off the operator
+    home, off this checkout, and off any path the helper did not make.
+    """
     resolved = Path(path).expanduser().resolve()
-    home = Path.home().resolve()
-    forbidden = {home, Path("/"), REPO_ROOT}
-    if resolved in forbidden:
-        raise HelperError(f"refusing to use {resolved} as a target (home, root, or the Brigade checkout)")
-    if resolved == REPO_ROOT or REPO_ROOT.is_relative_to(resolved):
-        raise HelperError(f"refusing to use {resolved}: it contains the Brigade checkout")
-    return resolved
+    targets = (root / "targets").resolve()
+    if resolved != targets and resolved.is_relative_to(targets):
+        return resolved
+    if resolved.is_relative_to(REPO_ROOT):
+        detail = "it is inside the Brigade checkout"
+    elif resolved.is_relative_to(Path.home().resolve()):
+        detail = "it is inside the operator home"
+    else:
+        detail = "it is outside the state root"
+    raise HelperError(f"refusing to use {resolved} as a target: {detail}; targets must live under {targets}")
 
 
 def record_capture(root: Path, name: str, record: dict) -> Path:
     path = root / "captures" / f"{now_stamp()}-{uuid.uuid4().hex[:6]}-{name}.json"
     path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.chmod(0o600)
     return path
 
 
@@ -273,15 +320,38 @@ def cmd_new_target(args: argparse.Namespace) -> int:
     """git init + brigade init in a fresh temp dir; print the path."""
     root = state_root(args)
     brigade = brigade_args(args)
-    target = Path(tempfile.mkdtemp(prefix=f"{now_stamp()}-", dir=root / "targets"))
 
     git = shutil.which("git")
     if not git:
         raise HelperError("git is required to create a target")
+
+    if args.dry_run:
+        return emit(
+            {
+                "action": "new-target",
+                "ok": True,
+                "dry_run": True,
+                "state_root": str(root),
+                "would_create_under": str(root / "targets"),
+                "would_run": [
+                    [git, "init", "-q", "-b", "main", "<target>"],
+                    brigade + ["init", "--target", "<target>", "--depth", args.depth, "--harnesses", args.harnesses],
+                ],
+            }
+        )
+
+    target = Path(tempfile.mkdtemp(prefix=f"{now_stamp()}-", dir=root / "targets"))
+    # Record before driving anything: a target the helper made must stay
+    # reclaimable by `cleanup`, including when the drive below fails.
+    record_target(root, target)
+
     git_record = run([git, "init", "-q", "-b", "main", str(target)], root=root, name="new-target-git", timeout=60)
     if git_record["returncode"] != 0:
         shutil.rmtree(target, ignore_errors=True)
-        return emit({"action": "new-target", "ok": False, "stage": "git-init", "git": slim(git_record)}, 1)
+        return emit(
+            {"action": "new-target", "ok": False, "stage": "git-init", "target": str(target), "git": slim(git_record)},
+            1,
+        )
 
     init_record = run(
         brigade + ["init", "--target", str(target), "--depth", args.depth, "--harnesses", args.harnesses],
@@ -290,6 +360,7 @@ def cmd_new_target(args: argparse.Namespace) -> int:
         timeout=args.timeout,
     )
     if init_record["returncode"] != 0:
+        shutil.rmtree(target, ignore_errors=True)
         return emit(
             {
                 "action": "new-target",
@@ -301,14 +372,11 @@ def cmd_new_target(args: argparse.Namespace) -> int:
             3,
         )
 
-    state = read_state(root)
-    state["created_targets"] = sorted(set(state["created_targets"]) | {str(target)})
-    write_state(root, state)
-
     return emit(
         {
             "action": "new-target",
             "ok": True,
+            "dry_run": False,
             "target": str(target),
             "depth": args.depth,
             "harnesses": args.harnesses,
@@ -323,20 +391,37 @@ def cmd_new_target(args: argparse.Namespace) -> int:
 def cmd_init(args: argparse.Namespace) -> int:
     """Run `brigade init` against an existing directory you already own."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     if not target.is_dir():
         raise HelperError(f"target is not a directory: {target}")
-    record = run(
-        brigade_args(args) + ["init", "--target", str(target), "--depth", args.depth, "--harnesses", args.harnesses],
-        root=root,
-        name="init",
-        timeout=args.timeout,
-    )
+    argv = brigade_args(args) + [
+        "init",
+        "--target",
+        str(target),
+        "--depth",
+        args.depth,
+        "--harnesses",
+        args.harnesses,
+    ]
+    if args.dry_run:
+        return emit(
+            {
+                "action": "init",
+                "ok": True,
+                "dry_run": True,
+                "target": str(target),
+                "depth": args.depth,
+                "harnesses": args.harnesses,
+                "would_run": argv,
+            }
+        )
+    record = run(argv, root=root, name="init", timeout=args.timeout)
     ok = record["returncode"] == 0
     return emit(
         {
             "action": "init",
             "ok": ok,
+            "dry_run": False,
             "target": str(target),
             "depth": args.depth,
             "harnesses": args.harnesses,
@@ -349,7 +434,7 @@ def cmd_init(args: argparse.Namespace) -> int:
 def cmd_doctor_target(args: argparse.Namespace) -> int:
     """`brigade doctor --json` against the temp target. 0 failed is the signal."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     record = run(
         brigade_args(args) + ["doctor", "--target", str(target), "--json"],
         root=root,
@@ -379,7 +464,7 @@ def cmd_doctor_target(args: argparse.Namespace) -> int:
 def cmd_work_verify(args: argparse.Namespace) -> int:
     """Bounded `brigade work verify run` in the temp target; return receipt id."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     argv = brigade_args(args) + [
         "work",
         "verify",
@@ -394,6 +479,17 @@ def cmd_work_verify(args: argparse.Namespace) -> int:
     ]
     if args.capture:
         argv += ["--capture", args.capture]
+    if args.dry_run:
+        return emit(
+            {
+                "action": "work-verify",
+                "ok": True,
+                "dry_run": True,
+                "target": str(target),
+                "command": args.command,
+                "would_run": argv,
+            }
+        )
     record = run(argv, root=root, name="work-verify", timeout=args.timeout)
     payload = record["json"] if isinstance(record["json"], dict) else {}
     status = payload.get("status")
@@ -402,6 +498,7 @@ def cmd_work_verify(args: argparse.Namespace) -> int:
         {
             "action": "work-verify",
             "ok": ok,
+            "dry_run": False,
             "target": str(target),
             "command": args.command,
             "run_id": payload.get("run_id"),
@@ -423,7 +520,7 @@ def pack_env(args: argparse.Namespace) -> dict[str, str]:
 def cmd_pack_setup(args: argparse.Namespace) -> int:
     """Preview (default) or apply non-secret pack instance config."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     apply = args.apply and not args.dry_run
     argv = brigade_args(args) + [
         "run",
@@ -463,7 +560,7 @@ def cmd_pack_setup(args: argparse.Namespace) -> int:
 def cmd_pack_doctor(args: argparse.Namespace) -> int:
     """Sanitized pack diagnostics. Without a listener, `endpoint` fails."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     record = run(
         brigade_args(args)
         + ["run", "cloud", "grokbot", "pack", "doctor", "--target", str(target), "--id", args.id, "--json"],
@@ -475,27 +572,31 @@ def cmd_pack_doctor(args: argparse.Namespace) -> int:
     payload = record["json"] if isinstance(record["json"], dict) else {}
     checks = payload.get("checks") if isinstance(payload.get("checks"), list) else []
     by_name = {check.get("check"): check.get("status") for check in checks if isinstance(check, dict)}
+    # A failing `endpoint` check is the expected reading with no listener up, so
+    # it does not sink the drive. Any other failing check does: a broken pack
+    # config must not read green at the top level.
+    failed = sorted(name for name, status in by_name.items() if name != "endpoint" and status == "fail")
+    ok = bool(checks) and not failed
     return emit(
         {
             "action": "grokbot-pack-doctor",
-            # The command answered with a sanitized check list. A failing
-            # endpoint check is the expected reading with no listener up.
-            "ok": bool(checks),
+            "ok": ok,
             "target": str(target),
             "pack_id": args.id,
             "checks": checks,
+            "failed_checks": failed,
             "config_resolved": by_name.get("config") == "ok",
             "listener_running": by_name.get("endpoint") == "ok",
             "doctor": slim(record),
         },
-        0 if checks else 3,
+        0 if ok else 3,
     )
 
 
 def cmd_pack_canary(args: argparse.Namespace) -> int:
     """Bounded non-mutating auth + inventory check against the pack listener."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     record = run(
         brigade_args(args)
         + ["run", "cloud", "grokbot", "pack", "canary", "--target", str(target), "--id", args.id, "--json"],
@@ -528,7 +629,7 @@ def cmd_pack_canary(args: argparse.Namespace) -> int:
 def cmd_pack_remove(args: argparse.Namespace) -> int:
     """Preview (default) or apply removal of pack config this run wrote."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     apply = args.apply and not args.dry_run
     argv = brigade_args(args) + [
         "run",
@@ -565,40 +666,50 @@ def cmd_pack_remove(args: argparse.Namespace) -> int:
 def cmd_feed(args: argparse.Namespace) -> int:
     """Validate an approved feed manifest. Validation only; never enqueues."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     if args.sample:
         manifest = root / "sample-feed-manifest.json"
-        manifest.write_text(json.dumps(FEED_SAMPLE, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        manifest.chmod(0o600)
+        if not args.dry_run:
+            manifest.write_text(json.dumps(FEED_SAMPLE, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            manifest.chmod(0o600)
     else:
         if not args.manifest:
             raise HelperError("pass --manifest PATH or --sample")
         manifest = Path(args.manifest).expanduser().resolve()
-    record = run(
-        brigade_args(args)
-        + [
-            "run",
-            "cloud",
-            "grokbot",
-            "feed",
-            "--target",
-            str(target),
-            "--manifest",
-            str(manifest),
-            "--limit",
-            str(args.limit),
-            "--json",
-        ],
-        root=root,
-        name="feed",
-        timeout=args.timeout,
-    )
+    argv = brigade_args(args) + [
+        "run",
+        "cloud",
+        "grokbot",
+        "feed",
+        "--target",
+        str(target),
+        "--manifest",
+        str(manifest),
+        "--limit",
+        str(args.limit),
+        "--json",
+    ]
+    if args.dry_run:
+        return emit(
+            {
+                "action": "grokbot-feed",
+                "ok": True,
+                "dry_run": True,
+                "target": str(target),
+                "manifest": str(manifest),
+                "sample": bool(args.sample),
+                "would_write_manifest": bool(args.sample),
+                "would_run": argv,
+            }
+        )
+    record = run(argv, root=root, name="feed", timeout=args.timeout)
     payload = record["json"] if isinstance(record["json"], dict) else {}
     ok = record["returncode"] == 0
     return emit(
         {
             "action": "grokbot-feed",
             "ok": ok,
+            "dry_run": False,
             "target": str(target),
             "manifest": str(manifest),
             "sample": bool(args.sample),
@@ -614,7 +725,7 @@ def cmd_feed(args: argparse.Namespace) -> int:
 def cmd_status(args: argparse.Namespace) -> int:
     """Safe Grok Bot job projections. Needs hub authority; reports why not."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     record = run(
         brigade_args(args) + ["run", "cloud", "grokbot", "status", "--target", str(target), "--json"],
         root=root,
@@ -641,7 +752,7 @@ def cmd_status(args: argparse.Namespace) -> int:
 def cmd_handoff_lint(args: argparse.Namespace) -> int:
     """Lint the handoff inbox of the temp target."""
     root = state_root(args)
-    target = guard_target(Path(args.target))
+    target = guard_target(Path(args.target), root)
     argv = brigade_args(args) + ["handoff", "lint", "--target", str(target), "--json"]
     if args.content_guard:
         argv.append("--content-guard")
@@ -666,19 +777,21 @@ def cmd_handoff_lint(args: argparse.Namespace) -> int:
 def cmd_evidence(args: argparse.Namespace) -> int:
     """Copy captures and receipts somewhere cleanup never looks."""
     root = state_root(args)
-    target = guard_target(Path(args.target)) if args.target else None
+    target = guard_target(Path(args.target), root) if args.target else None
     base = (
-        Path(args.evidence_root).expanduser().resolve()
+        guard_root(args.evidence_root, flag="--evidence-root", extra_allowed=(DEFAULT_EVIDENCE_ROOT,))
         if args.evidence_root
-        else REPO_ROOT / ".brigade" / "verification-evidence"
+        else DEFAULT_EVIDENCE_ROOT
     )
     evidence = base / f"{now_stamp()}-{args.label}"
-    (evidence / "captures").mkdir(parents=True, exist_ok=True)
+    if not args.dry_run:
+        (evidence / "captures").mkdir(parents=True, exist_ok=True)
 
     copied: list[str] = []
     for capture in sorted((root / "captures").glob("*.json")):
         destination = evidence / "captures" / capture.name
-        shutil.copy2(capture, destination)
+        if not args.dry_run:
+            shutil.copy2(capture, destination)
         copied.append(str(destination.relative_to(evidence)))
 
     if target is not None:
@@ -687,9 +800,21 @@ def cmd_evidence(args: argparse.Namespace) -> int:
             if not source.exists():
                 continue
             destination = evidence / "target-brigade" / relative
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(source, destination, dirs_exist_ok=True)
+            if not args.dry_run:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(source, destination, dirs_exist_ok=True)
             copied.append(str(destination.relative_to(evidence)))
+
+    if args.dry_run:
+        return emit(
+            {
+                "action": "evidence",
+                "ok": True,
+                "dry_run": True,
+                "evidence_dir": str(evidence),
+                "would_copy": copied,
+            }
+        )
 
     manifest = {
         "schema": "verify-brigade.evidence.v1",
@@ -702,7 +827,7 @@ def cmd_evidence(args: argparse.Namespace) -> int:
     }
     (evidence / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    return emit({"action": "evidence", "ok": True, "evidence_dir": str(evidence), "items": copied})
+    return emit({"action": "evidence", "ok": True, "dry_run": False, "evidence_dir": str(evidence), "items": copied})
 
 
 def cmd_cleanup(args: argparse.Namespace) -> int:
@@ -719,26 +844,30 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
 
     removed: list[str] = []
     skipped: list[dict] = []
+    # A target that a failed drive already deleted is still reclaimed: drop it
+    # from state.json so it stops being reported on every later cleanup.
+    reclaimed: set[str] = set()
     for entry in recorded:
         if not entry.is_relative_to(root / "targets"):
             skipped.append({"path": str(entry), "reason": "outside the state root"})
             continue
         if not entry.exists():
             skipped.append({"path": str(entry), "reason": "already gone"})
+            reclaimed.add(str(entry))
             continue
         if args.dry_run:
             removed.append(str(entry))
             continue
         shutil.rmtree(entry, ignore_errors=True)
         removed.append(str(entry))
+        reclaimed.add(str(entry))
 
     captures = sorted((root / "captures").glob("*.json"))
     if not args.dry_run:
         if not args.keep_captures:
             for capture in captures:
                 capture.unlink(missing_ok=True)
-        remaining = {entry for entry in state["created_targets"]} - set(removed)
-        state["created_targets"] = sorted(remaining)
+        state["created_targets"] = sorted(set(state["created_targets"]) - reclaimed)
         write_state(root, state)
 
     return emit(
@@ -767,11 +896,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--brigade", default=None, help="Brigade command (default: .venv/bin/brigade, then PATH).")
     parser.add_argument("--root", default=None, help="State root for targets and captures.")
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Timeout for each brigade call.")
-    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    # `subcommand`, not `command`: `work-verify --command` would otherwise
+    # overwrite the name of the subcommand in the failure envelope.
+    sub = parser.add_subparsers(dest="subcommand", metavar="<command>")
     sub.required = True
 
     def add_target(command: argparse.ArgumentParser) -> None:
         command.add_argument("--target", required=True, help="Temp target created by new-target.")
+
+    def add_dry_run(command: argparse.ArgumentParser, help: str) -> None:
+        command.add_argument("--dry-run", action="store_true", help=help)
 
     def add_pack(command: argparse.ArgumentParser) -> None:
         add_target(command)
@@ -784,12 +918,14 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("new-target", help="git init + brigade init in a fresh temp dir.")
     p.add_argument("--depth", default=DEFAULT_DEPTH, choices=["repo", "workspace"])
     p.add_argument("--harnesses", default=DEFAULT_HARNESSES)
+    add_dry_run(p, "Report the commands without creating a target.")
     p.set_defaults(func=cmd_new_target)
 
     p = sub.add_parser("init", help="Run brigade init against an existing directory.")
     add_target(p)
     p.add_argument("--depth", default=DEFAULT_DEPTH, choices=["repo", "workspace"])
     p.add_argument("--harnesses", default=DEFAULT_HARNESSES)
+    add_dry_run(p, "Report the command without writing into the target.")
     p.set_defaults(func=cmd_init)
 
     p = sub.add_parser("doctor-target", help="brigade doctor --json against the temp target.")
@@ -801,12 +937,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--command", default=DEFAULT_PROBE, help="Verification command to run in the target.")
     p.add_argument("--capture", default=None, help="Artifact id for atomic --capture.")
     p.add_argument("--command-timeout", type=int, default=60, help="Per-command timeout inside Brigade.")
+    add_dry_run(p, "Report the command without running a verification.")
     p.set_defaults(func=cmd_work_verify)
 
     p = sub.add_parser("grokbot-pack-setup", help="Preview or apply pack instance config.")
     add_pack(p)
     p.add_argument("--apply", action="store_true", help="Write config. Default is preview only.")
-    p.add_argument("--dry-run", action="store_true", help="Force preview even with --apply.")
+    add_dry_run(p, "Force preview even with --apply.")
     p.set_defaults(func=cmd_pack_setup)
 
     p = sub.add_parser("grokbot-pack-doctor", help="Sanitized pack diagnostics.")
@@ -820,7 +957,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("grokbot-pack-remove", help="Preview or apply removal of pack config.")
     add_pack(p)
     p.add_argument("--apply", action="store_true", help="Delete the files. Default is preview only.")
-    p.add_argument("--dry-run", action="store_true", help="Force preview even with --apply.")
+    add_dry_run(p, "Force preview even with --apply.")
     p.set_defaults(func=cmd_pack_remove)
 
     p = sub.add_parser("grokbot-feed", help="Validate an approved feed manifest (never enqueues).")
@@ -828,6 +965,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--manifest", default=None, help="Path to an approved private feed manifest.")
     p.add_argument("--sample", action="store_true", help="Write and validate a bundled sample manifest.")
     p.add_argument("--limit", type=int, default=1)
+    add_dry_run(p, "Report the command without writing the sample manifest.")
     p.set_defaults(func=cmd_feed)
 
     p = sub.add_parser("grokbot-status", help="Safe Grok Bot job projections.")
@@ -844,11 +982,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--target", default=None, help="Temp target whose receipts to copy.")
     p.add_argument("--label", default="run", help="Suffix for the evidence directory name.")
     p.add_argument("--evidence-root", default=None, help="Where evidence dirs live.")
+    add_dry_run(p, "Report what would be copied without creating the evidence dir.")
     p.set_defaults(func=cmd_evidence)
 
     p = sub.add_parser("cleanup", help="Remove only the targets this helper created.")
     p.add_argument("--target", default=None, help="Remove one recorded target instead of all of them.")
-    p.add_argument("--dry-run", action="store_true", help="Report what would be removed.")
+    add_dry_run(p, "Report what would be removed.")
     p.add_argument("--keep-captures", action="store_true", help="Leave capture files in the state root.")
     p.set_defaults(func=cmd_cleanup)
 
@@ -860,7 +999,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         return int(args.func(args))
     except HelperError as exc:
-        return emit({"action": args.command, "ok": False, "error": str(exc)}, 1)
+        return emit({"action": args.subcommand, "ok": False, "error": str(exc)}, 1)
 
 
 if __name__ == "__main__":

--- a/registry/skills/verify-brigade/features/README.md
+++ b/registry/skills/verify-brigade/features/README.md
@@ -1,0 +1,38 @@
+# Brigade feature map
+
+The maintained list of user-facing Brigade surfaces this skill knows how to
+drive. A proof that only exercises one entry point is incomplete when the
+change touched another one listed here.
+
+Every file below answers the same four questions: what the feature is
+(`Sub-features`), how a user reaches it (`How to get to it (user POV)`), the
+exact helper calls (`Driving it with control-brigade`), and what bites
+(`Gotchas`).
+
+| Feature | File | Drive with |
+|---|---|---|
+| Install and wiring health | [init-and-doctor.md](init-and-doctor.md) | `new-target`, `init`, `doctor-target` |
+| Work verification receipts | [work-verify-receipts.md](work-verify-receipts.md) | `work-verify` |
+| Grok Bot connector packs | [grokbot-pack-lifecycle.md](grokbot-pack-lifecycle.md) | `grokbot-pack-setup/-doctor/-canary/-remove` |
+| Grok Bot job queue and feed | [run-cloud-grokbot-queue.md](run-cloud-grokbot-queue.md) | `grokbot-feed`, `grokbot-status` |
+| Handoff inbox lint | [handoff-lint.md](handoff-lint.md) | `handoff-lint` |
+
+Not yet mapped, and worth adding when a change lands there: `brigade memory`,
+`brigade security`, `brigade scrub` / `guard`, `brigade outcome`,
+`brigade evidence`, `brigade code`, `brigade skills`, `brigade daily`,
+`brigade fleet`. Add a file with the same four H2s rather than stretching an
+existing one.
+
+Setup shared by every file:
+
+```bash
+C=registry/skills/verify-brigade/control-brigade.py
+TARGET=$($C new-target | python3 -c 'import json,sys; print(json.load(sys.stdin)["target"])')
+```
+
+Teardown, always:
+
+```bash
+$C evidence --target "$TARGET" --label <what-you-proved>
+$C cleanup
+```

--- a/registry/skills/verify-brigade/features/grokbot-pack-lifecycle.md
+++ b/registry/skills/verify-brigade/features/grokbot-pack-lifecycle.md
@@ -1,0 +1,101 @@
+# Grok Bot connector pack lifecycle
+
+First-party connector packs are the role-scoped MCP listeners Grok Bot talks
+to. `implementation-worker` is the pack an Implementation Worker runs behind.
+The lifecycle is: see the catalog, write non-secret instance config, diagnose
+it, canary it, remove it. No step here needs a real credential.
+
+## Sub-features
+
+- `pack list` / `pack show --id` - the packaged catalog: id, kind, version,
+  default bind, tool names.
+- `pack setup --id --bearer-env NAME | --bearer-file PATH` - previews, then
+  with `--apply` writes `.brigade/grokbot/packs/<id>.json` and
+  `.brigade/grokbot/<id>.json`. Optional `--bind`, `--allow-host`,
+  `--allow-origin`, and pack-specific paths (`--runtime-path`, `--ledger-path`,
+  `--action-state-path`, `--approval-dir`, ...). The bearer is stored as a
+  *reference*, never a value.
+- `pack doctor --id` - sanitized checks: `dependency`, `config`, `permissions`,
+  `queue`, `feed-authority`, `endpoint`. Details never carry credentials or job
+  content.
+- `pack canary --id` - bounded non-mutating authentication and inventory check
+  against the listener.
+- `pack remove --id` - previews the owned config and unit files, deletes them
+  with `--apply`.
+- `pack update`, `pack install-service`, and the `relay-*` family, not yet
+  driven by the helper.
+
+## How to get to it (user POV)
+
+An operator standing up an Implementation Worker seat runs:
+
+```bash
+brigade run cloud grokbot pack list --json
+brigade run cloud grokbot pack setup --target . --id implementation-worker \
+  --bearer-env GROKBOT_IMPL_BEARER            # preview
+brigade run cloud grokbot pack setup --target . --id implementation-worker \
+  --bearer-env GROKBOT_IMPL_BEARER --apply     # write
+brigade run cloud grokbot pack doctor --target . --id implementation-worker --json
+brigade run cloud grokbot pack canary --target . --id implementation-worker --json
+```
+
+They then start the listener and re-run doctor and canary until both are clean.
+
+## Driving it with control-brigade
+
+```bash
+C=registry/skills/verify-brigade/control-brigade.py
+P="--target $TARGET --id implementation-worker"
+
+$C grokbot-pack-setup  $P                # preview: writes nothing
+$C grokbot-pack-setup  $P --apply        # writes config
+$C grokbot-pack-doctor $P
+$C grokbot-pack-canary $P
+$C grokbot-pack-remove $P                # preview: deletes nothing
+$C grokbot-pack-remove $P --apply --dry-run   # --dry-run wins over --apply
+```
+
+Observed end state on a fresh target, with no listener running:
+
+- `setup` preview -> exit 0, `"applied": false`,
+  `"writes": [".brigade/grokbot/packs/implementation-worker.json", ".brigade/grokbot/implementation-worker.json"]`,
+  and neither file on disk afterwards.
+- `setup --apply` -> exit 0, `"applied": true`, and both files present under
+  `$TARGET/.brigade/grokbot/`. Check the files; the preview list is a promise,
+  the files are the proof.
+- `doctor` -> exit 0 from the helper (the CLI itself exits 1), with
+  `"config_resolved": true`, `"listener_running": false`, and checks
+  `dependency=fail, config=ok, permissions=ok, queue=fail,
+  feed-authority=skipped, endpoint=fail`.
+- `canary` -> exit 0 from the helper (the CLI exits 1), `"reason": "health"`,
+  `"listener_running": false`, `"expected_without_listener": true`.
+- `remove` preview -> exit 0, `"applied": false`, `"paths"` listing the two
+  files, both still on disk.
+
+**`endpoint: fail` and `reason: health` are the proof, not the failure.** The
+commands resolved the pack config, dialed the loopback bind the pack declares
+(read it from the `bind` field in the setup output), and reported honestly that
+nothing answered. A pack command that returned "ok" with no listener up would
+be the bug.
+
+## Gotchas
+
+- `pack setup` requires exactly one of `--bearer-file` / `--bearer-env`. With
+  neither, argparse rejects the call before Brigade sees it.
+- `pack doctor`'s `config` check *resolves* the bearer reference, so it fails
+  when the named env var is unset - which looks like a config bug and is not.
+  The helper sets a non-secret placeholder in `VERIFY_BRIGADE_PACK_BEARER` for
+  exactly this reason. Never put a real bearer in a verification run.
+- `dependency: fail` means the `mcp` server package is not importable in the
+  active interpreter. That is an environment fact about the checkout, not a
+  regression in the pack.
+- `queue: fail` on a fresh target is expected: no queue state exists yet.
+- Doctor output is deliberately sanitized to `{check, status}` pairs. Do not
+  wait for a detail string that explains the failure; there is none by design.
+- Several packs need more than a bearer (`--runtime-path`, `--ledger-path`,
+  `--action-state-path`, `--approval-dir`, and for `cerebro-memory`,
+  `--cli-executable` plus `--workdir`). `implementation-worker` needs only the
+  bearer reference, which is why it is the default pack to drive.
+- Ports are fixed per pack in `grokbot_packs.py`. If a real listener is already
+  bound on the host, a canary can reach *that* process. Drive with a `--bind`
+  you own, or read the bind in the setup output before trusting a green canary.

--- a/registry/skills/verify-brigade/features/handoff-lint.md
+++ b/registry/skills/verify-brigade/features/handoff-lint.md
@@ -1,0 +1,82 @@
+# Handoff inbox lint
+
+Memory Handoffs are how durable knowledge leaves a session. `brigade handoff
+lint` is the gate that keeps a handoff parseable by the ingester instead of
+being a free-form note nobody can route.
+
+## Sub-features
+
+- `handoff lint` with no paths validates every pending file in the inbox
+  (`.claude/memory-handoffs/` for a claude-owned target), skipping
+  `TEMPLATE.md` and `processed/`.
+- Explicit paths lint just those files, wherever they live.
+- `--content-guard` adds a leak scan (secrets, PII) plus injection heuristics
+  for instruction-shaped payloads; `--guard-policy` picks the policy.
+- `--strict` promotes standalone-readability warnings to failures.
+- `--json` returns `valid`, `count`, `content_guard`,
+  `injection_flagged_count`, `readability_flagged_count`, and a `results` array
+  with per-file `valid`, `errors`, `warnings`, `hints`, `readability`,
+  `injection_heuristics`, `action`, and `salvageable`.
+- Neighbors worth knowing: `handoff doctor` (inbox vs source config),
+  `handoff draft` (writes a linted handoff), `handoff migrate` (converts
+  homegrown notes), `handoff issues` / `import-issues`.
+
+## How to get to it (user POV)
+
+An agent finishing a session writes a handoff from
+`.claude/memory-handoffs/TEMPLATE.md`, then checks it before leaving:
+
+```bash
+brigade handoff lint --target . --json
+brigade handoff lint --target . --content-guard --strict
+```
+
+`"valid": true` means the ingester can route it. Anything else is a handoff
+that will be dropped or need a human.
+
+## Driving it with control-brigade
+
+```bash
+C=registry/skills/verify-brigade/control-brigade.py
+
+# empty inbox on a fresh target
+$C handoff-lint --target "$TARGET"
+
+# after dropping a handoff into $TARGET/.claude/memory-handoffs/
+$C handoff-lint --target "$TARGET" --content-guard
+
+# one explicit file
+$C handoff-lint --target "$TARGET" "$TARGET/.claude/memory-handoffs/2026-09-01-0000-sample.md"
+```
+
+Observed end states:
+
+- Fresh target, empty inbox -> exit 0, `{"valid": true, "count": 0,
+  "results": []}`. `valid: true` on zero files means "nothing is broken", not
+  "something was checked" - assert on `count` when you meant to lint a file.
+- One well-formed handoff -> exit 0, `count: 1`, and a result with
+  `"valid": true`, `"errors": []`, `"action": "no-card"`.
+- One handoff missing sections -> helper exit 3, `"valid": false`, and errors
+  naming each miss verbatim:
+  `missing required section: Type`, `missing required section: Summary`,
+  `missing required section: Recommended memory action`.
+
+The error strings are the stable handle. Assert on them rather than on the
+count of errors, which grows as checks are added.
+
+## Gotchas
+
+- `valid: true` with `count: 0` is the empty-inbox answer and is easy to
+  mistake for a pass. Always read `count`.
+- `##` is the section delimiter. A handoff body that uses `##` for its own
+  subheadings creates phantom sections; the template says use `###` or deeper.
+- The template forces exactly one branch: a card action (`create-card` /
+  `update-card`) must omit the document sections, and `no-card` must omit the
+  card sections. Leaving both in is a lint failure, not a warning.
+- `--content-guard` is a different failure class from schema lint. A handoff
+  can be structurally valid and still be flagged for a leak, so run both before
+  claiming a handoff is clean.
+- `--strict` changes the exit code, not the file. Readability warnings that
+  pass by default will fail under `--strict`.
+- Never lint the operator's real inbox to test a change. Drop the fixture into
+  the temp target, where cleanup takes it away.

--- a/registry/skills/verify-brigade/features/init-and-doctor.md
+++ b/registry/skills/verify-brigade/features/init-and-doctor.md
@@ -1,0 +1,88 @@
+# init and doctor
+
+Installing Brigade into a repo or workspace, and checking afterwards that the
+install is actually wired. This is the first thing a new user runs and the
+first thing that breaks when templates, harness manifests, or doctor checks
+change.
+
+## Sub-features
+
+- `brigade init --depth {repo,workspace}` writes bootstrap files
+  (`AGENTS.md`, `CLAUDE.md`, `MEMORY.md`, `TOOLS.md`, `USER.md`, `SOUL.md`,
+  `IDENTITY.md`, `HEARTBEAT.md`, `SAFETY_RULES.md`), `.brigade/`, `rules/`,
+  `hooks/`, and `scripts/`.
+- `--harnesses claude,codex,...` decides which harness dirs get files, and
+  which built-in skills (`brigade-work`, `ultra-work-scout`) get wired into
+  them. `--harnesses none` is the generic install.
+- The gitignore block between `>>> brigade gitignore block >>>` markers, or
+  `.git/info/exclude` with `--git-exclude`.
+- The memory owner (`brigade: memory owner -> claude`), overridable with
+  `--owner`.
+- `--dry-run`, `--force`, `--no-wire`, `--profile`, `--include`.
+- `brigade doctor` returns per-check `OK` / `WARN` / `FAIL` / `MANUAL`,
+  plus `ready`, `depth`, `harnesses`, `owner`, and a summary count.
+  `--agent` drops passes, `--json` makes it machine-readable, `--full` stops
+  condensing, `--operator` adds host-global checks.
+
+## How to get to it (user POV)
+
+A user clones or creates a repo and runs, from `CONTRIBUTING.md`:
+
+```bash
+target="$(mktemp -d)"
+git init -q -b main "$target"
+python -m brigade init --target "$target" --depth workspace --harnesses claude,codex
+python -m brigade doctor --target "$target"
+```
+
+Then they read the last lines of `init` (which harnesses were wired, who owns
+memory) and the doctor summary. The number they care about is `0 failed`.
+
+## Driving it with control-brigade
+
+```bash
+C=registry/skills/verify-brigade/control-brigade.py
+
+# creates the dir, git init, brigade init; prints "target"
+$C new-target --depth workspace --harnesses claude,codex
+
+TARGET=<the target it printed>
+
+# re-run init against an existing dir you already own
+$C init --target "$TARGET" --depth workspace --harnesses claude
+
+# the check
+$C doctor-target --target "$TARGET"
+```
+
+Proof of a healthy install, all from `doctor-target` output:
+
+- `"ok": true` and helper exit 0
+- `"ready": true`
+- `"summary": {"failed": 0, ...}` - warns are fine, fails are not
+- `"owner"`, `"depth"`, `"harnesses"` match what you asked `init` for
+
+Plus, on disk: `$TARGET/.brigade/config.json` exists, and
+`$TARGET/.claude/skills/brigade-work/` exists when claude was in
+`--harnesses`. Check the files, not only the summary.
+
+Observed baseline on a fresh `--depth workspace --harnesses claude,codex`
+target: `{"failed": 0, "manual": 0, "ok": 54, "total": 61, "warn": 6}`,
+`ready: true`, `owner: claude`. A change that moves `failed` off zero, or
+drops `ok` sharply, is the regression.
+
+## Gotchas
+
+- `brigade init` has no `--json`. Its output is prose; assert on exit code and
+  on the files it wrote. `doctor` does have `--json` - use it.
+- Six WARNs on a fresh target are expected, not a bug: memory-care, security,
+  backups, notifications, and friends are not initialized by `init`.
+- `init` refuses to install into `$HOME` without `--allow-home`. Do not pass
+  that flag while verifying - the helper refuses the home directory outright.
+- Piping `brigade doctor --json` into `head` returns exit 120 (SIGPIPE), not
+  the real exit code. Redirect to a file when the exit code matters.
+- `init` is idempotent-ish but not free: without `--force` it leaves existing
+  files alone, so a second `init` against a dirty target proves less than a
+  first `init` against a fresh one. Use `new-target` per proof.
+- Re-running `init` rewrites everything between the gitignore block markers.
+  Custom ignores added there do not survive.

--- a/registry/skills/verify-brigade/features/run-cloud-grokbot-queue.md
+++ b/registry/skills/verify-brigade/features/run-cloud-grokbot-queue.md
@@ -1,0 +1,87 @@
+# Grok Bot job queue and feed
+
+The private local job queue that Grok Bot workers lease from. Work only enters
+it through an explicitly approved manifest - the feed never invents jobs - and
+the queue is read back through sanitized projections.
+
+## Sub-features
+
+- `run cloud grokbot feed --manifest <path>` validates an approved manifest;
+  `--apply` enqueues, `--limit 1..10` bounds how many new jobs a single call
+  may create. Validation is the default.
+- `run cloud grokbot scout-feed` - the Repository Scout variant, under an
+  active-scout and daily limit.
+- `run cloud grokbot enqueue --file` - one envelope from JSON.
+- `run cloud grokbot status --json` - safe projections of queued, leased, and
+  completed jobs.
+- Lease/lifecycle verbs (`lease`, `heartbeat`, `complete`, `cancel`,
+  `reconcile`, `findings`, `relay`) and `serve` for the listener.
+- Manifest shape (`brigade.grokbot.feed.v1`): exactly
+  `{schema, approved, label, entries}`, each entry exactly
+  `{idempotency_key, spec}`, each spec exactly the nine keys `label`, `role`,
+  `repository`, `base_ref`, `ownership_paths`, `instructions`,
+  `verification_commands`, `artifact`, `timeout_seconds`.
+
+## How to get to it (user POV)
+
+An operator writes a private manifest of approved work, validates it, then
+enqueues:
+
+```bash
+brigade run cloud grokbot feed --target . --manifest ~/private/feed.json --limit 1 --json
+brigade run cloud grokbot feed --target . --manifest ~/private/feed.json --limit 1 --apply --json
+brigade run cloud grokbot status --target . --json
+```
+
+A worker seat then leases from the queue; the operator watches `status`.
+
+## Driving it with control-brigade
+
+```bash
+C=registry/skills/verify-brigade/control-brigade.py
+
+# writes a valid sample manifest (mode 0600) into the state root and validates it
+$C grokbot-feed --target "$TARGET" --sample
+
+# or point at a manifest you already own
+$C grokbot-feed --target "$TARGET" --manifest /path/to/feed.json --limit 1
+
+$C grokbot-status --target "$TARGET"
+```
+
+Observed end state on a fresh target:
+
+- `grokbot-feed --sample` -> exit 0, `{"valid": 1, "known": 0, "limit": 1}`.
+  `valid` counts entries that parsed and passed spec validation; `known` counts
+  entries already present under the same idempotency key. Because the helper
+  never passes `--apply`, `$TARGET/.brigade/` gains no queue state - diff the
+  directory before and after to confirm.
+- `grokbot-status` -> helper exit 3, `{"ok": false, "reason": "auth-failed"}`,
+  because a fresh target has no hub authority. That is the honest reading: the
+  command parsed, resolved the target, and refused to project a queue it cannot
+  authenticate to. A green `status` here would mean the helper picked up
+  someone else's credentials.
+
+To prove a validation failure is caught, break one field. `"ownership_paths":
+["docs/"]` (trailing slash) returns exit 2 and `error: invalid-ownership-paths`.
+
+## Gotchas
+
+- The manifest is read through an ownership and permission check before it is
+  parsed. It must be a regular file, owned by the calling uid, not group- or
+  world-writable, and not a symlink; otherwise every call returns
+  `unsafe-manifest` regardless of content. The helper's `--sample` writes mode
+  0600 for this reason.
+- Key sets are compared for exact equality, not superset. One extra key in the
+  manifest or in a spec is `malformed-manifest` / `unknown-key`, not a warning.
+- `ownership_paths` entries must not start with `/`, contain `\`, or have any
+  empty / `.` / `..` segment - so a trailing slash is invalid.
+- `artifact.kind` is role-bound: `implementation-worker` takes `draft-pr` or
+  `branch`; `repository-scout` takes `report`. Nothing else validates.
+- Any key whose name looks credential-shaped is rejected outright before
+  validation. Do not try to smuggle a token through a spec field.
+- `--apply` mutates the private queue. Never pass it during verification; use
+  a manifest you own and the default validate-only path.
+- `feed` is idempotent by `idempotency_key`, but a reused key with a *different*
+  spec is `idempotency-conflict`, not an overwrite. Change the key when you
+  change the spec.

--- a/registry/skills/verify-brigade/features/work-verify-receipts.md
+++ b/registry/skills/verify-brigade/features/work-verify-receipts.md
@@ -1,0 +1,96 @@
+# work verification receipts
+
+`brigade work verify run` is how a result counts. It executes the commands you
+name, writes a receipt under `.brigade/work/verify-runs/<run-id>/`, and can
+attribute the outcome to a skill or card in the same step. Everything in the
+outcome ledger and the `brigade work brief` loop is downstream of this.
+
+## Sub-features
+
+- `--command "<shell command>"`, repeatable. Rejected when it contains shell
+  metacharacters that the safety check does not allow.
+- `--argv-json '["prog","arg"]'` for one command executed with `shell=False`,
+  which is how you pass quotes, semicolons, and parentheses.
+- `--manifest <id>` for a registered verifier manifest with scoreable
+  subject/check metadata. Mutually exclusive with the other two.
+- `--capture <artifact-id>` (with `--capture-kind skill|card`) closes the loop
+  atomically: pass and failure both land in the outcome ledger, no separate
+  `brigade outcome capture` step.
+- `--timeout <s>` per command; `--no-reuse` to defeat the identical-tree
+  passing-receipt reuse.
+- Readers: `brigade work verify runs --limit N --json` and
+  `brigade work verify show <run-id|latest> --json`.
+
+## How to get to it (user POV)
+
+An agent finishing a change in a Brigade-wired repo runs, per `AGENTS.md`:
+
+```bash
+brigade work verify run --target . \
+  --argv-json '["./scripts/verify-focused","tests/test_thing.py"]' \
+  --capture brigade-work
+```
+
+and reports the `run_id` and `status`. Later, someone reads the receipt back
+with `brigade work verify show <run-id> --json`.
+
+## Driving it with control-brigade
+
+```bash
+C=registry/skills/verify-brigade/control-brigade.py
+$C work-verify --target "$TARGET" --capture verify-brigade
+```
+
+The default probe is `python3 --version`: no shell metacharacters, deterministic,
+exit 0. Override with `--command`, and bound the inner command with
+`--command-timeout`.
+
+Proof, from the helper's normalized output:
+
+- `"status": "completed"` and `"ok": true` (helper exit 0)
+- `"run_id"` present, shaped `<YYYYMMDD>-<HHMMSS>-work-verify-<hex>`
+- `"receipt_path"` points at a directory that exists
+- `"outcome_capture": {"artifact_id": "verify-brigade", "artifact_kind": "skill"}`
+  when `--capture` was passed
+
+Then look at the receipt on disk - stdout is the claim, the receipt is the
+evidence:
+
+```bash
+ls "$TARGET/.brigade/work/verify-runs/"
+```
+
+Observed on a fresh target: `run_id 20260901-024652-work-verify-757d99`,
+`status completed`.
+
+To prove a *failing* verification is recorded too (it must be - failures are
+the signal the outcome ledger needs):
+
+```bash
+$C work-verify --target "$TARGET" --command "false" --capture verify-brigade
+```
+
+Observed: helper exit 3, `"status": "failed"`, and a receipt written anyway at
+`20260901-024903-work-verify-ae8f0f`.
+
+## Gotchas
+
+- The `--command` shell-metacharacter check rejects things that look fine to a
+  human. `python3 -c 'print(1)'` passes; anything with `;`, `&&`, `|`, or
+  backticks does not. Use `--argv-json` for those.
+- `--capture` is mandatory in this repo's hook policy. A raw
+  `brigade work verify run` without `--capture brigade-work` is refused before
+  it runs, and no receipt exists to point at.
+- Passing receipts are reused when the tree fingerprint is unchanged, so a
+  second identical run can return the earlier `run_id`. That is correct
+  behavior, not a stale result. `--no-reuse` forces execution - but never pass
+  it to the repo's full `./scripts/verify` gate.
+- Status 75 from the full gate means another full verification already holds
+  the lock for this checkout. Do not retry it with a bigger timeout; run
+  `./scripts/verify-focused` or wait.
+- The receipt captures a code-graph delta by shelling out to the `graphtrail`
+  binary. On a host without it, `code_graph_delta` comes back
+  `{"ok": false, "status": "unavailable", ...}` and the run still completes -
+  do not read a missing binary as a failed verification.
+- `run_id` is not a join key across targets. Two different targets can hold
+  receipts with unrelated ids; always carry the target path alongside.

--- a/tests/test_verify_brigade_skill.py
+++ b/tests/test_verify_brigade_skill.py
@@ -1,0 +1,87 @@
+"""Keep the verify-brigade lever honest.
+
+The `registry/skills/verify-brigade/` skill exists so a change to the Brigade
+CLI can be proved by driving the CLI. Its helper is only useful if it still
+runs, so CI drives the same three commands a proof run starts with:
+new-target, doctor-target, cleanup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_DIR = REPO_ROOT / "registry" / "skills" / "verify-brigade"
+CONTROL = SKILL_DIR / "control-brigade.py"
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git is required to create a target")
+
+
+def control(*args: str, root: Path) -> tuple[int, dict]:
+    """Run one control-brigade subcommand and return (exit code, parsed JSON)."""
+    brigade = shlex.join([sys.executable, "-m", "brigade"])
+    argv = [sys.executable, str(CONTROL), "--brigade", brigade, "--root", str(root), *args]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(REPO_ROOT / "src"), env.get("PYTHONPATH", "")]))
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout=600, env=env, check=False)
+    assert proc.stdout, f"no JSON on stdout: {proc.stderr}"
+    return proc.returncode, json.loads(proc.stdout)
+
+
+def test_control_brigade_is_an_executable_helper():
+    assert CONTROL.is_file(), "the verify-brigade skill must ship its helper"
+    assert os.access(CONTROL, os.X_OK), "control-brigade.py must be executable"
+    assert (SKILL_DIR / "SKILL.md").is_file()
+    assert (SKILL_DIR / "features" / "README.md").is_file()
+
+
+def test_new_target_doctor_target_and_cleanup(tmp_path):
+    root = tmp_path / "state"
+
+    code, created = control("new-target", "--depth", "repo", "--harnesses", "claude", root=root)
+    assert code == 0, created
+    assert created["ok"] is True
+    assert created["action"] == "new-target"
+    target = Path(created["target"])
+    assert target.is_dir()
+    assert target.is_relative_to(root / "targets")
+    assert (target / ".brigade").is_dir()
+
+    code, health = control("doctor-target", "--target", str(target), root=root)
+    assert code == 0, health
+    assert health["ok"] is True
+    assert health["ready"] is True
+    assert health["summary"]["failed"] == 0
+    assert health["summary"]["total"] > 0
+
+    code, preview = control("cleanup", "--dry-run", root=root)
+    assert code == 0, preview
+    assert preview["dry_run"] is True
+    assert preview["would_remove"] == [str(target)]
+    assert target.is_dir(), "a dry run must not remove anything"
+
+    code, removed = control("cleanup", root=root)
+    assert code == 0, removed
+    assert removed["ok"] is True
+    assert removed["removed"] == [str(target)]
+    assert not target.exists()
+
+
+def test_cleanup_refuses_a_target_it_did_not_create(tmp_path):
+    root = tmp_path / "state"
+    stranger = tmp_path / "not-ours"
+    stranger.mkdir()
+
+    code, payload = control("cleanup", "--target", str(stranger), root=root)
+    assert code == 1
+    assert payload["ok"] is False
+    assert "refusing to remove" in payload["error"]
+    assert stranger.is_dir()

--- a/tests/test_verify_brigade_skill.py
+++ b/tests/test_verify_brigade_skill.py
@@ -2,8 +2,9 @@
 
 The `registry/skills/verify-brigade/` skill exists so a change to the Brigade
 CLI can be proved by driving the CLI. Its helper is only useful if it still
-runs, so CI drives the same three commands a proof run starts with:
-new-target, doctor-target, cleanup.
+runs, so CI drives the commands a proof run starts with (new-target,
+doctor-target, work-verify, cleanup) and the refusals that keep those drives
+away from the operator home and the Brigade checkout.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import json
 import os
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -25,15 +27,40 @@ CONTROL = SKILL_DIR / "control-brigade.py"
 pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git is required to create a target")
 
 
-def control(*args: str, root: Path) -> tuple[int, dict]:
+def control(
+    *args: str,
+    root: Path,
+    brigade: str | None = None,
+    env_extra: dict[str, str] | None = None,
+) -> tuple[int, dict]:
     """Run one control-brigade subcommand and return (exit code, parsed JSON)."""
-    brigade = shlex.join([sys.executable, "-m", "brigade"])
+    brigade = brigade or shlex.join([sys.executable, "-m", "brigade"])
     argv = [sys.executable, str(CONTROL), "--brigade", brigade, "--root", str(root), *args]
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(REPO_ROOT / "src"), env.get("PYTHONPATH", "")]))
+    if env_extra:
+        env.update(env_extra)
     proc = subprocess.run(argv, capture_output=True, text=True, timeout=600, env=env, check=False)
     assert proc.stdout, f"no JSON on stdout: {proc.stderr}"
     return proc.returncode, json.loads(proc.stdout)
+
+
+def sandbox(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
+    """A fake operator home and temp base for the helper subprocess.
+
+    The helper waves through any path under `$TMPDIR` before it measures a path
+    against the operator home. An autouse fixture in `conftest.py` repoints
+    `HOME` at a `tmp_path_factory` directory, which lives *inside* the temp
+    tree - so a probe under that home is allowed by the `$TMPDIR` clause and
+    the home refusal never runs. Hand the subprocess a home and a temp base
+    that are siblings instead, so "inside the operator home" is a state these
+    tests can actually reach, on any host and in CI.
+    """
+    home = tmp_path / "sandbox-home"
+    temp = tmp_path / "sandbox-tmp"
+    home.mkdir()
+    temp.mkdir()
+    return home, temp, {"HOME": str(home), "TMPDIR": str(temp)}
 
 
 def test_control_brigade_is_an_executable_helper():
@@ -85,3 +112,192 @@ def test_cleanup_refuses_a_target_it_did_not_create(tmp_path):
     assert payload["ok"] is False
     assert "refusing to remove" in payload["error"]
     assert stranger.is_dir()
+
+
+def test_work_verify_returns_a_receipt(tmp_path):
+    root = tmp_path / "state"
+
+    code, created = control("new-target", "--depth", "repo", "--harnesses", "claude", root=root)
+    assert code == 0, created
+    target = Path(created["target"])
+
+    code, verified = control("work-verify", "--target", str(target), "--command", "python3 --version", root=root)
+    assert code == 0, verified
+    assert verified["ok"] is True
+    assert verified["status"] == "completed"
+    assert verified["run_id"], "a work-verify drive must name the receipt it produced"
+    receipt = target / ".brigade" / "work" / "verify-runs" / verified["run_id"]
+    assert receipt.is_dir(), f"receipt directory missing: {receipt}"
+    assert Path(verified["receipt_path"]) == receipt
+
+
+@pytest.mark.parametrize(
+    ("unsafe", "detail"),
+    [
+        ("home", "inside the operator home"),
+        ("under-home", "inside the operator home"),
+        ("repo-root", "inside the Brigade checkout"),
+        ("under-repo-root", "inside the Brigade checkout"),
+        ("outside-state-root", "outside the state root"),
+    ],
+)
+def test_guard_target_refuses_unsafe_targets(tmp_path, unsafe, detail):
+    home, temp, env_extra = sandbox(tmp_path)
+    root = temp / "state"
+    candidates = {
+        "home": home,
+        "under-home": home / "verify-brigade-refusal-probe",
+        "repo-root": REPO_ROOT,
+        "under-repo-root": REPO_ROOT / "src",
+        "outside-state-root": tmp_path / "not-a-target",
+    }
+
+    code, payload = control("doctor-target", "--target", str(candidates[unsafe]), root=root, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "doctor-target"
+    assert "refusing" in payload["error"], payload
+    assert detail in payload["error"], payload
+
+
+def test_guard_target_accepts_a_path_under_the_state_root(tmp_path):
+    root = tmp_path / "state"
+    target = root / "targets" / "hand-made"
+    target.mkdir(parents=True)
+
+    _, payload = control("doctor-target", "--target", str(target), root=root)
+    assert payload["action"] == "doctor-target"
+    assert "error" not in payload, payload
+    assert payload["target"] == str(target)
+
+
+def test_root_inside_the_operator_home_is_refused(tmp_path):
+    home, _temp, env_extra = sandbox(tmp_path)
+    unsafe_root = home / "verify-brigade-refusal-probe"
+
+    code, payload = control("doctor", root=unsafe_root, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "doctor"
+    assert "refusing --root" in payload["error"], payload
+    assert "inside the operator home" in payload["error"], payload
+    assert not unsafe_root.exists(), "a refused --root must not be created"
+
+
+def test_root_inside_the_brigade_checkout_is_refused(tmp_path):
+    _home, _temp, env_extra = sandbox(tmp_path)
+    unsafe_root = REPO_ROOT / "verify-brigade-refusal-probe"
+
+    code, payload = control("doctor", root=unsafe_root, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "doctor"
+    assert "refusing --root" in payload["error"], payload
+    assert "inside the Brigade checkout" in payload["error"], payload
+    assert not unsafe_root.exists(), "a refused --root must not be created"
+
+
+def test_failed_brigade_init_leaves_no_target(tmp_path):
+    root = tmp_path / "state"
+    failing = shlex.join([sys.executable, "-c", "raise SystemExit(1)"])
+
+    code, created = control("new-target", root=root, brigade=failing)
+    assert code == 3, created
+    assert created["ok"] is False
+    assert created["stage"] == "brigade-init"
+    target = Path(created["target"])
+    assert not target.exists(), "a failed init must not leave a directory behind"
+
+    code, removed = control("cleanup", "--target", str(target), root=root)
+    assert code == 0, removed
+    assert removed["ok"] is True
+    assert removed["skipped"] == [{"path": str(target), "reason": "already gone"}]
+
+
+def test_init_dry_run_writes_nothing(tmp_path):
+    root = tmp_path / "state"
+    target = root / "targets" / "dry-run"
+    target.mkdir(parents=True)
+
+    code, payload = control("init", "--target", str(target), "--dry-run", root=root)
+    assert code == 0, payload
+    assert payload["ok"] is True
+    assert payload["dry_run"] is True
+    assert payload["would_run"], "a dry run must show the command it skipped"
+    assert list(target.iterdir()) == [], "a dry run must not write into the target"
+
+
+def test_new_target_dry_run_creates_nothing(tmp_path):
+    root = tmp_path / "state"
+
+    code, payload = control("new-target", "--dry-run", root=root)
+    assert code == 0, payload
+    assert payload["ok"] is True
+    assert payload["dry_run"] is True
+    assert payload["would_run"], "a dry run must show the commands it skipped"
+    assert list((root / "targets").iterdir()) == [], "a dry run must not create a target"
+    state = json.loads((root / "state.json").read_text()) if (root / "state.json").exists() else {}
+    assert state.get("created_targets", []) == [], "a dry run must not record a target"
+
+
+def test_work_verify_dry_run_writes_no_receipt(tmp_path):
+    root = tmp_path / "state"
+    target = root / "targets" / "dry-run"
+    target.mkdir(parents=True)
+
+    code, payload = control(
+        "work-verify", "--target", str(target), "--command", "python3 --version", "--dry-run", root=root
+    )
+    assert code == 0, payload
+    assert payload["ok"] is True
+    assert payload["dry_run"] is True
+    assert payload["would_run"], "a dry run must show the command it skipped"
+    assert list(target.iterdir()) == [], "a dry run must not write a receipt"
+
+
+def test_evidence_dry_run_creates_no_directory(tmp_path):
+    root = tmp_path / "state"
+    evidence_root = tmp_path / "evidence"
+
+    # Dry run first: the stamp has one-second resolution, so a real run in the
+    # same second would occupy the directory name the preview names.
+    code, preview = control(
+        "evidence", "--evidence-root", str(evidence_root), "--label", "probe", "--dry-run", root=root
+    )
+    assert code == 0, preview
+    assert preview["ok"] is True
+    assert preview["dry_run"] is True
+    assert not evidence_root.exists(), "a dry run must not create an evidence dir"
+
+    code, payload = control("evidence", "--evidence-root", str(evidence_root), "--label", "probe", root=root)
+    assert code == 0, payload
+    assert payload["dry_run"] is False
+    assert Path(payload["evidence_dir"]).is_dir()
+    assert (Path(payload["evidence_dir"]) / "manifest.json").is_file()
+
+
+def test_evidence_root_inside_the_operator_home_is_refused(tmp_path):
+    home, temp, env_extra = sandbox(tmp_path)
+    root = temp / "state"
+    unsafe = home / "verify-brigade-evidence-probe"
+
+    code, payload = control("evidence", "--evidence-root", str(unsafe), root=root, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "evidence"
+    assert "refusing --evidence-root" in payload["error"], payload
+    assert "inside the operator home" in payload["error"], payload
+    assert not unsafe.exists(), "a refused --evidence-root must not be created"
+
+
+def test_state_root_and_captures_are_private(tmp_path):
+    root = tmp_path / "state"
+
+    code, payload = control("doctor", root=root)
+    assert code in {0, 3}, payload
+    assert stat.S_IMODE((root).stat().st_mode) == 0o700
+    assert stat.S_IMODE((root / "captures").stat().st_mode) == 0o700
+    captures = sorted((root / "captures").glob("*.json"))
+    assert captures, "doctor must capture the commands it ran"
+    for capture in captures:
+        assert stat.S_IMODE(capture.stat().st_mode) == 0o600, capture

--- a/tests/test_verify_brigade_skill.py
+++ b/tests/test_verify_brigade_skill.py
@@ -29,13 +29,17 @@ pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git is requ
 
 def control(
     *args: str,
-    root: Path,
+    root: Path | None,
     brigade: str | None = None,
     env_extra: dict[str, str] | None = None,
 ) -> tuple[int, dict]:
-    """Run one control-brigade subcommand and return (exit code, parsed JSON)."""
+    """Run one control-brigade subcommand and return (exit code, parsed JSON).
+
+    `root=None` drops `--root` so the helper falls back to its default state
+    root under `$TMPDIR`, which is the path the symlink probes need.
+    """
     brigade = brigade or shlex.join([sys.executable, "-m", "brigade"])
-    argv = [sys.executable, str(CONTROL), "--brigade", brigade, "--root", str(root), *args]
+    argv = [sys.executable, str(CONTROL), "--brigade", brigade, *(["--root", str(root)] if root else []), *args]
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(REPO_ROOT / "src"), env.get("PYTHONPATH", "")]))
     if env_extra:
@@ -195,6 +199,93 @@ def test_root_inside_the_brigade_checkout_is_refused(tmp_path):
     assert "refusing --root" in payload["error"], payload
     assert "inside the Brigade checkout" in payload["error"], payload
     assert not unsafe_root.exists(), "a refused --root must not be created"
+
+
+def test_default_state_root_symlink_is_refused(tmp_path):
+    """A symlink planted at `$TMPDIR/verify-brigade` must not be followed.
+
+    The default state root gets the same treatment as `--root`: any local user
+    can pre-create the default path in a world-writable temp dir, so following
+    it would put every drive - including `cleanup`'s rmtree - wherever the
+    symlink points.
+    """
+    home, temp, env_extra = sandbox(tmp_path)
+    hideout = home / "secret"
+    hideout.mkdir()
+    (temp / "verify-brigade").symlink_to(hideout, target_is_directory=True)
+
+    code, payload = control("new-target", root=None, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "new-target"
+    assert "symlink" in payload["error"], payload
+    assert list(hideout.iterdir()) == [], "a refused state root must not be written through"
+
+
+def test_explicit_root_symlink_is_refused(tmp_path):
+    home, temp, env_extra = sandbox(tmp_path)
+    hideout = home / "secret"
+    hideout.mkdir()
+    planted = temp / "planted-root"
+    planted.symlink_to(hideout, target_is_directory=True)
+
+    code, payload = control("doctor", root=planted, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "doctor"
+    assert "symlink" in payload["error"], payload
+    assert list(hideout.iterdir()) == [], "a refused state root must not be written through"
+
+
+def test_state_root_subdirectory_symlink_is_refused(tmp_path):
+    home, temp, env_extra = sandbox(tmp_path)
+    hideout = home / "secret"
+    hideout.mkdir()
+    root = temp / "state"
+    root.mkdir()
+    (root / "targets").symlink_to(hideout, target_is_directory=True)
+
+    code, payload = control("doctor", root=root, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert "symlink" in payload["error"], payload
+    assert list(hideout.iterdir()) == [], "a refused state root must not be written through"
+
+
+def test_root_equal_to_the_temp_base_is_refused(tmp_path):
+    home, temp, env_extra = sandbox(tmp_path)
+
+    code, payload = control("doctor", root=temp, env_extra=env_extra)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "doctor"
+    assert "refusing --root" in payload["error"], payload
+    assert "temp base" in payload["error"], payload
+    assert not (temp / "targets").exists(), "a refused --root must not be populated"
+    assert stat.S_IMODE(temp.stat().st_mode) != 0o700, "a refused --root must not be chmodded"
+    assert list(home.iterdir()) == []
+
+
+@pytest.mark.skipif(hasattr(os, "geteuid") and os.geteuid() == 0, reason="root can write an unwritable directory")
+def test_unwritable_root_reports_the_json_envelope(tmp_path):
+    """A root the process cannot create must be a HelperError, not a traceback."""
+    locked = tmp_path / "locked"
+    locked.mkdir(mode=0o555)
+    try:
+        code, payload = control("doctor", root=locked / "state")
+        assert code == 1, payload
+        assert payload["ok"] is False
+        assert payload["action"] == "doctor"
+        assert "cannot prepare" in payload["error"], payload
+    finally:
+        locked.chmod(0o755)
+
+
+def test_skill_doc_states_what_the_helper_enforces():
+    """SKILL.md must not promise guarantees the helper does not make."""
+    doc = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    assert ".brigade/verification-evidence" in doc
+    assert "--manifest" in doc, "the one flag outside the target contract must be documented"
 
 
 def test_failed_brigade_init_leaves_no_target(tmp_path):

--- a/tests/test_verify_brigade_skill.py
+++ b/tests/test_verify_brigade_skill.py
@@ -32,33 +32,67 @@ def control(
     root: Path | None,
     brigade: str | None = None,
     env_extra: dict[str, str] | None = None,
+    script: Path | None = None,
+    cwd: Path | None = None,
 ) -> tuple[int, dict]:
     """Run one control-brigade subcommand and return (exit code, parsed JSON).
 
     `root=None` drops `--root` so the helper falls back to its default state
-    root under `$TMPDIR`, which is the path the symlink probes need.
+    root under `$TMPDIR`, which is the path the symlink probes need. `script`
+    runs a copy of the helper from a fake checkout; `cwd` matters because a
+    relative `$TMPDIR` resolves against the working directory.
     """
     brigade = brigade or shlex.join([sys.executable, "-m", "brigade"])
-    argv = [sys.executable, str(CONTROL), "--brigade", brigade, *(["--root", str(root)] if root else []), *args]
+    argv = [
+        sys.executable,
+        str(script or CONTROL),
+        "--brigade",
+        brigade,
+        *(["--root", str(root)] if root else []),
+        *args,
+    ]
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(REPO_ROOT / "src"), env.get("PYTHONPATH", "")]))
     if env_extra:
         env.update(env_extra)
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=600, env=env, check=False)
+    proc = subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+        check=False,
+        cwd=str(cwd) if cwd else None,
+    )
     assert proc.stdout, f"no JSON on stdout: {proc.stderr}"
     return proc.returncode, json.loads(proc.stdout)
+
+
+def fake_checkout(tmp_path: Path) -> tuple[Path, Path]:
+    """A copy of the helper inside a throwaway checkout; returns (root, script).
+
+    The helper reads its own `REPO_ROOT` as `Path(__file__).resolve().parents[3]`,
+    so a copy three directories down makes it treat a temp directory as the
+    Brigade checkout. That is the only way to plant a symlink at a default path
+    that lives *in* the checkout without writing into this one.
+    """
+    root = tmp_path / "checkout"
+    skill_dir = root / "registry" / "skills" / "verify-brigade"
+    skill_dir.mkdir(parents=True)
+    script = skill_dir / CONTROL.name
+    shutil.copy2(CONTROL, script)
+    return root, script
 
 
 def sandbox(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
     """A fake operator home and temp base for the helper subprocess.
 
-    The helper waves through any path under `$TMPDIR` before it measures a path
-    against the operator home. An autouse fixture in `conftest.py` repoints
-    `HOME` at a `tmp_path_factory` directory, which lives *inside* the temp
-    tree - so a probe under that home is allowed by the `$TMPDIR` clause and
-    the home refusal never runs. Hand the subprocess a home and a temp base
-    that are siblings instead, so "inside the operator home" is a state these
-    tests can actually reach, on any host and in CI.
+    An autouse fixture in `conftest.py` repoints `HOME` at a `tmp_path_factory`
+    directory, which can live *inside* the temp tree - and the helper keeps one
+    carve-out for a temp base that sits inside the home directory. Hand the
+    subprocess a home and a temp base that are siblings instead, so "inside the
+    operator home" and "under the temp base" are separate states these tests
+    can actually reach, on any host and in CI.
     """
     home = tmp_path / "sandbox-home"
     temp = tmp_path / "sandbox-tmp"
@@ -392,3 +426,151 @@ def test_state_root_and_captures_are_private(tmp_path):
     assert captures, "doctor must capture the commands it ran"
     for capture in captures:
         assert stat.S_IMODE(capture.stat().st_mode) == 0o600, capture
+
+
+def test_a_relative_tmpdir_cannot_move_the_temp_base_onto_the_checkout(tmp_path):
+    """`$TMPDIR=.` must be refused, not resolved against the working directory.
+
+    `tempfile.gettempdir()` returns a relative `$TMPDIR` verbatim, so the
+    default state root would resolve against the cwd - the Brigade checkout in
+    every documented invocation - and inherit the temp base allowance.
+    """
+    home, _temp, _env_extra = sandbox(tmp_path)
+    landing = REPO_ROOT / "verify-brigade"
+    assert not landing.exists(), "probe precondition: the checkout has no state root"
+
+    code, payload = control("doctor", root=None, env_extra={"HOME": str(home), "TMPDIR": "."}, cwd=REPO_ROOT)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "doctor"
+    assert "TMPDIR" in payload["error"], payload
+    assert not landing.exists(), "a relative $TMPDIR must not land a state root in the checkout"
+
+
+def test_a_temp_base_inside_the_checkout_is_still_refused(tmp_path):
+    """The checkout refusal runs before the temp base allowance, never after."""
+    checkout, script = fake_checkout(tmp_path)
+    home = tmp_path / "sandbox-home"
+    home.mkdir()
+    temp = checkout / "scratch"
+    temp.mkdir()
+
+    code, payload = control("doctor", root=None, env_extra={"HOME": str(home), "TMPDIR": str(temp)}, script=script)
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert "inside the Brigade checkout" in payload["error"], payload
+    assert not (temp / "verify-brigade").exists(), "a refused state root must not be created"
+
+
+def test_a_temp_base_inside_the_operator_home_is_still_allowed(tmp_path):
+    """The one carve-out: `$TMPDIR` itself inside the home, outside the checkout."""
+    home = tmp_path / "sandbox-home"
+    home.mkdir()
+    temp = home / "scratch"
+    temp.mkdir()
+
+    code, payload = control("doctor", root=None, env_extra={"HOME": str(home), "TMPDIR": str(temp)})
+    assert code in {0, 3}, payload
+    assert payload["action"] == "doctor"
+    assert "error" not in payload, payload
+    assert payload["state_root"] == str(temp / "verify-brigade")
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "../../../../escaped",
+        "nested/label",
+        "back\\slash",
+        "spaced label",
+        "x" * 65,
+        "",
+    ],
+)
+def test_evidence_refuses_an_unsafe_label(tmp_path, label):
+    home, temp, env_extra = sandbox(tmp_path)
+    root = temp / "state"
+    evidence_root = temp / "evidence"
+
+    code, payload = control(
+        "evidence",
+        "--evidence-root",
+        str(evidence_root),
+        "--label",
+        label,
+        root=root,
+        env_extra=env_extra,
+    )
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "evidence"
+    assert "refusing --label" in payload["error"], payload
+    assert list(home.iterdir()) == [], "a refused label must not write outside the evidence root"
+    assert not evidence_root.exists(), "a refused label must not create an evidence dir"
+
+
+def test_default_evidence_root_symlink_is_refused(tmp_path):
+    """A symlink at `<checkout>/.brigade/verification-evidence` must not be followed."""
+    checkout, script = fake_checkout(tmp_path)
+    home, temp, env_extra = sandbox(tmp_path)
+    hideout = home / "sneaky"
+    hideout.mkdir()
+    (checkout / ".brigade").mkdir()
+    (checkout / ".brigade" / "verification-evidence").symlink_to(hideout, target_is_directory=True)
+
+    code, payload = control(
+        "evidence", "--label", "symlinkprobe", root=temp / "state", env_extra=env_extra, script=script
+    )
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "evidence"
+    assert "symlink" in payload["error"], payload
+    assert list(hideout.iterdir()) == [], "a refused evidence root must not be written through"
+
+
+def test_explicit_evidence_root_symlink_is_refused(tmp_path):
+    home, temp, env_extra = sandbox(tmp_path)
+    hideout = home / "sneaky"
+    hideout.mkdir()
+    planted = temp / "planted-evidence"
+    planted.symlink_to(hideout, target_is_directory=True)
+
+    code, payload = control(
+        "evidence", "--evidence-root", str(planted), "--label", "probe", root=temp / "state", env_extra=env_extra
+    )
+    assert code == 1, payload
+    assert payload["ok"] is False
+    assert payload["action"] == "evidence"
+    assert "symlink" in payload["error"], payload
+    assert list(hideout.iterdir()) == [], "a refused evidence root must not be written through"
+
+
+def test_cleanup_skips_a_target_that_became_a_symlink(tmp_path):
+    """A recorded target swapped for a symlink is skipped, not reported removed."""
+    root = tmp_path / "state"
+    targets = root / "targets"
+    targets.mkdir(parents=True)
+    hideout = tmp_path / "hideout"
+    hideout.mkdir()
+    (hideout / "keep.txt").write_text("still here\n", encoding="utf-8")
+    swapped = targets / "swapped"
+    swapped.symlink_to(hideout, target_is_directory=True)
+    (root / "state.json").write_text(
+        json.dumps({"schema": "verify-brigade.state.v1", "created_targets": [str(swapped)]}) + "\n",
+        encoding="utf-8",
+    )
+
+    code, preview = control("cleanup", "--dry-run", root=root)
+    assert code == 0, preview
+    assert preview["would_remove"] == [], preview
+    assert preview["skipped"] == [{"path": str(swapped), "reason": "skipped-symlink"}], preview
+
+    code, payload = control("cleanup", root=root)
+    assert code == 0, payload
+    assert payload["ok"] is True
+    assert payload["removed"] == [], payload
+    assert payload["skipped"] == [{"path": str(swapped), "reason": "skipped-symlink"}], payload
+    assert swapped.is_symlink(), "cleanup must leave the swapped path alone"
+    assert (hideout / "keep.txt").is_file(), "cleanup must not remove what the symlink points at"
+    state = json.loads((root / "state.json").read_text(encoding="utf-8"))
+    assert state["created_targets"] == [str(swapped)], "a skipped target stays recorded"


### PR DESCRIPTION
## Summary

Agents (Claude, Codex, and above all Grok Bot Implementation Workers) need a reproducible way to prove a Brigade change works, not a narrated pytest run. This adds a repo-shipped verification skill in the shape pstack's `create-verification-skill` prescribes, with the "build the lever" principle applied: the drive is a helper CLI, not markdown.

- `registry/skills/verify-brigade/SKILL.md`: Launch, Doctor, Drive, Evidence, Cleanup, Helpers, grounded in this repo's real commands. Every drive runs in a temp target the helper creates; it refuses the operator home and the checkout.
- `registry/skills/verify-brigade/control-brigade.py` (stdlib only, executable, JSON on stdout, `--help`, `--dry-run` on every mutating subcommand): `doctor`, `new-target`, `init`, `doctor-target`, `work-verify` (returns receipt id and status), `grokbot-pack-setup|doctor|canary|remove`, `grokbot-feed` (validate only, never enqueues), `grokbot-status`, `handoff-lint`, `evidence`, `cleanup` (removes only what it created, never the evidence).
- `features/`: README index plus init-and-doctor, work-verify-receipts, grokbot-pack-lifecycle, run-cloud-grokbot-queue, handoff-lint, each with Sub-features, How to get to it (user POV), Driving it with control-brigade, Gotchas.
- `tests/test_verify_brigade_skill.py`: runs new-target, doctor-target, cleanup in tmp_path and asserts exit codes and JSON shape so CI keeps the lever honest.
- `registry/README.md`: index entry.

Proven once end to end before opening this PR: new-target, doctor, the init-and-doctor and pack-lifecycle (preview) features, evidence capture, cleanup; the evidence directory survived cleanup. No existing source or tests were modified.

## Verification

`brigade work verify run` receipt `20260901-030521-work-verify-dcdd58`: `./scripts/verify-focused tests/test_verify_brigade_skill.py` completed, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)