### PR TITLE
fix(verify): reject an interpreter from another checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ Thumbs.db
 !/scripts/ci_pytest_shard.py
 !/scripts/verify_lock.py
 !/scripts/check_size_ratchet_baseline.py
+!/scripts/verify_env.py
 /skills/
 
 # Local plan/spec scratch dirs only. Reviewed planning artifacts ARE

--- a/scripts/verify
+++ b/scripts/verify
@@ -15,6 +15,7 @@ if [ -z "${BRIGADE_VERIFY_LOCK_HELD:-}" ]; then
 fi
 
 PY=${PY:-.venv/bin}
+"$PY/python" scripts/verify_env.py
 "$PY/ruff" check .
 "$PY/ruff" format --check .
 "$PY/mypy"

--- a/scripts/verify-fast
+++ b/scripts/verify-fast
@@ -8,6 +8,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 PY=${PY:-.venv/bin}
+"$PY/python" scripts/verify_env.py
 "$PY/python" -c "import xdist" 2>/dev/null || {
     echo "pytest-xdist is not installed. Re-sync: pip install -e \".[dev]\"" >&2
     exit 1

--- a/scripts/verify-focused
+++ b/scripts/verify-focused
@@ -8,6 +8,7 @@ if (( $# == 0 )); then
 fi
 
 PY=${PY:-.venv/bin}
+"$PY/python" scripts/verify_env.py
 "$PY/ruff" check .
 "$PY/ruff" format --check .
 "$PY/mypy"

--- a/scripts/verify_env.py
+++ b/scripts/verify_env.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Fail fast when the selected interpreter imports brigade from another checkout.
+
+Borrowing a sibling checkout's virtualenv, or pointing PY at one, leaves the
+gate half-honest: ruff, mypy, and in-process tests read this tree because
+tests/conftest.py puts its src first on sys.path, while any test that spawns a
+bare subprocess imports whatever the editable install resolves to. That reads as
+an unrelated test failure 35 minutes into the run.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXPECTED = REPO_ROOT / "src" / "brigade"
+SETUP = 'python -m venv .venv && .venv/bin/pip install -e ".[dev]"'
+
+
+def main() -> int:
+    try:
+        import brigade
+    except ModuleNotFoundError:
+        print(
+            f"verify: {sys.executable} cannot import brigade.\n  expected: {EXPECTED}\n  fix:      {SETUP}",
+            file=sys.stderr,
+        )
+        return 1
+
+    resolved = Path(brigade.__file__).resolve().parent
+    if resolved != EXPECTED:
+        print(
+            "verify: this interpreter imports brigade from a different checkout.\n"
+            f"  resolved: {resolved}\n"
+            f"  expected: {EXPECTED}\n"
+            f"  python:   {sys.executable}\n"
+            f"  fix:      unset PY, or {SETUP}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_script.py
+++ b/tests/test_verify_script.py
@@ -142,6 +142,7 @@ def test_verify_full_gate_does_not_invoke_external_flock(tmp_path, monkeypatch):
     )
     assert completed.returncode == 0
     assert log_path.read_text().splitlines() == [
+        "python\tscripts/verify_env.py",
         "ruff\tcheck\t.",
         "ruff\tformat\t--check\t.",
         "mypy",
@@ -254,3 +255,44 @@ def test_agents_md_requires_focused_development_and_reserved_full_gate():
     assert "75" in text
     assert "must not be retried" in text
     assert "larger timeout" in text
+
+
+def _run_env_guard(tmp_path: Path, package_root: Path) -> subprocess.CompletedProcess:
+    """Run the guard with `brigade` resolving to package_root."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(package_root)
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts/verify_env.py")],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+    )
+
+
+def test_verify_env_guard_rejects_an_interpreter_from_another_checkout(tmp_path):
+    foreign = tmp_path / "other-checkout" / "src"
+    (foreign / "brigade").mkdir(parents=True)
+    (foreign / "brigade" / "__init__.py").write_text("")
+
+    result = _run_env_guard(tmp_path, foreign)
+
+    assert result.returncode != 0
+    assert str(foreign / "brigade") in result.stderr
+    assert str(ROOT / "src" / "brigade") in result.stderr
+    assert "pip install -e" in result.stderr
+
+
+def test_verify_env_guard_accepts_this_checkout(tmp_path):
+    result = _run_env_guard(tmp_path, ROOT / "src")
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("script", ["verify", "verify-fast", "verify-focused"])
+def test_verify_scripts_run_the_env_guard_before_linting(script):
+    text = (ROOT / "scripts" / script).read_text()
+
+    guard = '"$PY/python" scripts/verify_env.py'
+    assert guard in text
+    assert text.index(guard) < text.index('"$PY/ruff"')


### PR DESCRIPTION
## What

The three gate scripts default to `PY=.venv/bin`. A checkout without a local
virtualenv invites pointing `PY` at a sibling checkout's instead, and that
fails in the worst possible way: quietly, and 35 minutes late.

It fails quietly because `tests/conftest.py` puts this tree's `src` first on
`sys.path`. So ruff, mypy, and every in-process test read the correct code.
Only tests that spawn a bare subprocess escape that and import whatever the
editable install actually resolves to. If the two checkouts sit on different
branches, you get a few `ModuleNotFoundError` and `AttributeError` failures in
tests unrelated to your change, near the end of a long run, pointing nowhere
near the cause.

## How it was found

Exactly this, on a real run: `2 failed, 11018 passed` after 36m35s, in
`test_aboyeur.py` and `test_run_detach.py`. Neither test was anywhere near the
change under test. The cause was a `PY` override aimed at a checkout sitting on
a different branch that lacked `aboyeur_artifacts` and `proc.spawn_detached`.

## The change

`scripts/verify_env.py` compares the interpreter's resolved `brigade` package
against this checkout's `src/brigade`. On a mismatch it exits non-zero and
prints the resolved path, the expected path, the interpreter, and the fix:

```
verify: this interpreter imports brigade from a different checkout.
  resolved: /elsewhere/brigade/src/brigade
  expected: /this/checkout/src/brigade
  python:   /elsewhere/brigade/.venv/bin/python
  fix:      unset PY, or python -m venv .venv && .venv/bin/pip install -e ".[dev]"
```

All three gate scripts run it before any other check, so the failure costs a
second instead of most of an hour. In `verify-fast` it runs before the
pytest-xdist probe too, so a wrong interpreter is diagnosed as a wrong
interpreter rather than as a missing plugin.

## Why a hard failure

A warning would be printed once at the top of a 37-minute log, which is the
same as not printing it. There is no bypass flag on purpose: anyone with a real
reason to set `PY` can point it at a virtualenv whose editable install resolves
to this checkout, which is the correct thing to do regardless.

## No CI impact

No workflow invokes the gate scripts. CI shards pytest directly through
`scripts/ci_pytest_shard.py`, so the guard only affects local runs, which is
where the problem lives.

## Note on the .gitignore line

`scripts/verify_env.py` is allowlisted because the `/scripts/*` deny rule would
otherwise hide a brand-new script from git and from ruff. That second effect is
not hypothetical: `ruff format` flagged this file on its first gate run purely
because it was allowlisted.

## Verify

```bash
./scripts/verify-focused tests/test_verify_script.py

# and the real reproduction, which should fail with the message above:
/path/to/another/checkout/.venv/bin/python scripts/verify_env.py
```
