### PR TITLE
feat: add Worklore fleet backlog ledger

### DIFF
--- a/.claude/memory-handoffs/2026-08-31-worklore-store-http-review.md
+++ b/.claude/memory-handoffs/2026-08-31-worklore-store-http-review.md
@@ -1,0 +1,39 @@
+# Memory Handoff
+
+## Type
+
+bugfix
+
+## Title
+
+Worklore store and HTTP review behavior
+
+## Summary
+
+Worklore imports now identify unchanged observations without writing sync events and persist the replay counts with each idempotency key. The HTTP handlers validate supported query fields before dispatching deterministic keyset pagination and use the configured Brigade home for the feature gate.
+
+## Durable facts
+
+- A no-op import compares the item title and durable link projection, including stale state, but excludes sync timestamps.
+- Execution-link replays return the persisted link shape, while a run linked to a different item returns `link-conflict`.
+- Item detail retains its existing `events` key, while `/work/items/<id>/events` is the paginated event endpoint.
+
+## Evidence
+
+- files changed: `src/brigade/worklore_store.py`, `src/brigade/worklore_http.py`
+- commands run: `brigade work verify run --target . --command "./scripts/verify-focused tests/test_worklore_store.py tests/test_worklore_http.py tests/test_worklore_client.py" --capture brigade-work --timeout 900`
+- receipt: `20260901-020725-work-verify-733649`, `37 passed in 6.51s`
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/LEARNINGS.md
+
+## Suggested document content
+
+### Worklore imports and paged HTTP views
+
+No-op adapter observations must compare persisted fields rather than sync timestamps. Store the resulting unchanged count with the idempotency key so a replay returns the original count and creates no events. Keep OpsDeck item-detail events separate from the paginated per-item events endpoint.

--- a/.claude/memory-handoffs/2026-09-01-0253-worklore-operator-role.md
+++ b/.claude/memory-handoffs/2026-09-01-0253-worklore-operator-role.md
@@ -1,0 +1,36 @@
+# Memory Handoff
+
+## Type
+decision
+
+## Title
+Worklore operator role uses enrolled node tokens, not the Hub admin token
+
+## Summary
+Native Worklore mutations now authorize a Worklore-only operator role from `fleet.worklore.operator_nodes` (optional bounded env override `BRIGADE_WORKLORE_OPERATOR_NODES`). Ops Deck and `brigade fleet work` use an enrolled node token. The shared Hub admin token remains a backwards-compatible override and is not required or deployed for Ops Deck. Native create is retry-safe via `Idempotency-Key`.
+
+## Durable facts
+- An authenticated node is operator only when its `node_id` is configured. Operator nodes may create, patch, transition, reset attempts, and mutate operator links. Other nodes keep read, import, execution-link, and owned attempt permissions.
+- Operator-node audit events keep `actor_id` and `node_id` as that node and use `actor_type=operator`. Admin-token events stay `actor_id=admin` with `node_id` unset.
+- `POST /work/items` accepts `Idempotency-Key` (max 256). Table `work_create_keys` is keyed by `(actor_id, idempotency_key)`. Same key and same canonical payload returns the original item with no second event. Same key and a different payload returns 409 `import-conflict`.
+- `worklore_client.create_item` and `brigade fleet work create` send a node token and generate or accept the key. Do not send the Hub admin token for normal Worklore work.
+
+## Evidence
+- files changed: `src/brigade/worklore_http.py`, `src/brigade/worklore_store.py`, `src/brigade/worklore_client.py`, `src/brigade/fleet_hub_http.py`, `src/brigade/cli/fleet.py`, `tests/test_worklore_http.py`, `tests/test_worklore_store.py`, `tests/test_worklore_client.py`, `docs/phase-worklore-ledger.md`, `docs/phase-worklore-opsdeck-plan.md`, `docs/phase-worklore-core-plan.md`
+- commands run: `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_http.py","tests/test_worklore_store.py","tests/test_worklore_client.py"]' --capture brigade-work`
+- receipt: `20260901-025323-work-verify-9a20c7`, `47 passed in 4.21s`
+
+## Recommended memory action
+create-card
+
+## Target card
+worklore-operator-role.md
+
+## Suggested card content
+---
+title: Worklore operator role
+category: architecture
+updated: 2026-09-01
+---
+
+Authorize native Worklore mutations with enrolled operator node tokens listed in `fleet.worklore.operator_nodes` or `BRIGADE_WORKLORE_OPERATOR_NODES`. Keep the Hub admin token as a backwards-compatible override only. Ops Deck and CLI must not send it. Native create retries use `Idempotency-Key` stored in `work_create_keys` per operator identity; same payload replays, different payload returns `import-conflict`. Operator-node events keep the node id and `actor_type=operator`.

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -28,7 +28,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade dogfood` (extras): 1 command path(s)
 - `brigade evidence`: 11 command path(s)
 - `brigade extras`: 3 command path(s)
-- `brigade fleet`: 21 command path(s)
+- `brigade fleet`: 32 command path(s)
 - `brigade friction` (extras): 3 command path(s)
 - `brigade guard`: 1 command path(s)
 - `brigade handoff`: 17 command path(s)
@@ -210,6 +210,17 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade fleet sessions`
 - `brigade fleet sink`
 - `brigade fleet status`
+- `brigade fleet work attempt`
+- `brigade fleet work burn`
+- `brigade fleet work create`
+- `brigade fleet work link`
+- `brigade fleet work list`
+- `brigade fleet work patch`
+- `brigade fleet work show`
+- `brigade fleet work sync-brigade`
+- `brigade fleet work sync-github`
+- `brigade fleet work transition`
+- `brigade fleet work unlink`
 - `brigade friction add` (extras)
 - `brigade friction scan` (extras)
 - `brigade friction show` (extras)

--- a/docs/phase-worklore-brigade-plan.md
+++ b/docs/phase-worklore-brigade-plan.md
@@ -1,0 +1,536 @@
+# Worklore Brigade adapter implementation plan
+
+## Goal
+
+Read explicitly configured local Brigade task ledgers through the public
+`brigade work tasks` command and import them so the same task observed
+from two nodes resolves to one external link. Execute the tasks in order
+and check every box.
+
+Approved design: `docs/phase-worklore-ledger.md`.
+
+This plan is independently executable for normalize and public-command
+reads. Tasks 3 and 4 import `worklore_client.import_batch` from the core
+slice. Do not add that function here. Start Task 3 only after core Task 5
+is on the branch. Tests seed a temp `.brigade/work/tasks.json` and call
+the public command, then post to a fake `import_batch`. They do not edit
+Fleet Hub tables, the GitHub adapter, or Ops Deck.
+
+## Architecture
+
+- `worklore_brigade.py` turns one public task JSON object into an
+  observation. It never includes `tasks_path`, absolute paths, raw
+  receipt bodies, or prompt text.
+- `worklore_brigade_sync.py` walks only the configured target list, runs
+  `brigade work tasks --target {path} --all --json`, writes a retry
+  receipt, and posts one idempotent batch per identity.
+- Canonical identity is the configured `identity` string plus `#` plus
+  the ledger task id. Two nodes that share `identity=escoffier-labs/brigade`
+  and task `abc123` produce `escoffier-labs/brigade#abc123`.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| Create `src/brigade/worklore_brigade.py` | Task JSON to observation mapping. |
+| Create `src/brigade/worklore_brigade_sync.py` | Explicit targets, public command, retry receipt. |
+| Create `tests/test_worklore_brigade.py` | Normalizer, path stripping, two-node dedupe, CLI. |
+| Modify `src/brigade/cli/fleet.py` | `brigade fleet work sync-brigade`. |
+
+Do not modify `worklore_client.py`.
+
+## Pinned decisions
+
+- Config lives in `~/.brigade/fleet.toml`:
+
+```toml
+[fleet.worklore.brigade]
+targets = [
+  { path = "/var/lib/brigade/targets/brigade", identity = "escoffier-labs/brigade" },
+]
+```
+
+  `path` is a local directory the node can read. `identity` is
+  `owner/repository` or a stable workspace slug matching
+  `^[A-Za-z0-9][A-Za-z0-9._/-]{1,127}$`. Missing `targets` is a CLI
+  error. The adapter never searches `$HOME` for `.brigade` folders.
+- Read path is the public command
+  `brigade work tasks --target {path} --all --json`. That command already
+  prints full task objects, edges, and `tasks_path` from
+  `src/brigade/work_cmd/session/task_ops.py:27-55`. Public edges are
+  normalized as `source` / `target` / `type`
+  (`src/brigade/work_cmd/edges.py:126-155`, written at `:142-146`). Use
+  that output. Do not import `work_cmd.ledger._read_task_ledger` from the
+  adapter.
+- Drop `tasks_path` before any observation is built. Drop any string
+  value that starts with `/` or matches `^[A-Za-z]:\\`.
+- Observation fields follow the ledger import schema:
+  `external_key`, `link_type=brigade`, `title` from `task.text` (max 240),
+  `description` empty, `acceptance` from `task.acceptance` (stored as
+  source acceptance), `external_state` from `task.status`, `priority` as
+  source metadata only (Worklore scheduling priority is not overwritten),
+  `dependencies` as `{type,id}` pairs from edges where
+  `source == task_id`, `evidence_refs` as opaque ids from
+  `metadata.verify_run_id` or `metadata.receipt_id` when those values
+  match `^[A-Za-z0-9._-]{1,128}$`.
+- Completed Brigade status `done` sends `source_policy=completed` and
+  `proposed_status=completed`. Terminal `cancelled` and `dismissed` tasks send
+  `source_policy=completed` without `proposed_status`, so they leave the burn
+  queue without being represented as successful completion. The adapter never
+  POSTs a transition.
+- Adapter id is `brigade:{identity}`.
+- Retry receipt path is
+  `$BRIGADE_HOME/worklore/brigade/{safe_identity}.json` with mode 0600.
+  `safe_identity` replaces `:`, `/`, `\`, `<`, `>`, `"`, `|`, `?`, and
+  `*` with `-`. Identity `escoffier-labs/brigade` becomes
+  `escoffier-labs-brigade.json`. Same fields as the GitHub receipt,
+  including `skipped`. No task text.
+- Batch size is at most 500. One logical identity group is built per
+  `sync_brigade` invocation and split into consecutive 500-observation POSTs.
+  Two configured targets that share an identity merge into that group.
+  Identical duplicate observations dedupe by `external_key`. Divergent
+  observations with the same `external_key` fail closed with
+  `identity-conflict`; config order never selects a winner.
+  Two nodes each run their own invocation and each POST once. Hub
+  dedupe is by `external_key`. Idempotency key
+  `brigade:{identity}:{sha256(sorted fingerprints)[:24]}`. Empty
+  discovery still posts an empty batch so the hub cursor advances. A
+  same-fingerprint replay still updates hub cursor `last_success_at`
+  and `updated_at`. Each observation fingerprint covers every
+  source-authoritative field emitted by the adapter: `external_key`, `title`,
+  `acceptance`, `external_state`, `priority`, `dependencies`, `evidence_refs`,
+  `source_policy`, `proposed_status`, and `external_updated_at`. This lets text,
+  priority, evidence, and terminal-state changes advance the idempotency key,
+  and keeps two payloads that differ only in when the source last changed from
+  collapsing onto one key.
+- The adapter emits `external_updated_at` from the public task's `updated_at`,
+  bounded to 64 characters and only when the hub can parse it as an instant.
+  That is the source revision the hub's rollback guard compares: without one,
+  a Brigade identity has no high-water and an expired-key replay is
+  last-write-wins. A revision the guard cannot compare is worse than none, so
+  an unparseable value is omitted rather than forwarded.
+- Title and acceptance bounds come from `worklore_validate`
+  (`TITLE_MAX`, `ACCEPTANCE_MAX_ITEMS`, `ACCEPTANCE_ITEM_MAX`) rather than
+  local copies, so the adapter cannot drift from the hub contract.
+- Isolation is per task. A task the adapter cannot bound is skipped and
+  counted rather than failing its target, so one unsafe task never stops
+  the other tasks in the same ledger from reaching the hub.
+  `observations_for_target` returns the normalized observations with a
+  bounded `skipped` count; `sync_brigade` sums it into the result and the
+  retry receipt. A payload that is not a task list, and a list entry that
+  is not an object, remain `retryable-adapter-failure`: those are
+  malformed command output, not one unsafe task. Skipping never widens the
+  posted batch, so the idempotency key still covers exactly the
+  observations posted.
+- Hub refusals keep a stable code instead of collapsing to
+  `hub-unavailable`. `401` and `403` are `hub-unauthorized`, `409` is
+  `hub-conflict`, any other `4xx` is `hub-rejected`, and transport
+  failures, `5xx`, and unparsable refusals stay `hub-unavailable`. The
+  code is raised on `BrigadeSyncError` and recorded as the receipt
+  `last_error_code`; the hub message itself is never surfaced. Only
+  `hub-unavailable` means retrying the same batch can succeed.
+- In-house Brigade commits include a coding-agent `Co-Authored-By`
+  trailer. Known-good identities are in `AGENTS.md`.
+
+## Task 1: normalize public task JSON
+
+**Files:**
+
+- Create: `src/brigade/worklore_brigade.py`
+- Create: `tests/test_worklore_brigade.py`
+
+- [x] Write the failing tests
+
+```python
+from brigade import worklore_brigade as adapter
+
+
+def test_normalize_pending_task_strips_paths_and_keeps_acceptance():
+    observation = adapter.normalize_task(
+        {
+            "id": "abc123",
+            "text": "Add Worklore store",
+            "status": "pending",
+            "priority": "high",
+            "acceptance": ["pytest tests/test_worklore_store.py passes"],
+            "metadata": {
+                "verify_run_id": "run-xyz",
+                "receipt_id": "rec-1",
+                "run_path": "/var/lib/brigade/targets/brigade/.brigade/runs/run-xyz",
+            },
+        },
+        identity="escoffier-labs/brigade",
+        edges=[{"source": "abc123", "target": "def456", "type": "blocks"}],
+    )
+    assert observation["external_key"] == "escoffier-labs/brigade#abc123"
+    assert observation["link_type"] == "brigade"
+    assert observation["acceptance"] == ["pytest tests/test_worklore_store.py passes"]
+    assert observation["dependencies"] == [{"type": "blocks", "id": "def456"}]
+    assert observation["evidence_refs"] == ["run-xyz", "rec-1"]
+    assert observation["source_policy"] == "eligible"
+    dumped = json.dumps(observation)
+    assert "/var/lib" not in dumped
+    assert "tasks_path" not in observation
+
+
+def test_done_task_proposes_completed_without_transition_fields():
+    observation = adapter.normalize_task(
+        {
+            "id": "done-1",
+            "text": "Finished",
+            "status": "done",
+            "acceptance": ["shipped"],
+            "metadata": {},
+        },
+        identity="escoffier-labs/brigade",
+        edges=[],
+    )
+    assert observation["source_policy"] == "completed"
+    assert observation["proposed_status"] == "completed"
+    assert observation["external_state"] == "done"
+    assert "status" not in observation
+
+
+def test_normalize_rejects_home_paths_and_receipt_bodies():
+    with pytest.raises(adapter.BrigadeObservationError, match="unknown-field"):
+        adapter.normalize_task(
+            {
+                "id": "bad",
+                "text": "Nope",
+                "status": "pending",
+                "acceptance": ["x"],
+                "receipt_body": {"stdout": "secret"},
+            },
+            identity="escoffier-labs/brigade",
+            edges=[],
+        )
+    with pytest.raises(adapter.BrigadeObservationError, match="field-bound"):
+        adapter.normalize_task(
+            {
+                "id": "bad2",
+                "text": "See /workspace/notes/secret",
+                "status": "pending",
+                "acceptance": ["x"],
+            },
+            identity="escoffier-labs/brigade",
+            edges=[],
+        )
+```
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_brigade.py"]' --capture brigade-work
+```
+
+Expect FAIL: `ModuleNotFoundError: No module named 'brigade.worklore_brigade'`.
+
+- [x] Implement `normalize_task`. Title is `text` trimmed to 240
+  characters. Reject keys
+  `{receipt_body,prompt,transcript,token,secret,password,tasks_path}`.
+  Reject string values containing `/home/` or `C:\\Users\\`. Keep only
+  dependency ids from edges keyed `source` / `target` / `type` where
+  `source == task_id`. Do not keep file paths from footprint metadata.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_brigade.py tests/test_worklore_brigade.py
+git commit -m "$(cat <<'EOF'
+feat: normalize Brigade task ledger observations for Worklore
+
+EOF
+)"
+```
+
+## Task 2: explicit targets and public command
+
+**Files:**
+
+- Create: `src/brigade/worklore_brigade_sync.py`
+- Modify: `tests/test_worklore_brigade.py`
+
+- [x] Write the failing tests
+
+```python
+from brigade import worklore_brigade_sync as sync
+
+
+def test_load_config_requires_explicit_targets(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "fleet.toml").write_text("[fleet.worklore.brigade]\n")
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.BrigadeSyncError, match="targets"):
+        sync.load_brigade_config()
+
+
+def test_read_tasks_uses_public_command_and_drops_tasks_path(tmp_path, monkeypatch):
+    target = tmp_path / "repo"
+    target.mkdir()
+    recorded = {}
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        payload = {
+            "tasks_path": str(target / ".brigade" / "work" / "tasks.json"),
+            "tasks": [{
+                "id": "abc123",
+                "text": "Add store",
+                "status": "pending",
+                "acceptance": ["tests pass"],
+                "metadata": {},
+            }],
+            "edges": [{"source": "abc123", "target": "def456", "type": "blocks"}],
+        }
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    tasks, edges = sync.read_public_tasks(target)
+    assert recorded["argv"] == ["brigade", "work", "tasks", "--target", str(target), "--all", "--json"]
+    assert tasks[0]["id"] == "abc123"
+    assert edges[0]["source"] == "abc123"
+    assert "tasks_path" not in json.dumps(tasks)
+
+
+def test_two_nodes_same_identity_share_one_external_key(tmp_path):
+    task = {
+        "id": "abc123",
+        "text": "Shared",
+        "status": "pending",
+        "acceptance": ["ok"],
+        "metadata": {},
+    }
+    first = sync.observations_for_target(task, edges=[], identity="escoffier-labs/brigade")
+    second = sync.observations_for_target(task, edges=[], identity="escoffier-labs/brigade")
+    assert first[0]["external_key"] == second[0]["external_key"] == "escoffier-labs/brigade#abc123"
+```
+
+- [x] Run red through Brigade. Expect FAIL:
+  `ModuleNotFoundError: No module named 'brigade.worklore_brigade_sync'`.
+
+- [x] Implement config loading from `fleet.worklore.brigade` using the
+  `fleet.sink` pattern in `src/brigade/fleet_export.py:443-456`. Each
+  target must be a table with `path` and `identity`. `path` must exist
+  and be a directory at sync time. Implement `read_public_tasks` with a
+  30 second timeout. A non-zero command exit becomes
+  `BrigadeSyncError("retryable-adapter-failure")` with no stderr replay
+  if that stderr contains a path.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_brigade_sync.py tests/test_worklore_brigade.py
+git commit -m "$(cat <<'EOF'
+feat: read configured Brigade ledgers through the public task command
+
+EOF
+)"
+```
+
+## Task 3: idempotent post and two-node dedupe against a fake hub
+
+**Files:**
+
+- Modify: `src/brigade/worklore_brigade_sync.py`
+- Modify: `tests/test_worklore_brigade.py`
+
+Do not modify `worklore_client.py`.
+
+- [x] Write the failing tests
+
+```python
+from tests.support import PRIVATE_FILE_MODE, assert_private_mode
+
+
+def test_sync_merges_targets_that_share_identity(tmp_path, monkeypatch):
+    posts = []
+    seen = {}
+
+    def fake_import_batch(payload):
+        posts.append(payload)
+        created = 0
+        updated = 0
+        for obs in payload["observations"]:
+            key = obs["external_key"]
+            if key in seen:
+                updated += 1
+            else:
+                seen[key] = True
+                created += 1
+        return {"created": created, "updated": updated}
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import_batch)
+    monkeypatch.setattr(
+        sync,
+        "read_public_tasks",
+        lambda target: ([{
+            "id": "abc123",
+            "text": "Shared",
+            "status": "pending",
+            "acceptance": ["ok"],
+            "metadata": {},
+        }], []),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    (tmp_path / "node-a").mkdir()
+    (tmp_path / "node-b").mkdir()
+    result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=tmp_path / "node-a", identity="escoffier-labs/brigade"),
+            sync.Target(path=tmp_path / "node-b", identity="escoffier-labs/brigade"),
+        ]
+    )
+    assert len(posts) == 1
+    assert posts[0]["source_type"] == "brigade"
+    assert set(posts[0]) >= {"adapter_id", "source_type", "idempotency_key", "observations"}
+    assert [obs["external_key"] for obs in posts[0]["observations"]] == ["escoffier-labs/brigade#abc123"]
+    assert result["created"] == 1
+
+
+def test_sync_two_nodes_post_same_external_key(tmp_path, monkeypatch):
+    posts = []
+    seen = {}
+
+    def fake_import_batch(payload):
+        posts.append(payload)
+        created = 0
+        updated = 0
+        for obs in payload["observations"]:
+            key = obs["external_key"]
+            if key in seen:
+                updated += 1
+            else:
+                seen[key] = True
+                created += 1
+        return {"created": created, "updated": updated}
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import_batch)
+    monkeypatch.setattr(
+        sync,
+        "read_public_tasks",
+        lambda target: ([{
+            "id": "abc123",
+            "text": "Shared",
+            "status": "pending",
+            "acceptance": ["ok"],
+            "metadata": {},
+        }], []),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    (tmp_path / "node-a").mkdir()
+    (tmp_path / "node-b").mkdir()
+    first = sync.sync_brigade(targets=[sync.Target(path=tmp_path / "node-a", identity="escoffier-labs/brigade")])
+    second = sync.sync_brigade(targets=[sync.Target(path=tmp_path / "node-b", identity="escoffier-labs/brigade")])
+    keys = [obs["external_key"] for payload in posts for obs in payload["observations"]]
+    assert keys == ["escoffier-labs/brigade#abc123", "escoffier-labs/brigade#abc123"]
+    assert first["created"] == 1
+    assert second["created"] == 0
+    receipt = tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json"
+    assert json.loads(receipt.read_text())["last_error_code"] is None
+    assert_private_mode(receipt, PRIVATE_FILE_MODE)
+
+
+def test_hub_unavailable_is_retryable_and_keeps_local_ledger_usable(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(sync.worklore_client.FleetClientError("hub-unavailable")),
+    )
+    monkeypatch.setattr(sync, "read_public_tasks", lambda target: ([], []))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError, match="hub-unavailable"):
+        sync.sync_brigade(targets=[sync.Target(path=tmp_path, identity="escoffier-labs/brigade")])
+    receipt = tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json"
+    assert receipt.is_file()
+    assert_private_mode(receipt, PRIVATE_FILE_MODE)
+```
+
+- [x] Run red through Brigade. Expect FAIL on `sync_brigade` missing.
+
+- [x] Implement `sync_brigade`. Build one logical group per identity. Two
+  targets that share an identity merge identical observations, deduped by
+  `external_key`; divergent observations for one key fail with
+  `identity-conflict`. Split groups into consecutive batches of at most 500.
+  Fingerprint every source-authoritative observation field listed in the
+  pinned decisions. POST
+  `{adapter_id, source_type, idempotency_key, observations}` with
+  `source_type="brigade"`. Write the 0600 receipt. Empty discovery still
+  posts an empty batch. On hub failure
+  raise `BrigadeSyncError("hub-unavailable")` and leave the local
+  `.brigade/work/tasks.json` untouched.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_brigade_sync.py tests/test_worklore_brigade.py
+git commit -m "$(cat <<'EOF'
+feat: post idempotent Brigade Worklore import batches
+
+EOF
+)"
+```
+
+## Task 4: CLI
+
+**Files:**
+
+- Modify: `src/brigade/cli/fleet.py`
+- Modify: `tests/test_worklore_brigade.py`
+
+- [x] Write the failing test
+
+```python
+from brigade.cli import fleet as fleet_cli
+
+
+def test_sync_brigade_cli_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        fleet_cli.worklore_brigade_sync,
+        "sync_brigade",
+        lambda **kwargs: {"targets": 1, "posted": 1, "created": 1},
+    )
+    assert fleet_cli._dispatch_work_sync_brigade(argparse.Namespace(json=True)) == 0
+    assert '"posted": 1' in capsys.readouterr().out
+```
+
+- [x] Run red through Brigade. Expect FAIL: attribute missing.
+
+- [x] Add `brigade fleet work sync-brigade`. Import `worklore_brigade_sync`
+  as a module. `_dispatch_work_sync_brigade` reads config, calls
+  `worklore_brigade_sync.sync_brigade`, and returns 2 when `targets` is
+  missing, 1 on `hub-unavailable` or `retryable-adapter-failure`, 0 on
+  success. Default output is counts only. Do not add a separate `_impl`
+  function.
+
+- [x] Run green through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_brigade.py"]' --capture brigade-work
+```
+
+Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/cli/fleet.py tests/test_worklore_brigade.py
+git commit -m "$(cat <<'EOF'
+feat: add brigade fleet work sync-brigade
+
+EOF
+)"
+```
+
+## Verification
+
+All tasks use `./scripts/verify-focused tests/test_worklore_brigade.py`
+through `brigade work verify run --capture brigade-work`. Do not point
+`targets` at the operator home or this checkout during development. Use
+`tmp_path` the way `tests/test_worklore_brigade.py` does.

--- a/docs/phase-worklore-core-plan.md
+++ b/docs/phase-worklore-core-plan.md
@@ -1,0 +1,1119 @@
+# Worklore core implementation plan
+
+## Goal
+
+Ship the isolated Worklore store, validation, native HTTP contract, burn
+queue, and `brigade fleet work` CLI so a native fleet-maintenance item can
+be created without a repository and appear in the burn queue after it
+becomes ready. Execute the tasks in order and check every box.
+
+Approved design: `docs/phase-worklore-ledger.md`.
+
+This plan is independently executable. It does not implement the GitHub
+adapter, the Brigade adapter, or Ops Deck. Those slices have their own
+plans and talk to the import and read contracts defined here. This slice
+is the only owner of `import_batch` and `list_items`.
+
+## Integration precondition
+
+`docs/runbooks/fleet-hub-hogwarts.md` already uses "Phase 2" for the
+shipped hub. `src/brigade/fleet_hub.py:1-2` documents issue #1123 as that
+shipped phase. Do not block on an unnamed "active Fleet Hub phase 2
+branch".
+
+Tasks 1 through 5 add isolated modules and tests that do not edit
+`fleet_hub.py` routing, `fleet_hub_http.py` method tables, or
+`SCHEMA_VERSION`. Task 6 is the only integration task. Start it only when
+all three checks pass:
+
+1. Fresh `origin/main`. Run `git fetch origin` and rebase this branch so
+   `git merge-base --is-ancestor origin/main HEAD` succeeds.
+2. No live conflicting owner. Run `brigade fleet claims --json` and
+   confirm no unexpired claim names this checkout, `src/brigade/fleet_hub.py`,
+   or `src/brigade/fleet_hub_http.py` as its target.
+3. Operator confirmation. Record in the Task 6 checkbox that the operator
+   has said the warned concurrent Fleet Hub work has landed. Do not infer
+   that from a branch name or from `SCHEMA_VERSION`.
+
+Then set the Worklore schema bump to the then-current `SCHEMA_VERSION + 1`
+and add `/work` routes without rewriting events, claims, nodes, cloud,
+model, grokbot, or preference tables.
+
+Current `origin/main` and this worktree use `SCHEMA_VERSION = 13` in
+`src/brigade/fleet_hub.py:121`. Re-read that assignment after the rebase.
+Do not pick 14 from this worktree if `main` already took 14 or higher.
+
+`src/brigade/fleet_hub.py` is 1929 lines and is not in
+`LEGACY_OVERSIZED` (`tests/test_module_size_ratchet.py:10-25`). The
+ceiling is 2000. Task 6 may add the `worklore_store.ensure_schema(conn)`
+call next to `fleet_hub_preference.ensure_schema(conn)` at
+`src/brigade/fleet_hub.py:528` plus the version bump at `:121`. Do not
+land Worklore SQL, handlers, or validation inside `fleet_hub.py`.
+
+## Architecture
+
+- `worklore_validate.py` owns field bounds, lifecycle edges, burn
+  eligibility, and unknown-field rejection.
+- `worklore_store.py` owns the five additive SQLite tables, one-transaction
+  mutations, optimistic versions, import conflict rules, and
+  `PRAGMA foreign_keys=ON` on every connection it touches.
+- `worklore_http.py` owns path parsing, authz, JSON envelopes, and status
+  codes. Tests call it with a fake caller and an in-memory or temp SQLite
+  connection. They do not start `fleet_hub.make_server` until Task 6.
+- `worklore_client.py` is the only node or admin HTTP client for `/work`.
+  It owns `import_batch` and `list_items`. Adapter slices import those
+  names. They do not copy them.
+- `cli/fleet.py` adds `brigade fleet work` and dispatches through the
+  client.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| Create `src/brigade/worklore_validate.py` | Bounds, lifecycle edges, burn rules, forbidden import keys. |
+| Create `src/brigade/worklore_store.py` | Schema, CRUD, events, links, imports, attempts, burn query. |
+| Create `src/brigade/worklore_http.py` | `/work` handlers returning `(status, body)`. |
+| Create `src/brigade/worklore_client.py` | Authenticated `/work` transport, including PATCH, DELETE, and import timeout. |
+| Create `tests/test_worklore_validate.py` | Field and lifecycle unit tests. |
+| Create `tests/test_worklore_store.py` | SQLite transaction and burn tests. |
+| Create `tests/test_worklore_http.py` | Authz and JSON contract tests. |
+| Create `tests/test_worklore_client.py` | Client fail-closed and CLI tests. |
+| Modify `src/brigade/cli/fleet.py:45-270` | Register `fleet work` subcommands at the end of `register()`. |
+| Modify `src/brigade/fleet_hub.py:121` and `:492-529` | Task 6 only: schema bump and `ensure_schema`. |
+| Modify `src/brigade/fleet_hub_http.py:440-656` | Task 6 only: `/work` GET, POST, PATCH, DELETE. |
+| Modify `src/brigade/fleet_client.py` | Task 6 only: re-export worklore client names. |
+| Modify `tests/test_fleet_cloud.py:194-216` | Task 6 only: v4 migration still creates Worklore tables. |
+| Modify `tests/test_fleet_claims.py`, `tests/test_fleet_nodes.py`, `tests/test_fleet_dashboard.py` | Task 6 only: existing routes unchanged when Worklore is off. |
+
+## Pinned decisions
+
+- Identifiers: `work_id` is `wl-` plus 24 lowercase hex from
+  `secrets.token_hex(12)`. `link_id` is `lnk-` plus 24 hex. `event_id` is
+  the client key when it matches `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`,
+  otherwise `evt-` plus 24 hex. The event primary key is
+  `(work_id, event_id)`.
+- Create defaults: `status=captured`, `priority=normal`,
+  `burn_eligible=0`, `burn_rank=1000`, `token_appetite=medium`,
+  `execution_mode=manual`, `acceptance_json=[]`, `attempt_count=0`,
+  `version=1`.
+- Lifecycle edges: `captured` to `defining`, `ready`, or `canceled`.
+  `defining` to `ready`, `deferred`, or `canceled`. `ready` to `claimed`,
+  `deferred`, or `canceled`. `claimed` to `running`, `blocked`, or
+  `canceled`. `running` to `verifying`, `blocked`, or `canceled`.
+  `verifying` to `completed`, `blocked`, or `canceled`. `deferred` to
+  `ready` or `canceled`. `blocked` to `ready` or `canceled`. `completed`
+  or `canceled` to `archived`. No other edges.
+- API field `acceptance` maps to `acceptance_json`. Link field
+  `source_acceptance` maps to `source_acceptance_json`. Effective
+  acceptance is operator `acceptance` if non-empty, else the oldest
+  eligible link's `source_acceptance`.
+- `ready` and the burn queue require one to twenty effective acceptance
+  strings.
+- Burn eligibility requires `status=ready`, `burn_eligible=1`, effective
+  acceptance present, `execution_mode` in `{agent, agent-with-review}`,
+  empty `blocker`, `attempt_count < 2`, `review_after` absent or in the
+  past, and no link with `source_policy` other than `eligible`. Two
+  failed attempts exclude the item until `attempt-reset`.
+- Burn order: `burn_rank` ascending, then `spend_by` earliest with null
+  last, then `ready_at` oldest, then `work_id` ascending.
+- Unknown JSON fields return 400 with `code=unknown-field`.
+- Missing `If-Match` on PATCH, transition, or attempt returns 400 with
+  `code=if-match-required`. A stale `If-Match` returns 409 with
+  `code=version-conflict`.
+- Worklore mutation bodies max 262144 bytes. Import bodies max 1048576
+  bytes. Both are below `fleet_hub.MAX_BODY_BYTES`.
+- Dashboard cookies never authorize `/work`.
+- Node tokens may GET items, GET events, GET burn, POST imports for
+  adapters they own, POST execution links for their own `node_id/run_id`,
+  and POST `started`/`failed` attempts for those runs. They cannot PATCH
+  scheduling fields, POST transitions, or POST `reset`.
+- Admin Worklore mutations succeed on a hub started without
+  `--allow-admin-writes`. That flag remains scoped to `/events` and
+  `/claims` (`src/brigade/fleet_hub_http.py:575-584`,
+  `src/brigade/cli/fleet.py:65-72`).
+- Routes stay 404 until Task 6 sets `BRIGADE_WORKLORE_ENABLED=1` or
+  `[fleet.worklore] enabled = true`. Default is off.
+- Stable error codes: `unauthorized`, `forbidden`, `not-found`,
+  `version-conflict`, `if-match-required`, `invalid-transition`,
+  `unknown-field`, `field-bound`, `acceptance-required`,
+  `import-conflict`, `adapter-owner-mismatch`, `execution-mismatch`,
+  `attempt-forbidden`, `hub-unavailable`.
+- Errors never include SQLite text, tokens, filesystem paths, or upstream
+  bodies.
+- In-house Brigade commits in this plan include a coding-agent
+  `Co-Authored-By` trailer. Known-good identities are in `AGENTS.md`.
+  Substitute the agent that made the commit.
+
+## Task 1: validation module
+
+**Files:**
+
+- Create: `src/brigade/worklore_validate.py`
+- Create: `tests/test_worklore_validate.py`
+
+- [x] Write the failing tests
+
+```python
+from brigade import worklore_validate as v
+
+
+def test_create_payload_rejects_unknown_and_overlong_fields():
+    parsed = v.parse_create({"title": "Rotate NAS restic password", "kind": "fleet"})
+    assert parsed["title"] == "Rotate NAS restic password"
+    assert parsed["kind"] == "fleet"
+    assert parsed["status"] == "captured"
+    assert parsed["burn_rank"] == 1000
+    for raw, code in (
+        ({"title": "x", "kind": "fleet", "extra": True}, "unknown-field"),
+        ({"title": "", "kind": "fleet"}, "field-bound"),
+        ({"title": "x" * 241, "kind": "fleet"}, "field-bound"),
+        ({"title": "ok", "kind": "not-a-kind"}, "field-bound"),
+        ({"title": "ok\x00", "kind": "fleet"}, "field-bound"),
+    ):
+        with pytest.raises(v.WorkloreValidationError) as excinfo:
+            v.parse_create(raw)
+        assert excinfo.value.code == code
+
+
+def test_ready_requires_acceptance_and_burn_rules_match_spec():
+    item = {
+        "status": "ready",
+        "burn_eligible": 1,
+        "acceptance": ["restic snapshots --latest 1 succeeds"],
+        "execution_mode": "agent",
+        "blocker": None,
+        "attempt_count": 1,
+        "review_after": None,
+        "source_policies": ["eligible"],
+    }
+    assert v.burn_eligible(item) is True
+    item["attempt_count"] = 2
+    assert v.burn_eligible(item) is False
+    item["attempt_count"] = 1
+    item["source_policies"] = ["label-removed"]
+    assert v.burn_eligible(item) is False
+    item["source_policies"] = ["eligible"]
+    item["acceptance"] = []
+    with pytest.raises(v.WorkloreValidationError) as excinfo:
+        v.assert_ready(item)
+    assert excinfo.value.code == "acceptance-required"
+
+
+def test_lifecycle_edges_are_closed():
+    assert v.can_transition("captured", "ready") is True
+    assert v.can_transition("ready", "claimed") is True
+    assert v.can_transition("ready", "running") is False
+    assert v.can_transition("completed", "archived") is True
+    assert v.can_transition("archived", "ready") is False
+```
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_validate.py"]' --capture brigade-work
+```
+
+Expect FAIL: `ModuleNotFoundError: No module named 'brigade.worklore_validate'`.
+
+- [x] Implement the minimal module. Reject unknown keys with
+  `WorkloreValidationError("unknown field: {name}", code="unknown-field")`.
+  Enforce title 1-240, description max 8000, scope max 128, blocker max
+  2000, burn_rank 0-10000, kinds
+  `{repo,fleet,research,writing,admin,experiment,idea,other}`, priorities
+  `{low,normal,high,urgent}`, token appetites
+  `{small,medium,large,max}`, execution modes
+  `{manual,agent,agent-with-review}`. Reject C0/C1 controls with the same
+  helper shape as `fleet_hub._contains_controls` at
+  `src/brigade/fleet_hub.py:389`. `assert_ready` requires one to twenty
+  non-empty acceptance strings of at most 400 characters.
+  `burn_eligible(item)` reads `item["acceptance"]` as the already-resolved
+  effective list and `item.get("source_policies") or []` as the link
+  policies.
+
+- [x] Run green through Brigade with the same command. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_validate.py tests/test_worklore_validate.py
+git commit -m "$(cat <<'EOF'
+feat: validate Worklore fields and lifecycle edges
+
+EOF
+)"
+```
+
+Use the trailer identity of the agent that made the commit.
+
+## Task 2: store, events, and burn selection
+
+**Files:**
+
+- Create: `src/brigade/worklore_store.py`
+- Create: `tests/test_worklore_store.py`
+
+- [x] Write the failing tests
+
+```python
+import sqlite3
+
+from brigade import fleet_hub
+from brigade import worklore_store as store
+
+
+def _conn(tmp_path):
+    conn = fleet_hub.init_db(tmp_path / "worklore.db")
+    store.ensure_schema(conn)
+    return conn
+
+
+def test_create_and_transition_share_one_transaction(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Fleet maintenance", "kind": "fleet"}, actor_id="admin")
+    assert item["work_id"].startswith("wl-")
+    assert item["status"] == "captured"
+    assert item["version"] == 1
+    events = store.list_events(conn, item["work_id"])
+    assert [event["event_type"] for event in events] == ["created"]
+    updated = store.transition(
+        conn,
+        item["work_id"],
+        to_status="defining",
+        expected_version=1,
+        actor_type="operator",
+        actor_id="admin",
+    )
+    assert updated["status"] == "defining" and updated["version"] == 2
+    assert [event["event_type"] for event in store.list_events(conn, item["work_id"])] == [
+        "created",
+        "transitioned",
+    ]
+
+
+def test_ready_sets_ready_at_and_burn_order_is_stable(tmp_path):
+    conn = _conn(tmp_path)
+    first = store.create_item(conn, {"title": "A", "kind": "fleet"}, actor_id="admin")
+    second = store.create_item(conn, {"title": "B", "kind": "fleet"}, actor_id="admin")
+    for work_id, rank, spend_by in (
+        (second["work_id"], 10, "2026-09-01T00:00:00+00:00"),
+        (first["work_id"], 10, "2026-08-30T00:00:00+00:00"),
+    ):
+        store.patch_item(
+            conn,
+            work_id,
+            {
+                "acceptance": ["done"],
+                "burn_eligible": True,
+                "execution_mode": "agent",
+                "burn_rank": rank,
+                "spend_by": spend_by,
+            },
+            expected_version=1,
+            actor_id="admin",
+        )
+        store.transition(conn, work_id, to_status="ready", expected_version=2, actor_id="admin")
+    queue = store.burn_queue(conn)
+    assert [item["title"] for item in queue["items"]] == ["A", "B"]
+    assert queue["exclusions"]["attempt-limit"] == 0
+    assert queue["exclusions"]["source-policy"] == 0
+
+
+def test_exclusion_bucket_is_first_match(tmp_path):
+    conn = _conn(tmp_path)
+    store.create_item(conn, {"title": "Not ready", "kind": "fleet"}, actor_id="admin")
+    queue = store.burn_queue(conn)
+    assert queue["exclusions"]["not-ready"] == 1
+    assert queue["exclusions"]["acceptance-required"] == 0
+
+
+def test_work_links_require_existing_work_id(tmp_path):
+    conn = _conn(tmp_path)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO work_links (link_id, work_id, link_type, external_key, "
+            "source_policy, source_acceptance_json, synced_at) VALUES "
+            "('lnk-missing', 'wl-missing', 'url', 'https://example.com/a', "
+            "'eligible', '[]', '2026-08-29T00:00:00+00:00')"
+        )
+        conn.commit()
+
+
+def test_stale_version_does_not_write_an_event(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Conflict", "kind": "admin"}, actor_id="admin")
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.patch_item(conn, item["work_id"], {"priority": "high"}, expected_version=0, actor_id="admin")
+    assert excinfo.value.code == "version-conflict"
+    assert store.list_events(conn, item["work_id"])[0]["event_type"] == "created"
+    assert store.get_item(conn, item["work_id"])["version"] == 1
+```
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_store.py"]' --capture brigade-work
+```
+
+Expect FAIL: `ModuleNotFoundError: No module named 'brigade.worklore_store'`.
+
+- [x] Implement `ensure_schema` with the five tables and indexes from the
+  spec: `work_items_status`, `work_items_burn`, `work_items_ready_at`,
+  `work_events_work_id`, `work_links_external`. Use
+  `FOREIGN KEY (work_id) REFERENCES work_items(work_id)` with delete
+  restricted. `UNIQUE(link_type, external_key)` on `work_links`. Event
+  primary key is `(work_id, event_id)`. `ensure_schema` and every public
+  store function issue `PRAGMA foreign_keys=ON` on the connection before
+  any `BEGIN IMMEDIATE`. SQLite ignores that pragma inside a transaction.
+  Do not set that pragma in the test helper. `create_item`, `patch_item`,
+  `transition`, and `record_attempt` each run `BEGIN IMMEDIATE`, write
+  the projection and the event, then `COMMIT`. On validation or version
+  failure, `ROLLBACK`. `burn_queue` returns
+  `{"items": [...], "exclusions": {"acceptance-required": N, "not-ready": N, "not-eligible": N, "manual-mode": N, "blocker": N, "attempt-limit": N, "review-after": N, "source-policy": N}}`
+  and counts each excluded item in exactly one bucket using the first-match
+  order in `docs/phase-worklore-ledger.md`.
+
+- [x] Run green through Brigade with the same command. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_store.py tests/test_worklore_store.py
+git commit -m "$(cat <<'EOF'
+feat: store Worklore items and append-only events
+
+EOF
+)"
+```
+
+## Task 3: links, imports, attempts, and execution joins
+
+**Files:**
+
+- Modify: `src/brigade/worklore_store.py`
+- Modify: `tests/test_worklore_store.py`
+
+- [x] Write the failing tests
+
+```python
+def test_import_batch_is_idempotent_and_keeps_scheduling(tmp_path):
+    conn = _conn(tmp_path)
+    observation = {
+        "external_key": "escoffier-labs/brigade#1",
+        "link_type": "github",
+        "title": "Burn queue item",
+        "description": "Do the work",
+        "acceptance": ["tests pass"],
+        "external_state": "open",
+        "external_updated_at": "2026-08-29T00:00:00+00:00",
+        "url": "https://github.com/escoffier-labs/brigade/issues/1",
+        "display_ref": "escoffier-labs/brigade#1",
+        "source_policy": "eligible",
+    }
+    first = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    store.patch_item(
+        conn,
+        first["items"][0]["work_id"],
+        {"burn_rank": 5, "token_appetite": "large", "acceptance": ["operator override"]},
+        expected_version=1,
+        actor_id="admin",
+    )
+    conn.execute(
+        "UPDATE work_sync_cursors SET last_success_at = '2026-01-01T00:00:00+00:00', "
+        "updated_at = '2026-01-01T00:00:00+00:00' WHERE adapter_id = ?",
+        ("github:escoffier-labs",),
+    )
+    conn.commit()
+    second = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    replay_cursor = conn.execute(
+        "SELECT last_success_at, updated_at FROM work_sync_cursors WHERE adapter_id = ?",
+        ("github:escoffier-labs",),
+    ).fetchone()
+    assert replay_cursor[0] > "2026-01-01T00:00:00+00:00"
+    assert replay_cursor[1] > "2026-01-01T00:00:00+00:00"
+    later = dict(observation)
+    later["acceptance"] = ["source refreshed"]
+    later["external_updated_at"] = "2026-08-30T00:00:00+00:00"
+    store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1b",
+        observations=[later],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    replay = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    item = store.get_item(conn, first["items"][0]["work_id"])
+    links = store.list_links(conn, item["work_id"])
+    assert second["created"] == 1 and second["updated"] == 0
+    assert replay["created"] == second["created"]
+    assert replay["updated"] == 0
+    assert [entry["external_key"] for entry in replay["items"]] == [observation["external_key"]]
+    assert item["burn_rank"] == 5
+    assert item["token_appetite"] == "large"
+    assert item["acceptance"] == ["operator override"]
+    assert item["effective_acceptance"] == ["operator override"]
+    assert links[0]["source_acceptance"] == ["source refreshed"]
+    types = [event["event_type"] for event in store.list_events(conn, item["work_id"])]
+    assert types.count("sync-observed") == 2
+
+
+def test_import_rejects_secrets_paths_duplicate_keys_and_foreign_nodes(tmp_path):
+    conn = _conn(tmp_path)
+    with pytest.raises(store.WorkloreValidationError) as excinfo:
+        store.import_batch(
+            conn,
+            adapter_id="github:escoffier-labs",
+            source_type="github",
+            idempotency_key="batch-bad",
+            observations=[{"external_key": "a/b#1", "link_type": "github", "title": "x", "source_policy": "eligible", "prompt": "secret"}],
+            actor_id="node-a",
+            owner_node="node-a",
+        )
+    assert excinfo.value.code == "unknown-field"
+    store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-2",
+        observations=[{
+            "external_key": "a/b#2",
+            "link_type": "github",
+            "title": "One",
+            "url": "https://github.com/a/b/issues/2",
+            "external_state": "open",
+            "source_policy": "eligible",
+        }],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.import_batch(
+            conn,
+            adapter_id="github:other",
+            source_type="github",
+            idempotency_key="batch-3",
+            observations=[{
+                "external_key": "a/b#2",
+                "link_type": "github",
+                "title": "Two",
+                "url": "https://github.com/a/b/issues/2",
+                "external_state": "open",
+                "source_policy": "eligible",
+            }],
+            actor_id="node-b",
+            owner_node="node-b",
+        )
+    assert excinfo.value.code == "import-conflict"
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.import_batch(
+            conn,
+            adapter_id="github:escoffier-labs",
+            source_type="github",
+            idempotency_key="batch-4",
+            observations=[{
+                "external_key": "a/b#3",
+                "link_type": "github",
+                "title": "Three",
+                "url": "https://github.com/a/b/issues/3",
+                "external_state": "open",
+                "source_policy": "eligible",
+            }],
+            actor_id="node-b",
+            owner_node="node-b",
+        )
+    assert excinfo.value.code == "adapter-owner-mismatch"
+
+
+def test_execution_link_requires_existing_run_for_caller_node(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Join run", "kind": "fleet"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    linked = store.link_execution(conn, item["work_id"], node_id="node-a", run_id="run-1", actor_id="node-a")
+    assert linked["link_type"] == "fleet-run"
+    assert linked["external_key"] == "node-a/run-1"
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.link_execution(conn, item["work_id"], node_id="node-b", run_id="run-1", actor_id="node-a")
+    assert excinfo.value.code == "execution-mismatch"
+
+
+def test_record_attempt_failed_excludes_after_two(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Burn me", "kind": "fleet"}, actor_id="admin")
+    store.patch_item(
+        conn,
+        item["work_id"],
+        {"acceptance": ["done"], "burn_eligible": True, "execution_mode": "agent"},
+        expected_version=1,
+        actor_id="admin",
+    )
+    store.transition(conn, item["work_id"], to_status="ready", expected_version=2, actor_id="admin")
+    store.record_attempt(conn, item["work_id"], action="failed", expected_version=3, actor_id="admin")
+    store.record_attempt(conn, item["work_id"], action="failed", expected_version=4, actor_id="admin")
+    queue = store.burn_queue(conn)
+    assert queue["items"] == []
+    assert queue["exclusions"]["attempt-limit"] == 1
+    reset = store.record_attempt(conn, item["work_id"], action="reset", expected_version=5, actor_id="admin")
+    assert reset["attempt_count"] == 0
+
+
+def test_record_attempt_started_bumps_version_without_count(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Start me", "kind": "fleet"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    store.link_execution(conn, item["work_id"], node_id="node-a", run_id="run-1", actor_id="node-a")
+    started = store.record_attempt(
+        conn,
+        item["work_id"],
+        action="started",
+        expected_version=1,
+        actor_id="node-a",
+        node_id="node-a",
+        run_id="run-1",
+    )
+    assert started["attempt_count"] == 0
+    assert started["version"] == 2
+
+
+def test_node_failed_without_owned_fleet_run_is_forbidden(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "No run", "kind": "fleet"}, actor_id="admin")
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.record_attempt(
+            conn,
+            item["work_id"],
+            action="failed",
+            expected_version=1,
+            actor_id="node-a",
+            node_id="node-a",
+            run_id="run-missing",
+        )
+    assert excinfo.value.code == "attempt-forbidden"
+```
+
+- [x] Run red through Brigade with `tests/test_worklore_store.py`. Expect
+  FAIL on the new test names (`import_batch` / `link_execution` /
+  `record_attempt` missing).
+
+- [x] Implement `import_batch`, `link_execution`, `list_items`,
+  `list_links`, `list_all_events`, and `record_attempt`. First
+  observation of an external key creates a native-shaped item with
+  default scheduling and a `github` or `brigade` link. Later observations
+  update only `title`, `external_state`, `external_updated_at`,
+  `synced_at`, `stale_at`, `source_policy`, and `source_acceptance`.
+  They never write `burn_*`, `token_appetite`, `execution_mode`,
+  Worklore `priority`, operator `acceptance`, or `status`.   Persist
+  `(adapter_id, idempotency_key, fingerprint)` in `work_import_keys`.
+  Identical key plus fingerprint writes no observations or events, even
+  after a newer batch, and still updates `work_sync_cursors.last_success_at`
+  and `updated_at`. `record_attempt(conn, work_id, *, action,
+  expected_version, actor_id, node_id=None, run_id=None)` treats
+  `node_id` as the authenticated caller. A node `started` or `failed`
+  requires `run_id` naming a `fleet-run` link with
+  `external_key="{node_id}/{run_id}"`. Otherwise raise
+  `WorkloreForbidden` with `attempt-forbidden`. `started` increments
+  `version` and leaves `attempt_count` unchanged.
+  `list_items(conn, source="github")` returns items whose `links` include
+  that `link_type`. `link_execution` checks Fleet Hub `events` for
+  `(node_id, run_id)` and rejects another node's run when the actor is a
+  node. Missing source rows set `stale_at` and append `sync-stale`.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_store.py tests/test_worklore_store.py
+git commit -m "$(cat <<'EOF'
+feat: import Worklore observations without clobbering schedule fields
+
+EOF
+)"
+```
+
+## Task 4: HTTP handlers without hub routing
+
+**Files:**
+
+- Create: `src/brigade/worklore_http.py`
+- Create: `tests/test_worklore_http.py`
+
+- [x] Write the failing tests. Call `worklore_http.handle(conn, request)`
+  with a dataclass, not `make_server`.
+
+```python
+from brigade import fleet_hub
+from brigade import worklore_http as http
+from brigade import worklore_store as store
+
+
+def _req(method, path, *, admin=False, node=None, body=None, headers=None):
+    return http.Request(
+        method=method,
+        path=path,
+        is_admin=admin,
+        node_id=node,
+        body=body or {},
+        headers=headers or {},
+    )
+
+
+def _http_conn(tmp_path):
+    conn = fleet_hub.init_db(tmp_path / "db")
+    store.ensure_schema(conn)
+    return conn
+
+
+def test_cookie_caller_cannot_read_or_write(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, body = http.handle(conn, _req("GET", "/work/items"))
+    assert status == 401 and body["code"] == "unauthorized"
+
+
+def test_node_can_read_and_import_but_cannot_transition(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Native", "kind": "fleet"}),
+    )
+    assert status == 201
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}", node="node-a"))
+    assert status == 200 and body["item"]["title"] == "Native"
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            node="node-a",
+            body={"to_status": "defining"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 403 and body["code"] == "forbidden"
+
+
+def test_patch_and_transition_require_if_match(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Edit me", "kind": "admin"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(
+        conn,
+        _req("PATCH", f"/work/items/{work_id}", admin=True, body={"priority": "high"}),
+    )
+    assert status == 400 and body["code"] == "if-match-required"
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "defining"},
+        ),
+    )
+    assert status == 400 and body["code"] == "if-match-required"
+    status, ok = http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"priority": "high"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 200 and ok["item"]["version"] == 2
+    status, ready = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "defining"},
+            headers={"If-Match": "2"},
+        ),
+    )
+    assert status == 200 and ready["item"]["status"] == "defining"
+    status, conflict = http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"priority": "low"},
+            headers={"If-Match": "2"},
+        ),
+    )
+    assert status == 409 and conflict["code"] == "version-conflict"
+
+
+def test_invalid_transition_and_missing_item_use_stable_codes(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "X", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "running"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 400 and body["code"] == "invalid-transition"
+    status, body = http.handle(conn, _req("GET", "/work/items/wl-missing", admin=True))
+    assert status == 404 and body["code"] == "not-found"
+
+
+def test_attempts_body_is_action_and_optional_run_id(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Try", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/attempts",
+            node="node-a",
+            body={"action": "failed"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 403 and body["code"] == "attempt-forbidden"
+```
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_http.py"]' --capture brigade-work
+```
+
+Expect FAIL: `ModuleNotFoundError: No module named 'brigade.worklore_http'`.
+
+- [x] Implement `handle`. Supported paths: `GET /work/items`,
+  `GET /work/items/{work_id}`, `GET /work/items/{work_id}/events`,
+  `GET /work/events`, `GET /work/queue/burn`, `POST /work/items`,
+  `PATCH /work/items/{work_id}`, `POST /work/items/{work_id}/transitions`,
+  `POST /work/items/{work_id}/attempts`,
+  `POST /work/items/{work_id}/links`,
+  `DELETE /work/items/{work_id}/links/{link_id}`, `POST /work/imports`,
+  `POST /work/items/{work_id}/execution`. Attempts body is
+  `{ "action", "run_id"? }`. Pass authenticated `node_id` and optional
+  `run_id` into `record_attempt`. Missing admin or node identity
+  is 401. Cookie-only callers never reach this function. Map store
+  exceptions to the stable codes. Do not put SQLite errors in `error`.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_http.py tests/test_worklore_http.py
+git commit -m "$(cat <<'EOF'
+feat: add isolated Worklore HTTP handlers
+
+EOF
+)"
+```
+
+## Task 5: client and CLI
+
+**Files:**
+
+- Create: `src/brigade/worklore_client.py`
+- Create: `tests/test_worklore_client.py`
+- Modify: `src/brigade/cli/fleet.py:45-270` to register commands after
+  the preference parsers. Add `_dispatch_work_*` functions after
+  `register()`.
+
+- [x] Write the failing tests
+
+```python
+from brigade import worklore_client
+from brigade.cli import fleet as fleet_cli
+
+
+def test_client_fails_closed_when_hub_is_configured_and_down(monkeypatch):
+    monkeypatch.setattr(
+        worklore_client,
+        "load_fleet_settings",
+        lambda: {"hub_url": "http://127.0.0.1:9", "admin_token": "admin", "node_token": "node"},  # content-guard: allow loopback-ipv4
+    )
+    with pytest.raises(worklore_client.FleetClientError, match="hub-unavailable"):
+        worklore_client.create_item({"title": "Native", "kind": "fleet"})
+
+
+def test_fleet_work_create_and_burn_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        worklore_client,
+        "create_item",
+        lambda body: {"item": {"work_id": "wl-aaa", "title": body["title"], "status": "captured"}},
+    )
+    monkeypatch.setattr(
+        worklore_client,
+        "burn_queue",
+        lambda: {"items": [], "exclusions": {"acceptance-required": 1, "source-policy": 0}},
+    )
+    assert fleet_cli._dispatch_work_create(argparse.Namespace(title="X", kind="fleet", json=True)) == 0
+    assert '"wl-aaa"' in capsys.readouterr().out
+    assert fleet_cli._dispatch_work_burn(argparse.Namespace(json=True)) == 0
+    assert "acceptance-required" in capsys.readouterr().out
+```
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_client.py"]' --capture brigade-work
+```
+
+Expect FAIL: `ModuleNotFoundError: No module named 'brigade.worklore_client'`.
+
+- [x] Implement `worklore_client.py` with its own transport. Do not call
+  `fleet_client._admin_request` (`src/brigade/fleet_client.py:1384-1415`).
+  That helper emits only GET or POST, uses
+  `REPORT_TIMEOUT_SECONDS = 2.0` (`src/brigade/fleet_client.py:117`), and
+  cannot carry `If-Match`. Worklore GET/POST mutations use a 5.0s
+  timeout. PATCH and DELETE use the same 5.0s timeout and send
+  `If-Match`. `import_batch` uses `IMPORT_TIMEOUT_SECONDS = 30.0`.
+  `load_fleet_settings` still returns exactly `hub_url` / `admin_token` /
+  `node_token` (`src/brigade/fleet_client.py:200-226`). Normal create,
+  patch, transition, attempt reset, and operator-link mutations use the
+  enrolled node token plus `Idempotency-Key` on native create. The Hub
+  admin token remains a server-side override and is not used by the CLI
+  client. Node imports, execution links, and started/failed attempts
+  continue to use the node token. A configured hub that raises
+  `OSError` or `TimeoutError` becomes `FleetClientError("hub-unavailable")`.
+- [x] Export `create_item`, `get_item`, `list_items`, `list_events`,
+  `list_all_events`, `burn_queue`, `patch_item`, `transition`,
+  `record_attempt`, `add_link`, `delete_link`, `import_batch`, and
+  `link_execution`. `import_batch(payload)` takes one dict with keys
+  `adapter_id`, `source_type`, `idempotency_key`, and `observations`.
+  It does not take those values as separate keyword arguments.
+- [x] Add
+  `brigade fleet work create|show|list|burn|patch|transition|attempt|link|unlink`
+  to `register()` after the preference parsers at
+  `src/brigade/cli/fleet.py:251-270`. Dispatchers print JSON when
+  `--json` is set and never print tokens. `list` accepts `--source`.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_client.py src/brigade/cli/fleet.py tests/test_worklore_client.py
+git commit -m "$(cat <<'EOF'
+feat: add brigade fleet work client and CLI
+
+EOF
+)"
+```
+
+## Task 6: Fleet Hub integration after the precondition passes
+
+**Do not start this task until the three integration precondition checks
+above are true.**
+
+**Files:**
+
+- Modify: `src/brigade/fleet_hub.py:121` (`SCHEMA_VERSION`)
+- Modify: `src/brigade/fleet_hub.py:492-529` (`_apply_schema`)
+- Modify: `src/brigade/fleet_hub_http.py:440-656` (`do_GET`, `do_POST`, add
+  `do_PATCH`, `do_DELETE`)
+- Modify: `src/brigade/worklore_http.py` to add the fail-closed feature gate
+- Modify: `src/brigade/fleet_client.py` re-exports
+- Modify: `tests/test_fleet_cloud.py:194-216`
+- Modify: `tests/test_worklore_http.py` to add live-server tests
+- Modify: existing fleet HTTP tests only to prove `/work` is 404 when
+  disabled
+
+- [x] Fetch and rebase onto current `origin/main`. Confirm
+  `git merge-base --is-ancestor origin/main HEAD`. Run
+  `brigade fleet claims --json` and confirm no live conflicting owner.
+  Record the operator confirmation that the warned concurrent Fleet Hub
+  work has landed. Read the new `SCHEMA_VERSION`. Set
+  `NEXT = that number + 1`.
+
+- [x] Write the failing integration tests
+
+```python
+def test_worklore_enabled_is_fail_closed_and_reads_fleet_config(tmp_path):
+    config = tmp_path / "fleet.toml"
+    assert worklore_http.enabled(environ={}, config_path=config) is False
+    config.write_text("[fleet.worklore]\nenabled = true\n")
+    assert worklore_http.enabled(environ={}, config_path=config) is True
+    assert worklore_http.enabled(
+        environ={"BRIGADE_WORKLORE_ENABLED": "0"}, config_path=config
+    ) is False
+    assert worklore_http.enabled(
+        environ={"BRIGADE_WORKLORE_ENABLED": "1"}, config_path=config
+    ) is True
+
+
+def test_worklore_routes_are_absent_when_disabled(tmp_path):
+    with _hub(tmp_path) as hub:
+        status, body = _request(hub, "GET", "/work/items", token=ADMIN_TOKEN)
+        assert status == 404
+        assert body["error"] == "not found"
+
+
+def test_worklore_native_create_to_burn_on_enabled_hub(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "1")
+    with _hub(tmp_path) as hub:
+        status, created = _request(
+            hub, "POST", "/work/items", token=ADMIN_TOKEN, body={"title": "NAS restic", "kind": "fleet"}
+        )
+        assert status == 201
+        work_id = created["item"]["work_id"]
+        _request(
+            hub,
+            "PATCH",
+            f"/work/items/{work_id}",
+            token=ADMIN_TOKEN,
+            body={
+                "acceptance": ["restic snapshots --latest 1 succeeds"],
+                "burn_eligible": True,
+                "execution_mode": "agent",
+            },
+            extra_headers={"If-Match": "1"},
+        )
+        _request(
+            hub,
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            token=ADMIN_TOKEN,
+            body={"to_status": "ready"},
+            extra_headers={"If-Match": "2"},
+        )
+        status, queue = _request(hub, "GET", "/work/queue/burn", token=ADMIN_TOKEN)
+        assert status == 200
+        assert queue["items"][0]["work_id"] == work_id
+
+
+def test_admin_worklore_patch_succeeds_without_allow_admin_writes(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "1")
+    with _hub(tmp_path) as hub:
+        _, created = _request(
+            hub, "POST", "/work/items", token=ADMIN_TOKEN, body={"title": "Admin write", "kind": "admin"}
+        )
+        status, patched = _request(
+            hub,
+            "PATCH",
+            f"/work/items/{created['item']['work_id']}",
+            token=ADMIN_TOKEN,
+            body={"priority": "high"},
+            extra_headers={"If-Match": "1"},
+        )
+        assert status == 200
+        assert patched["item"]["priority"] == "high"
+
+
+def test_existing_claim_and_dashboard_routes_stay_unchanged(tmp_path):
+    with _hub(tmp_path) as hub:
+        assert _request(hub, "GET", "/claims", token=ADMIN_TOKEN)[0] == 200
+        assert _request(hub, "GET", "/health")[0] == 200
+```
+
+Reuse `_hub` and `_request` from `tests/test_fleet_cloud.py:280-307`.
+`_hub` already calls `make_server(..., allow_admin_writes=False)` because
+that keyword defaults to false at `src/brigade/fleet_hub.py:1851`.
+Extend `_request` with `extra_headers` rather than copying the helper.
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_http.py","tests/test_fleet_cloud.py","tests/test_fleet_claims.py","tests/test_fleet_nodes.py","tests/test_fleet_dashboard.py"]' --capture brigade-work
+```
+
+Expect FAIL on the new `/work` assertions until routing exists.
+
+- [x] In `_apply_schema`, call `worklore_store.ensure_schema(conn)` next
+  to `fleet_hub_preference.ensure_schema(conn)` at
+  `src/brigade/fleet_hub.py:528`. Bump `SCHEMA_VERSION` to `NEXT`. Keep
+  `_refuse_newer_schema` fail-closed.
+- [x] In `fleet_hub_http.py`, if
+  `worklore_http.enabled()` is false, leave `/work` as 404. If true, open
+  the request DB the same way `/claims` does, resolve `_caller`, and
+  delegate to `worklore_http.handle`. Add `do_PATCH` and `do_DELETE` that
+  only accept `/work/` paths. Dashboard cookie authorization must not
+  reach `handle`.
+- [x] Implement `worklore_http.enabled(environ=None, config_path=None)`.
+  `BRIGADE_WORKLORE_ENABLED` accepts `1`, `true`, `yes`, or `on` and
+  `0`, `false`, `no`, or `off`; a recognized environment value wins.
+  Otherwise read `[fleet.worklore] enabled` from
+  `config_path` or `~/.brigade/fleet.toml` using `toml_compat`. Missing,
+  malformed, or non-boolean configuration returns false. The default is
+  off.
+- [x] Update `test_v4_migration_preserves_existing_rows` so the migrated
+  database also has empty `work_items`.
+- [x] Re-export `create_item`, `list_items`, `burn_queue`,
+  `import_batch`, `record_attempt`, and `link_execution` from
+  `fleet_client.py` the way cloud helpers are re-exported.
+
+- [x] Run the same focused gate green. Expect `passed`.
+- [x] Run the broader fleet regression:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_validate.py","tests/test_worklore_store.py","tests/test_worklore_http.py","tests/test_worklore_client.py","tests/test_fleet_cloud.py","tests/test_fleet_claims.py","tests/test_fleet_nodes.py","tests/test_fleet_dashboard.py","tests/test_fleet_sync.py"]' --capture brigade-work
+```
+
+Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/fleet_hub.py src/brigade/fleet_hub_http.py src/brigade/fleet_client.py src/brigade/worklore_http.py tests/test_worklore_http.py tests/test_fleet_cloud.py
+git commit -m "$(cat <<'EOF'
+feat: expose Worklore routes on Fleet Hub after the integration precondition
+
+EOF
+)"
+```
+
+## Verification
+
+Every task runs `./scripts/verify-focused` through
+`brigade work verify run` with `--capture brigade-work`. Task 6 also
+re-runs the listed fleet suites. Do not claim success from a raw pytest
+invocation.

--- a/docs/phase-worklore-github-plan.md
+++ b/docs/phase-worklore-github-plan.md
@@ -1,0 +1,611 @@
+# Worklore GitHub adapter implementation plan
+
+## Goal
+
+Synchronize configured `burn-queue` GitHub issues into Worklore through
+`POST /work/imports` so the same issue observed twice creates one item,
+one link, and no duplicate observation event for an identical source
+revision. Execute the tasks in order and check every box.
+
+Approved design: `docs/phase-worklore-ledger.md`.
+
+This plan is independently executable for normalize and discover. Tasks 3
+and 4 import `worklore_client.import_batch` and
+`worklore_client.list_items` from the core slice. Do not add those
+functions here. Start Task 3 only after core Task 5 is on the branch.
+Tests use a fake `import_batch` and in-memory observation fixtures. They
+do not edit Fleet Hub tables, the Brigade adapter, or Ops Deck.
+
+## Architecture
+
+- `worklore_github.py` normalizes one issue into an import observation and
+  rejects credential-shaped fields, home paths, prompts, and transcripts.
+- `worklore_github_sync.py` lists labeled issues from configured
+  organizations through the approved GitHub read path, writes a local
+  retry receipt, and posts one idempotent batch.
+- `worklore_client.import_batch` and `worklore_client.list_items` from
+  core Task 5 are the only hub writers and readers.
+- GitHub credentials stay on the node. The hub never receives a token.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| Create `src/brigade/worklore_github.py` | Issue to observation mapping and source-policy rules. |
+| Create `src/brigade/worklore_github_sync.py` | Org discovery, batching, retry receipt. |
+| Create `tests/test_worklore_github.py` | Normalizer, privacy, discovery, and fake-hub tests. |
+| Modify `src/brigade/cli/fleet.py` | `brigade fleet work sync-github`. |
+| Modify `src/brigade/work_cmd/ledger/import_model.py` | Public alias `extract_issue_acceptance = _extract_issue_acceptance`. |
+
+Do not modify `worklore_client.py`.
+
+## Pinned decisions
+
+- External key is `owner/repository#number` with the repository name
+  lowercased and without `.git`.
+- First observation creates a Worklore item with default scheduling
+  (`burn_eligible=false`, `burn_rank=1000`, `token_appetite=medium`,
+  `execution_mode=manual`, `status=captured`). Later observations update
+  only GitHub-authoritative fields: title, source acceptance, open or
+  closed state, URL, source timestamp, and `source_policy`. Operator
+  `acceptance` is never sent and never overwritten.
+- Removing `burn-queue` marks `source_policy=label-removed`. The adapter
+  still sends the observation. It does not delete the item or transition
+  it. Burn eligibility on the hub treats any non-eligible link as
+  excluded (`exclusions["source-policy"]`).
+- Closing an issue sends `source_policy=closed` and
+  `proposed_status=completed`. The adapter never POSTs a transition.
+- Config lives in `~/.brigade/fleet.toml`:
+
+```toml
+[fleet.worklore.github]
+label = "burn-queue"
+state = "all"
+orgs = [
+  { name = "escoffier-labs", visibility = "public" },
+]
+```
+
+  Missing config is a CLI error, not a home-directory crawl. `label`
+  defaults to `burn-queue`. `state` defaults to `all`, meaning open and
+  closed. That config value does not become a `gh` flag.
+- Each org requires `visibility` of `public` or `private`.
+- Discovery command for a public org, in order: if
+  `shutil.which("octopool")` succeeds, run
+  `OCTOPOOL_NO_FALLBACK=1 octopool gh search issues --owner {org} --label {label} --limit 500 --json number,title,body,labels,state,url,updatedAt,repository`.
+  Otherwise run the same argv with `gh`. Never pass `--state all`.
+  Installed `gh search issues --state` accepts only `open` or `closed`
+  (default page size 30). Omit `--state` when config `state` is `all`.
+  Pass `--state open` or `--state closed` only when config says so.
+  Never add `--token`. Never log stdout that contains `token`,
+  `authorization`, or `bearer`.
+- Private orgs never use octopool. They run `gh search issues` with the
+  same flags.
+- Label removal is reconciled explicitly because a label-filtered search
+  cannot return an issue after the label disappears. Before discovery,
+  read existing GitHub items with
+  `worklore_client.list_items(source="github")`. Pass the returned `items`
+  into reconciliation so each existing GitHub link retains its item title,
+  source acceptance, URL, external timestamp, and source policy. For any
+  existing external key
+  absent from the search result, run
+  `octopool gh issue view {number} --repo {owner/repository} --json number,title,body,labels,state,url,updatedAt`
+  for a public org when octopool is present, else the equivalent `gh`
+  command. `gh issue view --json` has no `repository` field. Synthesize
+  `repository.nameWithOwner` from the `--repo` argument. Search results
+  do include `repository` and use `repository.nameWithOwner` when
+  present.
+- A 404 through octopool is inconclusive. Do not set `stale` and do not
+  change `source_policy`. A 404 through direct `gh` emits a tombstone
+  observation derived from the existing item and link, preserving its title,
+  source acceptance, URL, external timestamp, and source policy while setting
+  `stale=true`.
+- Batch size is at most 500 observations. Larger result sets split into
+  consecutive batches. Every posted batch, including an empty one, uses
+  the same idempotency-key format
+  `github:{org}:{sha256(sorted fingerprints)[:24]}` over the observations
+  in that posted batch. Do not use `{adapter_id}:{cursor}:{chunk_index}`.
+- Retry receipt path is
+  `$BRIGADE_HOME/worklore/github/{safe_adapter_id}.json` with mode 0600.
+  `safe_adapter_id` replaces `:`, `/`, `\`, `<`, `>`, `"`, `|`, `?`, and
+  `*` with `-`. Adapter id `github:escoffier-labs` becomes
+  `github-escoffier-labs.json`. The receipt stores `adapter_id`,
+  `idempotency_key`, `observation_count`, `skipped`, `last_error_code`,
+  and `updated_at`. It does not store issue bodies or hub payloads.
+- Adapter id is `github:{org}`.
+- Acceptance criteria come from
+  `brigade.work_cmd.ledger.import_model.extract_issue_acceptance`. Add
+  that public alias next to `_extract_issue_acceptance` at
+  `src/brigade/work_cmd/ledger/import_model.py:628`. Import
+  `from brigade.work_cmd.ledger.import_model import extract_issue_acceptance`.
+  Do not add the alias to `ledger/__init__.py` or `_OWNERS`. Do not
+  import the `_name` across module families. Do not copy a second parser.
+- URL must be `https://github.com/{owner}/{repo}/issues/{number}`. Other
+  hosts are rejected.
+- `discover_issues(orgs, *, label, state)` takes `orgs` as
+  `[{"name": "escoffier-labs", "visibility": "public"}]`. Every test
+  uses that signature. `sync_github` calls `discover_and_reconcile`, not
+  `discover_issues` alone.
+- Titles and acceptance are bounded to the hub contract before a batch is
+  posted, using `TITLE_MAX`, `ACCEPTANCE_MAX_ITEMS`, and
+  `ACCEPTANCE_ITEM_MAX` imported from `worklore_validate` so the two
+  cannot drift. A title is stripped and truncated to `TITLE_MAX`;
+  acceptance items are truncated to `ACCEPTANCE_ITEM_MAX`, items that are
+  blank or carry control characters are dropped, and the list is capped at
+  `ACCEPTANCE_MAX_ITEMS`. A title the
+  adapter cannot bound, such as one carrying control characters the hub
+  refuses, is `field-bound` and skips that issue alone. Tombstones bound
+  the existing item title and `source_acceptance` the same way.
+- Isolation is per issue and per link. One issue the adapter cannot
+  normalize, and one malformed existing github link, are skipped and
+  counted in `skipped`; neither aborts the org batch or the sync. A link
+  is malformed when the existing item is not an object, its `links` is not
+  an array, the link is not an object, or its `external_key` does not
+  parse as `owner/repo#number`. Links of another `link_type` are not
+  counted as malformed.
+- Hub refusals keep a stable code instead of collapsing to
+  `hub-unavailable`. `401` and `403` are `hub-unauthorized`, `409` is
+  `hub-conflict`, any other `4xx` is `hub-rejected`, and transport
+  failures, `5xx`, and unparsable refusals stay `hub-unavailable`. The
+  code is raised on `GitHubSyncError` and recorded as the receipt
+  `last_error_code`; the hub message itself is never surfaced. Only
+  `hub-unavailable` means retrying the same batch can succeed.
+- In-house Brigade commits include a coding-agent `Co-Authored-By`
+  trailer. Known-good identities are in `AGENTS.md`.
+
+## Task 1: normalize issues and reject unsafe fields
+
+**Files:**
+
+- Create: `src/brigade/worklore_github.py`
+- Create: `tests/test_worklore_github.py`
+- Modify: `src/brigade/work_cmd/ledger/import_model.py`
+
+- [x] Write the failing tests
+
+```python
+from brigade import worklore_github as gh
+
+
+def test_normalize_open_labeled_issue():
+    observation = gh.normalize_issue(
+        {
+            "number": 12,
+            "title": "Rotate restic password",
+            "body": "## Acceptance\n- restic snapshots --latest 1 succeeds\n",
+            "labels": [{"name": "burn-queue"}, {"name": "ops"}],
+            "state": "OPEN",
+            "url": "https://github.com/Escoffier-Labs/brigade/issues/12",
+            "updatedAt": "2026-08-29T12:00:00Z",
+            "repository": {"nameWithOwner": "Escoffier-Labs/brigade"},
+        }
+    )
+    assert observation["external_key"] == "escoffier-labs/brigade#12"
+    assert observation["link_type"] == "github"
+    assert observation["acceptance"] == ["restic snapshots --latest 1 succeeds"]
+    assert observation["source_policy"] == "eligible"
+    assert observation["proposed_status"] is None
+    assert "body" not in observation
+    assert "labels" not in observation
+
+
+def test_label_removal_and_close_are_observations_not_transitions():
+    closed = gh.normalize_issue(
+        {
+            "number": 3,
+            "title": "Done work",
+            "body": "",
+            "labels": [{"name": "burn-queue"}],
+            "state": "CLOSED",
+            "url": "https://github.com/escoffier-labs/brigade/issues/3",
+            "updatedAt": "2026-08-29T12:00:00Z",
+            "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+        }
+    )
+    assert closed["source_policy"] == "closed"
+    assert closed["proposed_status"] == "completed"
+    unlabeled = gh.normalize_issue(
+        {
+            "number": 4,
+            "title": "Still open",
+            "body": "",
+            "labels": [{"name": "docs"}],
+            "state": "OPEN",
+            "url": "https://github.com/escoffier-labs/brigade/issues/4",
+            "updatedAt": "2026-08-29T12:00:00Z",
+            "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+        }
+    )
+    assert unlabeled["source_policy"] == "label-removed"
+    assert unlabeled["proposed_status"] is None
+
+
+def test_normalize_rejects_tokens_home_paths_and_http_urls():
+    base = {
+        "number": 1,
+        "title": "Bad",
+        "body": "",
+        "labels": [{"name": "burn-queue"}],
+        "state": "OPEN",
+        "updatedAt": "2026-08-29T12:00:00Z",
+        "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+    }
+    with pytest.raises(gh.GitHubObservationError, match="unknown-field"):
+        gh.normalize_issue({**base, "url": "https://github.com/escoffier-labs/brigade/issues/1", "token": "abc"})
+    with pytest.raises(gh.GitHubObservationError, match="field-bound"):
+        gh.normalize_issue({**base, "url": "http://github.com/escoffier-labs/brigade/issues/1"})
+    with pytest.raises(gh.GitHubObservationError, match="field-bound"):
+        gh.normalize_issue({**base, "url": "https://github.com/escoffier-labs/brigade/issues/1", "body": "see /workspace/notes/secret"})
+```
+
+- [x] Run red through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_github.py"]' --capture brigade-work
+```
+
+Expect FAIL: `ModuleNotFoundError: No module named 'brigade.worklore_github'`.
+
+- [x] Implement `normalize_issue`. Pull acceptance through
+  `from brigade.work_cmd.ledger.import_model import extract_issue_acceptance`.
+  Drop `body` and `labels` from the
+  observation after derivation. Reject any key in
+  `{token,secret,password,authorization,prompt,transcript,receipt,path}`.
+  Reject a body or title that contains `/home/` or `C:\\Users\\`.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_github.py src/brigade/work_cmd/ledger/import_model.py tests/test_worklore_github.py
+git commit -m "$(cat <<'EOF'
+feat: normalize GitHub burn-queue issues for Worklore
+
+EOF
+)"
+```
+
+## Task 2: discovery through the approved read path
+
+**Files:**
+
+- Create: `src/brigade/worklore_github_sync.py`
+- Modify: `tests/test_worklore_github.py`
+
+- [x] Write the failing tests
+
+```python
+from brigade import worklore_github_sync as sync
+
+PUBLIC_ORG = [{"name": "escoffier-labs", "visibility": "public"}]
+
+
+def test_load_config_requires_explicit_orgs(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "fleet.toml").write_text("[fleet.worklore.github]\nlabel = \"burn-queue\"\n")
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.GitHubSyncError, match="orgs"):
+        sync.load_github_config()
+
+
+def test_discover_uses_octopool_when_present(monkeypatch):
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/octopool" if name == "octopool" else None)
+    recorded = {}
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        recorded["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+    assert recorded["argv"][:3] == ["octopool", "gh", "search"]
+    assert recorded["env"]["OCTOPOOL_NO_FALLBACK"] == "1"
+    assert "--token" not in recorded["argv"]
+    assert "--state" not in recorded["argv"]
+    assert "--limit" in recorded["argv"]
+
+
+def test_discover_falls_back_to_gh_and_rejects_non_json(monkeypatch):
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/gh" if name == "gh" else None)
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, stdout="not-json", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.GitHubSyncError, match="retryable-adapter-failure"):
+        sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+
+
+def test_private_org_never_uses_octopool(monkeypatch):
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/octopool")
+    recorded = {}
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    sync.discover_issues(
+        [{"name": "escoffier-labs", "visibility": "private"}],
+        label="burn-queue",
+        state="all",
+    )
+    assert recorded["argv"][0] == "gh"
+
+
+def test_reconcile_refreshes_previously_linked_issue_missing_from_label_search(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=json.dumps(
+                {
+                    "number": 12,
+                    "title": "Removed label",
+                    "body": "",
+                    "labels": [],
+                    "state": "OPEN",
+                    "url": "https://github.com/escoffier-labs/brigade/issues/12",
+                    "updatedAt": "2026-08-29T12:00:00Z",
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/octopool" if name == "octopool" else "/usr/bin/gh")
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[{
+            "title": "Removed label",
+            "links": [{
+                "link_type": "github",
+                "external_key": "escoffier-labs/brigade#12",
+                "source_acceptance": [],
+                "source_policy": "eligible",
+                "url": "https://github.com/escoffier-labs/brigade/issues/12",
+                "external_updated_at": "2026-08-28T12:00:00Z",
+            }],
+        }],
+    )
+    assert observations[0]["source_policy"] == "label-removed"
+    assert any("view" in argv for argv in calls)
+    assert all("repository" not in argv for argv in calls if "view" in argv)
+
+
+def test_pooled_404_is_inconclusive(monkeypatch):
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="HTTP 404")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/octopool" if name == "octopool" else None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[{
+            "title": "Existing title",
+            "links": [{
+                "link_type": "github",
+                "external_key": "escoffier-labs/brigade#12",
+                "source_acceptance": ["existing acceptance"],
+                "source_policy": "eligible",
+                "url": "https://github.com/escoffier-labs/brigade/issues/12",
+                "external_updated_at": "2026-08-28T12:00:00Z",
+            }],
+        }],
+    )
+    assert observations == []
+```
+
+Add a direct-`gh` 404 test with the same existing item fixture. It must return
+one observation with `stale is True`, `title == "Existing title"`,
+`acceptance == ["existing acceptance"]`, and unchanged `source_policy`.
+
+- [x] Run red through Brigade with `tests/test_worklore_github.py`. Expect
+  FAIL: `ModuleNotFoundError: No module named 'brigade.worklore_github_sync'`.
+
+- [x] Implement `load_github_config` by reading
+  `fleet.worklore.github` the same way `fleet_export.load_sink_config`
+  reads `fleet.sink` in `src/brigade/fleet_export.py:443-456`. Require a
+  non-empty `orgs` list of tables with `name` matching
+  `^[A-Za-z0-9][A-Za-z0-9-]{0,38}$` and `visibility` in
+  `{public, private}`. Implement `discover_issues` with a 30 second
+  timeout, `stdout=PIPE`, and no token flags. Parse the search response
+  as a JSON array and individual refresh responses as JSON objects.
+  Implement `discover_and_reconcile` so previously linked GitHub links absent
+  from search are refreshed individually. Its `existing_items` argument is the
+  `items` array returned by `list_items(source="github")`; it returns normalized
+  Worklore observations, never raw GitHub issue objects.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_github_sync.py tests/test_worklore_github.py
+git commit -m "$(cat <<'EOF'
+feat: discover labeled GitHub issues for Worklore imports
+
+EOF
+)"
+```
+
+## Task 3: idempotent batch post and retry receipt
+
+**Files:**
+
+- Modify: `src/brigade/worklore_github_sync.py`
+- Modify: `tests/test_worklore_github.py`
+
+Do not modify `worklore_client.py`.
+
+- [x] Write the failing tests
+
+```python
+from tests.support import PRIVATE_FILE_MODE, assert_private_mode
+
+
+def test_sync_posts_one_batch_and_skips_duplicate_revision(tmp_path, monkeypatch):
+    posts = []
+
+    def fake_import_batch(payload):
+        posts.append(payload)
+        return {"created": 1 if len(posts) == 1 else 0, "updated": 0 if len(posts) == 1 else 1}
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import_batch)
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "list_items",
+        lambda source=None: {"items": []},
+    )
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items: [{
+            "external_key": "escoffier-labs/brigade#12",
+            "link_type": "github",
+            "title": "Rotate restic password",
+            "acceptance": ["restic snapshots --latest 1 succeeds"],
+            "source_policy": "eligible",
+            "proposed_status": None,
+            "url": "https://github.com/escoffier-labs/brigade/issues/12",
+            "external_updated_at": "2026-08-29T12:00:00Z",
+        }],
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    first = sync.sync_github(orgs=PUBLIC_ORG)
+    second = sync.sync_github(orgs=PUBLIC_ORG)
+    assert first["posted"] == 1 and second["posted"] == 1
+    assert posts[0]["adapter_id"] == "github:escoffier-labs"
+    assert posts[0]["source_type"] == "github"
+    assert set(posts[0]) >= {"adapter_id", "source_type", "idempotency_key", "observations"}
+    assert posts[0]["idempotency_key"] == posts[1]["idempotency_key"]
+    assert posts[0]["idempotency_key"].startswith("github:escoffier-labs:")
+    receipt_path = tmp_path / "worklore" / "github" / "github-escoffier-labs.json"
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["last_error_code"] is None
+    assert "Rotate restic" not in json.dumps(receipt)
+    assert_private_mode(receipt_path, PRIVATE_FILE_MODE)
+
+
+def test_hub_unavailable_writes_retry_receipt_and_does_not_raise_raw_url(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(sync.worklore_client.FleetClientError("hub-unavailable")),
+    )
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items: [],
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError, match="hub-unavailable"):
+        sync.sync_github(orgs=PUBLIC_ORG)
+    receipt_path = tmp_path / "worklore" / "github" / "github-escoffier-labs.json"
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["last_error_code"] == "hub-unavailable"
+    assert_private_mode(receipt_path, PRIVATE_FILE_MODE)
+```
+
+- [x] Run red through Brigade. Expect FAIL on `sync_github` missing.
+
+- [x] Implement `sync_github`. Call `list_items(source="github")` then
+  `discover_and_reconcile`. Fingerprint each observation with SHA-256 of
+  `external_key`, `external_updated_at`, `source_policy`, and
+  acceptance. POST `{adapter_id, source_type, idempotency_key, observations}`
+  with `source_type="github"`. The idempotency key is
+  `github:{org}:{sha256(sorted fingerprints)[:24]}` over the observations
+  in that posted batch. On
+  `FleetClientError("hub-unavailable")` write the receipt and raise
+  `GitHubSyncError("hub-unavailable")` with no URL, token, or exception
+  text. Empty discovery still posts an empty batch so the hub cursor
+  advances. A same-fingerprint replay still updates hub cursor
+  `last_success_at` and `updated_at`. Write receipts with mode 0600.
+
+- [x] Run green through Brigade. Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/worklore_github_sync.py tests/test_worklore_github.py
+git commit -m "$(cat <<'EOF'
+feat: post idempotent GitHub Worklore import batches
+
+EOF
+)"
+```
+
+## Task 4: CLI
+
+**Files:**
+
+- Modify: `src/brigade/cli/fleet.py`
+- Modify: `tests/test_worklore_github.py`
+
+- [x] Write the failing test
+
+```python
+from brigade.cli import fleet as fleet_cli
+
+
+def test_sync_github_cli_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        fleet_cli.worklore_github_sync,
+        "sync_github",
+        lambda **kwargs: {"orgs": ["escoffier-labs"], "posted": 1, "created": 1},
+    )
+    args = argparse.Namespace(json=True)
+    assert fleet_cli._dispatch_work_sync_github(args) == 0
+    assert "escoffier-labs" in capsys.readouterr().out
+```
+
+- [x] Run red through Brigade. Expect FAIL: attribute missing.
+
+- [x] Add `brigade fleet work sync-github` next to the core `fleet work`
+  parsers at the end of `register()` (`src/brigade/cli/fleet.py:45-270`).
+  Import `worklore_github_sync` as a module. `_dispatch_work_sync_github`
+  reads config, calls `worklore_github_sync.sync_github`, prints JSON on
+  `--json`, and
+  returns 2 on missing orgs, 1 on `hub-unavailable`, 0 on success. Do not
+  print issue titles at default verbosity. Do not add a separate `_impl`
+  function.
+
+- [x] Run green through Brigade:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_worklore_github.py"]' --capture brigade-work
+```
+
+Expect `passed`.
+
+- [x] Commit:
+
+```bash
+git add src/brigade/cli/fleet.py tests/test_worklore_github.py
+git commit -m "$(cat <<'EOF'
+feat: add brigade fleet work sync-github
+
+EOF
+)"
+```
+
+## Verification
+
+All tasks use `./scripts/verify-focused tests/test_worklore_github.py`
+through `brigade work verify run --capture brigade-work`. Do not run live
+`gh` or `octopool` against real organizations in this slice.

--- a/docs/phase-worklore-ledger.md
+++ b/docs/phase-worklore-ledger.md
@@ -1,0 +1,706 @@
+# Worklore Ledger Specification
+
+Date: 2026-08-29
+Status: proposed for operator review
+
+## Decision summary
+
+Worklore is a durable, fleet-wide work ledger hosted by the Fleet Hub process. It accepts native work that has no repository, plus linked GitHub and Brigade records. Ops Deck becomes its main operator interface. Existing Fleet Hub claims and run events remain separate execution records.
+
+Implementation keeps isolated modules until the integration precondition in the core plan passes: this branch is rebased onto a freshly fetched `origin/main`, `brigade fleet claims` shows no live conflicting owner for this checkout or the hub tree, and the operator has confirmed that the warned concurrent Fleet Hub work has landed. Worklore code stays additive. Isolated store, validation, HTTP, and client modules may land before that confirmation. Hub routing and the schema bump wait for it.
+
+## Problem
+
+The current Ops Deck sprint board reads `tracking/backlog.json`. The live file reported 20 tasks and a last-updated date of 2026-04-20 when inspected on 2026-08-29. It cannot represent current fleet work without manual edits.
+
+The existing burn queue covers open GitHub issues carrying a `burn-queue` label. That excludes fleet maintenance, research, writing, administrative work, experiments, and ideas that do not belong in a repository. Brigade task ledgers hold detailed execution state, but each ledger belongs to one repository or workspace.
+
+Worklore must answer 2 questions across all of these sources:
+
+1. What useful work is available when prepaid model quota is about to reset?
+2. What happened after an item was selected?
+
+## Goals
+
+- Store native work without requiring GitHub, Git, or Brigade.
+- Present native, GitHub, and Brigade work in one queue.
+- Keep scheduling metadata independent from normal business priority.
+- Record an append-only sprint log for state changes and execution outcomes.
+- Join a work item to Fleet Hub claims, runs, and verification evidence without copying those records.
+- Give Ops Deck authenticated create, edit, defer, and archive actions.
+- Preserve useful local work when Fleet Hub is unavailable.
+
+## Non-goals
+
+- Replace GitHub issues or Brigade task ledgers.
+- Move Fleet Hub run journals into Worklore.
+- Turn expiring Fleet Hub claims into durable tasks.
+- Add automatic dispatch in the first release.
+- Add a new daemon, database service, frontend framework, or runtime dependency.
+- Store prompts, transcripts, credentials, private file paths, or arbitrary source payloads.
+- Synchronize every GitHub issue or every Brigade task by default.
+
+## Approaches considered
+
+### A. Extend the existing Brigade task ledger
+
+This reuses acceptance criteria, dependencies, seat class, and spend-by fields. It fails the fleet-wide requirement because ledgers are target-local and makes non-Brigade work depend on Brigade state.
+
+### B. Put the ledger in Ops Deck API
+
+This gives the UI a short path to CRUD operations. It makes a dashboard backend authoritative for work selected by multiple machines and leaves Fleet Hub execution joins dependent on another service.
+
+### C. Add a Worklore module to Fleet Hub
+
+This is the selected approach. It reuses the authenticated, fleet-reachable HTTP and SQLite process while keeping Worklore tables, validation, and routes separate from events and claims. Ops Deck API acts as a backend-for-frontend and holds no canonical Worklore records.
+
+## Authority model
+
+Worklore is authoritative for operator scheduling metadata:
+
+- burn eligibility
+- burn rank
+- token appetite
+- execution mode
+- operator acceptance override (`work_items.acceptance_json`, API field `acceptance`)
+- Worklore lifecycle state
+- deferral reason and review date
+- links between one work item and its external or execution records
+
+Each external system remains authoritative for its own record:
+
+| Source | External authority | Worklore authority |
+| --- | --- | --- |
+| Native | none | full record |
+| GitHub | issue title, body-derived source acceptance, labels, open or closed state, URL, `source_policy` | scheduling fields, operator acceptance, Worklore state, execution links |
+| Brigade | task text, source acceptance, dependencies, task completion, evidence references, `source_policy` | scheduling fields, operator acceptance, cross-source identity, sprint log |
+| Fleet Hub | claims, run lifecycle, node identity, lease expiry | association of those records with a work item |
+
+External sync never overwrites Worklore scheduling fields. That set includes operator `acceptance`, `burn_*`, `token_appetite`, `execution_mode`, Worklore `priority`, `status`, `blocker`, `review_after`, and `spend_by`.
+
+Source acceptance lives on the link as `source_acceptance_json` (API field `source_acceptance`). Later observations refresh that link field. They do not write `work_items.acceptance_json`.
+
+Effective acceptance is computed, not stored:
+
+1. If operator `acceptance` is a non-empty array, use it.
+2. Else use `source_acceptance` from the oldest link whose `source_policy` is `eligible`. That link is authoritative even when its `source_acceptance` is empty; a later eligible link is not consulted.
+3. Else the effective list is empty.
+
+`ready` and the burn queue use effective acceptance. A missing external record marks its link stale. It does not delete or complete the Worklore item.
+
+## Lifecycle
+
+The allowed Worklore states are:
+
+```text
+captured -> defining -> ready -> claimed -> running -> verifying -> completed
+   |            |          |          |          |
+   v            v          v          v          v
+canceled     deferred   deferred   blocked    blocked
+                |                     |
+                +-----> ready <-------+
+
+Any non-terminal state -> canceled
+completed or canceled -> archived
+```
+
+`captured` may also go directly to `ready` or `canceled`. `defining` may go to `ready`, `deferred`, or `canceled`.
+
+`claimed` in Worklore means the operator selected the item for an attempt. Fleet Hub's claim row remains the authority for whether a machine currently owns an execution target.
+
+Every state change appends a `work_event`. The current state on `work_items` is a transactionally maintained projection used for fast queries. Events are never edited or deleted through the API.
+
+## Burn eligibility
+
+An item appears in the burn queue only when all conditions hold:
+
+- `status = ready`
+- `burn_eligible = true`
+- effective acceptance has one to twenty criteria
+- `execution_mode` is `agent` or `agent-with-review`
+- no unresolved blocker is recorded
+- `attempt_count < 2` unless an operator records `attempt-reset`
+- `review_after` is absent or in the past
+- no `work_links` row for the item has `source_policy` other than `eligible`
+
+Normal priority and burn order are separate. The default burn ordering is:
+
+1. smallest numeric `burn_rank`
+2. earliest `spend_by`, with no deadline last
+3. oldest `ready_at`
+4. stable `work_id`
+
+This preserves the existing oldest-first behavior when items share the default rank, while allowing the operator to order work without pretending it is a normal priority.
+
+## Data model
+
+Worklore uses 6 additive SQLite tables. All timestamps are UTC ISO 8601 strings. JSON fields contain bounded arrays or objects validated before storage. `worklore_store` issues `PRAGMA foreign_keys=ON` on every connection it touches. Fleet Hub `open_db` and `init_db` do not set that pragma today.
+
+API field `acceptance` maps to column `acceptance_json`. API field `source_acceptance` maps to column `source_acceptance_json`. API field `detail` maps to column `detail_json`. Responses never expose the `_json` suffix.
+
+### `work_items`
+
+| Column | Type | Rules |
+| --- | --- | --- |
+| `work_id` | TEXT PRIMARY KEY | server-minted opaque ID |
+| `title` | TEXT NOT NULL | 1 to 240 characters |
+| `description` | TEXT | maximum 8,000 characters |
+| `kind` | TEXT NOT NULL | `repo`, `fleet`, `research`, `writing`, `admin`, `experiment`, `idea`, `other` |
+| `scope` | TEXT | operator label, maximum 128 characters |
+| `status` | TEXT NOT NULL | allowed lifecycle state |
+| `priority` | TEXT NOT NULL | `low`, `normal`, `high`, `urgent` |
+| `burn_eligible` | INTEGER NOT NULL | boolean |
+| `burn_rank` | INTEGER NOT NULL | 0 through 10,000, default 1,000 |
+| `token_appetite` | TEXT NOT NULL | `small`, `medium`, `large`, `max` |
+| `execution_mode` | TEXT NOT NULL | `manual`, `agent`, `agent-with-review` |
+| `acceptance_json` | TEXT NOT NULL | operator override, JSON array, default `[]` |
+| `blocker` | TEXT | maximum 2,000 characters |
+| `review_after` | TEXT | optional ISO-8601 timestamp, validated on create and patch |
+| `spend_by` | TEXT | optional ISO-8601 timestamp, validated on create and patch |
+| `ready_at` | TEXT | set when entering ready |
+| `attempt_count` | INTEGER NOT NULL | failed burn attempts, non-negative |
+| `version` | INTEGER NOT NULL | optimistic concurrency token |
+| `created_at` | TEXT NOT NULL | immutable |
+| `updated_at` | TEXT NOT NULL | changes with projection |
+| `archived_at` | TEXT | set only for archived items |
+
+### `work_links`
+
+| Column | Type | Rules |
+| --- | --- | --- |
+| `link_id` | TEXT PRIMARY KEY | server-minted opaque ID |
+| `work_id` | TEXT NOT NULL | foreign key with delete restricted |
+| `link_type` | TEXT NOT NULL | `github`, `brigade`, `fleet-run`, `fleet-claim`, `url` |
+| `external_key` | TEXT NOT NULL | canonical provider identity |
+| `display_ref` | TEXT | bounded safe label |
+| `url` | TEXT | `https` URL only when present |
+| `external_state` | TEXT | bounded provider state |
+| `external_updated_at` | TEXT | provider timestamp |
+| `source_policy` | TEXT NOT NULL | `eligible`, `label-removed`, `closed`, `completed`. Default `eligible` |
+| `source_acceptance_json` | TEXT NOT NULL | last observed source acceptance, default `[]` |
+| `synced_at` | TEXT NOT NULL | last successful observation, refreshed even when the observation is unchanged, or hub `received_at` for operator-created links |
+| `stale_at` | TEXT | set when the source cannot be found |
+| `adapter_id` | TEXT | adapter that first imported this identity, `NULL` for operator and fleet links |
+| `owner_node` | TEXT | node that owned that adapter on the first import |
+| `source_version` | TEXT | highest `external_updated_at` ever accepted for this identity. Internal; never in a response body |
+
+`UNIQUE(link_type, external_key)` prevents 2 Worklore items from mirroring the same external record.
+
+`source_version` is the rollback guard for import replay, and a usable revision is what buys
+an adapter the right to write. Any observation that would change the projection, including
+the one that creates the item, must carry an `external_updated_at` that parses as a
+timestamp. Once a high-water exists the revision must also be later than it: an equal
+revision carrying a different payload is refused, because two different payloads cannot both
+be the state at one revision, and accepting the second is exactly how A -> expire -> B ->
+replay A rolls back when a source stamps both observations with the same time. A refused
+observation writes nothing at all, not even `synced_at`, and is reported in `refused` with a
+named reason rather than folded into `unchanged`; "we kept the older projection" and
+"nothing was different" are not the same answer. Timestamps compare as instants, so a
+`-05:00` offset and a `Z` value order correctly rather than lexicographically. The guard
+costs one nullable column on a row that already exists, so it is bounded by the imported
+identities themselves and adds no table an adapter can grow.
+
+Identities imported before the column existed are seeded once, at migration, from their
+stored `external_updated_at` when it parses. That value is the revision of the projection
+those rows currently hold, which is what the guard compares against, so seeding it closes
+the window in which a just-migrated identity had no guard at all and could be replayed
+straight back. Unparseable values seed nothing.
+
+Requiring the revision on creation is what makes the guard total. An identity minted without
+one would carry no high-water, so the hub could not later tell a fresh observation from a
+replay of the one that minted it, and that identity would sit in the ledger permanently
+rollback-able. Refusing it instead means there is no projection in the ledger that a replay
+can roll back, and it costs an operator nothing they cannot see: the refusal names
+`source-revision-missing` per identity, and the valid siblings in the same batch still
+import.
+
+The one case a missing revision survives is an observation that changes nothing. It writes
+no projection, so there is no state for a revision to protect, and refusing every re-poll of
+a settled identity would be noise rather than a rollback worth reporting. After this change
+that case is reachable only for a link migrated from before the column existed whose
+`external_updated_at` was also NULL, since nothing else can enter the ledger unproven.
+
+One item carries at most 200 links of all types combined. Operator links, adapter imports, and fleet-run links claim from that one ceiling inside the writing transaction, so no caller can grow a single item's link set without limit and make every read that touches it expensive. Past the ceiling a link route returns 409 `link-conflict` and an import returns 409 `import-conflict`; no existing link is disturbed.
+
+The ceiling binds new writes only. A database written before it existed may hold an item over it, and that item is served rather than refused: every read path is cut by SQL, and an operator repairs the item by unlinking through the ordinary route on a running hub.
+
+`fleet-run` links are the one class ordinary execution grows on its own, so each item retains its most recent 50 of them and older ones expire when a new run is linked. Retention runs before the ceiling claim, so a busy item always has room for its next run instead of freezing at 200 and refusing every future one. It writes no `unlinked` event: this is storage policy, not an operator decision, and an event per expired run would only move the unbounded growth into the event log.
+
+Reads never load a whole link set to decide anything. Burn eligibility and effective acceptance come from a per-item SQL summary: the first non-eligible `source_policy` and the `source_acceptance_json` of the oldest eligible imported `github` or `brigade` link, read with `ORDER BY synced_at, link_id LIMIT 1`. That source link is the authority whenever operator acceptance is empty, including when its acceptance list is empty. A list page projects at most 50 links per item and sets `links_truncated` when it cut the set. Item detail returns one page of links with `links_next_cursor`. The full set is walked through that cursor.
+
+The per-item cut happens in SQL, not in Python. The list projection runs one indexed `WHERE work_id = ? ORDER BY synced_at, link_id LIMIT n + 1` query for each listed item. It returns at most 51 rows when `n` is 50, and the extra row is the only evidence needed to set `links_truncated`. This does not depend on the 200-link write ceiling holding: a database written before that ceiling existed can hold an item with far more links, and the page still costs its own budget rather than the item's history.
+
+GitHub keys use `owner/repository#number`. Brigade keys use a canonical repository identity plus the ledger task ID. Fleet run keys use `node_id/run_id`.
+
+`fleet-claim` is reserved. No first-release route creates it. Do not add a create path in any slice.
+
+`fleet-run` is created only by `POST /work/items/{work_id}/execution`.
+
+### `work_events`
+
+| Column | Type | Rules |
+| --- | --- | --- |
+| `work_id` | TEXT NOT NULL | foreign key with delete restricted |
+| `event_id` | TEXT NOT NULL | client key scoped to this item, or server-minted ID |
+| `event_type` | TEXT NOT NULL | bounded allowlist |
+| `from_status` | TEXT | required for transitions after creation |
+| `to_status` | TEXT | required for transitions |
+| `actor_type` | TEXT NOT NULL | `operator`, `node`, `adapter`, `system` |
+| `actor_id` | TEXT | authenticated or configured identity |
+| `node_id` | TEXT | authenticated node when applicable |
+| `run_id` | TEXT | associated Fleet Hub run when applicable |
+| `detail_json` | TEXT NOT NULL | bounded, event-specific safe fields |
+| `occurred_at` | TEXT NOT NULL | source timestamp |
+| `received_at` | TEXT NOT NULL | hub timestamp |
+| `seq` | INTEGER NOT NULL | hub-assigned insertion sequence. Server-internal ordering key, never returned in an event body |
+
+Primary key is `(work_id, event_id)`. A client-supplied `event_id` matching `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$` is stored as given and is unique only inside that `work_id`. Two items may reuse the same client key. Two events on one item may not. When the client omits the key, the server mints `evt-` plus 24 hex.
+
+Adapter observation events are the one event class an external source can grow without limit, so each item retains only its most recent 200 `sync-observed` and `sync-stale` events written with `actor_type=adapter`. The trim runs in the import transaction for the item that was just observed. Lifecycle events are never trimmed: `created`, `linked`, `unlinked`, `transitioned`, `execution-linked`, and every `attempt-*` event survive, as does any event an operator or node wrote. Adapter ownership is read from `work_links`, and the backfill that seeds it reads the `created` and `linked` events, so trimming observations never loses an ownership claim.
+
+`seq` is a monotonic counter assigned inside the writing transaction. It, not `occurred_at`, defines causal order, so an import batch that writes many events under one timestamp still reads back in the order it was written. Per-item event pages are ordered by `seq` ascending and their cursor carries only `seq`. The fleet-wide log stays reverse-chronological on `occurred_at` and breaks ties on `seq` descending, so its cursor carries `(occurred_at, seq)`. Cursors are opaque; `seq` is not part of any event response body.
+
+Required event types in the first release are `created`, `updated`, `transitioned`, `linked`, `unlinked`, `sync-observed`, `sync-stale`, `attempt-started`, `attempt-failed`, `attempt-reset`, and `execution-linked`.
+
+### `work_sync_cursors`
+
+| Column | Type | Rules |
+| --- | --- | --- |
+| `adapter_id` | TEXT PRIMARY KEY | configured source identity |
+| `source_type` | TEXT NOT NULL | `github` or `brigade` |
+| `owner_node` | TEXT NOT NULL | node id recorded on first successful import |
+| `cursor` | TEXT | opaque adapter cursor or content fingerprint |
+| `last_success_at` | TEXT | successful batch timestamp |
+| `last_error_code` | TEXT | bounded stable code, no raw error body |
+| `updated_at` | TEXT NOT NULL | hub timestamp |
+
+`adapter_id` must be its `source_type` followed by `:` and a bounded identifier (`github:escoffier-labs`, `brigade:rocinante`), so one source can never claim another's namespace. The first import that carries at least one observation records `owner_node` from the authenticated node (or `admin` when the admin token posts). An empty batch for an unclaimed `adapter_id` writes nothing at all, so it cannot reserve the namespace. Later imports from a different node return 403 `adapter-owner-mismatch` and do not write observations or the cursor.
+
+Importing is an operator-node authority, not an ordinary node one: `POST /work/imports` requires the admin token or a node listed in `fleet.worklore.operator_nodes`, so an enrolled but unlisted node cannot claim an adapter namespace at all. `admin` is a reserved node id for the same reason. It is the actor id and import owner the hub writes for the admin token, so a node presenting it would author events and own namespaces indistinguishable from the admin's. A node actor sending it is refused with 403 `forbidden`, and it is never accepted as a configured operator node.
+
+An external identity is `(work_id, link_type, external_key)`, never the external key alone. One item may carry the same key under two link types, an operator `url` link and an adapter-owned `github` link, say, and those are two separate identities: reading the key alone would let an adapter reach across types to claim an operator link, and let an eligible adapter link block the operator from deleting their own url.
+
+### `work_import_keys`
+
+| Column | Type | Rules |
+| --- | --- | --- |
+| `adapter_id` | TEXT NOT NULL | configured source identity |
+| `idempotency_key` | TEXT NOT NULL | client batch key, max 256 characters |
+| `fingerprint` | TEXT NOT NULL | SHA-256 hex of the canonical observation payload |
+| `created` | INTEGER NOT NULL | created count from the first accepted apply |
+| `updated` | INTEGER NOT NULL | updated count from the first accepted apply |
+| `unchanged` | INTEGER NOT NULL | unchanged count from the first accepted apply |
+| `refused` | INTEGER NOT NULL | per-identity refusals from the first accepted apply |
+| `received_at` | TEXT NOT NULL | hub timestamp of first accept |
+| `owner_node` | TEXT | node that owned the adapter on first accept, backfilled from `work_sync_cursors` |
+
+Primary key is `(adapter_id, idempotency_key)`. A replay with the same fingerprint returns the stored `created`, `updated`, `unchanged`, and `refused` counts from the first accepted apply. Refusal reasons are not stored, so a replay returns an empty `refused_details` array because it did not take those decisions. It recomputes `items` from current `work_links` rows matching the observation `external_key`s, updates `work_sync_cursors.last_success_at` and `updated_at`, and writes no observations or events. A replay with a different fingerprint returns 409 `import-conflict`. Keys survive later cursor advances.
+
+Keys are retained, not kept forever. Each accepted import expires keys past the most recent 500 for its adapter and the most recent 5,000 for its owning node, in the same transaction, indexed on `(adapter_id, received_at)` and `(owner_node, received_at)`. A replay inside the window returns its stored counts exactly. This is what keeps an adapter that posts an unchanged batch under a new key every minute from growing import-key storage without limit.
+
+A replay of an expired key is not short-circuited, because the key that proved it was a replay is gone. It is re-applied as a fresh batch, and `work_links.source_version` is what makes that safe: every observation in it is held against the high-water of its own external identity, so an expired batch carrying older observations than what a later batch already projected is refused per identity and reported in `refused`. It cannot roll the projection back to the state it captured. A re-applied batch whose observations are still the newest ones is applied and finds nothing to change, and reports the counts that apply produced, which may differ from the counts the original apply reported. A replayed observation that carries no usable revision is refused for the same reason, and so is the observation that would have created the identity in the first place, so there is no identity anywhere in the ledger for which replay is still last-write-wins. Both first-party adapters supply the revision when the source does. The GitHub adapter reports `updatedAt` and the Brigade adapter reports the task's `updated_at`, each emitted only when the hub can parse it as an instant. Neither fabricates one: a source record that reports no revision is passed through and refused by the hub, where the refusal is counted and named, rather than dropped in the adapter where nothing would report it.
+
+### `work_create_keys`
+
+| Column | Type | Rules |
+| --- | --- | --- |
+| `actor_id` | TEXT NOT NULL | operator identity (`admin` or the authenticated node id) |
+| `idempotency_key` | TEXT NOT NULL | `Idempotency-Key` header, max 256 characters |
+| `fingerprint` | TEXT NOT NULL | SHA-256 hex of the canonical native create payload |
+| `work_id` | TEXT NOT NULL | the item created on first accept |
+| `received_at` | TEXT NOT NULL | hub timestamp of first accept |
+
+Primary key is `(actor_id, idempotency_key)`. A replay with the same fingerprint returns the original item and writes no second `created` event. A replay with a different fingerprint returns 409 `import-conflict`. Keys are scoped per operator identity, so two operators may reuse the same key.
+
+Create keys are kept permanently, and that is deliberate. A row is written only by a create that actually minted an item, so the table holds exactly one identity row per durable work item that was created with an `Idempotency-Key`, and never more: replays return early and write nothing, and a create without the header writes no row at all. `work_id` is a foreign key with delete restricted, so a row cannot outlive its item or be quietly detached from it. That is the bound. There is no sweep, and there must not be one: unlike an import key, which a re-apply can safely reconstruct, expiring a create key would let a client retrying a create that already succeeded mint a second item. Permanent create idempotency is worth one bounded row per item.
+
+## Import observation schema
+
+The import envelope accepts only `adapter_id`, `source_type`, `idempotency_key`, and `observations`. Any other envelope key is 400 `unknown-field`. Each object in `observations` accepts only the keys in this table. Any other observation key is 400 `unknown-field`. Adapters drop provider-only fields such as `body` and `labels` after they derive `source_policy` and `acceptance`.
+
+| Key | Required | Stored on | Later observation |
+| --- | --- | --- | --- |
+| `external_key` | yes | `work_links.external_key` | identity, never rewritten |
+| `link_type` | yes | `work_links.link_type` | must stay `github` or `brigade` |
+| `title` | yes | `work_items.title` | refreshed. Source-authoritative |
+| `source_policy` | yes | `work_links.source_policy` | refreshed |
+| `description` | no | `work_items.description` on first create only | dropped |
+| `acceptance` | no | `work_links.source_acceptance_json` | refreshed. Never writes operator `acceptance` |
+| `external_state` | no | `work_links.external_state` | refreshed |
+| `external_updated_at` | no | `work_links.external_updated_at` | refreshed |
+| `url` | no | `work_links.url` | refreshed. `https` only |
+| `display_ref` | no | `work_links.display_ref` | refreshed |
+| `proposed_status` | no | `work_events.detail_json` on `sync-observed` | stored only. Never applied |
+| `priority` | no | `work_events.detail_json` on `sync-observed` | source metadata only. Never writes Worklore `priority` |
+| `dependencies` | no | `work_events.detail_json` on `sync-observed` | stored only |
+| `evidence_refs` | no | `work_events.detail_json` on `sync-observed` | stored only |
+| `stale` | no | `work_links.stale_at` when true | appends `sync-stale` |
+
+`source_policy` values: `eligible`, `label-removed`, `closed`, `completed`.
+
+`proposed_status` values when present: `completed`.
+
+`dependencies` items are `{ "type": "...", "id": "..." }` with both strings bounded to 128 characters.
+
+`evidence_refs` items match `^[A-Za-z0-9._-]{1,128}$`.
+
+## HTTP contract
+
+All responses are JSON unless noted. Unknown request fields are rejected. Request bodies use the existing Fleet Hub size limit, with Worklore endpoints applying smaller per-field bounds. Mutation bodies max 262144 bytes. Import bodies max 1048576 bytes.
+
+Error envelope:
+
+```json
+{ "error": "bounded operator text", "code": "stable-code" }
+```
+
+Stable codes: `unauthorized`, `forbidden`, `not-found`, `version-conflict`, `if-match-required`, `invalid-transition`, `unknown-field`, `field-bound`, `private-data`, `acceptance-required`, `import-conflict`, `adapter-owner-mismatch`, `execution-mismatch`, `attempt-forbidden`, `link-forbidden`, `link-conflict`, `hub-unavailable`, `internal-error`.
+
+- 400 `private-data`: a durable string carried a private home path (`/home`, `/Users`, a Windows user profile) or a credential-shaped value, including URL userinfo. Bounds, types, and control characters stay 400 `field-bound`.
+
+- 403 `link-forbidden`: the link type is fleet managed (`fleet-run`, `fleet-claim`), or the link is adapter-owned and its `source_policy` is still `eligible`.
+- 409 `link-conflict`: that `(link_type, external_key)` already belongs to a work item, including a `fleet-run` already joined to a different item.
+- 500 `internal-error`: an unexpected SQLite failure. The `error` string is the fixed text `internal error`; SQLite messages are never echoed to the caller.
+
+`If-Match` is the decimal integer `version` as a string (`1`, `2`, ...). It is required on `PATCH /work/items/{work_id}`, `POST /work/items/{work_id}/transitions`, and `POST /work/items/{work_id}/attempts`. It is optional on `DELETE /work/items/{work_id}/links/{link_id}`. A supplied stale value on any of those routes returns 409 `version-conflict`; a missing required header returns 400 `if-match-required`.
+
+Configured operator nodes and the admin token may mutate Worklore routes without `--allow-admin-writes`. That flag stays scoped to `POST /events` and `POST /claims` (`src/brigade/fleet_hub_http.py:575-584`). This is a deliberate Worklore exception. The admin token remains a backwards-compatible override. Normal Ops Deck and CLI work uses an enrolled node token listed in `fleet.worklore.operator_nodes` (optional bounded override: `BRIGADE_WORKLORE_OPERATOR_NODES`). Do not require or deploy the shared Hub admin token for Ops Deck.
+
+The read-only dashboard cookie does not authorize JSON routes. `_caller` in `src/brigade/fleet_hub_http.py:155-173` is bearer-only.
+
+### Read routes
+
+- `GET /work/items`: admin, operator node, or ordinary node token. Query: `status`, `kind`, `burn_eligible`, `source` (`github` / `brigade` / `native`), `limit` (1-100, default 50), `cursor`.
+- `GET /work/items/{work_id}`: admin, operator node, or ordinary node token. Item, one page of links, and up to 20 recent events, all cut by the database rather than read whole and sliced. Query: `links_limit` (1-100, default 50), `links_cursor`.
+- `GET /work/items/{work_id}/events`: admin, operator node, or ordinary node token. Cursor-paginated events for one item in hub insertion order.
+- `GET /work/events`: admin, operator node, or ordinary node token. Fleet-wide reverse-chronological sprint log. Query: `limit` (1-100, default 50), `cursor`, optional `work_id`, optional `event_type`.
+- `GET /work/queue/burn`: admin, operator node, or ordinary node token. Eligible items in deterministic order plus exclusion counts. Query: `limit` (1-100, default 50), `cursor`.
+
+`GET /work/queue/burn` is paged the same way. One read returns at most `limit` eligible items and examines at most 2,000 item rows in burn order, so a ledger that has grown without limit still answers in bounded time. `exclusions` counts the rows that read examined; a caller that wants whole-ledger totals follows `next_cursor` to the end and sums them, and a ledger smaller than one page reports them in a single read. A page loads links only for the item ids on that page.
+
+`GET /work/items` is paged. A reconciling adapter must follow `next_cursor` to the end of the listing, not read only the first page, or it cannot see label removal and staleness past the first `limit` items. `source=github` or `source=brigade` returns items that have at least one link of that type. `source=native` returns items with no `github` or `brigade` link. An unfiltered page reads directly from the item keyset. A filtered page examines at most 2,000 candidates in that same keyset order, and its source check is one indexed probe per candidate. If that budget ends before the page fills, the response can contain fewer than `limit` items but still carries the cursor of the last scanned row; callers continue from that cursor rather than treating an empty page as terminal. List items always include a `links` array so adapters can read `external_key` and `source_policy`, bounded to the first 50 links per item with `links_truncated` set when the set was cut. An adapter that sees `links_truncated` reads the rest through `GET /work/items/{work_id}` and its `links_next_cursor`.
+
+`GET /work/events` uses the same rule whenever `work_id` or `event_type` is supplied: it examines at most 2,000 reverse-chronological candidates and advances the cursor through the last scanned event, including on a sparse or empty filtered page. The unfiltered sprint log remains a direct indexed keyset page.
+
+`GET /work/items/{work_id}` returns links keyed on `(synced_at, link_id)` with `links_next_cursor`. A caller that follows that cursor to the end sees every link on the item exactly once, and one read costs a page rather than the item's whole link set.
+
+### Mutation routes
+
+- `POST /work/items`: admin token or configured operator node token. Creates a native item and its `created` event in one transaction. Optional `Idempotency-Key` (1-256 characters) is keyed by operator identity. Same key and same payload returns the original item with no second event. Same key and a different payload returns 409 `import-conflict`.
+- `PATCH /work/items/{work_id}`: admin token or configured operator node token. Requires `If-Match`.
+- `POST /work/items/{work_id}/transitions`: admin token or configured operator node token. Requires `If-Match`. Validates the lifecycle edge and appends the event in one transaction.
+- `POST /work/items/{work_id}/attempts`: body `{ "action", "run_id"? }` with `action` in `{started, failed, reset}`. Requires `If-Match`. `node_id` is the authenticated caller, not a body field. `reset` is admin or operator-node and sets `attempt_count` to 0. `started` appends `attempt-started`, increments `version`, and does not change `attempt_count`. `failed` increments `attempt_count` and `version` and appends `attempt-failed`. A node may send `started` or `failed` only when `run_id` names a `fleet-run` link whose `external_key` is `{node_id}/{run_id}`. Otherwise 403 `attempt-forbidden`.
+- `POST /work/items/{work_id}/links`: admin token or configured operator node token. Operator-managed `url`, `github`, or `brigade` links. Sets `synced_at` to hub `received_at`. Rejects `fleet-run` and `fleet-claim`.
+- `DELETE /work/items/{work_id}/links/{link_id}`: admin token or configured operator node token. Optional `If-Match` guards against a stale item version and returns 409 `version-conflict` when it does not match. Removes a link and records exactly one `unlinked` event. Work items are never deleted, and no scheduling field (`burn_rank`, `review_after`, `spend_by`, `ready_at`, `attempt_count`) changes. An adapter-owned `github` or `brigade` link may be removed only once its `source_policy` has left `eligible`; an eligible adapter link is 403 `link-forbidden`. Deleting the last non-eligible source link is how an operator converts an item to native, and that event's detail carries `became_native: true`.
+- `POST /work/imports`: admin token or configured operator node token. Body `{adapter_id, source_type, idempotency_key, observations}` with up to 500 observations. Each observation's `link_type` must equal the batch `source_type`. Returns `created`, `updated`, `unchanged`, `refused`, up to 20 `refused_details` (`external_key`, `link_type`, `reason`), and the observed items. A refusal is per identity and never aborts the batch: an identity an operator already linked by hand has no adapter owner and is refused `operator-managed-identity` while its valid siblings import, and an observation that cannot prove it is newer than the projection is refused `source-revision-stale`, `source-revision-missing`, or `source-revision-not-advanced`. There is still no adapter adoption of operator-managed links. A conflict that is about the batch rather than one identity, an identity owned by a different adapter or a different node, still returns 409 `import-conflict` or 403 `adapter-owner-mismatch`. A replay inside the key window returns the stored counts and an empty `refused_details` array because refusal reasons are not stored.
+- `POST /work/items/{work_id}/execution`: node token or admin token. Body `{ "node_id", "run_id" }`. The hub verifies that the run exists in Fleet Hub `events` for that node. A node may link only its own `node_id`. An admin may link any existing `(node_id, run_id)` so a mislinked run can be repaired. The hub decides that from the authenticated caller's admin flag, never from a reserved `actor_id` string, and the `execution-linked` event uses the same `actor_type` rule as every other route.
+
+An authenticated node is marked operator only when its `node_id` is in `fleet.worklore.operator_nodes` or the bounded `BRIGADE_WORKLORE_OPERATOR_NODES` override (comma-separated, max 32 ids, each matching `[A-Za-z0-9._-]{1,128}`, never `unknown` and never the reserved `admin`). Operator-node audit events keep that `node_id` and use `actor_type=operator`. Admin-token events keep `actor_id=admin` and `node_id` unset.
+
+### Request and response shapes
+
+Create body:
+
+```json
+{
+  "title": "Rotate NAS restic password",
+  "kind": "fleet",
+  "description": "",
+  "scope": "",
+  "priority": "normal",
+  "burn_eligible": false,
+  "burn_rank": 1000,
+  "token_appetite": "medium",
+  "execution_mode": "manual",
+  "acceptance": [],
+  "blocker": null,
+  "review_after": null,
+  "spend_by": null
+}
+```
+
+Only `title` and `kind` are required. Other keys use the create defaults.
+
+Patch body: any create-body field except `kind`. Unknown keys are rejected.
+
+Item object:
+
+```json
+{
+  "work_id": "wl-0123456789abcdef01234567",
+  "title": "Rotate NAS restic password",
+  "description": "",
+  "kind": "fleet",
+  "scope": null,
+  "status": "captured",
+  "priority": "normal",
+  "burn_eligible": false,
+  "burn_rank": 1000,
+  "token_appetite": "medium",
+  "execution_mode": "manual",
+  "acceptance": [],
+  "effective_acceptance": [],
+  "blocker": null,
+  "review_after": null,
+  "spend_by": null,
+  "ready_at": null,
+  "attempt_count": 0,
+  "version": 1,
+  "created_at": "2026-08-29T00:00:00+00:00",
+  "updated_at": "2026-08-29T00:00:00+00:00",
+  "archived_at": null
+}
+```
+
+Link object:
+
+```json
+{
+  "link_id": "lnk-0123456789abcdef01234567",
+  "work_id": "wl-0123456789abcdef01234567",
+  "link_type": "github",
+  "external_key": "escoffier-labs/brigade#1",
+  "display_ref": "escoffier-labs/brigade#1",
+  "url": "https://github.com/escoffier-labs/brigade/issues/1",
+  "external_state": "open",
+  "external_updated_at": "2026-08-29T00:00:00+00:00",
+  "source_policy": "eligible",
+  "source_acceptance": ["tests pass"],
+  "synced_at": "2026-08-29T00:00:00+00:00",
+  "stale_at": null
+}
+```
+
+Event object:
+
+```json
+{
+  "event_id": "evt-0123456789abcdef01234567",
+  "work_id": "wl-0123456789abcdef01234567",
+  "event_type": "created",
+  "from_status": null,
+  "to_status": "captured",
+  "actor_type": "operator",
+  "actor_id": "admin",
+  "node_id": null,
+  "run_id": null,
+  "detail": {},
+  "occurred_at": "2026-08-29T00:00:00+00:00",
+  "received_at": "2026-08-29T00:00:00+00:00"
+}
+```
+
+`GET /work/items` 200: `{ "items": [ { ...Item, "links": [Link], "links_truncated": false } ], "next_cursor": null }`.
+
+`GET /work/items/{work_id}` 200: `{ "item": Item, "links": [Link], "links_next_cursor": null, "recent_events": [Event] }`.
+
+`GET /work/items/{work_id}/events` and `GET /work/events` 200: `{ "events": [Event], "next_cursor": null }`.
+
+`GET /work/queue/burn` 200:
+
+```json
+{
+  "items": [Item],
+  "next_cursor": null,
+  "exclusions": {
+    "acceptance-required": 0,
+    "not-ready": 0,
+    "not-eligible": 0,
+    "manual-mode": 0,
+    "blocker": 0,
+    "attempt-limit": 0,
+    "review-after": 0,
+    "source-policy": 0
+  }
+}
+```
+
+An item is counted in exactly one exclusion bucket. Check in this order and stop at the first failure:
+
+1. `not-ready` when `status` is not `ready`
+2. `not-eligible` when `burn_eligible` is false
+3. `acceptance-required` when effective acceptance is empty or longer than twenty criteria
+4. `manual-mode` when `execution_mode` is `manual`
+5. `blocker` when an unresolved blocker is recorded
+6. `attempt-limit` when `attempt_count >= 2`
+7. `review-after` when `review_after` is in the future
+8. `source-policy` when any link has `source_policy` other than `eligible`
+
+`POST /work/items` 201: `{ "item": Item }`.
+
+`PATCH` and transition and attempt 200: `{ "item": Item }`.
+
+`POST /work/items/{work_id}/attempts` body:
+
+```json
+{ "action": "failed", "run_id": "run-1" }
+```
+
+`action` is required. `run_id` is required when the caller is a node and omitted for admin `reset`. Admin `started` and `failed` may omit `run_id`.
+
+`POST /work/items/{work_id}/links` 201: `{ "link": Link }`.
+
+`DELETE .../links/{link_id}` 200: `{ "ok": true }`.
+
+`POST /work/items/{work_id}/execution` 201: `{ "link": Link }` with `link_type=fleet-run`.
+
+`POST /work/imports` body:
+
+```json
+{
+  "adapter_id": "github:escoffier-labs",
+  "source_type": "github",
+  "idempotency_key": "github:escoffier-labs:0123456789abcdef01234567",
+  "observations": [
+    {
+      "external_key": "escoffier-labs/brigade#1",
+      "link_type": "github",
+      "title": "Burn queue item",
+      "source_policy": "eligible",
+      "description": "Do the work",
+      "acceptance": ["tests pass"],
+      "external_state": "open",
+      "external_updated_at": "2026-08-29T00:00:00+00:00",
+      "url": "https://github.com/escoffier-labs/brigade/issues/1",
+      "display_ref": "escoffier-labs/brigade#1",
+      "proposed_status": null
+    }
+  ]
+}
+```
+
+`POST /work/imports` 200: `{ "created": 1, "updated": 0, "unchanged": 0, "refused": 0, "refused_details": [], "items": [ { "work_id": "wl-...", "external_key": "escoffier-labs/brigade#1" } ] }`. A same-fingerprint replay returns the stored counts and an empty `refused_details` array, recomputes `items` as defined on `work_import_keys`, and still advances the cursor timestamps.
+
+Ops Deck API uses a server-held admin credential for browser mutations and never sends that credential to the browser. Every `/api/worklore` route, including GET, requires `X-API-Key`.
+
+## Source adapters
+
+Adapters normalize records and send idempotent batches to `POST /work/imports`. They do not write the Fleet Hub database directly. `import_batch` and `list_items` live in the core client only.
+
+### Native adapter
+
+Ops Deck creates native items through its API proxy. Native items can later gain GitHub, Brigade, or Fleet execution links without changing identity.
+
+### GitHub adapter
+
+The adapter discovers issues labeled `burn-queue` from configured organizations using the approved GitHub read path. It sends the issue identity, title, body-derived source acceptance, open or closed state, URL, source timestamp, and `source_policy`. GitHub credentials stay on the node running the adapter.
+
+The first observation creates a Worklore item with default scheduling metadata and writes source acceptance on the link. Later observations update only externally authoritative fields and the link snapshot, including `source_acceptance` and `source_policy`. Removing the label marks `source_policy=label-removed`. Closing an issue marks `source_policy=closed` and may send `proposed_status=completed`. The adapter never POSTs a transition. A 404 received through octopool is inconclusive and does not set `stale_at`. A 404 received through direct `gh` sets `stale_at` and appends `sync-stale`.
+
+### Brigade adapter
+
+The adapter reads selected local `.brigade/work/tasks.json` ledgers through Brigade's public task command and sends normalized task identity, text, source acceptance, dependencies, source priority, status, and evidence references. It never sends absolute paths or raw receipt contents.
+
+Selection is explicit by configured target. Worklore does not crawl a home directory for `.brigade` folders. A completed Brigade task records `source_policy=completed` and may send `proposed_status=completed`. The Worklore transition follows the same operator rule as GitHub.
+
+## Ops Deck integration
+
+Ops Deck API adds a narrow proxy under `/api/worklore`. Every method requires `X-API-Key`.
+
+- `GET /api/worklore/items`
+- `GET /api/worklore/items/{work_id}`
+- `GET /api/worklore/items/{work_id}/events`
+- `GET /api/worklore/events`
+- `GET /api/worklore/queue/burn`
+- `POST /api/worklore/items`
+- `PATCH /api/worklore/items/{work_id}`
+- `POST /api/worklore/items/{work_id}/transitions`
+- `POST /api/worklore/items/{work_id}/attempts`
+
+The API validates browser input before forwarding it and maps upstream connection failures to 503 with a stable error code. It does not cache mutations. Read requests may return a clearly marked last-known-good snapshot when Fleet Hub is unavailable. The snapshot file mode is `0600`.
+
+The existing Tasks page gains 3 views:
+
+- `Burn Queue`: eligible items, exclusion summary, token appetite, attempt count, and source.
+- `Work Board`: columns driven by Worklore status.
+- `Sprint Log`: `GET /api/worklore/events`, reverse-chronological, with item, transition, actor, run, and outcome links.
+
+The stale `tracking/backlog.json` route remains available during migration. It is removed only after native records are imported and the Worklore view has passed acceptance checks.
+
+## Failure and concurrency behavior
+
+- Fleet Hub downtime never blocks local GitHub, Brigade, or manual work. It blocks new canonical native mutations until the service returns.
+- Adapter batches are idempotent through `work_import_keys`. A failed batch can be retried without duplicate items, links, or events, including after a newer batch has advanced the cursor. Once the key has expired, the retry is re-applied rather than short-circuited, and `work_links.source_version` holds it to the per-identity high-water so it cannot roll a newer projection back.
+- Adapters retain a local retry receipt, not a copy of the Worklore database. The first release uses explicit retry rather than a background daemon. Receipt filenames replace `:`, `/`, `\`, `<`, `>`, `"`, `|`, `?`, and `*` with `-`. File mode is `0600`.
+- Each item mutation and its event append share one SQLite transaction.
+- Optimistic version checks prevent 2 Ops Deck sessions from silently overwriting each other.
+- Import conflict resolution follows the authority table. Conflicts produce a stable error or a `sync-observed` event. They never select a winner by arrival time.
+- Newer database versions fail closed under the existing Fleet Hub migration policy.
+- Worklore tables use foreign keys and indexes for status, burn eligibility, ready time, event work ID, external identity, adapter ownership, and burn order.
+- Imported identities are bounded per adapter (20,000 links) and per owning node (100,000 links). Past a ceiling an import refuses a new identity with 409 `import-conflict` and still accepts updates to work the adapter already imported.
+- Links are bounded per item (200 across all types), import keys are retained per adapter (500) and per owning node (5,000), and adapter observation events are retained per item (200). Native create keys are the one deliberate exception: they are permanent, at exactly one row per durable item, because expiring one would permit a duplicate create. No adapter, operator, or node can grow Worklore storage or read cost without limit, and no bound is reachable by ordinary use: a normal item carries 1 to 3 links and a normal adapter posts one batch per sync.
+- Migration holds existing rows to those ceilings rather than assuming they were written under them, and pays for each reconciliation according to what it costs. Schema setup prunes import keys and adapter observation events to their retention windows across every adapter, owner, and item, including partitions no recent import touched; that pass stays on every start, because an adapter that goes quiet leaves rows nothing else revisits, but it first names the over-quota partitions with an indexed aggregate, so a healthy hub finds none and writes nothing. Seeding `source_version` on identities imported before the column existed reads every imported link, so it runs once: `work_schema_meta` records the reconciliation version a database has completed and a hub that has done the work skips past it.
+- Links are not pruned. Each one is a distinct external identity, and dropping some would detach real imported work and free the identity for another adapter to claim. Nor does a database already over the 200-link ceiling refuse to start. Reads of an over-ceiling item are cut by SQL rather than by trusting the ceiling, new writes still enforce it, and the operator unlinks the excess through the ordinary route on a running hub. Refusing at startup instead would take the hub down and leave no running route to repair it with.
+- Every durable native text field (`title`, `description`, `scope`, each `acceptance` item, `blocker`) runs through the same private-path and credential checks as an imported observation, on create and on patch. A leak returns 422 `private-data` and nothing is written.
+- One GitHub sync run spends at most 200 issue refreshes and 300 seconds of reconciliation across every configured organization. Links left unrefreshed are reported in `skipped` and picked up by the next run.
+
+## Privacy and security
+
+- Admin credentials remain on trusted servers for node enrollment. They are not required for Ops Deck or `brigade fleet work` mutations.
+- Ordinary node tokens may read the ledger and link their own runs. They cannot import, edit scheduling metadata, transition work, or reset attempt counts.
+- Configured operator nodes use the same enrolled node token. They may import adapter batches, create, patch, transition, reset attempts, and manage operator links. Audit events from those nodes keep the node identity and use `actor_type=operator`. Adapter sync hosts must therefore be listed in `fleet.worklore.operator_nodes`.
+- Titles and descriptions are treated as untrusted text when rendered.
+- One canonical observation validator runs before every imported create and update, so a link created by a safe batch cannot be mutated by a later unsafe one. It rejects control characters, credential-shaped values, private home paths, malformed URLs and URL userinfo, over-long acceptance strings, and over-long acceptance, dependency, and evidence-reference lists, as well as raw prompts, transcripts, and receipt bodies.
+- URLs must use `https` and are rendered with escaping and safe link attributes.
+- API errors contain stable codes and bounded descriptions. They do not return SQLite errors, tokens, filesystem paths, or upstream response bodies.
+- SQLite exports omit private actor details unless the authenticated admin explicitly requests them.
+
+## Delivery slices
+
+### Slice 1: Native ledger and API
+
+Add isolated Worklore store, validation, migrations, native CRUD, transitions, attempts, event history, burn selection, `import_batch`, `list_items`, and CLI/API contract tests. Integrate with Fleet Hub routing only after the integration precondition passes.
+
+### Slice 2: GitHub adapter
+
+Add explicit synchronization of configured `burn-queue` issues, external identity dedupe, stale-link behavior, and source-policy exclusions. This slice imports core client functions. It does not add them.
+
+### Slice 3: Brigade adapter
+
+Add explicit target configuration, normalized ledger observations, dependency and evidence references, and source-state proposals. This slice imports core client functions. It does not add them.
+
+### Slice 4: Ops Deck
+
+Add the authenticated API proxy, Burn Queue, Work Board, Sprint Log, native item editor, stale-read behavior, and migration from the legacy JSON backlog.
+
+Each slice has its own implementation plan and can ship behind a disabled-by-default route or UI flag. No slice requires automatic dispatch.
+
+## Acceptance criteria
+
+- A native fleet-maintenance item can be created without a repository and appears in the burn queue after it becomes ready.
+- The same GitHub issue observed twice creates one item, one link, and no duplicate observation event for an identical source revision.
+- The same Brigade task observed from 2 nodes resolves to one external link.
+- Worklore scheduling edits and operator acceptance survive later external synchronization.
+- An item without effective acceptance criteria cannot enter `ready` or the burn queue.
+- A second failed burn attempt excludes the item until an operator records `attempt-reset` through `POST /work/items/{work_id}/attempts`.
+- Concurrent edits with the same version yield one success and one 409 conflict. A missing `If-Match` on PATCH, transition, or attempt yields 400 `if-match-required`.
+- A node cannot link another node's run to an item. An admin can repair a mislinked run.
+- Fleet Hub unavailability leaves local source work usable and produces an explicit retryable adapter failure.
+- Ops Deck can display a last-known-good read snapshot but cannot report a stale mutation as successful. Unauthenticated `/api/worklore` reads fail.
+- Existing Fleet Hub events, claims, cloud leases, model leases, dashboards, and CLI behavior pass unchanged.
+
+## Pressure-test decisions
+
+The following calls were made in sous mode after the operator authorized all 3 sources.
+
+- `evidence`: Host Worklore in Fleet Hub because the process already provides authenticated fleet access, SQLite WAL storage, schema migrations, and node identity.
+- `judgment`: Keep Worklore in separate modules and tables because planning records have a different retention and authority model from expiring claims and replicated run events.
+- `stated-constraint`: Support native, GitHub, and Brigade work. The operator explicitly authorized all 3 rather than selecting a native-only first product.
+- `judgment`: Deliver the sources in separate slices. This reduces conflict with concurrent Fleet Hub work and gives each adapter an independently testable contract.
+- `evidence`: Keep GitHub credentials off the hub. The current fleet design stores dedicated fleet credentials and treats nodes as authenticated producers.
+- `judgment`: Make imports node-side normalized batches. This avoids provisioning unrelated provider credentials on the hub and matches the current store-and-forward direction.
+- `evidence`: Keep Ops Deck API as a proxy. Its current Tasks page already consumes HTTP data, while the API already protects write routes with a server-side credential.
+- `judgment`: Require operator transitions for externally proposed completion in the first release. This avoids silently closing a cross-source item before evidence rules are defined.
+- `judgment`: Treat Worklore admin mutations as an explicit exception to `--allow-admin-writes`, which remains a guard for event and claim impersonation.
+
+## Deferred decisions
+
+These do not block the first 4 slices:
+
+- automatic dispatch from `GET /work/queue/burn`
+- recurrence rules for maintenance work
+- bulk editing and saved filters
+- notifications when a reset window opens
+- long-term archival outside Fleet Hub SQLite
+- automatic completion policies based on merged pull requests or Brigade verification receipts
+- a first-release HTTP route that creates `fleet-claim` links

--- a/docs/phase-worklore-opsdeck-plan.md
+++ b/docs/phase-worklore-opsdeck-plan.md
@@ -1,0 +1,669 @@
+# Worklore Ops Deck implementation plan
+
+## Goal
+
+Add the Ops Deck API proxy and the Tasks page Burn Queue, Work Board, and
+Sprint Log so an operator can create, edit, defer, and archive native
+Worklore items without sending a Fleet Hub credential to the browser.
+Execute the tasks in order and check every box.
+
+Contract: Ops Deck talks to Fleet Hub with an enrolled operator node
+token, never the shared Hub admin token. Hub authorization is the
+Worklore-only operator role from `fleet.worklore.operator_nodes` (optional
+bounded override `BRIGADE_WORKLORE_OPERATOR_NODES`). The admin token
+remains a backwards-compatible Hub override and is not required or
+deployed for Ops Deck. Native `POST /work/items` accepts `Idempotency-Key`.
+
+Approved design: `docs/phase-worklore-ledger.md`.
+
+This plan is independently executable in the `opsdeck-api` and `opsdeck`
+repositories. Those checkouts are not siblings of every Brigade worktree.
+Resolve them in this order and stop with a missing-checkout error if none
+exist:
+
+1. `WORKLORE_OPSDECK_API` and `WORKLORE_OPSDECK` when both are set and
+   are directories
+2. Peer directories named `opsdeck-api` and `opsdeck` next to
+   `git rev-parse --show-toplevel`
+3. Peer directories next to the parent of
+   `git rev-parse --git-common-dir`
+
+Do not search `$HOME`. Tests fake Fleet Hub HTTP. They do not edit
+Brigade source. Read those repos' `AGENTS.md` files before any edit.
+`opsdeck-api` is a single-file Express 5 server plus extracted modules
+such as `auth.js`. `opsdeck` is the React 19 SPA. Commits in those repos
+use conventional messages and never add `Co-Authored-By` trailers
+(`opsdeck-api/AGENTS.md:36`, `opsdeck/AGENTS.md:46`).
+
+## Architecture
+
+- `opsdeck-api/worklore.js` validates browser input, forwards `/api/worklore`
+  to Fleet Hub `/work`, and keeps a last-known-good read snapshot. It
+  holds no canonical Worklore rows.
+- `opsdeck-api/atomic-write.js` exports `atomicWriteFile` and
+  `atomicWriteJson`. `server.js` today keeps those functions module-local
+  at `server.js:188-197` and has no exports. Move them to the shared
+  module and import them from `server.js` and `worklore.js`.
+- `opsdeck-api/auth.js` gains a protected GET prefix for `/api/worklore`.
+- `opsdeck-api/server.js` mounts the routes and leaves `/api/backlog` and
+  `/api/tasks` in place.
+- `opsdeck/src/lib/worklore.ts` owns types and view helpers.
+- `opsdeck/src/pages/Tasks.tsx` adds three Worklore views behind
+  `VITE_WORKLORE_ENABLED=1` and keeps the current sprint and portfolio
+  views.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| Create `opsdeck-api/atomic-write.js` | Shared `atomicWriteFile` / `atomicWriteJson`. |
+| Create `opsdeck-api/worklore.js` | Proxy, snapshot, input bounds, stable errors. |
+| Create `opsdeck-api/worklore.test.js` | Unit tests with a fake hub. No live :8005. |
+| Modify `opsdeck-api/server.js` | Import atomic-write, mount `/api/worklore`, keep backlog routes. |
+| Modify `opsdeck-api/auth.js` | Require `X-API-Key` on `/api/worklore` GET. |
+| Modify `opsdeck-api/auth.test.js` | GET `/api/worklore` requires the key. |
+| Modify `opsdeck-api/server.test.js` | Spawned-server integration with an in-process fake hub. |
+| Modify `opsdeck-api/package.json` | Add `worklore.test.js` to `npm test`. |
+| Create `opsdeck/src/lib/worklore.ts` | Types, board columns, burn sort display. |
+| Create `opsdeck/src/lib/__tests__/worklore.test.ts` | Pure helper tests. |
+| Modify `opsdeck/src/pages/Tasks.tsx` | Burn Queue, Work Board, Sprint Log, native editor. |
+| Create `opsdeck/src/pages/__tests__/Tasks.test.tsx` | View rendering and stale-mutation guards. |
+| Modify `opsdeck/src/hooks/useApi.ts` | `apiFetch` keeps the JSON `code` on thrown errors. |
+
+## Pinned decisions
+
+- Feature flags: API routes exist only when `process.env.WORKLORE_ENABLED === '1'`.
+  UI Worklore views exist only when `import.meta.env.VITE_WORKLORE_ENABLED === '1'`.
+  Default is off.
+- Hub settings: `FLEET_HUB_URL` and an enrolled operator node token
+  (`FLEET_HUB_NODE_TOKEN` or the equivalent node-token setting) are
+  environment variables on the API process. The browser never receives
+  them. Do not set or deploy `FLEET_HUB_ADMIN_TOKEN` for Ops Deck.
+  `useApi.ts` continues to send `X-API-Key` from `src/lib/apiKey.ts`.
+- Auth: add `PROTECTED_GET_PREFIXES = ['/api/worklore']` to `auth.js`.
+  `requiresApiKey` returns true for every `/api/worklore` path, including
+  GET. POST and PATCH already require the key. Missing `OPSDECK_API_KEY`
+  still returns 503 `{ error: "API key is not configured" }`. Current
+  `auth.js:1-9` leaves ordinary GET open, so a GET-open assertion would
+  pass today. The new prefix is what makes the red test real.
+- Proxy timeout is 3000 ms. Connection failure, DNS failure, and timeout
+  map to HTTP 503 `{ error: "hub-unavailable", code: "hub-unavailable" }`
+  with no hub URL or token. Upstream 4xx JSON `code` is forwarded when it
+  is one of the core stable codes. Upstream bodies are otherwise dropped.
+- Read snapshot path is `process.env.WORKLORE_SNAPSHOT_PATH` or
+  `{XDG_CACHE_HOME || "$HOME/.cache"}/opsdeck-api/worklore-snapshot.json`.
+  Create the snapshot directory first with
+  `mkdir(parent, { recursive: true, mode: 0o700 })`, then `chmod` that
+  parent to `0o700` so an already-existing directory is not left at the
+  umask default. `atomicWriteFile` writes `${filePath}.tmp` through
+  `writeFile` with `{ mode: 0o600 }` and then renames. Do not rely on a
+  post-rename `chmod 0600` as the only file-mode control. Successful GET `/work/items`, GET `/work/events`,
+  and GET `/work/queue/burn` replace the snapshot. Failed GETs return the
+  snapshot plus `{ stale: true, source: "snapshot" }`. Failed POST or
+  PATCH never return 200 from a snapshot.
+- Browser create body may include `title`, `description`, `kind`,
+  `scope`, `priority`, `burn_eligible`, `burn_rank`, `token_appetite`,
+  `execution_mode`, `acceptance`, `blocker`, `review_after`, and
+  `spend_by` only. Unknown fields return 400 `{ code: "unknown-field" }`
+  without calling the hub. `acceptance` is the operator field and stays
+  `acceptance` on the Fleet Hub HTTP API. Fleet Hub maps it internally to
+  the private `work_items.acceptance_json` storage column.
+- Title 1-240 characters. Description max 8000. Acceptance 0-20 strings
+  of max 400 characters. The API does not invent acceptance for the
+  operator.
+- Board columns: `captured`, `defining`, `ready`, `claimed`, `running`,
+  `verifying`, `deferred`, `blocked`, `completed`, `canceled`. Archived
+  items stay behind the existing archive toggle.
+- `/api/backlog` and the sprint view remain until native records are
+  imported and the Worklore views have passed the tests in this plan.
+  Do not delete `tracking/backlog.json` handling in this slice.
+- CORS already allows `X-API-Key`. In the same `server.js` edit, add
+  `PATCH` to `Access-Control-Allow-Methods` at `server.js:63` and
+  `If-Match` to `Access-Control-Allow-Headers` at `server.js:64`.
+- `apiFetch` in `opsdeck/src/hooks/useApi.ts` currently throws
+  `Error(\`${r.status} ${r.statusText}\`)` and discards the body. Change
+  it so a JSON error body with a stable `code` is preserved on the thrown
+  Error (message includes `code`; keep `${status} ${statusText}` only as
+  fallback). Mutations keep using `apiFetch`.
+- `BIND_HOST=0.0.0.0` behavior stays. Do not hardcode LAN hosts in the
+  SPA. Keep `window.location.hostname` from `src/hooks/useApi.ts`.
+- Verification for `opsdeck-api` unit tests does not need a process on
+  port 8005. Integration tests spawn `server.js` the way
+  `startCronTestServer` does in `server.test.js:53-103`. That helper
+  cannot receive a JavaScript `hubHandler`. Stand up
+  `http.createServer` in the parent process and pass its URL as
+  `FLEET_HUB_URL` in the child env.
+- `isWorkloreEnabled(flag)` takes an optional string. When omitted it
+  reads `import.meta.env.VITE_WORKLORE_ENABLED`.
+- Verification for `opsdeck` is `./scripts/verify` from that repo root.
+
+## Task 1: API proxy and snapshot
+
+**Working directory:** `opsdeck-api` repo root
+
+**Files:**
+
+- Create: `atomic-write.js`
+- Create: `worklore.js`
+- Create: `worklore.test.js`
+- Modify: `package.json` `scripts.test`
+
+- [x] Write the failing tests
+
+```javascript
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createWorklore } from './worklore.js';
+
+function fakeHub(handler) {
+  return {
+    async request(method, path, { body, headers } = {}) {
+      return handler(method, path, body, headers);
+    },
+  };
+}
+
+test('create rejects unknown fields before calling the hub', async () => {
+  const calls = [];
+  const worklore = createWorklore({
+    hub: fakeHub((method, path, body) => {
+      calls.push({ method, path, body });
+      return { status: 201, json: { item: { work_id: 'wl-1' } } };
+    }),
+    snapshotPath: join(await mkdtemp(join(tmpdir(), 'wl-')), 'snap.json'),
+  });
+  const result = await worklore.createItem({ title: 'x', kind: 'fleet', prompt: 'nope' });
+  assert.equal(result.status, 400);
+  assert.equal(result.json.code, 'unknown-field');
+  assert.equal(calls.length, 0);
+});
+
+test('GET uses snapshot when the hub is down and marks it stale', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'wl-'));
+  const snapshotPath = join(dir, 'snap.json');
+  const live = createWorklore({
+    hub: fakeHub(() => ({ status: 200, json: { items: [{ work_id: 'wl-1', title: 'Live' }] } })),
+    snapshotPath,
+  });
+  await live.listItems();
+  const snapshotStat = await stat(snapshotPath);
+  assert.equal(snapshotStat.mode & 0o777, 0o600);
+  const parentStat = await stat(dir);
+  assert.equal(parentStat.mode & 0o777, 0o700);
+  const down = createWorklore({
+    hub: fakeHub(() => { throw new Error('connect ECONNREFUSED'); }),
+    snapshotPath,
+  });
+  const result = await down.listItems();
+  assert.equal(result.status, 200);
+  assert.equal(result.json.stale, true);
+  assert.equal(result.json.source, 'snapshot');
+  assert.equal(result.json.items[0].work_id, 'wl-1');
+});
+
+test('POST does not report snapshot success when the hub is down', async () => {
+  const worklore = createWorklore({
+    hub: fakeHub(() => { throw new Error('connect ECONNREFUSED'); }),
+    snapshotPath: join(await mkdtemp(join(tmpdir(), 'wl-')), 'snap.json'),
+  });
+  const result = await worklore.createItem({ title: 'Native', kind: 'fleet' });
+  assert.equal(result.status, 503);
+  assert.equal(result.json.code, 'hub-unavailable');
+  assert.equal(result.json.error, 'hub-unavailable');
+  assert.equal(result.json.item, undefined);
+});
+```
+
+- [x] Run red from the `opsdeck-api` repo root:
+
+```bash
+brigade work verify run --target . --command "node --test worklore.test.js" --capture brigade-work
+```
+
+Expect FAIL: `Cannot find module './worklore.js'`.
+
+- [x] Implement `createWorklore({ hub, snapshotPath })` with
+  `listItems`, `getItem`, `listEvents`, `burnQueue`, `createItem`,
+  `patchItem`, `transition`, and `recordAttempt`. Hub GET paths are
+  `/work/items`, `/work/items/{work_id}`, `/work/items/{work_id}/events`,
+  `/work/events`, and `/work/queue/burn`. Mutations use the server-held
+  operator node token inside the `hub` adapter, send `Idempotency-Key` on
+  native create, and forward `If-Match` on PATCH, transition, and attempt.
+  Snapshot writes mkdir the parent with
+  `{ recursive: true, mode: 0o700 }`, `chmod` that parent to `0o700`,
+  then call `atomicWriteJson` from `./atomic-write.js`.
+  `atomicWriteFile` passes `{ mode: 0o600 }` to `writeFile` for the
+  `.tmp` file before rename. Errors never include `FLEET_HUB_URL` or
+  the token.
+
+- [x] Add `worklore.test.js` to the `package.json` `test` script list.
+
+- [x] Run green with the same Brigade command. Expect `passed`.
+
+- [x] Commit in `opsdeck-api` only:
+
+```bash
+git add atomic-write.js worklore.js worklore.test.js package.json
+git commit -m "feat: add Worklore Fleet Hub proxy and snapshot"
+```
+
+  Do not add a co-author trailer.
+
+## Task 2: mount routes and keep backlog
+
+**Working directory:** `opsdeck-api` repo root
+
+**Files:**
+
+- Modify: `server.js` around the `/api/tasks` and `/api/backlog` block at
+  lines 2551-2698
+- Modify: `server.js:64` CORS headers
+- Modify: `server.js` to import `atomicWriteJson` from `./atomic-write.js`
+- Modify: `auth.js`
+- Modify: `auth.test.js`
+- Modify: `server.test.js`
+
+- [x] Write the failing tests
+
+```javascript
+test('worklore GET and writes require an API key', async () => {
+  const { requiresApiKey } = await import('./auth.js');
+  assert.equal(requiresApiKey('GET', '/api/worklore/items'), true);
+  assert.equal(requiresApiKey('GET', '/api/worklore/events'), true);
+  assert.equal(requiresApiKey('POST', '/api/worklore/items'), true);
+  assert.equal(requiresApiKey('PATCH', '/api/worklore/items/wl-1'), true);
+});
+```
+
+Add to `auth.test.js` using the existing import style, not a second
+import mechanism.
+
+Add a spawned-server test to `server.test.js`. Create the fake hub with
+`http.createServer` in the parent, then spawn `server.js` with
+`FLEET_HUB_URL` pointing at that listener:
+
+```javascript
+import http from 'node:http';
+
+async function startFakeHub(handler) {
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const body = raw ? JSON.parse(raw) : undefined;
+      const result = handler(req.method, req.url, body, req.headers);
+      res.writeHead(result.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result.json));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+async function startWorkloreTestServer({ enabled, hubHandler }) {
+  const hub = hubHandler ? await startFakeHub(hubHandler) : null;
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      BIND_HOST: '127.0.0.1',
+      PORT: String(port),
+      WORKLORE_ENABLED: enabled ? '1' : '0',
+      FLEET_HUB_URL: hub ? hub.url : '',
+      FLEET_HUB_NODE_TOKEN: 'test-node-token',
+      OPSDECK_API_KEY: 'test-api-key',
+    },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      const response = await fetch(`${baseUrl}/api/health`);
+      if (response.ok) break;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return {
+    apiKey: 'test-api-key',
+    hubToken: 'test-hub-token',
+    async fetch(pathname, options = {}) {
+      const res = await fetch(`${baseUrl}${pathname}`, options);
+      const text = await res.text();
+      const contentType = res.headers.get('content-type') || '';
+      const json = contentType.includes('application/json') && text
+        ? JSON.parse(text)
+        : null;
+      return { res, json };
+    },
+    async stop() {
+      child.kill('SIGTERM');
+      if (hub) await hub.close();
+    },
+  };
+}
+
+test('worklore routes are absent until WORKLORE_ENABLED=1', async () => {
+  const server = await startWorkloreTestServer({ enabled: false });
+  try {
+    const { res } = await server.fetch('/api/worklore/items', {
+      headers: { 'X-API-Key': server.apiKey },
+    });
+    assert.equal(res.status, 404);
+    const backlog = await server.fetch('/api/backlog');
+    assert.equal(backlog.res.status, 200);
+  } finally {
+    await server.stop();
+  }
+});
+
+test('enabled worklore create forwards If-Match on patch and transition', async () => {
+  const hubCalls = [];
+  const server = await startWorkloreTestServer({
+    enabled: true,
+    hubHandler: (method, path, body, headers) => {
+      hubCalls.push({ method, path, body, headers });
+      if (method === 'POST' && path === '/work/items') {
+        return { status: 201, json: { item: { work_id: 'wl-1', version: 1 } } };
+      }
+      return { status: 200, json: { item: { work_id: 'wl-1', version: 2 } } };
+    },
+  });
+  try {
+    const created = await server.fetch('/api/worklore/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': server.apiKey },
+      body: JSON.stringify({ title: 'NAS restic', kind: 'fleet' }),
+    });
+    assert.equal(created.res.status, 201);
+    await server.fetch('/api/worklore/items/wl-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': server.apiKey,
+        'If-Match': '1',
+      },
+      body: JSON.stringify({ burn_eligible: true }),
+    });
+    assert.equal(hubCalls[1].headers['if-match'] || hubCalls[1].headers['If-Match'], '1');
+    assert.equal(String(hubCalls[1].headers.authorization).startsWith('Bearer '), true);
+    assert.equal(JSON.stringify(created.json).includes(server.hubToken), false);
+  } finally {
+    await server.stop();
+  }
+});
+```
+
+- [x] Run red:
+
+```bash
+brigade work verify run --target . --command "node --test auth.test.js worklore.test.js" --capture brigade-work
+```
+
+Expect FAIL on the new `/api/worklore` assertions.
+
+- [x] In `auth.js`, treat any path equal to `/api/worklore` or starting
+  with `/api/worklore/` as a protected GET prefix.
+- [x] In `server.js`, when `WORKLORE_ENABLED === '1'`, construct the hub
+  adapter with `FLEET_HUB_URL` and the enrolled operator node token and mount:
+
+  - `GET /api/worklore/items`
+  - `GET /api/worklore/items/:work_id`
+  - `GET /api/worklore/items/:work_id/events`
+  - `GET /api/worklore/events`
+  - `GET /api/worklore/queue/burn`
+  - `POST /api/worklore/items`
+  - `PATCH /api/worklore/items/:work_id`
+  - `POST /api/worklore/items/:work_id/transitions`
+  - `POST /api/worklore/items/:work_id/attempts`
+
+  Leave `GET /api/backlog` and `PATCH /api/backlog/:id` unchanged.
+- [x] In the same CORS edit, add `PATCH` to
+  `Access-Control-Allow-Methods` at `server.js:63` and `If-Match` to
+  `Access-Control-Allow-Headers` at `server.js:64`.
+- [x] `startWorkloreTestServer` listens on 127.0.0.1 and a random port.
+  It must not change default `BIND_HOST=0.0.0.0` for production.
+
+- [x] Run the unit tests green, then the package script:
+
+```bash
+brigade work verify run --target . --command "npm test" --capture brigade-work
+```
+
+`npm test` still needs a live server for older `server.test.js` cases
+that hit `OPSDECK_API_URL`. Spawned Worklore tests do not. Report the
+actual npm result. If older live-server tests fail because :8005 is
+down, keep the spawned Worklore tests green and record that existing
+live-server dependency.
+
+- [x] Commit in `opsdeck-api`:
+
+```bash
+git add server.js auth.js auth.test.js server.test.js worklore.js atomic-write.js
+git commit -m "feat: mount Worklore proxy routes beside the legacy backlog"
+```
+
+  No co-author trailer.
+
+## Task 3: SPA helpers
+
+**Working directory:** `opsdeck` repo root
+
+**Files:**
+
+- Create: `src/lib/worklore.ts`
+- Create: `src/lib/__tests__/worklore.test.ts`
+
+- [x] Write the failing tests
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { boardColumn, burnLabel, isWorkloreEnabled } from '../worklore';
+
+describe('worklore helpers', () => {
+  it('maps statuses to board columns and leaves archived hidden', () => {
+    expect(boardColumn('ready')).toBe('ready');
+    expect(boardColumn('archived')).toBe(null);
+  });
+
+  it('labels burn appetite and attempt count', () => {
+    expect(burnLabel({ token_appetite: 'large', attempt_count: 1 })).toBe('large · 1 attempt');
+  });
+
+  it('is off unless the Vite flag is the string 1', () => {
+    expect(isWorkloreEnabled(undefined)).toBe(false);
+    expect(isWorkloreEnabled('1')).toBe(true);
+    expect(isWorkloreEnabled()).toBe(false);
+  });
+});
+```
+
+- [x] Run red:
+
+```bash
+brigade work verify run --target . --command "npx vitest --run src/lib/__tests__/worklore.test.ts" --capture brigade-work
+```
+
+Expect FAIL: `Failed to resolve import "../worklore"`.
+
+- [x] Implement `WorkloreItem`, `WorkloreBurnQueue`, `WorkloreEvent`,
+  `boardColumn`, `burnLabel`, and `isWorkloreEnabled`.
+  `isWorkloreEnabled(flag?: string)` uses `flag` when passed and
+  `import.meta.env.VITE_WORKLORE_ENABLED` when omitted. `boardColumn`
+  returns the status string for the ten live columns and `null` for
+  `archived`.
+
+- [x] Run green with the same command. Expect `passed`.
+
+- [x] Commit in `opsdeck`:
+
+```bash
+git add src/lib/worklore.ts src/lib/__tests__/worklore.test.ts
+git commit -m "feat: add Worklore view helpers"
+```
+
+  No co-author trailer.
+
+## Task 4: Tasks page views and native editor
+
+**Working directory:** `opsdeck` repo root
+
+**Files:**
+
+- Modify: `src/pages/Tasks.tsx`
+- Create: `src/pages/__tests__/Tasks.test.tsx`
+- Modify: `src/hooks/useApi.ts`
+
+- [x] Write the failing tests. Follow `src/pages/__tests__/Usage.test.tsx`
+  and mock `useApi` plus `apiFetch`.
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Tasks from '../Tasks';
+
+const useApiMock = vi.fn();
+const apiFetchMock = vi.fn();
+
+vi.mock('../../hooks/useApi', () => ({
+  useApi: (path: string) => useApiMock(path),
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+vi.mock('../../lib/worklore', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/worklore')>('../../lib/worklore');
+  return { ...actual, isWorkloreEnabled: () => true };
+});
+
+describe('Tasks Worklore views', () => {
+  beforeEach(() => {
+    useApiMock.mockImplementation((path: string) => {
+      if (path === '/api/worklore/queue/burn') {
+        return {
+          data: {
+            items: [{ work_id: 'wl-1', title: 'NAS restic', token_appetite: 'small', attempt_count: 0, kind: 'fleet' }],
+            exclusions: { 'acceptance-required': 1 },
+            stale: false,
+          },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+      if (path === '/api/worklore/items') {
+        return {
+          data: { items: [{ work_id: 'wl-1', title: 'NAS restic', status: 'ready' }], stale: false },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+      if (path === '/api/worklore/events') {
+        return {
+          data: {
+            events: [{ event_id: 'evt-1', work_id: 'wl-1', event_type: 'created', actor_type: 'operator' }],
+            stale: false,
+          },
+          loading: false,
+          error: null,
+          refetch: vi.fn(),
+        };
+      }
+      if (path === '/api/backlog') {
+        return { data: { meta: { lastUpdated: '2026-04-20', sprintName: 'Legacy' }, tasks: [] }, loading: false, error: null, refetch: vi.fn() };
+      }
+      if (path === '/api/tasks') {
+        return { data: { projects: [] }, loading: false, error: null, refetch: vi.fn() };
+      }
+      return { data: null, loading: false, error: null, refetch: vi.fn() };
+    });
+  });
+
+  it('shows burn queue items and the exclusion summary', async () => {
+    render(<Tasks />);
+    await userEvent.click(screen.getByRole('button', { name: 'Burn Queue' }));
+    expect(screen.getByText('NAS restic')).toBeInTheDocument();
+    expect(screen.getByText(/acceptance-required: 1/)).toBeInTheDocument();
+  });
+
+  it('keeps the legacy sprint toggle available', async () => {
+    render(<Tasks />);
+    expect(screen.getByRole('button', { name: 'Sprint' })).toBeInTheDocument();
+  });
+
+  it('renders the sprint log from the fleet-wide events route', async () => {
+    render(<Tasks />);
+    await userEvent.click(screen.getByRole('button', { name: 'Sprint Log' }));
+    expect(screen.getByText(/created/)).toBeInTheDocument();
+  });
+
+  it('does not treat a failed create as success', async () => {
+    apiFetchMock.mockRejectedValue(new Error('503 hub-unavailable'));
+    render(<Tasks />);
+    await userEvent.click(screen.getByRole('button', { name: 'New work' }));
+    await userEvent.type(screen.getByLabelText('Title'), 'Native item');
+    await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(screen.getByText(/hub-unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText('Created wl-')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [x] Run red:
+
+```bash
+brigade work verify run --target . --command "npx vitest --run src/pages/__tests__/Tasks.test.tsx" --capture brigade-work
+```
+
+Expect FAIL on missing Burn Queue controls.
+
+- [x] Extend `Tasks.tsx`. When `isWorkloreEnabled()` is true, add view
+  buttons `Burn Queue`, `Work Board`, and `Sprint Log` beside Sprint and
+  Portfolio (`Tasks.tsx:214-235`). Burn Queue lists eligible items with
+  token appetite, attempt count, kind, and exclusion counts. Work Board
+  renders the ten status columns. Sprint Log lists
+  `GET /api/worklore/events`. Do not fan out one request per item.
+  Native editor uses `apiFetch` for POST and PATCH and sends `If-Match`
+  from `item.version` on PATCH, transition, and attempt. In
+  `useApi.ts:64`, parse a JSON error body and throw an Error whose
+  message includes the stable `code` when present. Keep
+  `${status} ${statusText}` only when `code` is absent. Titles render
+  as text, not HTML. Links use `rel="noopener noreferrer"` and `https`
+  only.
+- [x] Keep the stale `tracking/backlog.json` sprint view and its 30-day
+  warning.
+
+- [x] Run the page test green, then the repo gate:
+
+```bash
+brigade work verify run --target . --argv-json '["./scripts/verify"]' --capture brigade-work
+```
+
+Expect `passed` from `./scripts/verify` (tsc, eslint, vitest).
+
+- [x] Commit in `opsdeck`:
+
+```bash
+git add src/pages/Tasks.tsx src/pages/__tests__/Tasks.test.tsx src/hooks/useApi.ts
+git commit -m "feat: add Worklore burn board and sprint log to Tasks"
+```
+
+  No co-author trailer.
+
+## Verification
+
+`opsdeck-api` tasks run `node --test worklore.test.js` and then `npm test`
+through Brigade with `--target .` at that repo root. `opsdeck` tasks run
+the named vitest file, then `./scripts/verify` through Brigade with
+`--target .` at that repo root. Do not claim the SPA works from a
+screenshot. Do not point the proxy at a personal home path in fixtures.
+Use `tmpdir()` and `wl-1` ids.

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 import math
 import os
 import sys
+from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Mapping
+
+from .. import worklore_brigade_sync, worklore_github_sync
 
 DEFAULT_PORT = 3774
 DEFAULT_DB_REL_PATH = Path(".brigade") / "fleet-hub.db"
@@ -376,6 +379,117 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_pref_pull = preference_sub.add_parser("pull", help="Refresh the local cache from the hub. Never fails a run.")
     p_pref_pull.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
     p_pref_pull.set_defaults(func=_dispatch_preference_pull)
+
+    p_work = fleet_sub.add_parser("work", help="Create, inspect, and schedule Worklore items on the fleet hub.")
+    work_sub = p_work.add_subparsers(dest="work_command", metavar="<work-command>")
+    work_sub.required = True
+    p_work_create = work_sub.add_parser("create", help="Create a native Worklore item (operator node token).")
+    p_work_create.add_argument("--title", required=True, help="Item title.")
+    p_work_create.add_argument("--kind", required=True, help="Item kind (fleet, admin, or other allowed kind).")
+    p_work_create.add_argument(
+        "--idempotency-key",
+        default=None,
+        help="Idempotency key for native create; generated when omitted.",
+    )
+    p_work_create.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_create.set_defaults(func=_dispatch_work_create)
+    p_work_show = work_sub.add_parser("show", help="Show one Worklore item.")
+    p_work_show.add_argument("work_id", help="Worklore item id.")
+    p_work_show.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_show.set_defaults(func=_dispatch_work_show)
+    p_work_list = work_sub.add_parser("list", help="List Worklore items.")
+    p_work_list.add_argument(
+        "--source",
+        default=None,
+        help="Filter by source (github, brigade, or native).",
+    )
+    p_work_list.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_list.set_defaults(func=_dispatch_work_list)
+    p_work_burn = work_sub.add_parser("burn", help="Show one page of the current burn queue.")
+    p_work_burn.add_argument("--limit", type=int, default=None, help="Items per page (1-100, default 50).")
+    p_work_burn.add_argument("--cursor", default=None, help="Page cursor from a previous burn read.")
+    p_work_burn.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_burn.set_defaults(func=_dispatch_work_burn)
+    p_work_patch = work_sub.add_parser(
+        "patch", help="Patch scheduling fields on a Worklore item (operator node token)."
+    )
+    p_work_patch.add_argument("work_id", help="Worklore item id.")
+    p_work_patch.add_argument("--if-match", required=True, help="Expected item version.")
+    p_work_patch.add_argument("--title", default=None, help="Replacement title.")
+    p_work_patch.add_argument("--description", default=None, help="Replacement description.")
+    p_work_patch.add_argument("--scope", default=None, help="Replacement scope.")
+    p_work_patch.add_argument("--priority", default=None, help="Replacement priority.")
+    p_work_patch.add_argument("--burn-rank", type=int, default=None, help="Replacement burn rank.")
+    burn_eligible = p_work_patch.add_mutually_exclusive_group()
+    burn_eligible.add_argument(
+        "--burn-eligible",
+        dest="burn_eligible",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Mark the item eligible for burn scheduling.",
+    )
+    burn_eligible.add_argument(
+        "--no-burn-eligible",
+        dest="burn_eligible",
+        action="store_const",
+        const=False,
+        help="Mark the item ineligible for burn scheduling.",
+    )
+    p_work_patch.add_argument("--token-appetite", default=None, help="Replacement token appetite.")
+    p_work_patch.add_argument("--execution-mode", default=None, help="Replacement execution mode.")
+    p_work_patch.add_argument("--acceptance", action="append", default=None, help="Acceptance criterion (repeatable).")
+    p_work_patch.add_argument("--blocker", default=None, help="Replacement blocker text.")
+    p_work_patch.add_argument("--review-after", default=None, help="Replacement review-after timestamp.")
+    p_work_patch.add_argument("--spend-by", default=None, help="Replacement spend-by timestamp.")
+    p_work_patch.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_patch.set_defaults(func=_dispatch_work_patch)
+    p_work_transition = work_sub.add_parser(
+        "transition", help="Move a Worklore item to another status (operator node token)."
+    )
+    p_work_transition.add_argument("work_id", help="Worklore item id.")
+    p_work_transition.add_argument("--to-status", required=True, help="Target status.")
+    p_work_transition.add_argument("--if-match", required=True, help="Expected item version.")
+    p_work_transition.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_transition.set_defaults(func=_dispatch_work_transition)
+    p_work_attempt = work_sub.add_parser("attempt", help="Record a started, failed, or reset attempt.")
+    p_work_attempt.add_argument("work_id", help="Worklore item id.")
+    p_work_attempt.add_argument(
+        "--action",
+        required=True,
+        choices=("started", "failed", "reset"),
+        help="Attempt action. reset requires an operator node token.",
+    )
+    p_work_attempt.add_argument("--run-id", default=None, help="Fleet run id for started or failed.")
+    p_work_attempt.add_argument("--if-match", required=True, help="Expected item version.")
+    p_work_attempt.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_attempt.set_defaults(func=_dispatch_work_attempt)
+    p_work_link = work_sub.add_parser("link", help="Add an operator-managed link (operator node token).")
+    p_work_link.add_argument("work_id", help="Worklore item id.")
+    p_work_link.add_argument("--link-type", required=True, help="Link type (url, github, or brigade).")
+    p_work_link.add_argument("--external-key", required=True, help="Stable external identity.")
+    p_work_link.add_argument("--url", default=None, help="Optional https URL.")
+    p_work_link.add_argument("--display-ref", default=None, help="Optional display label.")
+    p_work_link.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_link.set_defaults(func=_dispatch_work_link)
+    p_work_unlink = work_sub.add_parser("unlink", help="Remove one operator-managed link (operator node token).")
+    p_work_unlink.add_argument("work_id", help="Worklore item id.")
+    p_work_unlink.add_argument("link_id", help="Link id.")
+    p_work_unlink.add_argument("--if-match", default=None, help="Optional expected item version.")
+    p_work_unlink.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_unlink.set_defaults(func=_dispatch_work_unlink)
+    p_work_sync_github = work_sub.add_parser(
+        "sync-github",
+        help="Import labeled GitHub issues into Worklore.",
+    )
+    p_work_sync_github.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_sync_github.set_defaults(func=_dispatch_work_sync_github)
+    p_work_sync_brigade = work_sub.add_parser(
+        "sync-brigade",
+        help="Import configured Brigade ledgers into Worklore.",
+    )
+    p_work_sync_brigade.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_sync_brigade.set_defaults(func=_dispatch_work_sync_brigade)
 
 
 def _dispatch_serve(args: argparse.Namespace, *, environ: Mapping[str, str] | None = None) -> int:
@@ -1357,3 +1471,219 @@ def _dispatch_flush(args: argparse.Namespace) -> int:
     flushed = fleet_client.flush_spool(node_id)
     print(f"flushed {flushed} spooled event(s) for node {node_id}")
     return 0
+
+
+def _print_work_payload(payload: object, *, json_output: bool) -> int:
+    import json as _json
+
+    if json_output:
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    if isinstance(payload, dict):
+        item = payload.get("item")
+        if isinstance(item, dict) and item.get("work_id"):
+            print(f"{item.get('status') or 'ok'} {item['work_id']}")
+            return 0
+        items = payload.get("items")
+        if isinstance(items, list):
+            print(f"{len(items)} item(s)")
+            return 0
+        link = payload.get("link")
+        if isinstance(link, dict) and link.get("link_id"):
+            print(f"linked {link['link_id']}")
+            return 0
+    print("ok")
+    return 0
+
+
+def _run_work(args: argparse.Namespace, producer: Callable[[], object]) -> int:
+    from .. import worklore_client
+
+    try:
+        payload = producer()
+    except worklore_client.FleetClientError as exc:
+        error = worklore_client._safe_terminal_text(exc) or "fleet hub work failed"
+        if bool(getattr(args, "json", False)):
+            payload = {"error": error}
+            code = worklore_client._error_code(getattr(exc, "code", None))
+            if code is not None:
+                payload["code"] = code
+            print(json.dumps(payload, sort_keys=True), file=sys.stderr)
+            return 1
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return _print_work_payload(payload, json_output=bool(getattr(args, "json", False)))
+
+
+def _dispatch_work_create(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    return _run_work(
+        args,
+        lambda: worklore_client.create_item(
+            {"title": args.title, "kind": args.kind},
+            idempotency_key=getattr(args, "idempotency_key", None),
+        ),
+    )
+
+
+def _dispatch_work_show(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    return _run_work(args, lambda: worklore_client.get_item(args.work_id))
+
+
+def _dispatch_work_list(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    return _run_work(args, lambda: worklore_client.list_items(source=args.source))
+
+
+def _dispatch_work_burn(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    return _run_work(
+        args,
+        lambda: worklore_client.burn_queue(limit=getattr(args, "limit", None), cursor=getattr(args, "cursor", None)),
+    )
+
+
+def _dispatch_work_patch(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    body: dict[str, object] = {}
+    for name in (
+        "title",
+        "description",
+        "scope",
+        "priority",
+        "burn_rank",
+        "burn_eligible",
+        "token_appetite",
+        "execution_mode",
+        "acceptance",
+        "blocker",
+        "review_after",
+        "spend_by",
+    ):
+        value = getattr(args, name, None)
+        if value is not None:
+            body[name] = value
+    return _run_work(args, lambda: worklore_client.patch_item(args.work_id, body, if_match=args.if_match))
+
+
+def _dispatch_work_transition(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    return _run_work(
+        args,
+        lambda: worklore_client.transition(args.work_id, {"to_status": args.to_status}, if_match=args.if_match),
+    )
+
+
+def _dispatch_work_attempt(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    body: dict[str, object] = {"action": args.action}
+    if getattr(args, "run_id", None):
+        body["run_id"] = args.run_id
+    return _run_work(args, lambda: worklore_client.record_attempt(args.work_id, body, if_match=args.if_match))
+
+
+def _dispatch_work_link(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    body: dict[str, object] = {"link_type": args.link_type, "external_key": args.external_key}
+    if getattr(args, "url", None):
+        body["url"] = args.url
+    if getattr(args, "display_ref", None):
+        body["display_ref"] = args.display_ref
+    return _run_work(args, lambda: worklore_client.add_link(args.work_id, body))
+
+
+def _dispatch_work_unlink(args: argparse.Namespace) -> int:
+    from .. import worklore_client
+
+    return _run_work(
+        args,
+        lambda: worklore_client.delete_link(args.work_id, args.link_id, if_match=getattr(args, "if_match", None)),
+    )
+
+
+def _dispatch_work_sync_github(args: argparse.Namespace) -> int:
+    import json as _json
+
+    try:
+        config = worklore_github_sync.load_github_config()
+        result = worklore_github_sync.sync_github(
+            orgs=config["orgs"],
+            label=config["label"],
+            state=config["state"],
+        )
+    except worklore_github_sync.GitHubSyncError as exc:
+        print(str(exc), file=sys.stderr)
+        if exc.code == "field-bound":
+            return 2
+        return 1
+    counts: dict[str, int] = {}
+    for key in ("observation_count", "posted", "refused", "skipped"):
+        value = result.get(key, 0)
+        counts[key] = value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+    org_names = [org["name"] for org in config["orgs"] if isinstance(org, Mapping) and isinstance(org.get("name"), str)]
+    if bool(getattr(args, "json", False)):
+        print(
+            _json.dumps(
+                {
+                    "observation_count": counts["observation_count"],
+                    "orgs": org_names,
+                    "posted": counts["posted"],
+                    "refused": counts["refused"],
+                    "skipped": counts["skipped"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            f"posted {counts['posted']} batch(es), {counts['observation_count']} observation(s), "
+            f"refused {counts['refused']}, skipped {counts['skipped']}"
+        )
+    return 1 if counts["refused"] > 0 else 0
+
+
+def _dispatch_work_sync_brigade(args: argparse.Namespace) -> int:
+    import json as _json
+
+    try:
+        config = worklore_brigade_sync.load_brigade_config()
+        result = worklore_brigade_sync.sync_brigade(config["targets"])
+    except worklore_brigade_sync.BrigadeSyncError as exc:
+        print(str(exc), file=sys.stderr)
+        if exc.code == "field-bound":
+            return 2
+        return 1
+    counts: dict[str, int] = {}
+    for key in (
+        "created",
+        "identities",
+        "observation_count",
+        "posted",
+        "refused",
+        "skipped",
+        "targets",
+        "unchanged",
+        "updated",
+    ):
+        value = result.get(key, 0)
+        counts[key] = value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+    if bool(getattr(args, "json", False)):
+        print(_json.dumps(counts, indent=2, sort_keys=True))
+    else:
+        print(
+            f"targets {counts['targets']}, identities {counts['identities']}, "
+            f"posted {counts['posted']}, {counts['observation_count']} observation(s), "
+            f"created {counts['created']}, updated {counts['updated']}, unchanged {counts['unchanged']}, "
+            f"refused {counts['refused']}, skipped {counts['skipped']}"
+        )
+    return 1 if counts["refused"] > 0 else 0

--- a/src/brigade/fleet_client.py
+++ b/src/brigade/fleet_client.py
@@ -136,9 +136,7 @@ MAX_SESSION_HISTORY_RESPONSE_BYTES = 40 * 1024 * 1024
 # is a credential mismatch (a node token that is not this node's, or the
 # admin token on a hub without --allow-admin-writes), fixed by config.
 _RETRYABLE_4XX = frozenset({401, 403, 408, 429})
-
 _LOG = logging.getLogger("brigade.fleet")
-
 _CLOUD_API_EXPORTS = frozenset(
     {
         "CloudDecision",
@@ -162,12 +160,14 @@ _CLOUD_API_EXPORTS = frozenset(
 
 
 def __getattr__(name: str) -> Any:
-    """Lazily preserve the public cloud API without a circular import."""
+    """Lazily preserve the public cloud and Worklore APIs without a circular import."""
     if name in _CLOUD_API_EXPORTS:
-        from . import fleet_client_cloud
-
-        return getattr(fleet_client_cloud, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        module = "fleet_client_cloud"
+    elif name in {"burn_queue", "create_item", "import_batch", "link_execution", "list_items", "record_attempt"}:
+        module = "worklore_client"
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(__import__(f"brigade.{module}", fromlist=[name]), name)
 
 
 _SPOOL_PROCESS_LOCK = threading.Lock()

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -111,14 +111,14 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
-from . import fleet_command_deck, fleet_hub_preference
+from . import fleet_command_deck, fleet_hub_preference, worklore_store
 from .fleet_hub_status import (
     ACTIVE_EVENT_TTL_SECONDS as ACTIVE_EVENT_TTL_SECONDS,
     STALE_HISTORY_AFTER_SECONDS as STALE_HISTORY_AFTER_SECONDS,
     latest_status as latest_status,
 )
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 18
 DEFAULT_PORT = 3774
 MAX_BODY_BYTES = 8 * 1024 * 1024
 
@@ -537,6 +537,16 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
     from . import fleet_hub_model_roster
 
     fleet_hub_model_roster.ensure_schema(conn)
+    # v15 -> v16: Worklore tables. HTTP routes stay 404 until the feature gate opens.
+    # v16 -> v17: link adapter ownership (owner_node) and the per-identity source
+    # high-water.
+    # v17 -> v18: per-identity import refusals (work_import_keys.refused), the
+    # reconciliation marker (work_schema_meta) that keeps the one-time quota migration off
+    # every start, and the seeded high-water for identities imported before v17. A legacy
+    # item over the Worklore link ceiling no longer refuses startup: reads are cut by SQL,
+    # new writes still enforce the ceiling, and an operator unlinks the excess on a
+    # running hub rather than needing one that will not start.
+    worklore_store.ensure_schema(conn)
     conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 
 

--- a/src/brigade/fleet_hub_http.py
+++ b/src/brigade/fleet_hub_http.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlencode
 
-from . import fleet_command_deck, fleet_dashboard, fleet_hub_grokbot, fleet_hub_sessions
+from . import fleet_command_deck, fleet_dashboard, fleet_hub_grokbot, fleet_hub_sessions, worklore_http
 from . import fleet_hub as _hub
 from . import fleet_hub_model_roster
 from .fleet_hub import (
@@ -218,6 +218,80 @@ def make_handler(
             identity = identity.strip()
             if not identity:
                 return False
+            return True
+
+        def _worklore_path(self) -> str | None:
+            path = self.path.partition("?")[0]
+            if path == "/work" or path.startswith("/work/"):
+                return path
+            return None
+
+        def _read_worklore_body(self, path: str) -> dict[str, Any] | None:
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                self._send_json(400, {"error": "bad Content-Length"})
+                return None
+            limit = 1048576 if path == "/work/imports" else 262144
+            if self.command == "DELETE" and length == 0:
+                return {}
+            if length <= 0 or length > limit:
+                self._send_json(400, {"error": "missing or oversized body"})
+                return None
+            raw = self.rfile.read(length)
+            try:
+                parsed = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                self._send_json(400, {"error": "body is not valid JSON"})
+                return None
+            if not isinstance(parsed, dict):
+                self._send_json(400, {"error": "body is not valid JSON"})
+                return None
+            return parsed
+
+        def _handle_worklore(self) -> bool:
+            path = self._worklore_path()
+            if path is None:
+                return False
+            if not worklore_http.enabled():
+                self._send_json(404, {"error": "not found"})
+                return True
+            try:
+                conn = open_db(Path(db_path))
+            except (FleetHubError, sqlite3.Error):
+                self._send_json(500, {"error": "hub database error"})
+                return True
+            try:
+                caller = self._caller(conn)
+                if caller is None:
+                    return True
+                is_admin, node_id = caller
+                is_operator = bool(node_id) and node_id in worklore_http.operator_nodes()
+                body: dict[str, Any] = {}
+                if self.command in {"POST", "PATCH", "DELETE"}:
+                    parsed = self._read_worklore_body(path)
+                    if parsed is None:
+                        return True
+                    body = parsed
+                status, payload = worklore_http.handle(
+                    conn,
+                    worklore_http.Request(
+                        method=self.command,
+                        path=self.path,
+                        is_admin=is_admin,
+                        node_id=node_id,
+                        is_operator=is_operator,
+                        operator_authorization_resolved=True,
+                        body=body,
+                        headers={key: value for key, value in self.headers.items()},
+                    ),
+                )
+            except sqlite3.Error:
+                self._send_json(500, {"error": "hub database error"})
+                return True
+            finally:
+                conn.close()
+            self._send_json(status, payload)
             return True
 
         def _send_json(self, status: int, payload: dict[str, Any]) -> None:
@@ -517,6 +591,8 @@ def make_handler(
                     conn.close()
                 self._send_json(200, payload)
                 return
+            if self._handle_worklore():
+                return
             self._send_json(404, {"error": "not found"})
 
         def do_PUT(self) -> None:  # noqa: N802 - stdlib handler API
@@ -566,8 +642,25 @@ def make_handler(
                 conn.close()
             self._send_json(200, payload)
 
+        def do_PATCH(self) -> None:  # noqa: N802 - stdlib handler API
+            path = self.path.partition("?")[0]
+            if not path.startswith("/work/"):
+                self._send_json(404, {"error": "not found"})
+                return
+            self._handle_worklore()
+
+        def do_DELETE(self) -> None:  # noqa: N802 - stdlib handler API
+            path = self.path.partition("?")[0]
+            if not path.startswith("/work/"):
+                self._send_json(404, {"error": "not found"})
+                return
+            self._handle_worklore()
+
         def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
             path = self.path.partition("?")[0]
+            if path.startswith("/work/"):
+                self._handle_worklore()
+                return
             if path not in ("/events", "/claims", "/nodes", "/cloud", "/models", "/grokbot", "/sessions"):
                 self._send_json(404, {"error": "not found"})
                 return

--- a/src/brigade/toml_compat.py
+++ b/src/brigade/toml_compat.py
@@ -15,6 +15,48 @@ class TOMLDecodeError(ValueError):
     """Raised when the fallback TOML reader cannot parse local config."""
 
 
+class _CollectionState:
+    def __init__(self) -> None:
+        self._stack: list[str] = []
+        self._quote = ""
+        self._escaped = False
+
+    @property
+    def balanced(self) -> bool:
+        return not self._stack
+
+    def scan(self, fragment: str, line_number: int, *, preceded_by_newline: bool = False) -> None:
+        if preceded_by_newline:
+            self._scan_character("\n", line_number)
+        for character in fragment:
+            self._scan_character(character, line_number)
+
+    def _scan_character(self, character: str, line_number: int) -> None:
+        if self._quote:
+            if self._escaped:
+                self._escaped = False
+            elif character == "\\":
+                self._escaped = True
+            elif character == self._quote:
+                self._quote = ""
+            return
+        if character in {"'", '"'}:
+            self._quote = character
+            return
+        if character in {"[", "{"}:
+            self._stack.append(character)
+            return
+        if character == "]":
+            expected_opening = "["
+        elif character == "}":
+            expected_opening = "{"
+        else:
+            return
+        if not self._stack or self._stack[-1] != expected_opening:
+            raise TOMLDecodeError(f"mismatched closing delimiter on line {line_number}")
+        self._stack.pop()
+
+
 def loads(text: str) -> dict[str, Any]:
     if _stdlib_tomllib is not None:
         try:
@@ -27,10 +69,26 @@ def loads(text: str) -> dict[str, Any]:
 def _fallback_loads(text: str) -> dict[str, Any]:
     data: dict[str, Any] = {}
     current: dict[str, Any] = data
+    pending_key: str | None = None
+    pending_value: list[str] = []
+    pending_line_number = 0
+    pending_state: _CollectionState | None = None
 
     for line_number, raw_line in enumerate(text.splitlines(), start=1):
         line = _strip_comment(raw_line).strip()
         if not line:
+            continue
+        if pending_key is not None:
+            assert pending_state is not None
+            pending_value.append(line)
+            pending_state.scan(line, pending_line_number, preceded_by_newline=True)
+            if not pending_state.balanced:
+                continue
+            raw_value = "\n".join(pending_value)
+            current[pending_key] = _parse_value(raw_value, pending_line_number)
+            pending_key = None
+            pending_value.clear()
+            pending_state = None
             continue
         if line.startswith("[[") and line.endswith("]]"):
             current = _array_table(data, line[2:-2], line_number)
@@ -44,7 +102,19 @@ def _fallback_loads(text: str) -> dict[str, Any]:
         key = key.strip()
         if not key:
             raise TOMLDecodeError(f"invalid TOML key on line {line_number}")
-        current[key] = _parse_value(raw_value.strip(), line_number)
+        raw_value = raw_value.strip()
+        collection_state = _CollectionState()
+        collection_state.scan(raw_value, line_number)
+        if not collection_state.balanced:
+            pending_key = key
+            pending_value = [raw_value]
+            pending_line_number = line_number
+            pending_state = collection_state
+            continue
+        current[key] = _parse_value(raw_value, line_number)
+
+    if pending_key is not None:
+        raise TOMLDecodeError(f"incomplete TOML value on line {pending_line_number}")
 
     return data
 

--- a/src/brigade/work_cmd/ledger/import_model.py
+++ b/src/brigade/work_cmd/ledger/import_model.py
@@ -643,6 +643,9 @@ def _extract_issue_acceptance(body: object) -> list[str]:
     return _normalize_acceptance(extracted)
 
 
+extract_issue_acceptance = _extract_issue_acceptance
+
+
 def _task_issue_metadata(task: dict[str, Any]) -> dict[str, Any] | None:
     metadata = _metadata(task)
     issue = metadata.get("github_issue") if isinstance(metadata.get("github_issue"), dict) else None

--- a/src/brigade/worklore_brigade.py
+++ b/src/brigade/worklore_brigade.py
@@ -1,0 +1,235 @@
+"""Normalize one public Brigade task into a Worklore import observation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from .worklore_validate import (
+    ACCEPTANCE_ITEM_MAX,
+    ACCEPTANCE_MAX_ITEMS,
+    TITLE_MAX,
+    WorkloreValidationError,
+    as_datetime,
+    assert_no_private_data,
+    contains_private_path,
+)
+
+PRIORITY_MAX = 64
+EXTERNAL_STATE_MAX = 64
+DEPENDENCY_FIELD_MAX = 128
+SOURCE_REVISION_MAX = 64
+
+BLOCKED_KEYS = frozenset(
+    {
+        "receipt_body",
+        "prompt",
+        "transcript",
+        "token",
+        "secret",
+        "password",
+        "tasks_path",
+    }
+)
+IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{1,127}$")
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+DEP_TYPE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_TERMINAL_SUCCESS = "done"
+_TERMINAL_EXCLUDED = frozenset({"cancelled", "dismissed"})
+
+
+class BrigadeObservationError(Exception):
+    """A Brigade task cannot be turned into a Worklore observation."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+def _unknown_field(name: object) -> BrigadeObservationError:
+    return BrigadeObservationError(f"unknown field: {name}", code="unknown-field")
+
+
+def _field_bound(message: str) -> BrigadeObservationError:
+    return BrigadeObservationError(message, code="field-bound")
+
+
+def _reject_blocked_keys(value: object) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if key in BLOCKED_KEYS:
+                raise _unknown_field(key)
+            _reject_blocked_keys(item)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _reject_blocked_keys(item)
+
+
+def _reject_private_data(value: object, field: str) -> str:
+    """Apply the hub's canonical private-data rules client side, in the adapter's error type."""
+    if not isinstance(value, str):
+        raise _field_bound(f"{field} must be a string")
+    try:
+        return assert_no_private_data(value, field)
+    except WorkloreValidationError as exc:
+        raise BrigadeObservationError(str(exc), code=exc.code) from None
+
+
+def _require_identity(value: object) -> str:
+    if not isinstance(value, str) or not IDENTITY_RE.fullmatch(value):
+        raise _field_bound("identity must match the configured identity pattern")
+    return _reject_private_data(value, "identity")
+
+
+def _require_task_id(value: object, field: str) -> str:
+    if not isinstance(value, str) or not TASK_ID_RE.fullmatch(value):
+        raise _field_bound(f"{field} must be a bounded Brigade task id")
+    return value
+
+
+def _optional_priority(value: object) -> str | None:
+    if value is None:
+        return None
+    text = _reject_private_data(value, "priority")
+    if not text or len(text) > PRIORITY_MAX:
+        raise _field_bound(f"priority must be 1 to {PRIORITY_MAX} characters")
+    return text
+
+
+def _optional_source_revision(value: object) -> str | None:
+    """The task's ``updated_at`` as the source revision the hub's rollback guard compares.
+
+    Brigade tasks carry ``updated_at`` in their public payload, so this adapter has a real
+    revision to report and must report it: without one the hub has no high-water for a
+    Brigade identity and an expired-key replay is last-write-wins. Only a bounded value the
+    hub can parse as an instant is emitted, because a revision the guard cannot compare is
+    worse than none: it looks like proof and provides none.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text or len(text) > SOURCE_REVISION_MAX:
+        return None
+    try:
+        as_datetime(text)
+    except ValueError:
+        return None
+    return text
+
+
+def _acceptance_items(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise _field_bound("acceptance must be an array of strings")
+    if len(value) > ACCEPTANCE_MAX_ITEMS:
+        raise _field_bound(f"acceptance must have at most {ACCEPTANCE_MAX_ITEMS} items")
+    items: list[str] = []
+    for index, item in enumerate(value):
+        text = _reject_private_data(item, f"acceptance[{index}]")
+        if not text.strip() or len(text) > ACCEPTANCE_ITEM_MAX:
+            raise _field_bound(f"acceptance[{index}] must be a non-empty string")
+        items.append(text)
+    return items
+
+
+def _safe_dependency_part(value: object, pattern: re.Pattern[str]) -> str | None:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        return None
+    if contains_private_path(value):
+        return None
+    return value
+
+
+def _dependencies(edges: object, *, task_id: str) -> list[dict[str, str]]:
+    if edges is None:
+        return []
+    if not isinstance(edges, list):
+        raise _field_bound("edges must be an array")
+    seen: set[tuple[str, str]] = set()
+    items: list[dict[str, str]] = []
+    for edge in edges:
+        if not isinstance(edge, Mapping):
+            continue
+        if edge.get("source") != task_id:
+            continue
+        dep_type = _safe_dependency_part(edge.get("type"), DEP_TYPE_RE)
+        dep_id = _safe_dependency_part(edge.get("target"), TASK_ID_RE)
+        if dep_type is None or dep_id is None:
+            continue
+        if len(dep_type) > DEPENDENCY_FIELD_MAX or len(dep_id) > DEPENDENCY_FIELD_MAX:
+            continue
+        key = (dep_type, dep_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append({"type": dep_type, "id": dep_id})
+    return sorted(items, key=lambda item: (item["type"], item["id"]))
+
+
+def _evidence_refs(metadata: object) -> list[str]:
+    if not isinstance(metadata, Mapping):
+        return []
+    refs: list[str] = []
+    for key in ("verify_run_id", "receipt_id"):
+        value = metadata.get(key)
+        if isinstance(value, str) and EVIDENCE_REF_RE.fullmatch(value):
+            refs.append(value)
+    return refs
+
+
+def _source_policy(status: str) -> tuple[str, str | None]:
+    if status == _TERMINAL_SUCCESS:
+        return "completed", "completed"
+    if status in _TERMINAL_EXCLUDED:
+        return "completed", None
+    return "eligible", None
+
+
+def normalize_task(
+    task: Mapping[str, Any],
+    *,
+    identity: str,
+    edges: list[Mapping[str, Any]] | list[object] | None,
+) -> dict[str, Any]:
+    """Map one public Brigade task payload to a Worklore import observation."""
+    if not isinstance(task, Mapping):
+        raise _field_bound("task must be an object")
+    _reject_blocked_keys(task)
+    _reject_blocked_keys(edges)
+    resolved_identity = _require_identity(identity)
+    task_id = _require_task_id(task.get("id"), "id")
+    title = _reject_private_data(task.get("text"), "title").strip()[:TITLE_MAX]
+    if not title:
+        raise _field_bound("title is required")
+    status_raw = task.get("status")
+    if not isinstance(status_raw, str) or not status_raw.strip():
+        raise _field_bound("status is required")
+    status = _reject_private_data(status_raw.strip(), "status")
+    if len(status) > EXTERNAL_STATE_MAX:
+        raise _field_bound(f"external_state must be 1 to {EXTERNAL_STATE_MAX} characters")
+    source_policy, proposed_status = _source_policy(status)
+    observation: dict[str, Any] = {
+        "external_key": f"{resolved_identity}#{task_id}",
+        "link_type": "brigade",
+        "title": title,
+        "acceptance": _acceptance_items(task.get("acceptance")),
+        "external_state": status,
+        "dependencies": _dependencies(edges, task_id=task_id),
+        "evidence_refs": _evidence_refs(task.get("metadata")),
+        "source_policy": source_policy,
+        "proposed_status": proposed_status,
+    }
+    priority = _optional_priority(task.get("priority"))
+    if priority is not None:
+        observation["priority"] = priority
+    revision = _optional_source_revision(task.get("updated_at"))
+    # Same decision as the GitHub adapter: a task with no usable ``updated_at`` is passed
+    # through without a revision rather than rejected here or given a synthesized one. The
+    # hub refuses it per identity with a named reason, which an operator can see; an
+    # adapter-side skip would report nothing at all.
+    if revision is not None:
+        observation["external_updated_at"] = revision
+    return observation

--- a/src/brigade/worklore_brigade_sync.py
+++ b/src/brigade/worklore_brigade_sync.py
@@ -1,0 +1,466 @@
+"""Read configured Brigade ledgers through the public task command."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from . import toml_compat as tomllib
+from . import worklore_client
+from .fleet_client import FLEET_CONFIG_REL_PATH, brigade_home
+from .worklore_brigade import BrigadeObservationError, IDENTITY_RE, normalize_task
+
+COMMAND_TIMEOUT_SECONDS = 30
+BATCH_SIZE = 500
+MAX_REPORTED_SKIPPED = BATCH_SIZE
+HUB_STATUS_RE = re.compile(r"\bHTTP (\d{3})\b")
+HUB_CODE_BY_STATUS = {401: "hub-unauthorized", 403: "hub-unauthorized", 409: "hub-conflict"}
+RECEIPT_UNSAFE = str.maketrans(
+    {
+        ":": "-",
+        "/": "-",
+        "\\": "-",
+        "<": "-",
+        ">": "-",
+        '"': "-",
+        "|": "-",
+        "?": "-",
+        "*": "-",
+    }
+)
+FINGERPRINT_FIELDS = (
+    "acceptance",
+    "dependencies",
+    "evidence_refs",
+    "external_key",
+    "external_state",
+    # The source revision is part of what makes a batch this batch: two payloads that agree
+    # on everything else but disagree on when the source last changed are different
+    # observations, and must not collapse onto one idempotency key.
+    "external_updated_at",
+    "priority",
+    "proposed_status",
+    "source_policy",
+    "title",
+)
+
+
+class BrigadeSyncError(Exception):
+    """A Brigade discovery step failed with a bounded message."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+@dataclass(frozen=True)
+class Target:
+    path: Path
+    identity: str
+
+
+class _TaskResult(list[dict[str, Any]]):
+    """Normalized observations plus a bounded count of rejected tasks."""
+
+    def __init__(self, observations: Sequence[dict[str, Any]] = (), *, skipped: int = 0) -> None:
+        super().__init__(observations)
+        self.skipped = min(max(skipped, 0), MAX_REPORTED_SKIPPED)
+
+
+def _config_error(message: str) -> BrigadeSyncError:
+    return BrigadeSyncError(message, code="field-bound")
+
+
+def _adapter_failure() -> BrigadeSyncError:
+    return BrigadeSyncError("adapter command failed", code="retryable-adapter-failure")
+
+
+def load_brigade_config() -> dict[str, Any]:
+    """Read ``[fleet.worklore.brigade]`` from the fleet config."""
+    section = _read_brigade_section()
+    if section is None:
+        raise _config_error("Brigade Worklore config is missing targets")
+    return {"targets": _parse_targets(section.get("targets"))}
+
+
+def _read_brigade_section() -> dict[str, Any] | None:
+    config_path = brigade_home() / FLEET_CONFIG_REL_PATH.name
+    if not config_path.is_file():
+        return None
+    try:
+        payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    fleet = payload.get("fleet") if isinstance(payload, dict) else None
+    worklore = fleet.get("worklore") if isinstance(fleet, dict) else None
+    brigade = worklore.get("brigade") if isinstance(worklore, dict) else None
+    return brigade if isinstance(brigade, dict) else None
+
+
+def _parse_targets(raw: object) -> list[Target]:
+    if not isinstance(raw, list) or not raw:
+        raise _config_error("targets must be a non-empty list")
+    targets: list[Target] = []
+    seen: set[tuple[Path, str]] = set()
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise _config_error("targets items must be tables")
+        path = _require_target_path(item.get("path"))
+        identity = _require_identity(item.get("identity"))
+        key = (path, identity)
+        if key in seen:
+            raise _config_error("targets path and identity are duplicated")
+        seen.add(key)
+        targets.append(Target(path=path, identity=identity))
+    return targets
+
+
+def _require_identity(value: object) -> str:
+    if not isinstance(value, str) or not IDENTITY_RE.fullmatch(value):
+        raise _config_error("identity must match the configured identity pattern")
+    return value
+
+
+def _require_target_path(value: object) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise _config_error("path must be a non-empty string")
+    resolved = Path(value).expanduser().resolve()
+    if not resolved.is_dir():
+        raise _config_error("path must exist and be a directory")
+    return resolved
+
+
+def _target_path(target: Path | Target) -> Path:
+    return target.path if isinstance(target, Target) else Path(target)
+
+
+def _public_edge_is_valid(edge: object) -> bool:
+    if not isinstance(edge, Mapping):
+        return False
+    source = edge.get("source")
+    dest = edge.get("target")
+    edge_type = edge.get("type")
+    return (
+        isinstance(source, str)
+        and bool(source.strip())
+        and isinstance(dest, str)
+        and bool(dest.strip())
+        and isinstance(edge_type, str)
+        and bool(edge_type.strip())
+    )
+
+
+def read_public_tasks(target: Path | Target) -> tuple[list[Any], list[Any]]:
+    """Return ``(tasks, edges)`` from ``brigade work tasks --all --json``."""
+    display = _target_path(target).expanduser().resolve()
+    if not display.is_dir():
+        raise _config_error("path must exist and be a directory")
+    argv = ["brigade", "work", "tasks", "--target", str(display), "--all", "--json"]
+    try:
+        result = subprocess.run(  # noqa: S603 - argv is constructed, never shell-interpolated
+            argv,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise _adapter_failure() from None
+    if result.returncode != 0:
+        raise _adapter_failure()
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        raise _adapter_failure() from None
+    if not isinstance(payload, Mapping):
+        raise _adapter_failure()
+    tasks = payload.get("tasks")
+    edges = payload.get("edges")
+    if not isinstance(tasks, list) or not isinstance(edges, list):
+        raise _adapter_failure()
+    if not all(isinstance(task, Mapping) for task in tasks):
+        raise _adapter_failure()
+    if not all(_public_edge_is_valid(edge) for edge in edges):
+        raise _adapter_failure()
+    return tasks, edges
+
+
+def observations_for_target(
+    tasks: Mapping[str, Any] | list[object],
+    *,
+    edges: list[Mapping[str, Any]] | list[object] | None = None,
+    identity: str,
+) -> _TaskResult:
+    """Normalize public Brigade tasks, skipping and counting the unsafe ones.
+
+    A task the adapter cannot bound never reaches the hub and never aborts the
+    other tasks in the same target; only its bounded count is reported.
+    """
+    items: list[object]
+    if isinstance(tasks, Mapping):
+        items = [tasks]
+    elif isinstance(tasks, list):
+        items = tasks
+    else:
+        raise _adapter_failure()
+    observations = _TaskResult()
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise _adapter_failure()
+        try:
+            observations.append(normalize_task(item, identity=identity, edges=edges))
+        except BrigadeObservationError:
+            observations.skipped = min(observations.skipped + 1, MAX_REPORTED_SKIPPED)
+    return observations
+
+
+def _hub_error_code(exc: Exception) -> str:
+    """Classify a hub refusal so a permanent 4xx is not retried as transient."""
+    match = HUB_STATUS_RE.search(str(exc))
+    if match is None:
+        return "hub-unavailable"
+    status = int(match.group(1))
+    if not 400 <= status < 500:
+        return "hub-unavailable"
+    return HUB_CODE_BY_STATUS.get(status, "hub-rejected")
+
+
+def _hub_error(code: str) -> BrigadeSyncError:
+    return BrigadeSyncError(code, code=code)
+
+
+def _receipt_write_failed() -> BrigadeSyncError:
+    return BrigadeSyncError("receipt-write-failed", code="receipt-write-failed")
+
+
+def _identity_conflict() -> BrigadeSyncError:
+    return BrigadeSyncError("identity-conflict", code="identity-conflict")
+
+
+def _safe_identity(identity: str) -> str:
+    return identity.translate(RECEIPT_UNSAFE)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _as_count(value: object) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _observation_fingerprint(observation: Mapping[str, Any]) -> str:
+    payload = {field: observation.get(field) for field in FINGERPRINT_FIELDS}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _batch_idempotency_key(identity: str, observations: Sequence[Mapping[str, Any]]) -> str:
+    fingerprints = sorted(_observation_fingerprint(item) for item in observations)
+    digest = hashlib.sha256(
+        json.dumps(fingerprints, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"brigade:{identity}:{digest}"
+
+
+def _chunks(observations: list[dict[str, Any]], size: int) -> list[list[dict[str, Any]]]:
+    if not observations:
+        return [[]]
+    return [observations[index : index + size] for index in range(0, len(observations), size)]
+
+
+def _ensure_private_receipt_dir() -> Path:
+    directory = brigade_home() / "worklore" / "brigade"
+    directory.mkdir(parents=True, mode=0o700, exist_ok=True)
+    try:
+        directory.chmod(0o700)
+        directory.parent.chmod(0o700)
+    except OSError:
+        pass
+    return directory
+
+
+def _write_receipt(
+    identity: str,
+    *,
+    adapter_id: str,
+    idempotency_key: str,
+    observation_count: int,
+    last_error_code: str | None,
+    refused: int = 0,
+    skipped: int = 0,
+) -> None:
+    directory = _ensure_private_receipt_dir()
+    path = directory / f"{_safe_identity(identity)}.json"
+    payload = {
+        "adapter_id": adapter_id,
+        "idempotency_key": idempotency_key,
+        "last_error_code": last_error_code,
+        "observation_count": observation_count,
+        "refused": _as_count(refused),
+        "skipped": min(max(skipped, 0), MAX_REPORTED_SKIPPED),
+        "updated_at": _utc_now(),
+    }
+    fd, tmp_name = tempfile.mkstemp(dir=directory, prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+        os.chmod(path, 0o600)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _write_receipt_best_effort(
+    identity: str,
+    *,
+    adapter_id: str,
+    idempotency_key: str,
+    observation_count: int,
+    last_error_code: str | None,
+    refused: int = 0,
+    skipped: int = 0,
+) -> None:
+    try:
+        _write_receipt(
+            identity,
+            adapter_id=adapter_id,
+            idempotency_key=idempotency_key,
+            observation_count=observation_count,
+            last_error_code=last_error_code,
+            refused=refused,
+            skipped=skipped,
+        )
+    except OSError:
+        return
+
+
+def _require_targets(targets: object) -> list[Target]:
+    if not isinstance(targets, list) or not targets:
+        raise _config_error("targets must be a non-empty list")
+    if not all(isinstance(item, Target) for item in targets):
+        raise _config_error("targets must be a non-empty list")
+    return targets
+
+
+def _discover_groups(targets: list[Target]) -> tuple[list[tuple[str, list[dict[str, Any]], int]], int]:
+    order: list[str] = []
+    groups: dict[str, dict[str, dict[str, Any]]] = {}
+    skipped_by_identity: dict[str, int] = {}
+    skipped = 0
+    for target in targets:
+        identity = target.identity
+        if identity not in groups:
+            order.append(identity)
+            groups[identity] = {}
+            skipped_by_identity[identity] = 0
+        tasks, edges = read_public_tasks(target)
+        observations = observations_for_target(tasks, edges=edges, identity=identity)
+        target_skipped = min(max(int(getattr(observations, "skipped", 0)), 0), MAX_REPORTED_SKIPPED)
+        skipped_by_identity[identity] = min(
+            skipped_by_identity[identity] + target_skipped,
+            MAX_REPORTED_SKIPPED,
+        )
+        skipped = min(skipped + target_skipped, MAX_REPORTED_SKIPPED)
+        for observation in observations:
+            key = str(observation["external_key"])
+            existing = groups[identity].get(key)
+            if existing is None:
+                groups[identity][key] = observation
+                continue
+            if _observation_fingerprint(existing) != _observation_fingerprint(observation):
+                raise _identity_conflict()
+    return [
+        (
+            identity,
+            sorted(groups[identity].values(), key=lambda item: str(item["external_key"])),
+            skipped_by_identity[identity],
+        )
+        for identity in order
+    ], skipped
+
+
+def _add_hub_counts(totals: dict[str, int], response: object) -> None:
+    if not isinstance(response, Mapping):
+        return
+    totals["created"] += _as_count(response.get("created"))
+    totals["updated"] += _as_count(response.get("updated"))
+    totals["unchanged"] += _as_count(response.get("unchanged"))
+    totals["refused"] += _as_count(response.get("refused"))
+
+
+def sync_brigade(targets: object) -> dict[str, Any]:
+    """Read configured Brigade targets and post idempotent Worklore import batches."""
+    parsed = _require_targets(targets)
+    groups, skipped = _discover_groups(parsed)
+    posted = 0
+    observation_count = 0
+    totals = {"created": 0, "updated": 0, "unchanged": 0, "refused": 0}
+    for identity, observations, identity_skipped in groups:
+        adapter_id = f"brigade:{identity}"
+        identity_refused = 0
+        for chunk in _chunks(observations, BATCH_SIZE):
+            idempotency_key = _batch_idempotency_key(identity, chunk)
+            envelope = {
+                "adapter_id": adapter_id,
+                "source_type": "brigade",
+                "idempotency_key": idempotency_key,
+                "observations": chunk,
+            }
+            try:
+                response = worklore_client.import_batch(envelope)
+            except worklore_client.FleetClientError as exc:
+                code = _hub_error_code(exc)
+                _write_receipt_best_effort(
+                    identity,
+                    adapter_id=adapter_id,
+                    idempotency_key=idempotency_key,
+                    observation_count=len(chunk),
+                    last_error_code=code,
+                    refused=identity_refused,
+                    skipped=identity_skipped,
+                )
+                raise _hub_error(code) from None
+            identity_refused += _as_count(response.get("refused")) if isinstance(response, Mapping) else 0
+            _add_hub_counts(totals, response)
+            try:
+                _write_receipt(
+                    identity,
+                    adapter_id=adapter_id,
+                    idempotency_key=idempotency_key,
+                    observation_count=len(chunk),
+                    last_error_code="hub-partial" if identity_refused else None,
+                    refused=identity_refused,
+                    skipped=identity_skipped,
+                )
+            except OSError:
+                raise _receipt_write_failed() from None
+            posted += 1
+            observation_count += len(chunk)
+    return {
+        "targets": len(parsed),
+        "identities": len(groups),
+        "posted": posted,
+        "observation_count": observation_count,
+        "skipped": skipped,
+        "created": totals["created"],
+        "refused": totals["refused"],
+        "updated": totals["updated"],
+        "unchanged": totals["unchanged"],
+    }

--- a/src/brigade/worklore_client.py
+++ b/src/brigade/worklore_client.py
@@ -1,0 +1,393 @@
+"""Authenticated /work HTTP client. Independent urllib transport; never uses fleet_client._admin_request."""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Mapping
+
+from .fleet_client import (
+    FleetClientError,
+    _hub_open,
+    _require_encrypted_or_loopback_hub,
+    load_fleet_settings,
+)
+
+REQUEST_TIMEOUT_SECONDS = 5.0
+IMPORT_TIMEOUT_SECONDS = 30.0
+LIST_PAGE_SIZE = 100
+LIST_MAX_PAGES = 200
+LIST_MAX_ITEMS = 20000
+# A full listing page is a few hundred KiB; the cap stops a hostile or wedged hub
+# from streaming an unbounded body into memory. Refusal bodies are far smaller.
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+MAX_ERROR_RESPONSE_BYTES = 64 * 1024
+_ERROR_CODE_RE = re.compile(r"^[a-z][a-z0-9-]{0,127}$")
+
+__all__ = [
+    "FleetClientError",
+    "WorkloreListingError",
+    "IMPORT_TIMEOUT_SECONDS",
+    "REQUEST_TIMEOUT_SECONDS",
+    "WorkloreClientError",
+    "add_link",
+    "burn_queue",
+    "create_item",
+    "delete_link",
+    "get_item",
+    "import_batch",
+    "link_execution",
+    "list_item_links_all",
+    "list_all_events",
+    "list_events",
+    "LIST_MAX_ITEMS",
+    "LIST_MAX_PAGES",
+    "LIST_PAGE_SIZE",
+    "MAX_ERROR_RESPONSE_BYTES",
+    "MAX_RESPONSE_BYTES",
+    "list_items",
+    "list_items_all",
+    "load_fleet_settings",
+    "patch_item",
+    "record_attempt",
+    "transition",
+]
+
+
+class WorkloreListingError(FleetClientError):
+    """A paged Worklore listing exceeded its bounds or failed to advance."""
+
+
+class WorkloreClientError(FleetClientError):
+    """A Worklore hub refusal with its stable machine-readable code, when supplied."""
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _safe_terminal_text(value: object) -> str:
+    """Return displayable plain text without C0 or C1 terminal controls."""
+    text = str(value)
+    without_controls = "".join(" " if ord(char) < 32 or 127 <= ord(char) <= 159 else char for char in text)
+    return " ".join(without_controls.split())
+
+
+def _error_code(value: object) -> str | None:
+    return value if isinstance(value, str) and _ERROR_CODE_RE.fullmatch(value) else None
+
+
+def _hub_url() -> str:
+    """The configured hub, refused before a bearer token is attached unless it is
+    HTTPS or loopback HTTP (the same gate the rest of the fleet client uses)."""
+    hub = load_fleet_settings().get("hub_url", "")
+    if not hub:
+        raise FleetClientError("no fleet hub configured (~/.brigade/fleet.toml [fleet] hub_url)")
+    hub = hub.rstrip("/")
+    _require_encrypted_or_loopback_hub(hub)
+    return hub
+
+
+def _token(*, admin: bool | None = None) -> str:
+    settings = load_fleet_settings()
+    if admin is True:
+        token = settings.get("admin_token", "")
+        if not token:
+            raise FleetClientError(
+                "no fleet admin token configured (~/.brigade/fleet.toml [fleet] token_file or BRIGADE_FLEET_TOKEN)"
+            )
+        return token
+    if admin is False:
+        token = settings.get("node_token", "")
+        if not token:
+            raise FleetClientError(
+                "no fleet node token configured (~/.brigade/fleet.toml [fleet] node_token_file or BRIGADE_FLEET_NODE_TOKEN)"
+            )
+        return token
+    # Reads carry the least authority that works: the node token, with the admin
+    # token used only when nothing else is configured. Callers that need admin
+    # authority ask for it explicitly with ``admin=True``.
+    token = settings.get("node_token", "") or settings.get("admin_token", "")
+    if not token:
+        raise FleetClientError("no fleet token configured")
+    return token
+
+
+def _read_bounded(response: Any, *, limit: int) -> bytes:
+    """Read at most ``limit`` bytes, refusing a body that runs past the cap."""
+    reader = getattr(response, "read", None)
+    if reader is None:
+        raise FleetClientError("fleet hub work failed: response could not be read")
+    try:
+        raw = reader(limit + 1)
+    except TypeError as exc:
+        raise FleetClientError("fleet hub work failed: response does not support bounded reads") from exc
+    if not isinstance(raw, (bytes, bytearray)):
+        raise FleetClientError("fleet hub work failed: response was not bytes")
+    if len(raw) > limit:
+        raise FleetClientError(f"fleet hub work failed: response exceeded {limit} bytes")
+    return bytes(raw)
+
+
+def _http_error(exc: urllib.error.HTTPError) -> FleetClientError:
+    try:
+        refusal = json.loads(_read_bounded(exc, limit=MAX_ERROR_RESPONSE_BYTES).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, FleetClientError):
+        refusal = {}
+    if isinstance(refusal, dict):
+        code = _error_code(refusal.get("code"))
+        if code == "hub-unavailable":
+            return WorkloreClientError("hub-unavailable", code=code)
+        detail = refusal.get("error")
+        if isinstance(detail, str) and detail:
+            return WorkloreClientError(
+                f"fleet hub work failed: HTTP {exc.code}: {_safe_terminal_text(detail)}",
+                code=code,
+            )
+        return WorkloreClientError(f"fleet hub work failed: HTTP {exc.code}", code=code)
+    return WorkloreClientError(f"fleet hub work failed: HTTP {exc.code}")
+
+
+def _new_idempotency_key() -> str:
+    return secrets.token_hex(16)
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    token: str,
+    body: Mapping[str, Any] | None = None,
+    if_match: object = None,
+    query: Mapping[str, str] | None = None,
+    timeout: float = REQUEST_TIMEOUT_SECONDS,
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    url = _hub_url() + path
+    if query:
+        filtered = {key: value for key, value in query.items() if value}
+        if filtered:
+            url = f"{url}?{urllib.parse.urlencode(filtered)}"
+    headers = {"Authorization": f"Bearer {token}"}
+    data = None
+    if body is not None:
+        data = json.dumps(dict(body)).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if if_match is not None and str(if_match) != "":
+        headers["If-Match"] = str(if_match)
+    if idempotency_key is not None and str(idempotency_key) != "":
+        headers["Idempotency-Key"] = str(idempotency_key)
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with _hub_open(request, timeout=timeout) as response:
+            raw = _read_bounded(response, limit=MAX_RESPONSE_BYTES)
+    except urllib.error.HTTPError as exc:
+        raise _http_error(exc) from exc
+    except (OSError, TimeoutError) as exc:
+        raise FleetClientError("hub-unavailable") from exc
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FleetClientError("fleet hub work failed: invalid JSON") from exc
+    return payload if isinstance(payload, dict) else {}
+
+
+def _item_path(work_id: str, *parts: str) -> str:
+    segments = ["/work/items", urllib.parse.quote(work_id, safe="")]
+    segments.extend(urllib.parse.quote(part, safe="") for part in parts)
+    return "/".join(segments)
+
+
+def create_item(body: Mapping[str, Any], *, idempotency_key: str | None = None) -> dict[str, Any]:
+    key = idempotency_key if idempotency_key else _new_idempotency_key()
+    return _request(
+        "POST",
+        "/work/items",
+        token=_token(admin=False),
+        body=body,
+        idempotency_key=key,
+    )
+
+
+def get_item(
+    work_id: str,
+    *,
+    links_limit: int | None = None,
+    links_cursor: str | None = None,
+) -> dict[str, Any]:
+    query: dict[str, str] = {}
+    if links_limit is not None:
+        query["links_limit"] = str(links_limit)
+    if links_cursor:
+        query["links_cursor"] = links_cursor
+    return _request("GET", _item_path(work_id), token=_token(), query=query or None)
+
+
+def list_items(
+    source: str | None = None,
+    *,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """Return one page of Worklore items. Callers that need every page use ``list_items_all``."""
+    query: dict[str, str] = {}
+    if source:
+        query["source"] = source
+    if limit is not None:
+        query["limit"] = str(limit)
+    if cursor:
+        query["cursor"] = cursor
+    return _request("GET", "/work/items", token=_token(), query=query or None)
+
+
+def list_items_all(
+    source: str | None = None,
+    *,
+    page_size: int = LIST_PAGE_SIZE,
+    max_pages: int = LIST_MAX_PAGES,
+    max_items: int = LIST_MAX_ITEMS,
+) -> list[Any]:
+    """Follow ``next_cursor`` to the end of a Worklore listing under explicit bounds.
+
+    Raises ``WorkloreListingError`` when the hub repeats a cursor (a cycle), keeps handing out
+    cursors past ``max_pages``, or returns more than ``max_items`` rows, so a misbehaving hub
+    cannot spin the adapter forever.
+    """
+    items: list[Any] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    for _ in range(max_pages):
+        payload = list_items(source, limit=page_size, cursor=cursor)
+        page = payload.get("items")
+        if not isinstance(page, list):
+            raise WorkloreListingError("fleet hub work failed: items must be an array")
+        items.extend(page)
+        if len(items) > max_items:
+            raise WorkloreListingError(f"fleet hub work failed: listing exceeded {max_items} items")
+        next_cursor = payload.get("next_cursor")
+        if not next_cursor:
+            return items
+        if not isinstance(next_cursor, str):
+            raise WorkloreListingError("fleet hub work failed: next_cursor must be a string")
+        if next_cursor in seen_cursors:
+            raise WorkloreListingError("fleet hub work failed: listing cursor did not advance")
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    raise WorkloreListingError(f"fleet hub work failed: listing exceeded {max_pages} pages")
+
+
+def list_item_links_all(
+    work_id: str,
+    *,
+    page_size: int = LIST_PAGE_SIZE,
+    max_pages: int = LIST_MAX_PAGES,
+    max_items: int = LIST_MAX_ITEMS,
+) -> list[Any]:
+    """Follow one item's paged links to completion under the listing bounds."""
+    links: list[Any] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    for _ in range(max_pages):
+        payload = get_item(work_id, links_limit=page_size, links_cursor=cursor)
+        page = payload.get("links")
+        if not isinstance(page, list):
+            raise WorkloreListingError("fleet hub work failed: links must be an array")
+        links.extend(page)
+        if len(links) > max_items:
+            raise WorkloreListingError(f"fleet hub work failed: link listing exceeded {max_items} items")
+        next_cursor = payload.get("links_next_cursor")
+        if next_cursor is None:
+            return links
+        if not isinstance(next_cursor, str) or not next_cursor:
+            raise WorkloreListingError("fleet hub work failed: links_next_cursor must be a non-empty string")
+        if next_cursor in seen_cursors:
+            raise WorkloreListingError("fleet hub work failed: link listing cursor did not advance")
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    raise WorkloreListingError(f"fleet hub work failed: link listing exceeded {max_pages} pages")
+
+
+def list_events(work_id: str) -> dict[str, Any]:
+    return _request("GET", _item_path(work_id, "events"), token=_token())
+
+
+def list_all_events() -> dict[str, Any]:
+    return _request("GET", "/work/events", token=_token())
+
+
+def burn_queue(*, limit: int | None = None, cursor: str | None = None) -> dict[str, Any]:
+    """Return one page of the burn queue. The hub bounds the page; follow ``next_cursor`` for more."""
+    query: dict[str, str] = {}
+    if limit is not None:
+        query["limit"] = str(limit)
+    if cursor:
+        query["cursor"] = cursor
+    return _request("GET", "/work/queue/burn", token=_token(), query=query or None)
+
+
+def patch_item(work_id: str, body: Mapping[str, Any], *, if_match: object = None) -> dict[str, Any]:
+    return _request(
+        "PATCH",
+        _item_path(work_id),
+        token=_token(admin=False),
+        body=body,
+        if_match=if_match,
+    )
+
+
+def transition(work_id: str, body: Mapping[str, Any], *, if_match: object = None) -> dict[str, Any]:
+    return _request(
+        "POST",
+        _item_path(work_id, "transitions"),
+        token=_token(admin=False),
+        body=body,
+        if_match=if_match,
+    )
+
+
+def record_attempt(work_id: str, body: Mapping[str, Any], *, if_match: object = None) -> dict[str, Any]:
+    return _request(
+        "POST",
+        _item_path(work_id, "attempts"),
+        token=_token(admin=False),
+        body=body,
+        if_match=if_match,
+    )
+
+
+def add_link(work_id: str, body: Mapping[str, Any]) -> dict[str, Any]:
+    return _request("POST", _item_path(work_id, "links"), token=_token(admin=False), body=body)
+
+
+def delete_link(work_id: str, link_id: str, *, if_match: object = None) -> dict[str, Any]:
+    return _request(
+        "DELETE",
+        _item_path(work_id, "links", link_id),
+        token=_token(admin=False),
+        if_match=if_match,
+    )
+
+
+def import_batch(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _request(
+        "POST",
+        "/work/imports",
+        token=_token(admin=False),
+        body=payload,
+        timeout=IMPORT_TIMEOUT_SECONDS,
+    )
+
+
+def link_execution(work_id: str, body: Mapping[str, Any]) -> dict[str, Any]:
+    return _request(
+        "POST",
+        _item_path(work_id, "execution"),
+        token=_token(admin=False),
+        body=body,
+    )

--- a/src/brigade/worklore_github.py
+++ b/src/brigade/worklore_github.py
@@ -1,0 +1,196 @@
+"""Normalize one GitHub issue into a Worklore import observation."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from brigade.work_cmd.ledger.import_model import extract_issue_acceptance
+
+from .worklore_validate import (
+    ACCEPTANCE_ITEM_MAX,
+    ACCEPTANCE_MAX_ITEMS,
+    TITLE_MAX,
+    WorkloreValidationError,
+    assert_no_private_data,
+    contains_controls,
+)
+
+ISSUE_FIELDS = frozenset(
+    {
+        "number",
+        "title",
+        "body",
+        "labels",
+        "state",
+        "url",
+        "updatedAt",
+        "repository",
+        "stale",
+    }
+)
+BURN_QUEUE_LABEL = "burn-queue"
+
+
+class GitHubObservationError(Exception):
+    """A GitHub issue cannot be turned into a Worklore observation."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+def _unknown_field(name: object) -> GitHubObservationError:
+    return GitHubObservationError(f"unknown field: {name}", code="unknown-field")
+
+
+def _field_bound(message: str) -> GitHubObservationError:
+    return GitHubObservationError(message, code="field-bound")
+
+
+def _reject_private_data(value: object, field: str) -> str:
+    """Apply the hub's canonical private-data rules client side, in the adapter's error type."""
+    if not isinstance(value, str):
+        raise _field_bound(f"{field} must be a string")
+    try:
+        return assert_no_private_data(value, field)
+    except WorkloreValidationError as exc:
+        raise GitHubObservationError(str(exc), code=exc.code) from None
+
+
+def bounded_title(value: object, field: str = "title") -> str:
+    """Trim a provider title to the Worklore contract the hub enforces."""
+    text = _reject_private_data(value, field).strip()
+    if not text:
+        raise _field_bound(f"{field} is required")
+    if contains_controls(text):
+        raise _field_bound(f"{field} must not contain control characters")
+    return text[:TITLE_MAX]
+
+
+def bounded_acceptance(values: object, field: str = "acceptance") -> list[str]:
+    """Trim provider acceptance to the item count and length the hub accepts."""
+    if values is None:
+        return []
+    if not isinstance(values, list):
+        raise _field_bound(f"{field} must be an array of strings")
+    bounded: list[str] = []
+    for index, value in enumerate(values):
+        text = _reject_private_data(value, f"{field}[{index}]").strip()[:ACCEPTANCE_ITEM_MAX].strip()
+        if not text or contains_controls(text):
+            continue
+        bounded.append(text)
+        if len(bounded) == ACCEPTANCE_MAX_ITEMS:
+            break
+    return bounded
+
+
+def _normalize_repo(name_with_owner: object) -> tuple[str, str]:
+    if not isinstance(name_with_owner, str) or not name_with_owner.strip():
+        raise _field_bound("repository.nameWithOwner is required")
+    owner, separator, repo = name_with_owner.strip().partition("/")
+    if not separator or not owner or not repo or "/" in repo:
+        raise _field_bound("repository.nameWithOwner must be owner/repo")
+    if repo.lower().endswith(".git"):
+        repo = repo[: -len(".git")]
+    if not repo:
+        raise _field_bound("repository.nameWithOwner must be owner/repo")
+    return owner.lower(), repo.lower()
+
+
+def _parse_issue_url(url: object, *, owner: str, repo: str, number: int) -> str:
+    if not isinstance(url, str):
+        raise _field_bound("url must be an https GitHub issue URL")
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "github.com" or parsed.params or parsed.query or parsed.fragment:
+        raise _field_bound("url must be https://github.com/{owner}/{repo}/issues/{number}")
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 4 or parts[2] != "issues":
+        raise _field_bound("url must be https://github.com/{owner}/{repo}/issues/{number}")
+    url_owner, url_repo, _, url_number = parts
+    if url_repo.lower().endswith(".git"):
+        raise _field_bound("url must be https://github.com/{owner}/{repo}/issues/{number}")
+    if url_owner.lower() != owner or url_repo.lower() != repo:
+        raise _field_bound("url repository must match repository.nameWithOwner")
+    if url_number != str(number):
+        raise _field_bound("url issue number must match number")
+    return url
+
+
+def _label_names(labels: object) -> list[str]:
+    if labels is None:
+        return []
+    if not isinstance(labels, list):
+        raise _field_bound("labels must be an array")
+    names: list[str] = []
+    for item in labels:
+        if not isinstance(item, Mapping) or not isinstance(item.get("name"), str):
+            raise _field_bound("labels items must have a name")
+        names.append(item["name"])
+    return names
+
+
+def _issue_number(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise _field_bound("number must be a positive integer")
+    return value
+
+
+def normalize_issue(issue: Mapping[str, Any]) -> dict[str, Any]:
+    """Map one GitHub issue payload to a Worklore import observation."""
+    if not isinstance(issue, Mapping):
+        raise _field_bound("issue must be an object")
+    unknown = [name for name in issue if name not in ISSUE_FIELDS]
+    if unknown:
+        raise _unknown_field(unknown[0])
+    number = _issue_number(issue.get("number"))
+    title = bounded_title(issue.get("title"))
+    body = issue.get("body", "")
+    if body is None:
+        body = ""
+    _reject_private_data(body, "body")
+    repository = issue.get("repository")
+    if not isinstance(repository, Mapping):
+        raise _field_bound("repository is required")
+    owner, repo = _normalize_repo(repository.get("nameWithOwner"))
+    url = _parse_issue_url(issue.get("url"), owner=owner, repo=repo, number=number)
+    state_raw = issue.get("state")
+    if not isinstance(state_raw, str) or not state_raw.strip():
+        raise _field_bound("state is required")
+    state = state_raw.strip().lower()
+    if state not in {"open", "closed"}:
+        raise _field_bound("state must be open or closed")
+    labels = _label_names(issue.get("labels"))
+    if state == "closed":
+        source_policy = "closed"
+        proposed_status: str | None = "completed"
+    elif BURN_QUEUE_LABEL in labels:
+        source_policy = "eligible"
+        proposed_status = None
+    else:
+        source_policy = "label-removed"
+        proposed_status = None
+    observation: dict[str, Any] = {
+        "external_key": f"{owner}/{repo}#{number}",
+        "link_type": "github",
+        "title": title,
+        "acceptance": bounded_acceptance(extract_issue_acceptance(body)),
+        "source_policy": source_policy,
+        "proposed_status": proposed_status,
+        "url": url,
+    }
+    updated_at = issue.get("updatedAt")
+    # The hub will not project an observation without a parseable revision, and this is
+    # where one could be fabricated. It is not. An issue GitHub returned without
+    # ``updatedAt`` is passed through unstamped so the hub refuses it by name and counts
+    # it; dropping it here would turn a reported refusal into a silent skip.
+    if updated_at is not None:
+        if not isinstance(updated_at, str) or not updated_at.strip():
+            raise _field_bound("updatedAt must be a timestamp string")
+        observation["external_updated_at"] = updated_at
+    if "stale" in issue:
+        stale = issue["stale"]
+        if not isinstance(stale, bool):
+            raise _field_bound("stale must be a boolean")
+        observation["stale"] = stale
+    return observation

--- a/src/brigade/worklore_github_sync.py
+++ b/src/brigade/worklore_github_sync.py
@@ -1,0 +1,740 @@
+"""Discover labeled GitHub issues for Worklore imports."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+
+from . import toml_compat as tomllib
+from . import worklore_client, worklore_store
+from .fleet_client import FLEET_CONFIG_REL_PATH, brigade_home
+from .worklore_github import (
+    GitHubObservationError,
+    bounded_acceptance,
+    bounded_title,
+    normalize_issue,
+)
+
+SEARCH_TIMEOUT_SECONDS = 30
+DEFAULT_LABEL = "burn-queue"
+DEFAULT_STATE = "all"
+ORG_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,38}$")
+EXTERNAL_KEY_RE = re.compile(r"^([^/#]+)/([^/#]+)#(\d+)$")
+SEARCH_JSON_FIELDS = "number,title,body,labels,state,url,updatedAt,repository"
+VIEW_JSON_FIELDS = "number,title,body,labels,state,url,updatedAt"
+ALLOWED_STATES = frozenset({"all", "open", "closed"})
+ALLOWED_VISIBILITY = frozenset({"public", "private"})
+BATCH_SIZE = 500
+SEARCH_RESULT_LIMIT = BATCH_SIZE
+MAX_REPORTED_SKIPPED = BATCH_SIZE
+# Reconciliation refreshes one previously linked issue per subprocess call, each of which
+# may take SEARCH_TIMEOUT_SECONDS. A ledger with thousands of stale links would otherwise
+# turn one sync into hours of GitHub calls, so a run spends at most this many refreshes and
+# this much wall clock across every org. Links left unrefreshed are reported as skipped and
+# picked up by the next run.
+RECONCILE_MAX_REFRESHES = 200
+RECONCILE_BUDGET_SECONDS = 300.0
+HUB_STATUS_RE = re.compile(r"\bHTTP (\d{3})\b")
+HUB_CODE_BY_STATUS = {401: "hub-unauthorized", 403: "hub-unauthorized", 409: "hub-conflict"}
+HTTP_404_SIGNALS = frozenset({"HTTP 404", "HTTP 404\n", "HTTP 404\r\n"})
+RECEIPT_UNSAFE = str.maketrans(
+    {
+        ":": "-",
+        "/": "-",
+        "\\": "-",
+        "<": "-",
+        ">": "-",
+        '"': "-",
+        "|": "-",
+        "?": "-",
+        "*": "-",
+    }
+)
+
+
+class GitHubSyncError(Exception):
+    """A GitHub discovery or reconcile step failed with a bounded message."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+class _DiscoveryResult(list[dict[str, Any]]):
+    """Normalized observations plus a bounded count of rejected provider records."""
+
+    def __init__(self, observations: Sequence[dict[str, Any]] = (), *, skipped: int = 0) -> None:
+        super().__init__(observations)
+        self.skipped = min(max(skipped, 0), MAX_REPORTED_SKIPPED)
+
+
+class _UnsafeGitHubObservation(Exception):
+    """A provider record that cannot cross the Worklore safety boundary."""
+
+
+_GitHubLink = tuple[Mapping[str, Any], Mapping[str, Any], str, str, int]
+
+
+class _RefreshBudget:
+    """The refresh count and wall clock one reconcile run may spend."""
+
+    def __init__(self, *, max_refreshes: int | None = None, seconds: float | None = None) -> None:
+        limit = RECONCILE_MAX_REFRESHES if max_refreshes is None else max_refreshes
+        window = RECONCILE_BUDGET_SECONDS if seconds is None else seconds
+        self.remaining = max(int(limit), 0)
+        self.deadline = time.monotonic() + max(float(window), 0.0)
+
+    def spend(self) -> bool:
+        """Claim one refresh, or return False once the count or the clock is spent."""
+        if self.remaining <= 0 or time.monotonic() >= self.deadline:
+            self.remaining = 0
+            return False
+        self.remaining -= 1
+        return True
+
+
+def _config_error(message: str) -> GitHubSyncError:
+    return GitHubSyncError(message, code="field-bound")
+
+
+def _adapter_failure() -> GitHubSyncError:
+    return GitHubSyncError("adapter command failed", code="retryable-adapter-failure")
+
+
+def _search_truncated() -> GitHubSyncError:
+    return GitHubSyncError("search result limit reached", code="search-truncated")
+
+
+def load_github_config() -> dict[str, Any]:
+    """Read ``[fleet.worklore.github]`` from the fleet config."""
+    section = _read_github_section()
+    if section is None:
+        raise _config_error("GitHub Worklore config is missing orgs")
+    label = section.get("label", DEFAULT_LABEL)
+    if not isinstance(label, str) or not label.strip():
+        raise _config_error("label must be a non-empty string")
+    state = section.get("state", DEFAULT_STATE)
+    if not isinstance(state, str) or state.strip() not in ALLOWED_STATES:
+        raise _config_error("state must be all, open, or closed")
+    return {
+        "label": label.strip(),
+        "state": state.strip(),
+        "orgs": _parse_orgs(section.get("orgs")),
+    }
+
+
+def _read_github_section() -> dict[str, Any] | None:
+    config_path = brigade_home() / FLEET_CONFIG_REL_PATH.name
+    if not config_path.is_file():
+        return None
+    try:
+        payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    fleet = payload.get("fleet") if isinstance(payload, dict) else None
+    worklore = fleet.get("worklore") if isinstance(fleet, dict) else None
+    github = worklore.get("github") if isinstance(worklore, dict) else None
+    return github if isinstance(github, dict) else None
+
+
+def _parse_orgs(raw: object) -> list[dict[str, str]]:
+    if not isinstance(raw, list) or not raw:
+        raise _config_error("orgs must be a non-empty list")
+    orgs: list[dict[str, str]] = []
+    seen_names: set[str] = set()
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise _config_error("orgs items must be tables")
+        name = item.get("name")
+        visibility = item.get("visibility")
+        if not isinstance(name, str) or not ORG_NAME_RE.fullmatch(name):
+            raise _config_error("orgs name is invalid")
+        if visibility not in ALLOWED_VISIBILITY:
+            raise _config_error("orgs visibility must be public or private")
+        folded = name.lower()
+        if folded in seen_names:
+            raise _config_error("orgs name is duplicated")
+        seen_names.add(folded)
+        orgs.append({"name": name, "visibility": str(visibility)})
+    return orgs
+
+
+def _require_label(label: object) -> str:
+    if not isinstance(label, str) or not label.strip():
+        raise _config_error("label must be a non-empty string")
+    return label.strip()
+
+
+def _require_state(state: object) -> str:
+    if not isinstance(state, str) or state.strip() not in ALLOWED_STATES:
+        raise _config_error("state must be all, open, or closed")
+    return state.strip()
+
+
+def _use_octopool(visibility: str) -> bool:
+    return visibility == "public" and shutil.which("octopool") is not None
+
+
+def _search_argv(org_name: str, *, label: str, state: str, use_octopool: bool) -> list[str]:
+    argv = [
+        "gh",
+        "search",
+        "issues",
+        "--owner",
+        org_name,
+        "--label",
+        label,
+        "--limit",
+        str(SEARCH_RESULT_LIMIT),
+        "--json",
+        SEARCH_JSON_FIELDS,
+    ]
+    if state in {"open", "closed"}:
+        argv.extend(["--state", state])
+    if use_octopool:
+        return ["octopool", *argv]
+    return argv
+
+
+def _view_argv(owner: str, repo: str, number: int, *, use_octopool: bool) -> list[str]:
+    argv = [
+        "gh",
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        f"{owner}/{repo}",
+        "--json",
+        VIEW_JSON_FIELDS,
+    ]
+    if use_octopool:
+        return ["octopool", *argv]
+    return argv
+
+
+def _run_github(argv: list[str], *, use_octopool: bool) -> subprocess.CompletedProcess[str]:
+    env = None
+    if use_octopool:
+        env = os.environ.copy()
+        env["OCTOPOOL_NO_FALLBACK"] = "1"
+    try:
+        return subprocess.run(  # noqa: S603 - argv is constructed, never shell-interpolated
+            argv,
+            timeout=SEARCH_TIMEOUT_SECONDS,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise _adapter_failure() from None
+
+
+def _is_http_404(result: subprocess.CompletedProcess[str]) -> bool:
+    if result.returncode == 0:
+        return False
+    for stream in (result.stdout or "", result.stderr or ""):
+        if stream in HTTP_404_SIGNALS:
+            return True
+        try:
+            payload = json.loads(stream)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, Mapping) and payload.get("status") == 404:
+            return True
+    return False
+
+
+def _parse_search_stdout(stdout: str) -> list[object]:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        raise _adapter_failure() from None
+    if not isinstance(payload, list):
+        raise _adapter_failure()
+    return payload
+
+
+def _parse_view_stdout(stdout: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        raise _adapter_failure() from None
+    if not isinstance(payload, dict):
+        raise _adapter_failure()
+    return payload
+
+
+def _search_item_owner(item: Mapping[str, Any]) -> str | None:
+    repository = item.get("repository")
+    if not isinstance(repository, Mapping):
+        return None
+    name_with_owner = repository.get("nameWithOwner")
+    if not isinstance(name_with_owner, str):
+        return None
+    owner, separator, remainder = name_with_owner.strip().partition("/")
+    if not separator or not owner or not remainder:
+        return None
+    return owner.lower()
+
+
+def _normalize_search_payload(payload: list[object], *, org_name: str) -> _DiscoveryResult:
+    expected_owner = org_name.lower()
+    observations = _DiscoveryResult()
+    for item in payload:
+        if not isinstance(item, Mapping):
+            raise _adapter_failure()
+        if _search_item_owner(item) != expected_owner:
+            raise _adapter_failure()
+        try:
+            observations.append(normalize_issue(item))
+        except GitHubObservationError:
+            observations.skipped = min(observations.skipped + 1, MAX_REPORTED_SKIPPED)
+    return observations
+
+
+def discover_issues(orgs: object, *, label: str, state: str) -> _DiscoveryResult:
+    """List labeled issues for each org through octopool or direct gh."""
+    parsed_orgs = _parse_orgs(orgs)
+    label_value = _require_label(label)
+    state_value = _require_state(state)
+    observations = _DiscoveryResult()
+    for org in parsed_orgs:
+        use_octopool = _use_octopool(org["visibility"])
+        result = _run_github(
+            _search_argv(org["name"], label=label_value, state=state_value, use_octopool=use_octopool),
+            use_octopool=use_octopool,
+        )
+        if result.returncode != 0:
+            raise _adapter_failure()
+        payload = _parse_search_stdout(result.stdout)
+        if len(payload) >= SEARCH_RESULT_LIMIT:
+            raise _search_truncated()
+        normalized = _normalize_search_payload(payload, org_name=org["name"])
+        observations.extend(normalized)
+        observations.skipped = min(observations.skipped + normalized.skipped, MAX_REPORTED_SKIPPED)
+    return observations
+
+
+def _parse_external_key(raw: object) -> tuple[str, str, int]:
+    if not isinstance(raw, str):
+        raise _config_error("external key is invalid")
+    match = EXTERNAL_KEY_RE.fullmatch(raw.strip())
+    if match is None:
+        raise _config_error("external key is invalid")
+    owner, repo, number_text = match.groups()
+    if repo.lower().endswith(".git"):
+        repo = repo[: -len(".git")]
+    if not repo:
+        raise _config_error("external key is invalid")
+    number = int(number_text)
+    if number < 1:
+        raise _config_error("external key is invalid")
+    return owner.lower(), repo.lower(), number
+
+
+def _github_links(existing_items: object) -> tuple[list[_GitHubLink], int]:
+    """Return well-formed github links plus a count of malformed ones skipped."""
+    if existing_items is None:
+        existing_items = []
+    if not isinstance(existing_items, list):
+        raise _config_error("existing items must be an array")
+    links: list[_GitHubLink] = []
+    skipped = 0
+    for item in existing_items:
+        if not isinstance(item, Mapping):
+            skipped += 1
+            continue
+        item_links = item.get("links")
+        if item_links is None:
+            continue
+        if not isinstance(item_links, list):
+            skipped += 1
+            continue
+        for link in item_links:
+            if not isinstance(link, Mapping):
+                skipped += 1
+                continue
+            if link.get("link_type") != "github":
+                continue
+            try:
+                owner, repo, number = _parse_external_key(link.get("external_key"))
+            except GitHubSyncError:
+                skipped += 1
+                continue
+            links.append((item, link, owner, repo, number))
+    return links, skipped
+
+
+def _complete_link_projections(existing_items: object) -> list[object]:
+    """Expand capped item link projections before using them for reconciliation."""
+    if not isinstance(existing_items, list):
+        raise _config_error("existing items must be an array")
+    completed: list[object] = []
+    for item in existing_items:
+        if not isinstance(item, Mapping) or item.get("links_truncated") is not True:
+            completed.append(item)
+            continue
+        work_id = item.get("work_id")
+        if not isinstance(work_id, str) or not work_id.strip():
+            raise GitHubSyncError("complete link listing could not be proven", code="links-incomplete")
+        try:
+            links = worklore_client.list_item_links_all(work_id)
+        except worklore_client.FleetClientError as exc:
+            raise GitHubSyncError("complete link listing could not be proven", code="links-incomplete") from exc
+        expanded = dict(item)
+        expanded["links"] = links
+        expanded["links_truncated"] = False
+        completed.append(expanded)
+    return completed
+
+
+def _require_existing_link_url(url: object, *, owner: str, repo: str, number: int) -> str:
+    if not isinstance(url, str) or not url.strip():
+        raise _UnsafeGitHubObservation()
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "github.com" or parsed.params or parsed.query or parsed.fragment:
+        raise _UnsafeGitHubObservation()
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 4 or parts[2] != "issues":
+        raise _UnsafeGitHubObservation()
+    url_owner, url_repo, _, url_number = parts
+    if url_repo.lower().endswith(".git"):
+        raise _UnsafeGitHubObservation()
+    if url_owner.lower() != owner or url_repo.lower() != repo or url_number != str(number):
+        raise _UnsafeGitHubObservation()
+    return url
+
+
+def _stale_tombstone(
+    item: Mapping[str, Any],
+    link: Mapping[str, Any],
+    *,
+    owner: str,
+    repo: str,
+    number: int,
+) -> dict[str, Any]:
+    try:
+        title = bounded_title(item.get("title"), "existing item title")
+        acceptance = bounded_acceptance(link.get("source_acceptance"), "existing link source_acceptance")
+    except GitHubObservationError:
+        raise _UnsafeGitHubObservation() from None
+    source_policy = link.get("source_policy")
+    if not isinstance(source_policy, str) or not source_policy.strip():
+        raise _UnsafeGitHubObservation()
+    url = _require_existing_link_url(link.get("url"), owner=owner, repo=repo, number=number)
+    tombstone: dict[str, Any] = {
+        "external_key": f"{owner}/{repo}#{number}",
+        "link_type": "github",
+        "title": title,
+        "acceptance": acceptance,
+        "source_policy": source_policy,
+        "proposed_status": None,
+        "url": url,
+        "stale": True,
+    }
+    updated_at = link.get("external_updated_at")
+    if updated_at is not None:
+        if not isinstance(updated_at, str) or not updated_at.strip():
+            raise _UnsafeGitHubObservation()
+        tombstone["external_updated_at"] = updated_at
+    return tombstone
+
+
+def _refresh_missing_link(
+    *,
+    owner: str,
+    repo: str,
+    number: int,
+    visibility: str,
+    item: Mapping[str, Any],
+    link: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    use_octopool = _use_octopool(visibility)
+    result = _run_github(
+        _view_argv(owner, repo, number, use_octopool=use_octopool),
+        use_octopool=use_octopool,
+    )
+    if result.returncode != 0:
+        if _is_http_404(result):
+            if use_octopool:
+                return None
+            return _stale_tombstone(item, link, owner=owner, repo=repo, number=number)
+        raise _adapter_failure()
+    payload = dict(_parse_view_stdout(result.stdout))
+    payload["repository"] = {"nameWithOwner": f"{owner}/{repo}"}
+    try:
+        return normalize_issue(payload)
+    except GitHubObservationError:
+        raise _UnsafeGitHubObservation() from None
+
+
+def discover_and_reconcile(
+    orgs: object,
+    *,
+    label: str,
+    state: str,
+    existing_items: object,
+    budget: _RefreshBudget | None = None,
+) -> _DiscoveryResult:
+    """Discover labeled issues, then refresh previously linked GitHub issues under a budget.
+
+    ``budget`` bounds how many refreshes this run may make and how long it may spend on
+    them. Pass one budget across several calls to bound a whole multi-org sync.
+    """
+    parsed_orgs = _parse_orgs(orgs)
+    refresh_budget = _RefreshBudget() if budget is None else budget
+    discovered = discover_issues(parsed_orgs, label=label, state=state)
+    links, malformed = _github_links(_complete_link_projections(existing_items))
+    observations = _DiscoveryResult(discovered, skipped=discovered.skipped + malformed)
+    seen = {str(observation["external_key"]) for observation in observations}
+    org_by_name = {org["name"].lower(): org for org in parsed_orgs}
+    for item, link, owner, repo, number in links:
+        key = f"{owner}/{repo}#{number}"
+        if key in seen:
+            continue
+        org = org_by_name.get(owner)
+        if org is None:
+            continue
+        if not refresh_budget.spend():
+            observations.skipped = min(observations.skipped + 1, MAX_REPORTED_SKIPPED)
+            continue
+        visibility = org["visibility"]
+        try:
+            refreshed = _refresh_missing_link(
+                owner=owner,
+                repo=repo,
+                number=number,
+                visibility=visibility,
+                item=item,
+                link=link,
+            )
+        except _UnsafeGitHubObservation:
+            observations.skipped = min(observations.skipped + 1, MAX_REPORTED_SKIPPED)
+            continue
+        if refreshed is not None:
+            observations.append(refreshed)
+            seen.add(key)
+    return observations
+
+
+def _hub_error_code(exc: Exception) -> str:
+    """Classify a hub refusal so a permanent 4xx is not retried as transient."""
+    match = HUB_STATUS_RE.search(str(exc))
+    if match is None:
+        return "hub-unavailable"
+    status = int(match.group(1))
+    if not 400 <= status < 500:
+        return "hub-unavailable"
+    return HUB_CODE_BY_STATUS.get(status, "hub-rejected")
+
+
+def _hub_error(code: str) -> GitHubSyncError:
+    return GitHubSyncError(code, code=code)
+
+
+def _receipt_write_failed() -> GitHubSyncError:
+    return GitHubSyncError("receipt-write-failed", code="receipt-write-failed")
+
+
+def _safe_adapter_id(adapter_id: str) -> str:
+    return adapter_id.translate(RECEIPT_UNSAFE)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _batch_idempotency_key(org_name: str, observations: Sequence[Mapping[str, Any]]) -> str:
+    digest = worklore_store.observation_fingerprint(observations)
+    return f"github:{org_name.lower()}:{digest}"
+
+
+def _as_count(value: object) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _chunks(observations: list[dict[str, Any]], size: int) -> list[list[dict[str, Any]]]:
+    if not observations:
+        return [[]]
+    return [observations[index : index + size] for index in range(0, len(observations), size)]
+
+
+def _ensure_private_receipt_dir() -> Path:
+    directory = brigade_home() / "worklore" / "github"
+    directory.mkdir(parents=True, mode=0o700, exist_ok=True)
+    try:
+        directory.chmod(0o700)
+        directory.parent.chmod(0o700)
+    except OSError:
+        pass
+    return directory
+
+
+def _write_receipt(
+    adapter_id: str,
+    *,
+    idempotency_key: str,
+    observation_count: int,
+    last_error_code: str | None,
+    refused: int = 0,
+    skipped: int = 0,
+) -> None:
+    directory = _ensure_private_receipt_dir()
+    path = directory / f"{_safe_adapter_id(adapter_id)}.json"
+    payload = {
+        "adapter_id": adapter_id,
+        "idempotency_key": idempotency_key,
+        "last_error_code": last_error_code,
+        "observation_count": observation_count,
+        "refused": _as_count(refused),
+        "skipped": min(max(skipped, 0), MAX_REPORTED_SKIPPED),
+        "updated_at": _utc_now(),
+    }
+    fd, tmp_name = tempfile.mkstemp(dir=directory, prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+        os.chmod(path, 0o600)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _write_receipt_best_effort(
+    adapter_id: str,
+    *,
+    idempotency_key: str,
+    observation_count: int,
+    last_error_code: str | None,
+    refused: int = 0,
+    skipped: int = 0,
+) -> None:
+    try:
+        _write_receipt(
+            adapter_id,
+            idempotency_key=idempotency_key,
+            observation_count=observation_count,
+            last_error_code=last_error_code,
+            refused=refused,
+            skipped=skipped,
+        )
+    except OSError:
+        return
+
+
+def _write_listing_failure_receipts(parsed_orgs: Sequence[Mapping[str, Any]], code: str) -> None:
+    for org in parsed_orgs:
+        _write_receipt_best_effort(
+            f"github:{org['name'].lower()}",
+            idempotency_key="",
+            observation_count=0,
+            last_error_code=code,
+        )
+
+
+def sync_github(
+    orgs: object,
+    *,
+    label: str = DEFAULT_LABEL,
+    state: str = DEFAULT_STATE,
+) -> dict[str, Any]:
+    """Discover labeled GitHub issues and post idempotent Worklore import batches."""
+    parsed_orgs = _parse_orgs(orgs)
+    label_value = _require_label(label)
+    state_value = _require_state(state)
+    try:
+        items = worklore_client.list_items_all(source="github")
+    except worklore_client.WorkloreListingError as exc:
+        code = "hub-rejected"
+        _write_listing_failure_receipts(parsed_orgs, code)
+        raise _hub_error(code) from exc
+    except worklore_client.FleetClientError as exc:
+        code = _hub_error_code(exc)
+        _write_listing_failure_receipts(parsed_orgs, code)
+        raise _hub_error(code) from None
+    try:
+        completed_items = _complete_link_projections(items)
+    except GitHubSyncError as exc:
+        _write_listing_failure_receipts(parsed_orgs, exc.code)
+        raise _hub_error(exc.code) from None
+    posted = 0
+    observation_count = 0
+    refused_count = 0
+    skipped_count = 0
+    # One budget for the whole sync, so total reconcile work stays bounded no matter how
+    # many organizations are configured.
+    refresh_budget = _RefreshBudget()
+    for org in parsed_orgs:
+        adapter_id = f"github:{org['name'].lower()}"
+        observations = discover_and_reconcile(
+            [org],
+            label=label_value,
+            state=state_value,
+            existing_items=completed_items,
+            budget=refresh_budget,
+        )
+        skipped = min(max(int(getattr(observations, "skipped", 0)), 0), MAX_REPORTED_SKIPPED)
+        skipped_count = min(skipped_count + skipped, MAX_REPORTED_SKIPPED)
+        org_refused = 0
+        ordered_observations = sorted(observations, key=lambda item: str(item["external_key"]))
+        for chunk in _chunks(ordered_observations, BATCH_SIZE):
+            idempotency_key = _batch_idempotency_key(org["name"], chunk)
+            envelope = {
+                "adapter_id": adapter_id,
+                "source_type": "github",
+                "idempotency_key": idempotency_key,
+                "observations": chunk,
+            }
+            try:
+                result = worklore_client.import_batch(envelope)
+            except worklore_client.FleetClientError as exc:
+                code = _hub_error_code(exc)
+                _write_receipt_best_effort(
+                    adapter_id,
+                    idempotency_key=idempotency_key,
+                    observation_count=len(chunk),
+                    last_error_code=code,
+                    refused=org_refused,
+                    skipped=skipped,
+                )
+                raise _hub_error(code) from None
+            refused = _as_count(result.get("refused")) if isinstance(result, Mapping) else 0
+            org_refused += refused
+            refused_count += refused
+            try:
+                _write_receipt(
+                    adapter_id,
+                    idempotency_key=idempotency_key,
+                    observation_count=len(chunk),
+                    last_error_code="hub-partial" if org_refused else None,
+                    refused=org_refused,
+                    skipped=skipped,
+                )
+            except OSError:
+                raise _receipt_write_failed() from None
+            posted += 1
+            observation_count += len(chunk)
+    return {
+        "posted": posted,
+        "observation_count": observation_count,
+        "refused": refused_count,
+        "skipped": skipped_count,
+    }

--- a/src/brigade/worklore_http.py
+++ b/src/brigade/worklore_http.py
@@ -1,0 +1,475 @@
+"""Isolated /work handlers: path parsing, authz, JSON envelopes, and status codes."""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+from urllib.parse import parse_qs, urlsplit
+
+from . import toml_compat
+from . import worklore_store as store
+from .fleet_client import FLEET_CONFIG_REL_PATH, brigade_home
+from .worklore_validate import WorkloreValidationError
+
+_ENABLED_TRUE = frozenset({"1", "true", "yes", "on"})
+_ENABLED_FALSE = frozenset({"0", "false", "no", "off"})
+_OPERATOR_NODES_ENV = "BRIGADE_WORKLORE_OPERATOR_NODES"
+_OPERATOR_NODES_MAX = 32
+_OPERATOR_NODE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+# ``admin`` is the actor id and the import owner_node this module writes for the hub admin
+# token, so a node presenting it as its own id would author events and own adapter
+# namespaces indistinguishable from the admin's. The id is reserved: a node actor may not
+# use it, and it is never accepted as a configured operator node.
+RESERVED_NODE_ID = "admin"
+# Numeric request fields are small counters. Bounding the digit count before any
+# int() keeps a caller from spending CPU on a million-digit literal, and keeps
+# CPython's 4300-digit conversion guard from surfacing as an unhandled ValueError.
+_MAX_NUMBER_DIGITS = 10
+# An opaque page cursor is base64 of a small JSON object (~120 chars in practice).
+_MAX_CURSOR_CHARS = 512
+
+_STATUS_BY_CODE = {
+    "unauthorized": 401,
+    "forbidden": 403,
+    "not-found": 404,
+    "version-conflict": 409,
+    "if-match-required": 400,
+    "invalid-transition": 400,
+    "unknown-field": 400,
+    "field-bound": 400,
+    "private-data": 400,
+    "acceptance-required": 400,
+    "import-conflict": 409,
+    "adapter-owner-mismatch": 403,
+    "execution-mismatch": 403,
+    "attempt-forbidden": 403,
+    "attempt-conflict": 409,
+    "link-forbidden": 403,
+    "link-conflict": 409,
+    "hub-unavailable": 503,
+    "internal-error": 500,
+}
+
+_STORE_ERRORS = (
+    store.WorkloreConflict,
+    store.WorkloreNotFound,
+    store.WorkloreForbidden,
+    WorkloreValidationError,
+)
+
+
+@dataclass(frozen=True)
+class Request:
+    """Authenticated caller plus a parsed /work request."""
+
+    method: str
+    path: str
+    is_admin: bool = False
+    node_id: str | None = None
+    is_operator: bool = False
+    operator_authorization_resolved: bool = False
+    body: Mapping[str, Any] = field(default_factory=dict)
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+
+def enabled(
+    environ: Mapping[str, str] | None = None,
+    config_path: str | Path | None = None,
+) -> bool:
+    """Fail-closed Worklore feature gate: recognized env wins, else TOML boolean."""
+    env = os.environ if environ is None else environ
+    raw = env.get("BRIGADE_WORKLORE_ENABLED")
+    if raw is not None:
+        value = str(raw).strip().lower()
+        if value in _ENABLED_TRUE:
+            return True
+        if value in _ENABLED_FALSE:
+            return False
+    return _worklore_section(config_path).get("enabled") is True
+
+
+def operator_nodes(
+    environ: Mapping[str, str] | None = None,
+    config_path: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Worklore-only operator node ids from env override or ``fleet.worklore.operator_nodes``."""
+    env = os.environ if environ is None else environ
+    if _OPERATOR_NODES_ENV in env:
+        return _parse_operator_nodes_env(env.get(_OPERATOR_NODES_ENV, ""))
+    return _normalize_operator_nodes(_worklore_section(config_path).get("operator_nodes"))
+
+
+def _worklore_section(config_path: str | Path | None = None) -> dict[str, Any]:
+    path = Path(config_path) if config_path is not None else brigade_home() / FLEET_CONFIG_REL_PATH.name
+    try:
+        payload = toml_compat.loads(path.read_text(encoding="utf-8"))
+    except (OSError, toml_compat.TOMLDecodeError):
+        return {}
+    fleet = payload.get("fleet") if isinstance(payload, dict) else None
+    section = fleet.get("worklore") if isinstance(fleet, dict) else None
+    return section if isinstance(section, dict) else {}
+
+
+def _parse_operator_nodes_env(raw: object) -> tuple[str, ...]:
+    if not isinstance(raw, str) or not raw.strip():
+        return ()
+    return _normalize_operator_nodes(part.strip() for part in raw.split(","))
+
+
+def _normalize_operator_nodes(raw: object) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if isinstance(raw, (str, bytes, Mapping)) or not isinstance(raw, Iterable):
+        return ()
+    seen: set[str] = set()
+    nodes: list[str] = []
+    for value in raw:
+        if not isinstance(value, str):
+            continue
+        node_id = value.strip()
+        if node_id in {"unknown", RESERVED_NODE_ID} or not _OPERATOR_NODE_RE.fullmatch(node_id):
+            continue
+        if node_id in seen:
+            continue
+        seen.add(node_id)
+        nodes.append(node_id)
+        if len(nodes) >= _OPERATOR_NODES_MAX:
+            break
+    return tuple(nodes)
+
+
+def handle(conn: sqlite3.Connection, request: Request) -> tuple[int, dict[str, Any]]:
+    """Dispatch one /work request and map store errors to the stable JSON contract."""
+    request = _snapshot_operator_authorization(request)
+    try:
+        return _dispatch(conn, request)
+    except _STORE_ERRORS as exc:
+        return _mapped_error(exc)
+    except sqlite3.Error:
+        return _error("internal-error", "internal error")
+    except (ValueError, OverflowError):
+        # A number that survived the digit bound but is still out of range (an
+        # If-Match or cursor sequence wider than SQLite's INTEGER, say) becomes the
+        # ordinary field-bound refusal instead of a traceback.
+        return _error("field-bound", "request field is out of bounds")
+
+
+def _dispatch(conn: sqlite3.Connection, request: Request) -> tuple[int, dict[str, Any]]:
+    if not request.is_admin and not request.node_id:
+        return _error("unauthorized")
+    if not request.is_admin and request.node_id == RESERVED_NODE_ID:
+        return _error("forbidden", f"node id {RESERVED_NODE_ID!r} is reserved for the hub admin token")
+    parsed = urlsplit(request.path)
+    parts = [part for part in parsed.path.split("/") if part]
+    query = {key: values[-1] for key, values in parse_qs(parsed.query, keep_blank_values=True).items() if values}
+    method = request.method.upper()
+    if parts[:1] != ["work"]:
+        return _error("not-found")
+    rest = parts[1:]
+    if rest == ["items"] and method == "GET":
+        _validate_query(query, {"status", "kind", "burn_eligible", "source", "limit", "cursor"})
+        return 200, store.list_items(
+            conn,
+            status=query.get("status"),
+            kind=query.get("kind"),
+            burn_eligible=query.get("burn_eligible"),
+            source=query.get("source"),
+            limit=_bounded_limit(query.get("limit", 50)),
+            cursor=_bounded_cursor(query.get("cursor")),
+        )
+    if rest == ["items"] and method == "POST":
+        _require_operator(request)
+        item = store.create_item(
+            conn,
+            dict(request.body),
+            actor_id=_actor_id(request),
+            actor_type=_actor_type(request),
+            node_id=_event_node_id(request),
+            idempotency_key=_idempotency_key(request),
+        )
+        return 201, {"item": item}
+    if rest == ["events"] and method == "GET":
+        _validate_query(query, {"work_id", "event_type", "limit", "cursor"})
+        return 200, store.list_all_events(
+            conn,
+            work_id=query.get("work_id"),
+            event_type=query.get("event_type"),
+            limit=_bounded_limit(query.get("limit", 50)),
+            cursor=_bounded_cursor(query.get("cursor")),
+        )
+    if rest == ["queue", "burn"] and method == "GET":
+        _validate_query(query, {"limit", "cursor"})
+        return 200, store.burn_queue(
+            conn,
+            limit=_bounded_limit(query.get("limit", store.BURN_PAGE_DEFAULT)),
+            cursor=_bounded_cursor(query.get("cursor")),
+        )
+    if rest == ["imports"] and method == "POST":
+        return _import_batch(conn, request)
+    if len(rest) >= 2 and rest[0] == "items":
+        return _item_route(conn, request, method, rest[1], rest[2:], query)
+    return _error("not-found")
+
+
+def _item_route(
+    conn: sqlite3.Connection,
+    request: Request,
+    method: str,
+    work_id: str,
+    tail: list[str],
+    query: Mapping[str, str],
+) -> tuple[int, dict[str, Any]]:
+    if not tail and method == "GET":
+        _validate_query(query, {"links_limit", "links_cursor"})
+        item = store.get_item(conn, work_id)
+        links = store.list_links_page(
+            conn,
+            work_id,
+            limit=_bounded_limit(query.get("links_limit", store.LINK_PAGE_DEFAULT)),
+            cursor=_bounded_cursor(query.get("links_cursor")),
+        )
+        return 200, {
+            "item": item,
+            "links": links["links"],
+            "links_next_cursor": links["next_cursor"],
+            "recent_events": store.recent_events(conn, work_id),
+        }
+    if not tail and method == "PATCH":
+        _require_operator(request)
+        item = store.patch_item(
+            conn,
+            work_id,
+            dict(request.body),
+            expected_version=_if_match(request),
+            actor_id=_actor_id(request),
+            actor_type=_actor_type(request),
+            node_id=_event_node_id(request),
+        )
+        return 200, {"item": item}
+    if tail == ["events"] and method == "GET":
+        _validate_query(query, {"limit", "cursor"})
+        return 200, store.list_events_page(
+            conn,
+            work_id,
+            limit=_bounded_limit(query.get("limit", 50)),
+            cursor=_bounded_cursor(query.get("cursor")),
+        )
+    if tail == ["transitions"] and method == "POST":
+        _require_operator(request)
+        body = _object_body(request.body, allowed={"to_status"})
+        item = store.transition(
+            conn,
+            work_id,
+            to_status=str(body.get("to_status") or ""),
+            expected_version=_if_match(request),
+            actor_id=_actor_id(request),
+            actor_type=_actor_type(request),
+            node_id=_event_node_id(request),
+        )
+        return 200, {"item": item}
+    if tail == ["attempts"] and method == "POST":
+        return _record_attempt(conn, request, work_id)
+    if tail == ["links"] and method == "POST":
+        _require_operator(request)
+        added = store.add_link(
+            conn,
+            work_id,
+            dict(request.body),
+            actor_id=_actor_id(request),
+            actor_type=_actor_type(request),
+            node_id=_event_node_id(request),
+        )
+        return 201, {"link": added}
+    if len(tail) == 2 and tail[0] == "links" and method == "DELETE":
+        _require_operator(request)
+        expected_version = _optional_if_match(request)
+        store.delete_link(
+            conn,
+            work_id,
+            tail[1],
+            expected_version=expected_version,
+            actor_id=_actor_id(request),
+            actor_type=_actor_type(request),
+            node_id=_event_node_id(request),
+        )
+        return 200, {"ok": True}
+    if tail == ["execution"] and method == "POST":
+        return _link_execution(conn, request, work_id)
+    return _error("not-found")
+
+
+def _record_attempt(
+    conn: sqlite3.Connection,
+    request: Request,
+    work_id: str,
+) -> tuple[int, dict[str, Any]]:
+    body = _object_body(request.body, allowed={"action", "run_id"})
+    action = body.get("action")
+    if action == "reset" and not request.is_admin and not _is_operator(request):
+        return _error("forbidden")
+    expected_version = _if_match(request)
+    run_id = body.get("run_id")
+    item = store.record_attempt(
+        conn,
+        work_id,
+        action=str(action or ""),
+        expected_version=expected_version,
+        actor_id=_actor_id(request),
+        actor_type=_actor_type(request),
+        node_id=None if request.is_admin else request.node_id,
+        run_id=run_id,
+    )
+    return 200, {"item": item}
+
+
+def _import_batch(conn: sqlite3.Connection, request: Request) -> tuple[int, dict[str, Any]]:
+    # Importing writes work items and claims an adapter namespace, so it needs a node the
+    # operator configured for Worklore, not merely a node enrolled in the fleet.
+    _require_operator(request)
+    body = _object_body(
+        request.body,
+        allowed={"adapter_id", "source_type", "idempotency_key", "observations"},
+    )
+    owner = request.node_id or "admin"
+    return 200, store.import_batch(
+        conn,
+        adapter_id=str(body.get("adapter_id") or ""),
+        source_type=str(body.get("source_type") or ""),
+        idempotency_key=str(body.get("idempotency_key") or ""),
+        observations=body.get("observations"),
+        actor_id=_actor_id(request),
+        owner_node=owner,
+    )
+
+
+def _link_execution(
+    conn: sqlite3.Connection,
+    request: Request,
+    work_id: str,
+) -> tuple[int, dict[str, Any]]:
+    body = _object_body(request.body, allowed={"node_id", "run_id"})
+    node_id = str(body.get("node_id") or "")
+    run_id = str(body.get("run_id") or "")
+    if not request.is_admin and node_id != request.node_id:
+        return _error("execution-mismatch", "node may link only its own run")
+    link = store.link_execution(
+        conn,
+        work_id,
+        node_id=node_id,
+        run_id=run_id,
+        actor_id=_actor_id(request),
+        actor_type=_actor_type(request),
+        is_admin=request.is_admin,
+    )
+    return 201, {"link": link}
+
+
+def _object_body(raw: object, *, allowed: set[str]) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise WorkloreValidationError("body must be an object", code="field-bound")
+    unknown = [key for key in raw if key not in allowed]
+    if unknown:
+        raise WorkloreValidationError(f"unknown field: {unknown[0]}", code="unknown-field")
+    return dict(raw)
+
+
+def _bounded_limit(value: object) -> object:
+    """Pass ``limit`` through untouched once its digit count is bounded; the store
+    still owns the 1-100 range check and its message."""
+    if isinstance(value, str) and len(value) > _MAX_NUMBER_DIGITS:
+        raise WorkloreValidationError("limit must be an integer from 1 to 100", code="field-bound")
+    return value
+
+
+def _bounded_cursor(value: str | None) -> str | None:
+    """Refuse an oversized cursor before it is decoded, so no wide integer can be
+    smuggled into the page sequence."""
+    if value is not None and len(value) > _MAX_CURSOR_CHARS:
+        raise WorkloreValidationError("cursor is invalid", code="field-bound")
+    return value
+
+
+def _validate_query(query: Mapping[str, str], allowed: set[str]) -> None:
+    unknown = next((key for key in query if key not in allowed), None)
+    if unknown is not None:
+        raise WorkloreValidationError(f"unknown field: {unknown}", code="unknown-field")
+
+
+def _require_operator(request: Request) -> None:
+    if request.is_admin or _is_operator(request):
+        return
+    raise store.WorkloreForbidden("operator token required", code="forbidden")
+
+
+def _is_operator(request: Request) -> bool:
+    return request.is_operator
+
+
+def _snapshot_operator_authorization(request: Request) -> Request:
+    """Read operator configuration once so every authorization use agrees for this request."""
+    if request.operator_authorization_resolved:
+        return request
+    if request.is_admin or not request.node_id:
+        return replace(request, operator_authorization_resolved=True)
+    return replace(
+        request,
+        is_operator=request.node_id in operator_nodes(),
+        operator_authorization_resolved=True,
+    )
+
+
+def _event_node_id(request: Request) -> str | None:
+    return None if request.is_admin else request.node_id
+
+
+def _idempotency_key(request: Request) -> str | None:
+    raw = _header(request, "Idempotency-Key")
+    if raw is None or raw == "":
+        return None
+    return raw
+
+
+def _if_match(request: Request) -> int:
+    raw = _header(request, "If-Match")
+    if raw is None or raw == "":
+        raise WorkloreValidationError("If-Match is required", code="if-match-required")
+    text = str(raw).strip()
+    if not text.isdigit() or len(text) > _MAX_NUMBER_DIGITS:
+        raise WorkloreValidationError("If-Match is required", code="if-match-required")
+    return int(text)
+
+
+def _optional_if_match(request: Request) -> int | None:
+    raw = _header(request, "If-Match")
+    return None if raw is None or raw == "" else _if_match(request)
+
+
+def _header(request: Request, name: str) -> str | None:
+    wanted = name.lower()
+    for key, value in request.headers.items():
+        if str(key).lower() == wanted:
+            return None if value is None else str(value)
+    return None
+
+
+def _actor_id(request: Request) -> str:
+    return "admin" if request.is_admin else str(request.node_id)
+
+
+def _actor_type(request: Request) -> str:
+    return "operator" if request.is_admin or _is_operator(request) else "node"
+
+
+def _error(code: str, message: str | None = None) -> tuple[int, dict[str, Any]]:
+    return _STATUS_BY_CODE[code], {"error": message or code.replace("-", " "), "code": code}
+
+
+def _mapped_error(exc: Exception) -> tuple[int, dict[str, Any]]:
+    code = exc.code  # type: ignore[attr-defined]
+    if code not in _STATUS_BY_CODE:
+        return 400, {"error": "request failed", "code": "field-bound"}
+    return _STATUS_BY_CODE[code], {"error": str(exc), "code": code}

--- a/src/brigade/worklore_store.py
+++ b/src/brigade/worklore_store.py
@@ -1,0 +1,1920 @@
+"""SQLite projection and append-only events for Worklore items."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import secrets
+import sqlite3
+import sys
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from binascii import Error as BinasciiError
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Sequence, TypeVar
+
+from .worklore_validate import (
+    ACCEPTANCE_ITEM_MAX,
+    ACCEPTANCE_MAX_ITEMS,
+    CREATE_FIELDS,
+    DEPENDENCIES_MAX_ITEMS,
+    DESCRIPTION_MAX,
+    EVIDENCE_REFS_MAX_ITEMS,
+    KINDS,  # noqa: F401
+    TITLE_MAX,
+    TRANSITIONS,  # noqa: F401
+    WorkloreValidationError,
+    as_datetime,
+    assert_ready,
+    can_transition,
+    parse_create,
+    safe_https_url,
+    safe_optional_text,
+    safe_text,
+)
+
+PATCH_FIELDS = CREATE_FIELDS - {"kind"}
+EXCLUSION_BUCKETS = (
+    "acceptance-required",
+    "not-ready",
+    "not-eligible",
+    "manual-mode",
+    "blocker",
+    "attempt-limit",
+    "review-after",
+    "source-policy",
+)
+OBSERVATION_FIELDS = frozenset(
+    {
+        "external_key",
+        "link_type",
+        "title",
+        "source_policy",
+        "description",
+        "acceptance",
+        "external_state",
+        "external_updated_at",
+        "url",
+        "display_ref",
+        "proposed_status",
+        "priority",
+        "dependencies",
+        "evidence_refs",
+        "stale",
+    }
+)
+IMPORT_LINK_TYPES = frozenset({"github", "brigade"})
+ADMIN_LINK_TYPES = frozenset({"url", "github", "brigade"})
+SOURCE_TYPES = frozenset({"github", "brigade"})
+SOURCE_POLICIES = frozenset({"eligible", "label-removed", "closed", "completed"})
+EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+IMPORT_MAX_OBSERVATIONS = 500
+# Total storage ceilings for imported work. One batch is already capped at
+# IMPORT_MAX_OBSERVATIONS; these bound what an adapter, and the node that owns it, can
+# accumulate across many batches. Both sit far above a normal GitHub org or Brigade
+# workspace sync, and they refuse only new identities, never an update to work the
+# adapter already imported.
+ADAPTER_IMPORT_MAX_LINKS = 20000
+OWNER_IMPORT_MAX_LINKS = 100000
+# One work item may carry at most ITEM_MAX_LINKS links of every type combined. Operator
+# links, adapter imports, and fleet-run links all claim from the same ceiling inside the
+# writing transaction, so no caller can grow one item's link set without limit and make
+# every read that touches it expensive. The ceiling binds new writes only. A database
+# written before it existed may hold an item over it, and that item is served, not
+# refused: every read path is cut by SQL rather than by trusting the ceiling, and an
+# operator repairs the item by unlinking through the ordinary route on a running hub.
+ITEM_MAX_LINKS = 200
+# Fleet-run links are the one link class ordinary execution grows on its own, so each item
+# retains the most recent FLEET_RUN_LINK_RETENTION of them and older ones expire when a new
+# run is linked. Without this a busy item reaches ITEM_MAX_LINKS and can never be linked to
+# another run again. Retention is silent, the way adapter observation events are: it writes
+# no `unlinked` event, because it is storage policy rather than an operator decision.
+FLEET_RUN_LINK_RETENTION = 50
+# A list page projects at most this many links per item and says so with
+# ``links_truncated``. The full set is read through the paged link route.
+ITEM_LINK_PROJECTION_MAX = 50
+LINK_PAGE_DEFAULT = 50
+# Import keys are retained, not kept forever: the most recent keys per adapter and per
+# owning node stay exact, older ones expire. A replay inside the window returns the stored
+# counts unchanged; a replay of an expired key is re-applied as a fresh batch, and the
+# per-identity source high-water below is what stops that re-apply from rolling a newer
+# projection back to the older observations the expired batch carried.
+ADAPTER_IMPORT_KEY_RETENTION = 500
+OWNER_IMPORT_KEY_RETENTION = 5000
+# The rollback guard for expired-key replay. ``work_links.source_version`` holds the
+# highest ``external_updated_at`` ever accepted for one external identity, so an
+# observation is applied only when the source can prove it is at least that recent. One
+# nullable column on a row that already exists keeps the guard bounded by the imported
+# identities themselves: no side table, and nothing an adapter can grow past the link
+# ceilings. A source that never sends a usable timestamp never gets a projection at all:
+# a revision is what buys the right to write, so such an observation is refused rather
+# than applied, and there is no identity anywhere in the ledger without a guard.
+_LINK_SOURCE_VERSION_COLUMN = "source_version"
+# Adapter observation events are the only events an external source can grow without
+# limit, so each item retains the most recent ADAPTER_SYNC_EVENT_RETENTION of them.
+# Lifecycle events (created, linked, transitioned, attempt-*, unlinked) are never trimmed.
+ADAPTER_SYNC_EVENT_RETENTION = 200
+ADAPTER_SYNC_EVENT_TYPES = ("sync-observed", "sync-stale")
+# Reconciling existing rows against the quotas, and backfilling a newly added column, is a
+# per-database migration and not a per-start cost. ``work_schema_meta`` records the highest
+# reconciliation this database has completed, so an ordinary hub start pays for idempotent
+# DDL only and never re-walks the whole event log. Bump this whenever a new migration must
+# touch rows that were written before it.
+WORKLORE_RECONCILE_VERSION = 2
+_RECONCILED_VERSION_KEY = "reconciled_version"
+# Why one imported observation was not applied. Every reason is per identity: the rest of
+# the batch is imported normally, and the count and a bounded list of reasons come back on
+# the import result so an operator sees a refusal instead of inferring it from a silence.
+REFUSED_OPERATOR_MANAGED = "operator-managed-identity"
+REFUSED_ADAPTER_IDENTITY_CONFLICT = "adapter-identity-conflict"
+REFUSED_OWNER_NODE_MISMATCH = "owner-node-mismatch"
+REFUSED_REVISION_STALE = "source-revision-stale"
+REFUSED_REVISION_MISSING = "source-revision-missing"
+REFUSED_REVISION_NOT_ADVANCED = "source-revision-not-advanced"
+# One import result carries at most this many refusal details. The count is always exact.
+REFUSED_DETAILS_MAX = 20
+# One burn read returns at most BURN_PAGE_DEFAULT items and examines at most
+# BURN_SCAN_MAX rows. Past the scan budget the page stops and hands back a cursor rather
+# than walking a ledger that has grown without limit.
+BURN_PAGE_DEFAULT = 50
+BURN_SCAN_MAX = 2000
+# Filtered fleet-wide listings walk their global keyset in bounded chunks. Filters that do
+# not share an order-compatible index, especially source existence, are tested per candidate.
+LIST_SCAN_MAX = 2000
+DETAIL_RECENT_EVENTS = 20
+_BURN_SCAN_CHUNK = 200
+# SQLite defaults to 999 bound variables per statement, so page-scoped IN () lookups are
+# split well under that.
+_SQL_VARIABLE_CHUNK = 200
+ADAPTER_ID_MAX = 256
+ADAPTER_SUFFIX_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,239}$")
+IDEMPOTENCY_KEY_MAX = 256
+EXTERNAL_KEY_MAX = 256
+DISPLAY_REF_MAX = 256
+EXTERNAL_STATE_MAX = 64
+# Attempt run ids are public correlation labels, not receipt bodies or paths. 128 characters
+# covers Brigade's generated run ids while keeping every indexed attempt identity small.
+ATTEMPT_RUN_ID_MAX = 128
+# Every attempt action consumes a durable event. This ceiling applies to new writes, including
+# privileged ones, so a stream of distinct run ids cannot make one item's event log unbounded.
+ITEM_MAX_ATTEMPT_EVENTS = 100
+
+_ITEM_COLUMNS = (
+    "work_id",
+    "title",
+    "description",
+    "kind",
+    "scope",
+    "status",
+    "priority",
+    "burn_eligible",
+    "burn_rank",
+    "token_appetite",
+    "execution_mode",
+    "acceptance_json",
+    "blocker",
+    "review_after",
+    "spend_by",
+    "ready_at",
+    "attempt_count",
+    "version",
+    "created_at",
+    "updated_at",
+    "archived_at",
+)
+_EVENT_SEQ_SQL = "(SELECT COALESCE(MAX(seq), 0) + 1 FROM work_events)"
+_EVENT_COLUMNS = (
+    "work_id",
+    "event_id",
+    "event_type",
+    "from_status",
+    "to_status",
+    "actor_type",
+    "actor_id",
+    "node_id",
+    "run_id",
+    "detail_json",
+    "occurred_at",
+    "received_at",
+)
+_EVENT_INSERT_COLUMNS = (*_EVENT_COLUMNS, "seq")
+_EVENT_PAGE_COLUMNS = (*_EVENT_COLUMNS, "seq")
+# Adapter ownership is stored on the link, not re-derived from the item's event history,
+# so an import checks it with one indexed read and storage bounds can count it. The
+# source high-water rides the same row and the same read, and stays out of _LINK_COLUMNS
+# so it never reaches an API response as if it were source-reported data.
+_LINK_OWNER_COLUMNS = ("adapter_id", "owner_node")
+_LINK_CLAIM_COLUMNS = (*_LINK_OWNER_COLUMNS, _LINK_SOURCE_VERSION_COLUMN)
+_LINK_COLUMNS = (
+    "link_id",
+    "work_id",
+    "link_type",
+    "external_key",
+    "display_ref",
+    "url",
+    "external_state",
+    "external_updated_at",
+    "source_policy",
+    "source_acceptance_json",
+    "synced_at",
+    "stale_at",
+)
+
+# The burn order from the spec: smallest burn_rank, then earliest spend_by with "no
+# deadline" last, then oldest ready_at, then work_id. COALESCE keeps NULL and empty
+# indistinguishable so a keyset cursor never drops a NULL-valued row, and the same
+# expressions back an index, the ORDER BY, and the cursor comparison.
+_BURN_KEY_SQL = (
+    "burn_rank, (spend_by IS NULL OR spend_by = ''), (COALESCE(spend_by, '')), (COALESCE(ready_at, '')), work_id"
+)
+_BURN_ORDER_SQL = (
+    "burn_rank ASC, (spend_by IS NULL OR spend_by = '') ASC, COALESCE(spend_by, '') ASC, "
+    "COALESCE(ready_at, '') ASC, work_id ASC"
+)
+_BURN_CURSOR_FIELDS = ("burn_rank", "spend_by", "ready_at", "work_id")
+
+_SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS work_items (
+        work_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        description TEXT,
+        kind TEXT NOT NULL,
+        scope TEXT,
+        status TEXT NOT NULL,
+        priority TEXT NOT NULL,
+        burn_eligible INTEGER NOT NULL,
+        burn_rank INTEGER NOT NULL,
+        token_appetite TEXT NOT NULL,
+        execution_mode TEXT NOT NULL,
+        acceptance_json TEXT NOT NULL,
+        blocker TEXT,
+        review_after TEXT,
+        spend_by TEXT,
+        ready_at TEXT,
+        attempt_count INTEGER NOT NULL,
+        version INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        archived_at TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS work_links (
+        link_id TEXT PRIMARY KEY,
+        work_id TEXT NOT NULL,
+        link_type TEXT NOT NULL,
+        external_key TEXT NOT NULL,
+        display_ref TEXT,
+        url TEXT,
+        external_state TEXT,
+        external_updated_at TEXT,
+        source_policy TEXT NOT NULL,
+        source_acceptance_json TEXT NOT NULL,
+        synced_at TEXT NOT NULL,
+        stale_at TEXT,
+        adapter_id TEXT,
+        owner_node TEXT,
+        source_version TEXT,
+        FOREIGN KEY (work_id) REFERENCES work_items(work_id) ON DELETE RESTRICT,
+        UNIQUE (link_type, external_key)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS work_events (
+        work_id TEXT NOT NULL,
+        event_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        from_status TEXT,
+        to_status TEXT,
+        actor_type TEXT NOT NULL,
+        actor_id TEXT,
+        node_id TEXT,
+        run_id TEXT,
+        detail_json TEXT NOT NULL,
+        occurred_at TEXT NOT NULL,
+        received_at TEXT NOT NULL,
+        seq INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (work_id, event_id),
+        FOREIGN KEY (work_id) REFERENCES work_items(work_id) ON DELETE RESTRICT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS work_sync_cursors (
+        adapter_id TEXT PRIMARY KEY,
+        source_type TEXT NOT NULL,
+        owner_node TEXT NOT NULL,
+        cursor TEXT,
+        last_success_at TEXT,
+        last_error_code TEXT,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS work_import_keys (
+        adapter_id TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        fingerprint TEXT NOT NULL,
+        created INTEGER NOT NULL,
+        updated INTEGER NOT NULL,
+        unchanged INTEGER NOT NULL DEFAULT 0,
+        refused INTEGER NOT NULL DEFAULT 0,
+        received_at TEXT NOT NULL,
+        owner_node TEXT,
+        PRIMARY KEY (adapter_id, idempotency_key)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS work_schema_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS work_create_keys (
+        actor_id TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        fingerprint TEXT NOT NULL,
+        work_id TEXT NOT NULL,
+        received_at TEXT NOT NULL,
+        PRIMARY KEY (actor_id, idempotency_key),
+        FOREIGN KEY (work_id) REFERENCES work_items(work_id) ON DELETE RESTRICT
+    )
+    """,
+)
+
+_INDEX_STATEMENTS = (
+    "CREATE INDEX IF NOT EXISTS work_items_status ON work_items (status)",
+    "CREATE INDEX IF NOT EXISTS work_items_burn ON work_items (burn_eligible)",
+    "CREATE INDEX IF NOT EXISTS work_items_ready_at ON work_items (ready_at)",
+    "CREATE INDEX IF NOT EXISTS work_events_work_id ON work_events (work_id)",
+    "CREATE INDEX IF NOT EXISTS work_events_seq ON work_events (seq)",
+    "CREATE INDEX IF NOT EXISTS work_events_work_seq ON work_events (work_id, seq)",
+    "CREATE INDEX IF NOT EXISTS work_links_external ON work_links (link_type, external_key)",
+    "CREATE INDEX IF NOT EXISTS work_links_work_id ON work_links (work_id)",
+    # Backs the per-item ORDER BY that the list projection's window function cuts on, so a
+    # page reads its per-item link budget out of the index instead of sorting a legacy
+    # item's whole link set.
+    "CREATE INDEX IF NOT EXISTS work_links_work_order ON work_links (work_id, synced_at, link_id)",
+    # The bounded item and burn summaries use exact source-policy probes. These indexes
+    # let every probe stop after its first matching link, even for pre-ceiling items.
+    "CREATE INDEX IF NOT EXISTS work_links_work_policy_order ON work_links (work_id, source_policy, synced_at, link_id)",
+    "CREATE INDEX IF NOT EXISTS work_links_work_policy_type_stale "
+    "ON work_links (work_id, source_policy, link_type, stale_at)",
+    "CREATE INDEX IF NOT EXISTS work_links_work_policy_type_order "
+    "ON work_links (work_id, source_policy, link_type, synced_at, link_id)",
+    "CREATE INDEX IF NOT EXISTS work_links_adapter ON work_links (adapter_id)",
+    "CREATE INDEX IF NOT EXISTS work_links_owner ON work_links (owner_node)",
+    "CREATE INDEX IF NOT EXISTS work_import_keys_adapter ON work_import_keys (adapter_id, received_at)",
+    "CREATE INDEX IF NOT EXISTS work_import_keys_owner ON work_import_keys (owner_node, received_at)",
+    "CREATE INDEX IF NOT EXISTS work_events_adapter_retention ON work_events (work_id, actor_type, event_type, seq)",
+    # The retention sweep filters adapter observation event types before it discovers the
+    # affected item partitions. Keep that filter first and retain work_id for the per-item
+    # deletes that follow.
+    "CREATE INDEX IF NOT EXISTS work_events_adapter_event_work_seq "
+    "ON work_events (actor_type, event_type, work_id, seq)",
+    # Attempt writes count a single item's three event types through this index before
+    # appending. A separate identity index makes authenticated retry probes constant-time.
+    "CREATE INDEX IF NOT EXISTS work_events_attempt_work_seq ON work_events (work_id, event_type, seq)",
+    "CREATE INDEX IF NOT EXISTS work_events_attempt_identity ON work_events (work_id, event_type, node_id, run_id)",
+    # The item page orders by (created_at, work_id) and the sprint log by (occurred_at DESC,
+    # seq DESC). Both are the keyset the cursor walks, so an index in exactly that order lets
+    # a page read its rows straight out of the index instead of sorting the whole table.
+    "CREATE INDEX IF NOT EXISTS work_items_created_order ON work_items (created_at, work_id)",
+    "CREATE INDEX IF NOT EXISTS work_events_recent ON work_events (occurred_at DESC, seq DESC)",
+    # Ownership and the source high-water are keyed by the full external identity,
+    # (work_id, link_type, external_key). No extra index is needed for it: the
+    # UNIQUE (link_type, external_key) constraint already resolves that lookup to one row.
+    # Fleet-run retention deletes the oldest of one item's run links.
+    "CREATE INDEX IF NOT EXISTS work_links_work_type ON work_links (work_id, link_type, synced_at)",
+    f"CREATE INDEX IF NOT EXISTS work_items_burn_order ON work_items ({_BURN_KEY_SQL})",
+)
+
+T = TypeVar("T")
+
+
+class WorkloreConflict(Exception):
+    """A Worklore optimistic-concurrency or import conflict."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class WorkloreSchemaError(Exception):
+    """A stored Worklore database cannot be brought up to the current storage contract.
+
+    Reserved for a migration that genuinely cannot proceed. Nothing raises it today: rows
+    written before a quota existed are reconciled or served under SQL-bounded reads rather
+    than refused, because a hub that will not start is a hub an operator cannot repair
+    through. Kept so callers that already catch it stay valid.
+    """
+
+
+class WorkloreNotFound(Exception):
+    """A Worklore item was not found."""
+
+    def __init__(self, message: str = "work item not found", *, code: str = "not-found") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class WorkloreForbidden(Exception):
+    """A Worklore caller is not allowed to perform this mutation."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _mint_id(prefix: str) -> str:
+    return f"{prefix}{secrets.token_hex(12)}"
+
+
+def _pragma_foreign_keys(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA foreign_keys=ON")
+
+
+def _in_transaction(conn: sqlite3.Connection, body: Callable[[], T]) -> T:
+    _pragma_foreign_keys(conn)
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        result = body()
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+    return result
+
+
+def _load_json_list(raw: object) -> list[Any]:
+    if not raw:
+        return []
+    parsed = json.loads(str(raw))
+    return parsed if isinstance(parsed, list) else []
+
+
+def _review_after_future(value: object) -> bool:
+    if value is None or value == "":
+        return False
+    if not isinstance(value, str):
+        return True
+    try:
+        parsed = as_datetime(value)
+    except ValueError:
+        return True
+    return parsed > datetime.now(timezone.utc)
+
+
+def _empty_link_summary() -> dict[str, Any]:
+    return {
+        "blocking_policy": None,
+        "source_acceptance": [],
+        "has_source_link": False,
+        "has_eligible_non_stale_source_link": False,
+    }
+
+
+def _source_policies(summary: Mapping[str, Any]) -> list[str]:
+    """Return the bounded source-policy sequence ``exclusion_bucket`` reads.
+
+    Native work has no imported source link and remains eligible. Imported work needs at
+    least one eligible non-stale source link; a stale source is no longer authority for burn.
+    """
+    if summary.get("has_source_link") and not summary.get("has_eligible_non_stale_source_link"):
+        return ["stale-source"]
+    policy = summary.get("blocking_policy")
+    return [] if policy is None else [str(policy)]
+
+
+def _row_to_item(row: Any, summary: Mapping[str, Any]) -> dict[str, Any]:
+    """Own acceptance wins; otherwise the oldest eligible source link is authoritative, empty or not."""
+    values = dict(zip(_ITEM_COLUMNS, row, strict=True))
+    acceptance = _load_json_list(values.pop("acceptance_json"))
+    return {
+        **values,
+        "burn_eligible": bool(values["burn_eligible"]),
+        "attempt_count": int(values["attempt_count"]),
+        "version": int(values["version"]),
+        "acceptance": acceptance,
+        "effective_acceptance": list(acceptance) if acceptance else list(summary["source_acceptance"]),
+    }
+
+
+def _select_item_row(conn: sqlite3.Connection, work_id: str) -> Any:
+    row = conn.execute(
+        f"SELECT {', '.join(_ITEM_COLUMNS)} FROM work_items WHERE work_id = ?",
+        (work_id,),
+    ).fetchone()
+    if row is None:
+        raise WorkloreNotFound()
+    return row
+
+
+def _require_version(item: Mapping[str, Any], expected_version: int) -> None:
+    if int(item["version"]) != int(expected_version):
+        raise WorkloreConflict("work item version does not match", code="version-conflict")
+
+
+def _append_event(
+    conn: sqlite3.Connection,
+    *,
+    work_id: str,
+    event_type: str,
+    from_status: str | None,
+    to_status: str | None,
+    actor_type: str,
+    actor_id: str | None,
+    now: str,
+    node_id: str | None = None,
+    run_id: str | None = None,
+    detail: Mapping[str, Any] | None = None,
+) -> None:
+    placeholders = ", ".join(["?"] * len(_EVENT_COLUMNS) + [_EVENT_SEQ_SQL])
+    conn.execute(
+        f"INSERT INTO work_events ({', '.join(_EVENT_INSERT_COLUMNS)}) VALUES ({placeholders})",
+        (
+            work_id,
+            _mint_id("evt-"),
+            event_type,
+            from_status,
+            to_status,
+            actor_type,
+            actor_id,
+            node_id,
+            run_id,
+            json.dumps(dict(detail) if detail is not None else {}),
+            now,
+            now,
+        ),
+    )
+
+
+def _insert_item(conn: sqlite3.Connection, item: Mapping[str, Any]) -> None:
+    conn.execute(
+        f"INSERT INTO work_items ({', '.join(_ITEM_COLUMNS)}) VALUES ({', '.join('?' for _ in _ITEM_COLUMNS)})",
+        (
+            item["work_id"],
+            item["title"],
+            item["description"],
+            item["kind"],
+            item["scope"],
+            item["status"],
+            item["priority"],
+            1 if item["burn_eligible"] else 0,
+            item["burn_rank"],
+            item["token_appetite"],
+            item["execution_mode"],
+            json.dumps(item["acceptance"]),
+            item["blocker"],
+            item["review_after"],
+            item["spend_by"],
+            item["ready_at"],
+            item["attempt_count"],
+            item["version"],
+            item["created_at"],
+            item["updated_at"],
+            item["archived_at"],
+        ),
+    )
+
+
+def _update_item(conn: sqlite3.Connection, item: Mapping[str, Any]) -> None:
+    assignments = [name for name in _ITEM_COLUMNS if name != "work_id"]
+    conn.execute(
+        f"UPDATE work_items SET {', '.join(f'{name} = ?' for name in assignments)} WHERE work_id = ?",
+        (
+            item["title"],
+            item["description"],
+            item["kind"],
+            item["scope"],
+            item["status"],
+            item["priority"],
+            1 if item["burn_eligible"] else 0,
+            item["burn_rank"],
+            item["token_appetite"],
+            item["execution_mode"],
+            json.dumps(item["acceptance"]),
+            item["blocker"],
+            item["review_after"],
+            item["spend_by"],
+            item["ready_at"],
+            item["attempt_count"],
+            item["version"],
+            item["created_at"],
+            item["updated_at"],
+            item["archived_at"],
+            item["work_id"],
+        ),
+    )
+
+
+def _item_from_create(parsed: Mapping[str, Any], *, work_id: str, now: str) -> dict[str, Any]:
+    return {
+        "work_id": work_id,
+        "title": parsed["title"],
+        "description": parsed["description"],
+        "kind": parsed["kind"],
+        "scope": parsed["scope"],
+        "status": parsed["status"],
+        "priority": parsed["priority"],
+        "burn_eligible": bool(parsed["burn_eligible"]),
+        "burn_rank": parsed["burn_rank"],
+        "token_appetite": parsed["token_appetite"],
+        "execution_mode": parsed["execution_mode"],
+        "acceptance": list(parsed["acceptance"]),
+        "effective_acceptance": list(parsed["acceptance"]),
+        "blocker": parsed["blocker"],
+        "review_after": parsed["review_after"],
+        "spend_by": parsed["spend_by"],
+        "ready_at": None,
+        "attempt_count": 0,
+        "version": 1,
+        "created_at": now,
+        "updated_at": now,
+        "archived_at": None,
+    }
+
+
+def _parse_patch(item: Mapping[str, Any], raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise WorkloreValidationError("patch body must be an object", code="field-bound")
+    unknown = [name for name in raw if name not in PATCH_FIELDS]
+    if unknown:
+        raise WorkloreValidationError(f"unknown field: {unknown[0]}", code="unknown-field")
+    merged = {
+        "title": item["title"],
+        "kind": item["kind"],
+        "description": item["description"],
+        "scope": item["scope"],
+        "priority": item["priority"],
+        "burn_eligible": item["burn_eligible"],
+        "burn_rank": item["burn_rank"],
+        "token_appetite": item["token_appetite"],
+        "execution_mode": item["execution_mode"],
+        "acceptance": item["acceptance"],
+        "blocker": item["blocker"],
+        "review_after": item["review_after"],
+        "spend_by": item["spend_by"],
+    }
+    merged.update(raw)
+    return parse_create(merged)
+
+
+def exclusion_bucket(item: Mapping[str, Any], source_policies: Sequence[str]) -> str | None:
+    """Return the first burn-queue exclusion bucket an item falls into, or None when it is eligible."""
+    if item["status"] != "ready":
+        return "not-ready"
+    if not item["burn_eligible"]:
+        return "not-eligible"
+    acceptance = item.get("effective_acceptance") or []
+    if not isinstance(acceptance, list) or not acceptance or len(acceptance) > ACCEPTANCE_MAX_ITEMS:
+        return "acceptance-required"
+    if item["execution_mode"] == "manual":
+        return "manual-mode"
+    blocker = item.get("blocker")
+    if isinstance(blocker, str) and blocker:
+        return "blocker"
+    if int(item["attempt_count"]) >= 2:
+        return "attempt-limit"
+    if _review_after_future(item.get("review_after")):
+        return "review-after"
+    if any(policy != "eligible" for policy in source_policies):
+        return "source-policy"
+    return None
+
+
+def _loaded_item(conn: sqlite3.Connection, work_id: str) -> dict[str, Any]:
+    return _row_to_item(_select_item_row(conn, work_id), _link_summary(conn, work_id))
+
+
+def _field_bound(message: str) -> WorkloreValidationError:
+    return WorkloreValidationError(message, code="field-bound")
+
+
+def _require_text(value: object, field: str, *, max_len: int, min_len: int = 1) -> str:
+    """One canonical bounded-string check for every value the hub durably stores."""
+    return safe_text(value, field, max_len=max_len, min_len=min_len)
+
+
+def _optional_text(value: object, field: str, *, max_len: int) -> str | None:
+    return safe_optional_text(value, field, max_len=max_len)
+
+
+def _https_url(value: object, field: str = "url") -> str | None:
+    return safe_https_url(value, field)
+
+
+def observation_fingerprint(observations: Sequence[Mapping[str, Any]]) -> str:
+    """Return the canonical SHA-256 fingerprint used for import idempotency."""
+    canonical = json.dumps(list(observations), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _observation_fingerprint(observations: Sequence[Mapping[str, Any]]) -> str:
+    return observation_fingerprint(observations)
+
+
+def _parse_observation(raw: object, *, source_type: str) -> dict[str, Any]:
+    """The one canonical observation validator, run before every imported create and update.
+
+    Every durable string is checked by the same primitives, so a batch that creates a link
+    and a later batch that updates it are held to identical bounds and private-data rules.
+    """
+    if not isinstance(raw, Mapping):
+        raise _field_bound("observation must be an object")
+    unknown = [name for name in raw if name not in OBSERVATION_FIELDS]
+    if unknown:
+        raise WorkloreValidationError(f"unknown field: {unknown[0]}", code="unknown-field")
+    for field in ("external_key", "link_type", "title", "source_policy"):
+        if field not in raw:
+            raise _field_bound(f"{field} is required")
+    link_type = raw["link_type"]
+    if link_type not in IMPORT_LINK_TYPES:
+        raise _field_bound("link_type must be github or brigade")
+    if link_type != source_type:
+        raise _field_bound("link_type must match the batch source_type")
+    source_policy = raw["source_policy"]
+    if source_policy not in SOURCE_POLICIES:
+        raise _field_bound("source_policy must be an allowed source policy")
+    acceptance = raw.get("acceptance", [])
+    if acceptance is None:
+        acceptance = []
+    if not isinstance(acceptance, list):
+        raise _field_bound("acceptance must be an array of strings")
+    if len(acceptance) > ACCEPTANCE_MAX_ITEMS:
+        raise _field_bound(f"acceptance must have at most {ACCEPTANCE_MAX_ITEMS} items")
+    acceptance = [
+        _require_text(item, f"acceptance[{index}]", max_len=ACCEPTANCE_ITEM_MAX)
+        for index, item in enumerate(acceptance)
+    ]
+    stale = raw.get("stale", False)
+    if stale is None:
+        stale = False
+    if not isinstance(stale, bool):
+        raise _field_bound("stale must be a boolean")
+    proposed_status = raw.get("proposed_status")
+    if proposed_status not in (None, "completed"):
+        raise _field_bound("proposed_status must be completed when present")
+    dependencies = raw.get("dependencies")
+    if dependencies is not None:
+        if not isinstance(dependencies, list):
+            raise _field_bound("dependencies must be an array")
+        if len(dependencies) > DEPENDENCIES_MAX_ITEMS:
+            raise _field_bound(f"dependencies must have at most {DEPENDENCIES_MAX_ITEMS} items")
+        parsed_deps: list[dict[str, str]] = []
+        for item in dependencies:
+            if not isinstance(item, Mapping) or "type" not in item or "id" not in item:
+                raise _field_bound("dependencies items must have type and id")
+            parsed_deps.append(
+                {
+                    "type": _require_text(item["type"], "dependencies.type", max_len=128),
+                    "id": _require_text(item["id"], "dependencies.id", max_len=128),
+                }
+            )
+        dependencies = parsed_deps
+    evidence_refs = raw.get("evidence_refs")
+    if evidence_refs is not None:
+        if isinstance(evidence_refs, list) and len(evidence_refs) > EVIDENCE_REFS_MAX_ITEMS:
+            raise _field_bound(f"evidence_refs must have at most {EVIDENCE_REFS_MAX_ITEMS} items")
+        if not isinstance(evidence_refs, list) or any(
+            not isinstance(item, str) or not EVIDENCE_REF_RE.fullmatch(item) for item in evidence_refs
+        ):
+            raise _field_bound("evidence_refs items must match the evidence token pattern")
+    return {
+        "external_key": _require_text(raw["external_key"], "external_key", max_len=EXTERNAL_KEY_MAX),
+        "link_type": str(link_type),
+        "title": _require_text(raw["title"], "title", max_len=TITLE_MAX),
+        "source_policy": str(source_policy),
+        "description": _optional_text(raw.get("description"), "description", max_len=DESCRIPTION_MAX),
+        "acceptance": list(acceptance),
+        "external_state": _optional_text(raw.get("external_state"), "external_state", max_len=EXTERNAL_STATE_MAX),
+        "external_updated_at": _optional_text(raw.get("external_updated_at"), "external_updated_at", max_len=64),
+        "url": _https_url(raw.get("url")),
+        "display_ref": _optional_text(raw.get("display_ref"), "display_ref", max_len=DISPLAY_REF_MAX),
+        "proposed_status": proposed_status,
+        "priority": _optional_text(raw.get("priority"), "priority", max_len=64),
+        "dependencies": dependencies,
+        "evidence_refs": list(evidence_refs) if evidence_refs is not None else None,
+        "stale": stale,
+    }
+
+
+def _event_from_page_row(row: Any) -> dict[str, Any]:
+    """Project a paged row, dropping the private insertion sequence from the response."""
+    return _event_from_row(tuple(row)[: len(_EVENT_COLUMNS)])
+
+
+def _cursor_seq(values: Mapping[str, str]) -> int:
+    raw = values["seq"]
+    if not raw.isdigit():
+        raise _field_bound("cursor is invalid")
+    return int(raw)
+
+
+def _event_from_row(row: Any) -> dict[str, Any]:
+    values = dict(zip(_EVENT_COLUMNS, row, strict=True))
+    detail = json.loads(str(values.pop("detail_json") or "{}"))
+    return {**values, "detail": detail if isinstance(detail, dict) else {}}
+
+
+def _row_to_link(row: Any) -> dict[str, Any]:
+    values = dict(zip(_LINK_COLUMNS, row, strict=True))
+    return {**values, "source_acceptance": _load_json_list(values.pop("source_acceptance_json"))}
+
+
+def _full_link_rows(conn: sqlite3.Connection, work_id: str) -> list[Any]:
+    return list(
+        conn.execute(
+            f"SELECT {', '.join(_LINK_COLUMNS)} FROM work_links WHERE work_id = ? ORDER BY synced_at ASC, link_id ASC",
+            (work_id,),
+        )
+    )
+
+
+def _links_by_work_id(
+    conn: sqlite3.Connection,
+    work_ids: Sequence[str],
+    columns: tuple[str, ...],
+    *,
+    per_item_limit: int,
+) -> tuple[dict[str, list[Any]], set[str]]:
+    """Group up to ``per_item_limit`` link rows per item, in synced-at order.
+
+    The cut happens in SQL, not in Python: every item's indexed query returns at most
+    ``per_item_limit + 1`` rows, the extra one being the only evidence the projection needs
+    that the set was truncated. A page therefore costs its own budget even against a legacy
+    item that accumulated links before ``ITEM_MAX_LINKS`` was enforced on write, which is
+    exactly the row set Python must never be handed.
+
+    The second return value names the items whose link set was cut, so the caller can
+    report the truncation instead of silently shortening it.
+    """
+    grouped: dict[str, list[Any]] = {work_id: [] for work_id in work_ids}
+    truncated: set[str] = set()
+    if per_item_limit <= 0:
+        return grouped, set(work_ids)
+    for work_id in work_ids:
+        rows = conn.execute(
+            f"SELECT {', '.join(columns)} FROM work_links WHERE work_id = ? "
+            "ORDER BY synced_at ASC, link_id ASC LIMIT ?",
+            (work_id, per_item_limit + 1),
+        ).fetchall()
+        grouped[work_id] = rows[:per_item_limit]
+        if len(rows) > per_item_limit:
+            truncated.add(work_id)
+    return grouped, truncated
+
+
+def _claim_item_link(conn: sqlite3.Connection, work_id: str, *, code: str) -> None:
+    """Refuse a new link once one item is carrying ``ITEM_MAX_LINKS`` of them.
+
+    Read inside the writing transaction, so two concurrent writers cannot both pass the
+    ceiling. Every link path claims from this one count: operator links, adapter imports,
+    and fleet-run links.
+    """
+    count = int(conn.execute("SELECT COUNT(*) FROM work_links WHERE work_id = ?", (work_id,)).fetchone()[0])
+    if count >= ITEM_MAX_LINKS:
+        raise WorkloreConflict(f"work item has reached its {ITEM_MAX_LINKS} link ceiling", code=code)
+
+
+def _has_source_link(conn: sqlite3.Connection, work_id: str) -> bool:
+    placeholders = ", ".join("?" for _ in IMPORT_LINK_TYPES)
+    row = conn.execute(
+        f"SELECT 1 FROM work_links WHERE work_id = ? AND link_type IN ({placeholders}) LIMIT 1",
+        (work_id, *sorted(IMPORT_LINK_TYPES)),
+    ).fetchone()
+    return row is not None
+
+
+def _find_link(conn: sqlite3.Connection, link_type: str, external_key: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        f"SELECT {', '.join(_LINK_COLUMNS)} FROM work_links WHERE link_type = ? AND external_key = ?",
+        (link_type, external_key),
+    ).fetchone()
+    return _row_to_link(row) if row is not None else None
+
+
+def _link_claim(
+    conn: sqlite3.Connection, work_id: str, link_type: str, external_key: str
+) -> tuple[str, str | None, str | None] | None:
+    """Return ``(adapter_id, owner_node, source_version)`` for a claimed identity, or None.
+
+    The identity is ``(work_id, link_type, external_key)``, never the external key alone.
+    One item may carry the same key under two link types, an operator ``url`` link and an
+    adapter-owned ``github`` link, say, and those are two separate identities: reading the
+    key alone would let either one answer for the other, which is how an adapter could
+    reach across types to claim an operator link and how an eligible adapter link could
+    block the operator from deleting their own url.
+
+    None means this identity is operator managed: no adapter has ever claimed it, so no
+    adapter may adopt or mutate it. Ownership and the source high-water are read from the
+    same link row in one indexed lookup, no matter how long the item's event history grows.
+    """
+    row = conn.execute(
+        f"SELECT {', '.join(_LINK_CLAIM_COLUMNS)} FROM work_links "
+        "WHERE work_id = ? AND link_type = ? AND external_key = ?",
+        (work_id, link_type, external_key),
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return str(row[0]), None if row[1] is None else str(row[1]), None if row[2] is None else str(row[2])
+
+
+def _owning_adapter(
+    conn: sqlite3.Connection, work_id: str, link_type: str, external_key: str
+) -> tuple[str, str | None] | None:
+    """Return the ``(adapter_id, owner_node)`` that first imported this identity, or None."""
+    claim = _link_claim(conn, work_id, link_type, external_key)
+    return None if claim is None else (claim[0], claim[1])
+
+
+def _source_version(value: object) -> datetime | None:
+    """Parse a source-reported timestamp into a comparable instant, or None.
+
+    ``external_updated_at`` is stored as bounded free text because sources disagree about
+    format, so an unparseable value is treated exactly like an absent one: it never
+    establishes a high-water and never satisfies one. Refusing to compare is the safe
+    direction, because the only thing a bad parse could otherwise authorize is a rollback.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return as_datetime(value)
+    except ValueError:
+        return None
+
+
+def _revision_refusal(stored: object, incoming: object, *, changed: bool, stale_transition: bool = False) -> str | None:
+    """Return why ``incoming`` must not be applied over the stored high-water, or None.
+
+    An observation may write the projection only when the source proves which revision it
+    is speaking for. A parseable ``external_updated_at`` is that proof, and it is required
+    before any mutation, not merely used to break ties between two proofs:
+
+    - No usable incoming revision: the source proved nothing, so it may not create the
+      identity and it may not change one. Refusing is what makes the guard total. If an
+      unproven change were applied whenever no high-water existed yet, then A -> expire ->
+      replay A would roll the projection back for exactly the identities that never had a
+      guard, which is the rollback this function exists to prevent. The refusal is
+      reported per identity rather than folded into the unchanged count, because "we
+      silently kept the old projection" and "nothing was different" are not the same
+      answer to an operator.
+    - Older than the high-water: an expired-key replay or an out-of-order delivery.
+    - Equal to the high-water but carrying a different payload: two different payloads
+      cannot both be the state at one revision, so the one already projected stands. This
+      is what stops A -> expire -> B -> replay A from rolling back when a source stamps
+      both observations with the same timestamp. A direct GitHub 404 is the exception:
+      moving an identity from live to stale is monotonic, so it may add that one-way marker
+      at the stored provider revision. An equal revision can never clear the marker.
+
+    An observation that changes nothing is never refused, with or without a revision:
+    applying nothing cannot roll anything back, so there is no state for a revision to
+    protect, and refusing it would make every re-poll of a settled identity noisy. That is
+    the only case a missing revision survives, and it is safe precisely because it writes
+    no projection. ``stored`` is ``None`` on creation, which is a change like any other:
+    an unproven observation does not get to mint an item.
+    """
+    if not changed:
+        return None
+    candidate = _source_version(incoming)
+    if candidate is None:
+        return REFUSED_REVISION_MISSING
+    high_water = _source_version(stored)
+    if high_water is None:
+        return None
+    if candidate < high_water:
+        return REFUSED_REVISION_STALE
+    if candidate == high_water and not stale_transition:
+        return REFUSED_REVISION_NOT_ADVANCED
+    return None
+
+
+def _insert_link(
+    conn: sqlite3.Connection,
+    link: Mapping[str, Any],
+    *,
+    adapter_id: str | None = None,
+    owner_node: str | None = None,
+    source_version: str | None = None,
+) -> None:
+    """Insert one link, stamping adapter ownership and the first source high-water on it.
+
+    Operator and fleet-run links carry neither: no adapter owns them, so no adapter may
+    later mutate them, and there is nothing for a replay to roll back.
+    """
+    columns = (*_LINK_COLUMNS, *_LINK_CLAIM_COLUMNS)
+    conn.execute(
+        f"INSERT INTO work_links ({', '.join(columns)}) VALUES ({', '.join('?' for _ in columns)})",
+        (
+            link["link_id"],
+            link["work_id"],
+            link["link_type"],
+            link["external_key"],
+            link.get("display_ref"),
+            link.get("url"),
+            link.get("external_state"),
+            link.get("external_updated_at"),
+            link["source_policy"],
+            json.dumps(list(link.get("source_acceptance") or [])),
+            link["synced_at"],
+            link.get("stale_at"),
+            adapter_id,
+            owner_node,
+            source_version,
+        ),
+    )
+
+
+def _import_headroom(conn: sqlite3.Connection, *, adapter_id: str, owner_node: str) -> Callable[[], None]:
+    """Return a claim function that refuses a new imported identity past the storage ceilings.
+
+    The two counts are taken once per batch and then tracked in memory, so a 500
+    observation batch costs two indexed counts rather than one per observation.
+    """
+    counts = [
+        int(conn.execute("SELECT COUNT(*) FROM work_links WHERE adapter_id = ?", (adapter_id,)).fetchone()[0]),
+        int(conn.execute("SELECT COUNT(*) FROM work_links WHERE owner_node = ?", (owner_node,)).fetchone()[0]),
+    ]
+
+    def _claim() -> None:
+        if counts[0] >= ADAPTER_IMPORT_MAX_LINKS:
+            raise WorkloreConflict(
+                f"adapter has reached its {ADAPTER_IMPORT_MAX_LINKS} imported item ceiling",
+                code="import-conflict",
+            )
+        if counts[1] >= OWNER_IMPORT_MAX_LINKS:
+            raise WorkloreConflict(
+                f"owner node has reached its {OWNER_IMPORT_MAX_LINKS} imported item ceiling",
+                code="import-conflict",
+            )
+        counts[0] += 1
+        counts[1] += 1
+
+    return _claim
+
+
+def _update_link(conn: sqlite3.Connection, link: Mapping[str, Any], *, source_version: str | None = None) -> None:
+    """Apply an accepted observation to a link and advance its source high-water.
+
+    ``COALESCE`` keeps the stored high-water when this observation carried no usable
+    timestamp, so a source that goes quiet about ``external_updated_at`` can never erase
+    the guard that an earlier, timestamped observation established.
+    """
+    conn.execute(
+        "UPDATE work_links SET display_ref = ?, url = ?, external_state = "
+        "CASE WHEN ? = 1 AND ? IS NULL THEN external_state ELSE ? END, external_updated_at = ?, "
+        "source_policy = ?, source_acceptance_json = ?, synced_at = ?, stale_at = ?, "
+        "source_version = COALESCE(?, source_version) WHERE link_id = ?",
+        (
+            link.get("display_ref"),
+            link.get("url"),
+            1 if link.get("stale_at") is not None else 0,
+            link.get("external_state"),
+            link.get("external_state"),
+            link.get("external_updated_at"),
+            link["source_policy"],
+            json.dumps(list(link.get("source_acceptance") or [])),
+            link["synced_at"],
+            link.get("stale_at"),
+            source_version,
+            link["link_id"],
+        ),
+    )
+
+
+def _touch_link_synced_at(conn: sqlite3.Connection, link_id: str, now: str) -> None:
+    """Record that an unchanged observation was seen without adding events or bumping the item."""
+    conn.execute("UPDATE work_links SET synced_at = ? WHERE link_id = ?", (now, link_id))
+
+
+def _observation_detail(adapter_id: str, parsed: Mapping[str, Any]) -> dict[str, Any]:
+    detail: dict[str, Any] = {
+        "adapter_id": adapter_id,
+        "external_key": parsed["external_key"],
+        "link_type": parsed["link_type"],
+    }
+    if parsed.get("proposed_status") is not None:
+        detail["proposed_status"] = parsed["proposed_status"]
+    if parsed.get("priority") is not None:
+        detail["priority"] = parsed["priority"]
+    if parsed.get("dependencies") is not None:
+        detail["dependencies"] = parsed["dependencies"]
+    if parsed.get("evidence_refs") is not None:
+        detail["evidence_refs"] = parsed["evidence_refs"]
+    return detail
+
+
+def _link_from_observation(parsed: Mapping[str, Any], *, work_id: str, link_id: str, now: str) -> dict[str, Any]:
+    return {
+        "link_id": link_id,
+        "work_id": work_id,
+        "link_type": parsed["link_type"],
+        "external_key": parsed["external_key"],
+        "display_ref": parsed.get("display_ref") or parsed["external_key"],
+        "url": parsed.get("url"),
+        "external_state": parsed.get("external_state"),
+        "external_updated_at": parsed.get("external_updated_at"),
+        "source_policy": parsed["source_policy"],
+        "source_acceptance": list(parsed.get("acceptance") or []),
+        "synced_at": now,
+        "stale_at": now if parsed.get("stale") else None,
+    }
+
+
+def _observed_source_version(parsed: Mapping[str, Any]) -> str | None:
+    """The high-water an accepted observation establishes, or None when it proves nothing.
+
+    Only a parseable timestamp is stored, so the column holds a value ``_source_version``
+    can always compare and a source cannot poison the guard with unparseable text.
+    """
+    raw = parsed.get("external_updated_at")
+    return str(raw) if _source_version(raw) is not None else None
+
+
+def _observation_link_projection(current_link: Mapping[str, Any], parsed: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the source-link projection an observation is allowed to change.
+
+    A direct 404 tombstone has no current external state. Retaining that existing value
+    lets its equal-revision transition add only the durable stale marker.
+    """
+    return {
+        "display_ref": parsed.get("display_ref") or parsed["external_key"],
+        "url": parsed.get("url"),
+        "external_state": (
+            current_link["external_state"]
+            if parsed.get("stale") and parsed.get("external_state") is None
+            else parsed.get("external_state")
+        ),
+        "external_updated_at": parsed.get("external_updated_at"),
+        "source_policy": parsed["source_policy"],
+        "source_acceptance": list(parsed.get("acceptance") or []),
+    }
+
+
+def _observation_changed(
+    current_item: Mapping[str, Any], current_link: Mapping[str, Any], parsed: Mapping[str, Any]
+) -> bool:
+    """Return whether an observation changes its source-link projection.
+
+    The item title is separately revision-gated by the importer. That keeps an equal
+    source poll from clobbering an operator title edit while still allowing a newer source
+    revision to advance the title projection.
+    """
+    expected = _observation_link_projection(current_link, parsed)
+    return any(current_link[field] != value for field, value in expected.items()) or (
+        current_link["stale_at"] is not None
+    ) != bool(parsed.get("stale"))
+
+
+def _one_way_stale_transition(
+    current_item: Mapping[str, Any], current_link: Mapping[str, Any], parsed: Mapping[str, Any]
+) -> bool:
+    """Return whether this observation changes only a live source link to stale."""
+    return (
+        bool(parsed.get("stale"))
+        and current_link["stale_at"] is None
+        and all(
+            current_link[field] == value for field, value in _observation_link_projection(current_link, parsed).items()
+        )
+    )
+
+
+def _items_for_observations(
+    conn: sqlite3.Connection, observations: Sequence[Mapping[str, Any]]
+) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for observation in observations:
+        link = _find_link(conn, str(observation["link_type"]), str(observation["external_key"]))
+        if link is not None:
+            items.append({"work_id": str(link["work_id"]), "external_key": str(link["external_key"])})
+    return items
+
+
+def _touch_cursor(
+    conn: sqlite3.Connection,
+    *,
+    adapter_id: str,
+    source_type: str,
+    owner_node: str,
+    now: str,
+) -> None:
+    existing = conn.execute(
+        "SELECT adapter_id FROM work_sync_cursors WHERE adapter_id = ?",
+        (adapter_id,),
+    ).fetchone()
+    if existing is None:
+        conn.execute(
+            "INSERT INTO work_sync_cursors (adapter_id, source_type, owner_node, cursor, "
+            "last_success_at, last_error_code, updated_at) VALUES (?, ?, ?, NULL, ?, NULL, ?)",
+            (adapter_id, source_type, owner_node, now, now),
+        )
+        return
+    conn.execute(
+        "UPDATE work_sync_cursors SET last_success_at = ?, updated_at = ? WHERE adapter_id = ?",
+        (now, now, adapter_id),
+    )
+
+
+def _require_adapter_namespace(adapter_id: str, source_type: str) -> None:
+    """Pin an adapter to its own ``<source_type>:`` namespace.
+
+    Without this a ``brigade`` adapter could claim ``github:escoffier-labs`` and take the
+    cursor ownership that keeps the real GitHub adapter's imports separate.
+    """
+    prefix = f"{source_type}:"
+    if not adapter_id.startswith(prefix) or not ADAPTER_SUFFIX_RE.fullmatch(adapter_id[len(prefix) :]):
+        raise _field_bound(f"adapter_id must be {prefix} followed by a bounded identifier")
+
+
+def _cursor_owner(conn: sqlite3.Connection, adapter_id: str) -> str | None:
+    row = conn.execute(
+        "SELECT owner_node FROM work_sync_cursors WHERE adapter_id = ?",
+        (adapter_id,),
+    ).fetchone()
+    return str(row[0]) if row is not None else None
+
+
+def _require_owned_fleet_run(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    node_id: str,
+    run_id: str | None,
+) -> None:
+    if not run_id:
+        raise WorkloreForbidden("node attempt requires an owned fleet-run", code="attempt-forbidden")
+    row = conn.execute(
+        "SELECT 1 FROM work_links WHERE work_id = ? AND link_type = 'fleet-run' AND external_key = ?",
+        (work_id, f"{node_id}/{run_id}"),
+    ).fetchone()
+    if row is None:
+        raise WorkloreForbidden("node attempt requires an owned fleet-run", code="attempt-forbidden")
+
+
+def _hub_run_exists(conn: sqlite3.Connection, node_id: str, run_id: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM events WHERE node_id = ? AND run_id = ? LIMIT 1",
+        (node_id, run_id),
+    ).fetchone()
+    return row is not None
+
+
+def _backfill_link_owners(conn: sqlite3.Connection) -> None:
+    """Copy adapter ownership from the event log onto the link row it describes.
+
+    Ownership used to be re-derived by walking an item's whole event history on every
+    observation. This one-time pass keeps the same first-claim-wins answer while making
+    every later lookup a single indexed read.
+    """
+    claimed: set[tuple[str, str, str]] = set()
+    for work_id, detail_json, node_id in conn.execute(
+        "SELECT work_id, detail_json, node_id FROM work_events ORDER BY seq ASC"
+    ).fetchall():
+        try:
+            detail = json.loads(str(detail_json or "{}"))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(detail, Mapping):
+            continue
+        external_key = detail.get("external_key")
+        adapter_id = detail.get("adapter_id")
+        link_type = detail.get("link_type")
+        if not isinstance(external_key, str) or not isinstance(adapter_id, str) or not adapter_id:
+            continue
+        # An adapter can only ever have claimed an import link type, and the identity it
+        # claimed is (work_id, link_type, external_key). An event that does not name its
+        # link type cannot prove which identity it claimed, so it stamps nothing rather
+        # than risk stamping an operator link that happens to share the key.
+        if not isinstance(link_type, str) or link_type not in IMPORT_LINK_TYPES:
+            continue
+        claim = (str(work_id), link_type, external_key)
+        if claim in claimed:
+            continue
+        claimed.add(claim)
+        conn.execute(
+            "UPDATE work_links SET adapter_id = ?, owner_node = ? "
+            "WHERE work_id = ? AND link_type = ? AND external_key = ?",
+            (adapter_id, None if node_id is None else str(node_id), str(work_id), link_type, external_key),
+        )
+
+
+def _backfill_import_key_owners(conn: sqlite3.Connection) -> None:
+    """Stamp existing import keys with the node that owns their adapter.
+
+    The owning node already lives on ``work_sync_cursors``, so the per-owner retention
+    ceiling applies to keys written before the column existed instead of exempting them.
+    """
+    conn.execute(
+        "UPDATE work_import_keys SET owner_node = "
+        "(SELECT cursors.owner_node FROM work_sync_cursors cursors WHERE cursors.adapter_id = "
+        "work_import_keys.adapter_id) WHERE owner_node IS NULL"
+    )
+
+
+def _trim_import_keys(conn: sqlite3.Connection, *, adapter_id: str, owner_node: str) -> None:
+    """Expire import keys past the retention window for this adapter and its owning node.
+
+    Newest first, so every key inside the window keeps its exact stored counts and an
+    honest replay still short-circuits. Both deletes run in the import transaction.
+    """
+    for column, value, keep in (
+        ("adapter_id", adapter_id, ADAPTER_IMPORT_KEY_RETENTION),
+        ("owner_node", owner_node, OWNER_IMPORT_KEY_RETENTION),
+    ):
+        conn.execute(
+            f"DELETE FROM work_import_keys WHERE {column} = ? AND rowid NOT IN ("
+            f"SELECT rowid FROM work_import_keys WHERE {column} = ? "
+            "ORDER BY received_at DESC, rowid DESC LIMIT ?)",
+            (value, value, keep),
+        )
+
+
+def _trim_adapter_events(conn: sqlite3.Connection, work_id: str) -> None:
+    """Keep only the most recent adapter observation events on one item.
+
+    This is the whole adapter event-storage policy: ``sync-observed`` and ``sync-stale``
+    written by an adapter expire past ``ADAPTER_SYNC_EVENT_RETENTION`` per item. Lifecycle
+    events, and any event an operator or node wrote, are never removed.
+    """
+    placeholders = ", ".join("?" for _ in ADAPTER_SYNC_EVENT_TYPES)
+    scope = f"work_id = ? AND actor_type = 'adapter' AND event_type IN ({placeholders})"
+    conn.execute(
+        f"DELETE FROM work_events WHERE {scope} AND seq NOT IN ("
+        f"SELECT seq FROM work_events WHERE {scope} ORDER BY seq DESC LIMIT ?)",
+        (work_id, *ADAPTER_SYNC_EVENT_TYPES, work_id, *ADAPTER_SYNC_EVENT_TYPES, ADAPTER_SYNC_EVENT_RETENTION),
+    )
+
+
+def _prune_import_keys_to_quota(conn: sqlite3.Connection) -> None:
+    """Cut any adapter or owner whose import keys are over the retention window back to it.
+
+    ``_trim_import_keys`` only runs for the adapter and owner an import touched, so keys a
+    hub accumulated before retention existed, or under an adapter that has since gone
+    quiet, would sit outside the quota forever. The over-quota partitions are found first
+    with an indexed aggregate rather than by ranking every row: on a healthy hub that
+    aggregate returns nothing and the pass writes nothing at all. Any key that survives
+    keeps its exact stored counts, so an honest replay still short-circuits. NULL owners
+    partition together, which bounds them too.
+    """
+    for column, keep in (
+        ("adapter_id", ADAPTER_IMPORT_KEY_RETENTION),
+        ("owner_node", OWNER_IMPORT_KEY_RETENTION),
+    ):
+        over_quota = conn.execute(
+            f"SELECT {column} FROM work_import_keys GROUP BY {column} HAVING COUNT(*) > ?",
+            (keep,),
+        ).fetchall()
+        for row in over_quota:
+            match = "IS NULL" if row[0] is None else "= ?"
+            values: tuple[object, ...] = () if row[0] is None else (row[0],)
+            conn.execute(
+                f"DELETE FROM work_import_keys WHERE {column} {match} AND rowid NOT IN ("
+                f"SELECT rowid FROM work_import_keys WHERE {column} {match} "
+                "ORDER BY received_at DESC, rowid DESC LIMIT ?)",
+                (*values, *values, keep),
+            )
+
+
+def _prune_adapter_events_to_quota(conn: sqlite3.Connection) -> None:
+    """Cut any item whose adapter observation events are over the per-item window back to it.
+
+    Same reason and same shape as the import keys: ``_trim_adapter_events`` only runs for
+    items an import touched, and the over-quota items are found with an aggregate the
+    ``(work_id, actor_type, event_type, seq)`` index answers, so a healthy hub does not walk
+    its event log. Lifecycle events, and any event an operator or node wrote, are never
+    removed.
+    """
+    placeholders = ", ".join("?" for _ in ADAPTER_SYNC_EVENT_TYPES)
+    over_quota = conn.execute(
+        f"SELECT work_id FROM work_events WHERE actor_type = 'adapter' AND event_type IN ({placeholders}) "
+        "GROUP BY work_id HAVING COUNT(*) > ?",
+        (*ADAPTER_SYNC_EVENT_TYPES, ADAPTER_SYNC_EVENT_RETENTION),
+    ).fetchall()
+    for row in over_quota:
+        _trim_adapter_events(conn, str(row[0]))
+
+
+def _trim_fleet_run_links(conn: sqlite3.Connection, work_id: str) -> None:
+    """Expire one item's oldest fleet-run links so a new run always has room to link.
+
+    Import keys and adapter events expire for the same reason: they are the classes a
+    running fleet grows on its own. Newest first by ``synced_at`` then insertion order, so
+    the recent execution history an operator actually reads survives. This writes no
+    ``unlinked`` event; retention is storage policy, not an operator decision, and an
+    ``unlinked`` event per run would simply move the unbounded growth into the event log.
+    """
+    keep = max(FLEET_RUN_LINK_RETENTION - 1, 0)
+    conn.execute(
+        "DELETE FROM work_links WHERE work_id = ? AND link_type = 'fleet-run' AND rowid NOT IN ("
+        "SELECT rowid FROM work_links WHERE work_id = ? AND link_type = 'fleet-run' "
+        "ORDER BY synced_at DESC, rowid DESC LIMIT ?)",
+        (work_id, work_id, keep),
+    )
+
+
+def _bootstrap_link_source_versions(conn: sqlite3.Connection) -> None:
+    """Seed the per-identity high-water on imported links written before the column existed.
+
+    v17 added ``source_version`` and deliberately left it NULL, on the reasoning that the
+    stored ``external_updated_at`` is the last reported timestamp rather than the highest
+    ever accepted. That reasoning left every already-imported identity with no guard at all
+    until its source happened to send another timestamped observation, so an expired-key
+    replay could roll a migrated identity straight back. The last reported timestamp is in
+    fact the revision of the projection those rows currently hold, which is exactly what
+    the guard compares against, so it is seeded here. Only parseable values are seeded, so
+    the column keeps holding nothing the guard cannot compare.
+    """
+    rows = conn.execute(
+        "SELECT link_id, external_updated_at FROM work_links "
+        f"WHERE {_LINK_SOURCE_VERSION_COLUMN} IS NULL AND adapter_id IS NOT NULL AND external_updated_at IS NOT NULL"
+    ).fetchall()
+    seeded = [(str(row[0]), str(row[1])) for row in rows if _source_version(row[1]) is not None]
+    for index in range(0, len(seeded), _SQL_VARIABLE_CHUNK):
+        conn.executemany(
+            f"UPDATE work_links SET {_LINK_SOURCE_VERSION_COLUMN} = ? WHERE link_id = ?",
+            [(version, link_id) for link_id, version in seeded[index : index + _SQL_VARIABLE_CHUNK]],
+        )
+
+
+def _reconciled_version(conn: sqlite3.Connection) -> int:
+    """The highest migration reconciliation this database has completed, 0 when none."""
+    try:
+        row = conn.execute(f"SELECT value FROM work_schema_meta WHERE key = '{_RECONCILED_VERSION_KEY}'").fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    if row is None:
+        return 0
+    try:
+        return int(str(row[0]))
+    except ValueError:
+        return 0
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    """Create the Worklore tables and named indexes, and reconcile pre-quota rows once.
+
+    Migration is not only additive columns. A database written before a quota existed can
+    hold rows that violate it, so import keys and adapter events are pruned to their
+    retention windows and imported links are seeded with the source high-water they were
+    upgraded without.
+
+    The two reconciliations are paid for differently. Seeding the high-water reads every
+    imported link, so it runs once: ``work_schema_meta`` records the version it completed
+    and a hub that has already done the work skips straight past it. The quota passes stay
+    on every start, because an adapter that goes quiet after a busy week leaves rows nothing
+    else will ever revisit, but they no longer rank every row to find them: an indexed
+    aggregate names the over-quota partitions first, and on a healthy hub it names none and
+    the passes write nothing.
+
+    Nothing here refuses a database. An item carrying more than ``ITEM_MAX_LINKS`` links is
+    a legacy row, not a corrupt one: every read path cuts by SQL rather than trusting the
+    ceiling, new writes still enforce it, and an operator repairs the item by unlinking
+    through the ordinary route. Refusing at startup instead would take the hub down and
+    leave no running route to repair it with.
+
+    A caller that already owns a transaction, which is how Fleet Hub applies its schema,
+    keeps it; otherwise the migration commits its own work and rolls back cleanly rather
+    than stranding an open write.
+    """
+    owns_transaction = not conn.in_transaction
+    try:
+        _apply_worklore_schema(conn)
+    except BaseException:
+        if owns_transaction and conn.in_transaction:
+            conn.rollback()
+        raise
+    if owns_transaction and conn.in_transaction:
+        conn.commit()
+
+
+def _apply_worklore_schema(conn: sqlite3.Connection) -> None:
+    _pragma_foreign_keys(conn)
+    reconciled = _reconciled_version(conn)
+    for statement in _SCHEMA_STATEMENTS:
+        conn.execute(statement)
+    columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(work_import_keys)")}
+    if "unchanged" not in columns:
+        conn.execute("ALTER TABLE work_import_keys ADD COLUMN unchanged INTEGER NOT NULL DEFAULT 0")
+    if "owner_node" not in columns:
+        conn.execute("ALTER TABLE work_import_keys ADD COLUMN owner_node TEXT")
+        _backfill_import_key_owners(conn)
+    event_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(work_events)")}
+    if "seq" not in event_columns:
+        conn.execute("ALTER TABLE work_events ADD COLUMN seq INTEGER NOT NULL DEFAULT 0")
+        conn.execute("UPDATE work_events SET seq = rowid")
+    link_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(work_links)")}
+    if "adapter_id" not in link_columns:
+        conn.execute("ALTER TABLE work_links ADD COLUMN adapter_id TEXT")
+        conn.execute("ALTER TABLE work_links ADD COLUMN owner_node TEXT")
+        _backfill_link_owners(conn)
+    if _LINK_SOURCE_VERSION_COLUMN not in link_columns:
+        conn.execute(f"ALTER TABLE work_links ADD COLUMN {_LINK_SOURCE_VERSION_COLUMN} TEXT")
+    if "refused" not in columns:
+        conn.execute("ALTER TABLE work_import_keys ADD COLUMN refused INTEGER NOT NULL DEFAULT 0")
+    for statement in _INDEX_STATEMENTS:
+        conn.execute(statement)
+    if reconciled < WORKLORE_RECONCILE_VERSION:
+        _bootstrap_link_source_versions(conn)
+        conn.execute(
+            "INSERT INTO work_schema_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (_RECONCILED_VERSION_KEY, str(WORKLORE_RECONCILE_VERSION)),
+        )
+    _prune_import_keys_to_quota(conn)
+    _prune_adapter_events_to_quota(conn)
+
+
+def get_item(conn: sqlite3.Connection, work_id: str) -> dict[str, Any]:
+    """Return one Worklore item projection."""
+    _pragma_foreign_keys(conn)
+    return _loaded_item(conn, work_id)
+
+
+def list_events(conn: sqlite3.Connection, work_id: str) -> list[dict[str, Any]]:
+    """Return events for one item in insertion order."""
+    _pragma_foreign_keys(conn)
+    rows = conn.execute(
+        f"SELECT {', '.join(_EVENT_COLUMNS)} FROM work_events WHERE work_id = ? ORDER BY seq ASC",
+        (work_id,),
+    ).fetchall()
+    return [_event_from_row(row) for row in rows]
+
+
+def recent_events(conn: sqlite3.Connection, work_id: str, *, limit: int = DETAIL_RECENT_EVENTS) -> list[dict[str, Any]]:
+    """Return the last ``limit`` events for one item, oldest first.
+
+    The database does the ordering and the cut, so an item detail read costs the events it
+    shows rather than every event the item has ever recorded.
+    """
+    _pragma_foreign_keys(conn)
+    rows = conn.execute(
+        f"SELECT {', '.join(_EVENT_COLUMNS)} FROM work_events WHERE work_id = ? ORDER BY seq DESC LIMIT ?",
+        (work_id, max(int(limit), 0)),
+    ).fetchall()
+    return [_event_from_row(row) for row in reversed(rows)]
+
+
+def create_item(
+    conn: sqlite3.Connection,
+    raw: object,
+    *,
+    actor_id: str,
+    actor_type: str = "operator",
+    node_id: str | None = None,
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    """Create a native Worklore item and its created event in one transaction."""
+    parsed = parse_create(raw)
+    key = None
+    if idempotency_key is not None:
+        key = _require_text(idempotency_key, "idempotency_key", max_len=IDEMPOTENCY_KEY_MAX)
+    fingerprint = _create_fingerprint(parsed)
+
+    def _write() -> dict[str, Any]:
+        now = _utc_now()
+        if key is not None:
+            stored = conn.execute(
+                "SELECT fingerprint, work_id FROM work_create_keys WHERE actor_id = ? AND idempotency_key = ?",
+                (actor_id, key),
+            ).fetchone()
+            if stored is not None:
+                if str(stored[0]) != fingerprint:
+                    raise WorkloreConflict("idempotency key reused with a different payload", code="import-conflict")
+                return _loaded_item(conn, str(stored[1]))
+        item = _item_from_create(parsed, work_id=_mint_id("wl-"), now=now)
+        _insert_item(conn, item)
+        _append_event(
+            conn,
+            work_id=item["work_id"],
+            event_type="created",
+            from_status=None,
+            to_status=item["status"],
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=now,
+            node_id=node_id,
+        )
+        if key is not None:
+            conn.execute(
+                "INSERT INTO work_create_keys (actor_id, idempotency_key, fingerprint, work_id, received_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (actor_id, key, fingerprint, item["work_id"], now),
+            )
+        return _loaded_item(conn, item["work_id"])
+
+    return _in_transaction(conn, _write)
+
+
+def _create_fingerprint(parsed: Mapping[str, Any]) -> str:
+    payload = {name: parsed[name] for name in parsed if name != "status"}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def patch_item(
+    conn: sqlite3.Connection,
+    work_id: str,
+    raw: object,
+    *,
+    expected_version: int,
+    actor_id: str,
+    actor_type: str = "operator",
+    node_id: str | None = None,
+) -> dict[str, Any]:
+    """Patch mutable fields and append an updated event in one transaction."""
+
+    def _write() -> dict[str, Any]:
+        current = _loaded_item(conn, work_id)
+        _require_version(current, expected_version)
+        parsed = _parse_patch(current, raw)
+        now = _utc_now()
+        updated = {
+            **current,
+            "title": parsed["title"],
+            "description": parsed["description"],
+            "scope": parsed["scope"],
+            "priority": parsed["priority"],
+            "burn_eligible": bool(parsed["burn_eligible"]),
+            "burn_rank": parsed["burn_rank"],
+            "token_appetite": parsed["token_appetite"],
+            "execution_mode": parsed["execution_mode"],
+            "acceptance": list(parsed["acceptance"]),
+            "blocker": parsed["blocker"],
+            "review_after": parsed["review_after"],
+            "spend_by": parsed["spend_by"],
+            "version": int(current["version"]) + 1,
+            "updated_at": now,
+        }
+        _update_item(conn, updated)
+        _append_event(
+            conn,
+            work_id=work_id,
+            event_type="updated",
+            from_status=current["status"],
+            to_status=current["status"],
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=now,
+            node_id=node_id,
+        )
+        return _loaded_item(conn, work_id)
+
+    return _in_transaction(conn, _write)
+
+
+def transition(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    to_status: str,
+    expected_version: int,
+    actor_id: str,
+    actor_type: str = "operator",
+    node_id: str | None = None,
+) -> dict[str, Any]:
+    """Move one item along a legal lifecycle edge in one transaction."""
+
+    def _write() -> dict[str, Any]:
+        current = _loaded_item(conn, work_id)
+        _require_version(current, expected_version)
+        if not can_transition(str(current["status"]), to_status):
+            raise WorkloreValidationError(
+                f"cannot transition from {current['status']} to {to_status}",
+                code="invalid-transition",
+            )
+        if to_status == "ready":
+            assert_ready({"acceptance": current["effective_acceptance"]})
+        now = _utc_now()
+        ready_at = current["ready_at"]
+        archived_at = current["archived_at"]
+        if to_status == "ready" and current["status"] != "ready":
+            ready_at = now
+        if to_status == "archived":
+            archived_at = now
+        updated = {
+            **current,
+            "status": to_status,
+            "ready_at": ready_at,
+            "archived_at": archived_at,
+            "version": int(current["version"]) + 1,
+            "updated_at": now,
+        }
+        _update_item(conn, updated)
+        _append_event(
+            conn,
+            work_id=work_id,
+            event_type="transitioned",
+            from_status=str(current["status"]),
+            to_status=to_status,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=now,
+            node_id=node_id,
+        )
+        return _loaded_item(conn, work_id)
+
+    return _in_transaction(conn, _write)
+
+
+def _burn_key(row: Any) -> tuple[Any, ...]:
+    """The burn sort key for one item row, matching ``_BURN_KEY_SQL`` column for column."""
+    work_id, spend_by, ready_at, burn_rank = str(row[0]), row[14], row[15], int(row[8])
+    spend = "" if spend_by is None else str(spend_by)
+    return (burn_rank, 1 if spend == "" else 0, spend, "" if ready_at is None else str(ready_at), work_id)
+
+
+def _burn_cursor_key(values: Mapping[str, str]) -> tuple[Any, ...]:
+    raw_rank = values["burn_rank"]
+    if not raw_rank.isdigit():
+        raise _field_bound("cursor is invalid")
+    spend = values["spend_by"]
+    return (int(raw_rank), 1 if spend == "" else 0, spend, values["ready_at"], values["work_id"])
+
+
+def _burn_rows(conn: sqlite3.Connection, *, after: tuple[Any, ...] | None, limit: int) -> list[Any]:
+    predicate = f" WHERE ({_BURN_KEY_SQL}) > (?, ?, ?, ?, ?)" if after is not None else ""
+    params = (*(after or ()), limit)
+    return list(
+        conn.execute(
+            f"SELECT {', '.join(_ITEM_COLUMNS)} FROM work_items{predicate} ORDER BY {_BURN_ORDER_SQL} LIMIT ?",
+            params,
+        )
+    )
+
+
+def burn_queue(
+    conn: sqlite3.Connection,
+    *,
+    limit: object = BURN_PAGE_DEFAULT,
+    cursor: object | None = None,
+) -> dict[str, Any]:
+    """Return one bounded page of eligible items in burn order plus first-match exclusion counts.
+
+    The page holds at most ``limit`` items and examines at most ``BURN_SCAN_MAX`` rows, so a
+    ledger that has grown without limit still answers in bounded time and memory. Exclusion
+    counts cover the rows this page examined; walking ``next_cursor`` to the end sums them to
+    the whole-ledger totals, and a ledger smaller than one page reports them in one read.
+    """
+    _pragma_foreign_keys(conn)
+    page_size = _parse_limit(limit)
+    after = _burn_cursor_key(_decode_cursor(cursor, "burn", _BURN_CURSOR_FIELDS)) if cursor is not None else None
+    exclusions = {name: 0 for name in EXCLUSION_BUCKETS}
+    eligible: list[dict[str, Any]] = []
+    scanned = 0
+    while len(eligible) < page_size and scanned < BURN_SCAN_MAX:
+        rows = _burn_rows(conn, after=after, limit=min(_BURN_SCAN_CHUNK, BURN_SCAN_MAX - scanned))
+        if not rows:
+            break
+        for row in rows:
+            scanned += 1
+            after = _burn_key(row)
+            summary = _link_summary(conn, str(row[0]))
+            item = _row_to_item(row, summary)
+            bucket = exclusion_bucket(item, _source_policies(summary))
+            if bucket is None:
+                eligible.append(item)
+            else:
+                exclusions[bucket] += 1
+            if len(eligible) >= page_size:
+                break
+    next_cursor = None
+    if after is not None and _burn_rows(conn, after=after, limit=1):
+        next_cursor = _encode_cursor(
+            "burn",
+            {
+                "burn_rank": str(after[0]),
+                "spend_by": str(after[2]),
+                "ready_at": str(after[3]),
+                "work_id": str(after[4]),
+            },
+        )
+    return {"items": eligible, "exclusions": exclusions, "next_cursor": next_cursor}
+
+
+def list_links(conn: sqlite3.Connection, work_id: str) -> list[dict[str, Any]]:
+    """Return every link on one item in synced-at order.
+
+    Bounded by ``ITEM_MAX_LINKS`` because that ceiling is enforced on write. Reads that
+    answer a caller use ``list_links_page`` so the response size is a page, not a ceiling.
+    """
+    _pragma_foreign_keys(conn)
+    return [_row_to_link(row) for row in _full_link_rows(conn, work_id)]
+
+
+def list_links_page(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    limit: object = LINK_PAGE_DEFAULT,
+    cursor: object | None = None,
+) -> dict[str, Any]:
+    """Return one deterministic page of an item's links with an explicit next cursor.
+
+    Ordered and keyed by ``(synced_at, link_id)``, the same order ``list_links`` uses, so a
+    caller that follows ``next_cursor`` to the end sees every link exactly once.
+    """
+    _pragma_foreign_keys(conn)
+    _select_item_row(conn, work_id)
+    page_size = _parse_limit(limit)
+    cursor_values = _decode_cursor(cursor, "links", ("synced_at", "link_id")) if cursor is not None else None
+    params: list[object] = [work_id]
+    predicate = ""
+    if cursor_values is not None:
+        predicate = " AND (synced_at > ? OR (synced_at = ? AND link_id > ?))"
+        params.extend([cursor_values["synced_at"], cursor_values["synced_at"], cursor_values["link_id"]])
+    rows = conn.execute(
+        f"SELECT {', '.join(_LINK_COLUMNS)} FROM work_links WHERE work_id = ?{predicate} "
+        "ORDER BY synced_at ASC, link_id ASC LIMIT ?",
+        (*params, page_size + 1),
+    ).fetchall()
+    rows, next_cursor = _page(
+        list(rows),
+        limit=page_size,
+        kind="links",
+        fields=("synced_at", "link_id"),
+        row_values=lambda row: {"synced_at": str(row[10]), "link_id": str(row[0])},
+    )
+    return {"links": [_row_to_link(row) for row in rows], "next_cursor": next_cursor}
+
+
+def _parse_limit(value: object) -> int:
+    if isinstance(value, bool):
+        raise _field_bound("limit must be an integer from 1 to 100")
+    if isinstance(value, str):
+        if not value.isdigit():
+            raise _field_bound("limit must be an integer from 1 to 100")
+        value = int(value)
+    if not isinstance(value, int) or not 1 <= value <= 100:
+        raise _field_bound("limit must be an integer from 1 to 100")
+    return value
+
+
+def _parse_bool(value: object, field: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.lower()
+        if normalized in {"true", "1"}:
+            return True
+        if normalized in {"false", "0"}:
+            return False
+    raise _field_bound(f"{field} must be a boolean")
+
+
+def _encode_cursor(kind: str, values: Mapping[str, str]) -> str:
+    payload = json.dumps({"kind": kind, "values": dict(values)}, sort_keys=True, separators=(",", ":"))
+    return urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _decode_cursor(value: object, kind: str, fields: tuple[str, ...]) -> dict[str, str]:
+    if not isinstance(value, str) or not value:
+        raise _field_bound("cursor is invalid")
+    try:
+        padding = "=" * (-len(value) % 4)
+        payload = json.loads(urlsafe_b64decode((value + padding).encode("ascii")).decode("utf-8"))
+    except (BinasciiError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        raise _field_bound("cursor is invalid") from None
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("kind") != kind
+        or not isinstance(payload.get("values"), Mapping)
+    ):
+        raise _field_bound("cursor is invalid")
+    values = payload["values"]
+    if set(values) != set(fields) or any(not isinstance(values[field], str) for field in fields):
+        raise _field_bound("cursor is invalid")
+    return {field: values[field] for field in fields}
+
+
+def _page(
+    rows: list[Any], *, limit: int, kind: str, fields: tuple[str, ...], row_values: Callable[[Any], dict[str, str]]
+) -> tuple[list[Any], str | None]:
+    visible = rows[:limit]
+    if len(rows) <= limit or not visible:
+        return visible, None
+    return visible, _encode_cursor(kind, row_values(visible[-1]))
+
+
+# Keep Worklore's established public import surface in this module.  The operations
+# themselves live separately from the schema and low-level SQLite primitives above.
+from . import worklore_store_operations as _worklore_store_operations  # noqa: E402
+
+_worklore_store_operations.bind_core(sys.modules[__name__])
+
+from .worklore_store_operations import (  # noqa: E402, F401
+    add_link,
+    delete_link,
+    import_batch,
+    link_execution,
+    list_all_events,
+    list_events_page,
+    list_items,
+    record_attempt,
+    _link_summaries,
+    _link_summary,
+)

--- a/src/brigade/worklore_store_operations.py
+++ b/src/brigade/worklore_store_operations.py
@@ -1,0 +1,1081 @@
+"""Worklore query, link, attempt, and adapter-import operations.
+
+The public functions are re-exported from :mod:`brigade.worklore_store` to preserve
+its API while keeping the SQLite schema and primitive helpers in one core module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from .worklore_validate import parse_create, safe_optional_text
+
+if TYPE_CHECKING:
+    from .worklore_store import (  # noqa: F401
+        ADAPTER_ID_MAX,
+        ADMIN_LINK_TYPES,
+        DISPLAY_REF_MAX,
+        EXTERNAL_KEY_MAX,
+        IDEMPOTENCY_KEY_MAX,
+        IMPORT_LINK_TYPES,
+        IMPORT_MAX_OBSERVATIONS,
+        KINDS,
+        REFUSED_ADAPTER_IDENTITY_CONFLICT,
+        REFUSED_DETAILS_MAX,
+        REFUSED_OPERATOR_MANAGED,
+        REFUSED_OWNER_NODE_MISMATCH,
+        SOURCE_POLICIES,
+        SOURCE_TYPES,
+        TRANSITIONS,
+        WorkloreConflict,
+        WorkloreForbidden,
+        WorkloreNotFound,
+        WorkloreValidationError,
+        _EVENT_PAGE_COLUMNS,
+        _ITEM_COLUMNS,
+        _LINK_COLUMNS,
+        _append_event,
+        _claim_item_link,
+        _cursor_owner,
+        _cursor_seq,
+        _decode_cursor,
+        _empty_link_summary,
+        _event_from_page_row,
+        _field_bound,
+        _find_link,
+        _has_source_link,
+        _https_url,
+        _hub_run_exists,
+        _import_headroom,
+        _in_transaction,
+        _insert_item,
+        _insert_link,
+        _item_from_create,
+        _items_for_observations,
+        _link_claim,
+        _link_from_observation,
+        _load_json_list,
+        _links_by_work_id,
+        _loaded_item,
+        _mint_id,
+        _observation_changed,
+        _observation_detail,
+        _observation_fingerprint,
+        _one_way_stale_transition,
+        _observed_source_version,
+        _optional_text,
+        _owning_adapter,
+        _page,
+        _parse_bool,
+        _parse_limit,
+        _parse_observation,
+        _pragma_foreign_keys,
+        _require_adapter_namespace,
+        _require_owned_fleet_run,
+        _require_text,
+        _require_version,
+        _revision_refusal,
+        _row_to_item,
+        _row_to_link,
+        _source_version,
+        _select_item_row,
+        _touch_cursor,
+        _touch_link_synced_at,
+        _trim_adapter_events,
+        _trim_fleet_run_links,
+        _trim_import_keys,
+        _update_item,
+        _update_link,
+        _utc_now,
+    )
+
+
+_CORE_BINDING_NAMES = (
+    "ADAPTER_ID_MAX",
+    "ADMIN_LINK_TYPES",
+    "DISPLAY_REF_MAX",
+    "EXTERNAL_KEY_MAX",
+    "IDEMPOTENCY_KEY_MAX",
+    "IMPORT_LINK_TYPES",
+    "IMPORT_MAX_OBSERVATIONS",
+    "KINDS",
+    "REFUSED_ADAPTER_IDENTITY_CONFLICT",
+    "REFUSED_DETAILS_MAX",
+    "REFUSED_OPERATOR_MANAGED",
+    "REFUSED_OWNER_NODE_MISMATCH",
+    "SOURCE_POLICIES",
+    "SOURCE_TYPES",
+    "TRANSITIONS",
+    "WorkloreConflict",
+    "WorkloreForbidden",
+    "WorkloreNotFound",
+    "WorkloreValidationError",
+    "_EVENT_PAGE_COLUMNS",
+    "_ITEM_COLUMNS",
+    "_LINK_COLUMNS",
+    "_append_event",
+    "_claim_item_link",
+    "_cursor_owner",
+    "_cursor_seq",
+    "_decode_cursor",
+    "_empty_link_summary",
+    "_event_from_page_row",
+    "_field_bound",
+    "_find_link",
+    "_has_source_link",
+    "_https_url",
+    "_hub_run_exists",
+    "_import_headroom",
+    "_in_transaction",
+    "_insert_item",
+    "_insert_link",
+    "_item_from_create",
+    "_items_for_observations",
+    "_link_claim",
+    "_link_from_observation",
+    "_load_json_list",
+    "_links_by_work_id",
+    "_loaded_item",
+    "_mint_id",
+    "_observation_changed",
+    "_observation_detail",
+    "_observation_fingerprint",
+    "_one_way_stale_transition",
+    "_observed_source_version",
+    "_optional_text",
+    "_owning_adapter",
+    "_page",
+    "_parse_bool",
+    "_parse_limit",
+    "_parse_observation",
+    "_pragma_foreign_keys",
+    "_require_adapter_namespace",
+    "_require_owned_fleet_run",
+    "_require_text",
+    "_require_version",
+    "_revision_refusal",
+    "_row_to_item",
+    "_row_to_link",
+    "_source_version",
+    "_select_item_row",
+    "_touch_cursor",
+    "_touch_link_synced_at",
+    "_trim_adapter_events",
+    "_trim_fleet_run_links",
+    "_trim_import_keys",
+    "_update_item",
+    "_update_link",
+    "_utc_now",
+)
+
+_CORE: ModuleType | None = None
+
+
+def bind_core(core: ModuleType) -> None:
+    """Bind verified store helpers once, after the store facade has initialized."""
+    global _CORE
+
+    if _CORE is not None:
+        if _CORE is not core:
+            raise RuntimeError("worklore store operations core is already bound")
+        return
+    missing = [name for name in _CORE_BINDING_NAMES if not hasattr(core, name)]
+    if missing:
+        raise RuntimeError("worklore store operations core binding is incomplete")
+    globals().update({name: getattr(core, name) for name in _CORE_BINDING_NAMES})
+    _CORE = core
+
+
+def _core() -> ModuleType:
+    """Return the facade binding or fail before any operation can use unbound helpers."""
+    if _CORE is None:
+        raise RuntimeError("worklore store operations core is not bound")
+    return _CORE
+
+
+_ATTEMPT_EVENT_TYPES = ("attempt-started", "attempt-failed", "attempt-reset")
+
+
+def record_attempt(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    action: str,
+    expected_version: int,
+    actor_id: str,
+    actor_type: str = "operator",
+    node_id: str | None = None,
+    run_id: object | None = None,
+) -> dict[str, Any]:
+    """Record a bounded attempt, treating an authenticated run/action retry as a no-op."""
+    actions = {
+        "started": ("attempt-started", lambda count: count),
+        "failed": ("attempt-failed", lambda count: count + 1),
+        "reset": ("attempt-reset", lambda count: 0),
+    }
+    if action not in actions:
+        raise WorkloreValidationError("action must be started, failed, or reset", code="field-bound")
+    event_type, next_count = actions[action]
+    core = _core()
+    # Reset is intentionally not associated with an execution run. Discard the supplied
+    # value before validation or persistence so it cannot become an event-log side channel.
+    accepted_run_id = (
+        None if action == "reset" else safe_optional_text(run_id, "run_id", max_len=core.ATTEMPT_RUN_ID_MAX)
+    )
+
+    def _write() -> dict[str, Any]:
+        current = _loaded_item(conn, work_id)
+        if node_id is not None and action in {"started", "failed"}:
+            _require_owned_fleet_run(conn, work_id, node_id=node_id, run_id=accepted_run_id)
+        if accepted_run_id is not None:
+            duplicate = conn.execute(
+                "SELECT 1 FROM work_events WHERE work_id = ? AND event_type = ? "
+                "AND node_id IS ? AND run_id = ? LIMIT 1",
+                (work_id, event_type, node_id, accepted_run_id),
+            ).fetchone()
+            if duplicate is not None:
+                return current
+        _require_version(current, expected_version)
+        placeholders = ", ".join("?" for _ in _ATTEMPT_EVENT_TYPES)
+        at_ceiling = conn.execute(
+            "SELECT 1 FROM work_events INDEXED BY work_events_attempt_work_seq "
+            f"WHERE work_id = ? AND event_type IN ({placeholders}) "
+            "LIMIT 1 OFFSET ?",
+            (work_id, *_ATTEMPT_EVENT_TYPES, core.ITEM_MAX_ATTEMPT_EVENTS - 1),
+        ).fetchone()
+        if at_ceiling is not None:
+            raise WorkloreConflict(
+                f"work item has reached its {core.ITEM_MAX_ATTEMPT_EVENTS} attempt event ceiling",
+                code="attempt-conflict",
+            )
+        now = _utc_now()
+        updated = {
+            **current,
+            "attempt_count": next_count(int(current["attempt_count"])),
+            "version": int(current["version"]) + 1,
+            "updated_at": now,
+        }
+        _update_item(conn, updated)
+        _append_event(
+            conn,
+            work_id=work_id,
+            event_type=event_type,
+            from_status=str(current["status"]),
+            to_status=str(current["status"]),
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=now,
+            node_id=node_id,
+            run_id=accepted_run_id,
+            detail={"action": action},
+        )
+        return _loaded_item(conn, work_id)
+
+    return _in_transaction(conn, _write)
+
+
+def _link_summary(conn: sqlite3.Connection, work_id: str) -> dict[str, Any]:
+    """Read bounded burn/detail facts for one item through indexed LIMIT probes.
+
+    A schema-v18 database may contain a legacy item with far more than the current write
+    ceiling. These facts retain the full projection semantics without aggregating that
+    partition: every probe identifies one policy/type state in a composite index and stops
+    at its first match. The closed link-type contract makes source-policy exclusions apply
+    only to imported source links, without a negative predicate that could scan an
+    unbounded partition.
+    """
+    _core()
+    source_types = tuple(sorted(IMPORT_LINK_TYPES))
+    source_placeholders = ", ".join("?" for _ in source_types)
+    source_params = (work_id, *source_types)
+    has_source_link = conn.execute(
+        f"SELECT 1 FROM work_links WHERE work_id = ? AND link_type IN ({source_placeholders}) LIMIT 1",
+        source_params,
+    ).fetchone()
+    eligible_source_link = conn.execute(
+        f"SELECT 1 FROM work_links WHERE work_id = ? AND source_policy = 'eligible' "
+        f"AND link_type IN ({source_placeholders}) AND stale_at IS NULL LIMIT 1",
+        source_params,
+    ).fetchone()
+    authoritative = min(
+        (
+            conn.execute(
+                "SELECT source_acceptance_json, synced_at, link_id FROM work_links "
+                "INDEXED BY work_links_work_policy_type_order WHERE work_id = ? "
+                "AND source_policy = 'eligible' AND link_type = ? ORDER BY synced_at ASC, link_id ASC LIMIT 1",
+                (work_id, link_type),
+            ).fetchone()
+            for link_type in source_types
+        ),
+        key=lambda row: (str(row[1]), str(row[2])) if row is not None else ("~", "~"),
+        default=None,
+    )
+    blocking_policy = None
+    for policy in sorted(SOURCE_POLICIES - {"eligible"}):
+        source_blocker = conn.execute(
+            f"SELECT 1 FROM work_links WHERE work_id = ? AND source_policy = ? "
+            f"AND link_type IN ({source_placeholders}) AND stale_at IS NULL LIMIT 1",
+            (work_id, policy, *source_types),
+        ).fetchone()
+        if source_blocker is not None:
+            blocking_policy = policy
+            break
+    return {
+        "blocking_policy": blocking_policy,
+        "source_acceptance": _load_json_list(None if authoritative is None else authoritative[0]),
+        "has_source_link": has_source_link is not None,
+        "has_eligible_non_stale_source_link": eligible_source_link is not None,
+    }
+
+
+def _link_summaries(conn: sqlite3.Connection, work_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
+    """Summarize exactly ``work_ids`` without aggregating any item's link partition."""
+    return {work_id: _link_summary(conn, work_id) for work_id in work_ids}
+
+
+_LIST_SCAN_CHUNK = 200
+
+
+def _item_candidates(conn: sqlite3.Connection, *, after: Mapping[str, str] | None, limit: int) -> list[Any]:
+    predicate = ""
+    params: tuple[object, ...] = ()
+    if after is not None:
+        predicate = " WHERE (created_at > ? OR (created_at = ? AND work_id > ?))"
+        params = (after["created_at"], after["created_at"], after["work_id"])
+    return list(
+        conn.execute(
+            f"SELECT {', '.join(_ITEM_COLUMNS)} FROM work_items{predicate} "
+            "ORDER BY created_at ASC, work_id ASC LIMIT ?",
+            (*params, limit),
+        )
+    )
+
+
+def _source_matches(conn: sqlite3.Connection, work_id: str, source: str | None) -> bool:
+    """Test one item's source through a bounded, order-compatible index probe."""
+    if source is None:
+        return True
+    if source in _core().IMPORT_LINK_TYPES:
+        row = conn.execute(
+            "SELECT 1 FROM work_links INDEXED BY work_links_work_type WHERE work_id = ? AND link_type = ? LIMIT 1",
+            (work_id, source),
+        ).fetchone()
+        return row is not None
+    source_types = tuple(sorted(_core().IMPORT_LINK_TYPES))
+    placeholders = ", ".join("?" for _ in source_types)
+    row = conn.execute(
+        f"SELECT 1 FROM work_links INDEXED BY work_links_work_type WHERE work_id = ? "
+        f"AND link_type IN ({placeholders}) LIMIT 1",
+        (work_id, *source_types),
+    ).fetchone()
+    return row is None
+
+
+def _item_matches(
+    conn: sqlite3.Connection,
+    row: Any,
+    *,
+    status: str | None,
+    kind: str | None,
+    burn_eligible: bool | None,
+    source: str | None,
+) -> bool:
+    return (
+        (status is None or str(row[5]) == status)
+        and (kind is None or str(row[3]) == kind)
+        and (burn_eligible is None or bool(row[7]) is burn_eligible)
+        and _source_matches(conn, str(row[0]), source)
+    )
+
+
+def _filtered_item_rows(
+    conn: sqlite3.Connection,
+    *,
+    page_size: int,
+    cursor: Mapping[str, str] | None,
+    status: str | None,
+    kind: str | None,
+    burn_eligible: bool | None,
+    source: str | None,
+) -> tuple[list[Any], str | None]:
+    """Walk at most ``LIST_SCAN_MAX`` globally ordered item candidates for one page."""
+    core = _core()
+    after = cursor
+    rows: list[Any] = []
+    scanned = 0
+    while len(rows) < page_size and scanned < core.LIST_SCAN_MAX:
+        candidates = _item_candidates(conn, after=after, limit=min(_LIST_SCAN_CHUNK, core.LIST_SCAN_MAX - scanned))
+        if not candidates:
+            break
+        for candidate in candidates:
+            scanned += 1
+            after = {"created_at": str(candidate[18]), "work_id": str(candidate[0])}
+            if _item_matches(conn, candidate, status=status, kind=kind, burn_eligible=burn_eligible, source=source):
+                rows.append(candidate)
+            if len(rows) >= page_size:
+                break
+    next_cursor = None
+    if after is not None and _item_candidates(conn, after=after, limit=1):
+        next_cursor = core._encode_cursor("items", after)
+    return rows, next_cursor
+
+
+def list_items(
+    conn: sqlite3.Connection,
+    *,
+    status: str | None = None,
+    kind: str | None = None,
+    burn_eligible: object | None = None,
+    source: str | None = None,
+    limit: object = 50,
+    cursor: object | None = None,
+) -> dict[str, Any]:
+    """Return a deterministically paged item projection with its links."""
+    core = _core()
+    _pragma_foreign_keys(conn)
+    page_size = _parse_limit(limit)
+    if status is not None and status not in {*TRANSITIONS, "archived"}:
+        raise _field_bound("status must be an allowed work status")
+    if kind is not None and kind not in KINDS:
+        raise _field_bound("kind must be an allowed work kind")
+    if source is not None and source not in {"github", "brigade", "native"}:
+        raise _field_bound("source must be github, brigade, or native")
+    cursor_values = _decode_cursor(cursor, "items", ("created_at", "work_id")) if cursor is not None else None
+    parsed_burn_eligible: bool | None = None
+    if burn_eligible is not None:
+        parsed_burn_eligible = _parse_bool(burn_eligible, "burn_eligible")
+    if status is None and kind is None and parsed_burn_eligible is None and source is None:
+        item_rows = _item_candidates(conn, after=cursor_values, limit=page_size + 1)
+        item_rows, next_cursor = _page(
+            item_rows,
+            limit=page_size,
+            kind="items",
+            fields=("created_at", "work_id"),
+            row_values=lambda row: {"created_at": str(row[18]), "work_id": str(row[0])},
+        )
+    else:
+        item_rows, next_cursor = _filtered_item_rows(
+            conn,
+            page_size=page_size,
+            cursor=cursor_values,
+            status=status,
+            kind=kind,
+            burn_eligible=parsed_burn_eligible,
+            source=source,
+        )
+    work_ids = [str(row[0]) for row in item_rows]
+    summaries = _link_summaries(conn, work_ids)
+    links_by_work, truncated = _links_by_work_id(
+        conn,
+        work_ids,
+        _LINK_COLUMNS,
+        per_item_limit=core.ITEM_LINK_PROJECTION_MAX,
+    )
+    items: list[dict[str, Any]] = []
+    for work_id, row in zip(work_ids, item_rows, strict=True):
+        item = _row_to_item(row, summaries.get(work_id, _empty_link_summary()))
+        item["links"] = [_row_to_link(link) for link in links_by_work.get(work_id, [])]
+        item["links_truncated"] = work_id in truncated
+        items.append(item)
+    return {"items": items, "next_cursor": next_cursor}
+
+
+def _event_candidates(conn: sqlite3.Connection, *, after: Mapping[str, str] | None, limit: int) -> list[Any]:
+    predicate = ""
+    params: tuple[object, ...] = ()
+    if after is not None:
+        predicate = " WHERE (occurred_at < ? OR (occurred_at = ? AND seq < ?))"
+        params = (after["occurred_at"], after["occurred_at"], _cursor_seq(after))
+    return list(
+        conn.execute(
+            f"SELECT {', '.join(_EVENT_PAGE_COLUMNS)} FROM work_events{predicate} "
+            "ORDER BY occurred_at DESC, seq DESC LIMIT ?",
+            (*params, limit),
+        )
+    )
+
+
+def _filtered_event_rows(
+    conn: sqlite3.Connection,
+    *,
+    page_size: int,
+    cursor: Mapping[str, str] | None,
+    work_id: str | None,
+    event_type: str | None,
+) -> tuple[list[Any], str | None]:
+    """Walk at most ``LIST_SCAN_MAX`` reverse-chronological event candidates for one page."""
+    core = _core()
+    after = cursor
+    rows: list[Any] = []
+    scanned = 0
+    while len(rows) < page_size and scanned < core.LIST_SCAN_MAX:
+        candidates = _event_candidates(conn, after=after, limit=min(_LIST_SCAN_CHUNK, core.LIST_SCAN_MAX - scanned))
+        if not candidates:
+            break
+        for candidate in candidates:
+            scanned += 1
+            after = {"occurred_at": str(candidate[10]), "seq": str(candidate[12])}
+            if (work_id is None or str(candidate[0]) == work_id) and (
+                event_type is None or str(candidate[2]) == event_type
+            ):
+                rows.append(candidate)
+            if len(rows) >= page_size:
+                break
+    next_cursor = None
+    if after is not None and _event_candidates(conn, after=after, limit=1):
+        next_cursor = core._encode_cursor("events", after)
+    return rows, next_cursor
+
+
+def list_all_events(
+    conn: sqlite3.Connection,
+    *,
+    work_id: str | None = None,
+    event_type: str | None = None,
+    limit: object = 50,
+    cursor: object | None = None,
+) -> dict[str, Any]:
+    """Return fleet-wide events in reverse chronological order."""
+    _core()
+    _pragma_foreign_keys(conn)
+    page_size = _parse_limit(limit)
+    if work_id is not None:
+        _require_text(work_id, "work_id", max_len=256)
+    if event_type is not None:
+        _require_text(event_type, "event_type", max_len=128)
+    cursor_values = _decode_cursor(cursor, "events", ("occurred_at", "seq")) if cursor is not None else None
+    if work_id is None and event_type is None:
+        rows = _event_candidates(conn, after=cursor_values, limit=page_size + 1)
+        rows, next_cursor = _page(
+            rows,
+            limit=page_size,
+            kind="events",
+            fields=("occurred_at", "seq"),
+            row_values=lambda row: {"occurred_at": str(row[10]), "seq": str(row[12])},
+        )
+    else:
+        rows, next_cursor = _filtered_event_rows(
+            conn,
+            page_size=page_size,
+            cursor=cursor_values,
+            work_id=work_id,
+            event_type=event_type,
+        )
+    return {"events": [_event_from_page_row(row) for row in rows], "next_cursor": next_cursor}
+
+
+def list_events_page(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    limit: object = 50,
+    cursor: object | None = None,
+) -> dict[str, Any]:
+    """Return a Worklore item's events in deterministic chronological order."""
+    _core()
+    _pragma_foreign_keys(conn)
+    _select_item_row(conn, work_id)
+    page_size = _parse_limit(limit)
+    cursor_values = _decode_cursor(cursor, "item-events", ("seq",)) if cursor is not None else None
+    params: list[object] = [work_id]
+    predicate = ""
+    if cursor_values is not None:
+        predicate = " AND seq > ?"
+        params.append(_cursor_seq(cursor_values))
+    rows = conn.execute(
+        f"SELECT {', '.join(_EVENT_PAGE_COLUMNS)} FROM work_events WHERE work_id = ?{predicate} "
+        "ORDER BY seq ASC LIMIT ?",
+        (*params, page_size + 1),
+    ).fetchall()
+    rows, next_cursor = _page(
+        list(rows),
+        limit=page_size,
+        kind="item-events",
+        fields=("seq",),
+        row_values=lambda row: {"seq": str(row[12])},
+    )
+    return {"events": [_event_from_page_row(row) for row in rows], "next_cursor": next_cursor}
+
+
+def _parse_admin_link(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise _field_bound("link body must be an object")
+    allowed = {"link_type", "external_key", "url", "display_ref"}
+    unknown = [name for name in raw if name not in allowed]
+    if unknown:
+        raise WorkloreValidationError(f"unknown field: {unknown[0]}", code="unknown-field")
+    link_type = raw.get("link_type")
+    if link_type not in ADMIN_LINK_TYPES:
+        raise WorkloreForbidden("link type is adapter or fleet managed", code="link-forbidden")
+    external_key = _require_text(raw.get("external_key"), "external_key", max_len=EXTERNAL_KEY_MAX)
+    url = _https_url(raw.get("url"))
+    if link_type == "url":
+        url = _https_url(url or external_key)
+    return {
+        "link_type": str(link_type),
+        "external_key": external_key,
+        "url": url,
+        "display_ref": _optional_text(raw.get("display_ref"), "display_ref", max_len=DISPLAY_REF_MAX),
+    }
+
+
+def add_link(
+    conn: sqlite3.Connection,
+    work_id: str,
+    raw: object,
+    *,
+    actor_id: str,
+    actor_type: str = "operator",
+    node_id: str | None = None,
+) -> dict[str, Any]:
+    """Add a documented operator-managed link without using SQLite errors as an API."""
+    _core()
+
+    def _write() -> dict[str, Any]:
+        current = _loaded_item(conn, work_id)
+        parsed = _parse_admin_link(raw)
+        if _find_link(conn, parsed["link_type"], parsed["external_key"]) is not None:
+            raise WorkloreConflict("external link already exists", code="link-conflict")
+        _claim_item_link(conn, work_id, code="link-conflict")
+        now = _utc_now()
+        link = {
+            "link_id": _mint_id("lnk-"),
+            "work_id": work_id,
+            **parsed,
+            "source_policy": "eligible",
+            "source_acceptance": [],
+            "synced_at": now,
+            "stale_at": None,
+        }
+        _insert_link(conn, link)
+        _append_event(
+            conn,
+            work_id=work_id,
+            event_type="linked",
+            from_status=str(current["status"]),
+            to_status=str(current["status"]),
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=now,
+            node_id=node_id,
+            detail={"external_key": link["external_key"], "link_type": link["link_type"]},
+        )
+        return {**link}
+
+    return _in_transaction(conn, _write)
+
+
+def delete_link(
+    conn: sqlite3.Connection,
+    work_id: str,
+    link_id: str,
+    *,
+    expected_version: int | None = None,
+    actor_id: str,
+    actor_type: str = "operator",
+    node_id: str | None = None,
+) -> dict[str, Any]:
+    """Remove one operator-managed or retired source link and record the durable unlink event.
+
+    An adapter-owned ``github`` or ``brigade`` link may be removed only once its
+    ``source_policy`` has left ``eligible``; an eligible adapter link stays protected so an
+    operator cannot detach live imported work. Removing the last source link converts the item
+    to ``native``. Scheduling fields are never touched here.
+    """
+    _core()
+
+    def _write() -> dict[str, Any]:
+        current = _loaded_item(conn, work_id)
+        if expected_version is not None and current["version"] != expected_version:
+            raise WorkloreConflict("item version does not match", code="version-conflict")
+        link = conn.execute(
+            f"SELECT {', '.join(_LINK_COLUMNS)} FROM work_links WHERE link_id = ? AND work_id = ?",
+            (link_id, work_id),
+        ).fetchone()
+        if link is None:
+            raise WorkloreNotFound("work link not found")
+        parsed = _row_to_link(link)
+        link_type = str(parsed["link_type"])
+        source_policy = str(parsed["source_policy"])
+        if link_type not in ADMIN_LINK_TYPES:
+            raise WorkloreForbidden("link is adapter or fleet managed", code="link-forbidden")
+        owner = _owning_adapter(conn, work_id, link_type, str(parsed["external_key"]))
+        adapter = None if owner is None else owner[0]
+        if adapter is not None and source_policy == "eligible":
+            raise WorkloreForbidden("adapter link is still eligible", code="link-forbidden")
+        conn.execute("DELETE FROM work_links WHERE link_id = ?", (link_id,))
+        detail: dict[str, Any] = {"external_key": parsed["external_key"], "link_type": link_type}
+        if link_type in IMPORT_LINK_TYPES:
+            detail["source_policy"] = source_policy
+            if adapter is not None:
+                detail["adapter_id"] = adapter
+            if not _has_source_link(conn, work_id):
+                detail["became_native"] = True
+        now = _utc_now()
+        current["version"] = int(current["version"]) + 1
+        current["updated_at"] = now
+        _update_item(conn, current)
+        _append_event(
+            conn,
+            work_id=work_id,
+            event_type="unlinked",
+            from_status=str(current["status"]),
+            to_status=str(current["status"]),
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=now,
+            node_id=node_id,
+            detail=detail,
+        )
+        return current
+
+    return _in_transaction(conn, _write)
+
+
+def link_execution(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    node_id: str,
+    run_id: str,
+    actor_id: str,
+    actor_type: str = "node",
+    is_admin: bool = False,
+) -> dict[str, Any]:
+    """Join a Fleet Hub run to a Worklore item as a fleet-run link.
+
+    ``is_admin`` is the caller's authority, passed explicitly by the HTTP boundary rather than
+    inferred from a reserved ``actor_id`` string. Only an admin may link another node's run.
+    """
+    _core()
+
+    def _write() -> dict[str, Any]:
+        current = _loaded_item(conn, work_id)
+        if not is_admin and actor_id != node_id:
+            raise WorkloreForbidden("node may link only its own run", code="execution-mismatch")
+        if not _hub_run_exists(conn, node_id, run_id):
+            raise WorkloreForbidden("fleet run was not found for that node", code="execution-mismatch")
+        external_key = f"{node_id}/{run_id}"
+        existing = _find_link(conn, "fleet-run", external_key)
+        if existing is not None:
+            if existing["work_id"] == work_id:
+                return existing
+            raise WorkloreConflict("fleet run is already linked to another work item", code="link-conflict")
+        # Retention runs before the claim, so an item whose ceiling is already full of its
+        # own past runs makes room for this one instead of refusing every future run.
+        _trim_fleet_run_links(conn, work_id)
+        _claim_item_link(conn, work_id, code="link-conflict")
+        now = _utc_now()
+        link: dict[str, Any] = {
+            "link_id": _mint_id("lnk-"),
+            "work_id": work_id,
+            "link_type": "fleet-run",
+            "external_key": external_key,
+            "display_ref": external_key,
+            "url": None,
+            "external_state": None,
+            "external_updated_at": None,
+            "source_policy": "eligible",
+            "source_acceptance": [],
+            "synced_at": now,
+            "stale_at": None,
+        }
+        _insert_link(conn, link)
+        _append_event(
+            conn,
+            work_id=work_id,
+            event_type="execution-linked",
+            from_status=str(current["status"]),
+            to_status=str(current["status"]),
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=now,
+            node_id=node_id,
+            run_id=run_id,
+            detail={"external_key": link["external_key"]},
+        )
+        stored_link = _find_link(conn, "fleet-run", external_key)
+        assert stored_link is not None
+        return stored_link
+
+    return _in_transaction(conn, _write)
+
+
+def import_batch(
+    conn: sqlite3.Connection,
+    *,
+    adapter_id: str,
+    source_type: str,
+    idempotency_key: str,
+    observations: object,
+    actor_id: str,
+    owner_node: str,
+) -> dict[str, Any]:
+    """Apply one adapter observation batch without clobbering schedule fields.
+
+    Returns counts, bounded ``refused_details``, and ``items`` containing each resolved
+    observation's ``work_id`` and ``external_key``. A refusal is per identity: one
+    observation the hub will not apply, while valid siblings still import.
+    """
+    _core()
+    adapter = _require_text(adapter_id, "adapter_id", max_len=ADAPTER_ID_MAX)
+    if source_type not in SOURCE_TYPES:
+        raise _field_bound("source_type must be github or brigade")
+    _require_adapter_namespace(adapter, source_type)
+    key = _require_text(idempotency_key, "idempotency_key", max_len=IDEMPOTENCY_KEY_MAX)
+    if not isinstance(observations, list):
+        raise _field_bound("observations must be an array")
+    if len(observations) > IMPORT_MAX_OBSERVATIONS:
+        raise _field_bound(f"observations must have at most {IMPORT_MAX_OBSERVATIONS} items")
+    parsed_observations = [_parse_observation(item, source_type=source_type) for item in observations]
+    fingerprint = _observation_fingerprint(list(observations))
+
+    def _write() -> dict[str, Any]:
+        now = _utc_now()
+        existing_owner = _cursor_owner(conn, adapter)
+        if existing_owner is not None and existing_owner != owner_node:
+            raise WorkloreForbidden("adapter is owned by another node", code="adapter-owner-mismatch")
+        if not parsed_observations and existing_owner is None:
+            # An empty first batch has nothing to reconcile, so it must not write the
+            # cursor row that would hand this node the adapter namespace forever.
+            return {"created": 0, "updated": 0, "unchanged": 0, "refused": 0, "refused_details": [], "items": []}
+        stored = conn.execute(
+            "SELECT fingerprint, created, updated, unchanged, refused FROM work_import_keys "
+            "WHERE adapter_id = ? AND idempotency_key = ?",
+            (adapter, key),
+        ).fetchone()
+        if stored is not None:
+            if str(stored[0]) != fingerprint:
+                raise WorkloreConflict("idempotency key reused with a different payload", code="import-conflict")
+            _touch_cursor(
+                conn,
+                adapter_id=adapter,
+                source_type=source_type,
+                owner_node=owner_node,
+                now=now,
+            )
+            return {
+                "created": int(stored[1]),
+                "updated": int(stored[2]),
+                "unchanged": int(stored[3]),
+                "refused": int(stored[4]),
+                # Counts are stored and replayed exactly; the reasons are not, because a
+                # replay re-reports a decision it did not take.
+                "refused_details": [],
+                "items": _items_for_observations(conn, parsed_observations),
+            }
+        created = 0
+        updated = 0
+        unchanged = 0
+        refused = 0
+        refused_details: list[dict[str, str]] = []
+
+        def _refuse(observation: Mapping[str, Any], reason: str) -> None:
+            nonlocal refused
+            refused += 1
+            if len(refused_details) < REFUSED_DETAILS_MAX:
+                refused_details.append(
+                    {
+                        "external_key": str(observation["external_key"]),
+                        "link_type": str(observation["link_type"]),
+                        "reason": reason,
+                    }
+                )
+
+        claim_headroom = _import_headroom(conn, adapter_id=adapter, owner_node=owner_node)
+        for parsed in parsed_observations:
+            existing = _find_link(conn, parsed["link_type"], parsed["external_key"])
+            detail = _observation_detail(adapter, parsed)
+            if existing is not None:
+                work_id = str(existing["work_id"])
+                claim = _link_claim(conn, work_id, parsed["link_type"], parsed["external_key"])
+                if claim is None:
+                    # An operator linked this identity by hand, so no adapter may adopt or
+                    # mutate it. That is a fact about one identity, not about the batch:
+                    # refusing the whole batch would let a single hand-linked issue stop an
+                    # org's entire sync, so the sibling observations still import.
+                    _refuse(parsed, REFUSED_OPERATOR_MANAGED)
+                    continue
+                owner_adapter, owner_event_node, high_water = claim
+                if owner_adapter != adapter:
+                    _refuse(parsed, REFUSED_ADAPTER_IDENTITY_CONFLICT)
+                    continue
+                if owner_event_node is not None and owner_event_node != owner_node:
+                    _refuse(parsed, REFUSED_OWNER_NODE_MISMATCH)
+                    continue
+                current = _loaded_item(conn, work_id)
+                changed = _observation_changed(current, existing, parsed)
+                incoming_version = _source_version(parsed.get("external_updated_at"))
+                stored_version = _source_version(high_water)
+                title_changed = current["title"] != parsed["title"]
+                title_same_revision = (
+                    incoming_version is not None and stored_version is not None and incoming_version == stored_version
+                )
+                title_update = (
+                    title_changed
+                    and incoming_version is not None
+                    and (stored_version is None or incoming_version > stored_version)
+                )
+                changed_for_revision = changed or (title_changed and not title_same_revision)
+                stale_transition = _one_way_stale_transition(current, existing, parsed) and (
+                    stored_version == incoming_version
+                )
+                reason = _revision_refusal(
+                    high_water,
+                    parsed.get("external_updated_at"),
+                    changed=changed_for_revision,
+                    stale_transition=stale_transition,
+                )
+                if reason is not None:
+                    # A replay of an expired import key, an out-of-order delivery, or a
+                    # source that will not say which revision it is speaking for. Nothing
+                    # is written, not even synced_at: the projection already on record
+                    # stands and the refusal is reported rather than folded into the
+                    # unchanged count.
+                    _refuse(parsed, reason)
+                    continue
+                if not changed_for_revision:
+                    _touch_link_synced_at(conn, str(existing["link_id"]), now)
+                    unchanged += 1
+                    continue
+                if stale_transition:
+                    conn.execute(
+                        "UPDATE work_links SET stale_at = ?, synced_at = ? WHERE link_id = ?",
+                        (now, now, existing["link_id"]),
+                    )
+                else:
+                    if title_update:
+                        current["title"] = parsed["title"]
+                        current["version"] = int(current["version"]) + 1
+                        current["updated_at"] = now
+                        _update_item(conn, current)
+                    link = _link_from_observation(parsed, work_id=work_id, link_id=str(existing["link_id"]), now=now)
+                    _update_link(conn, link, source_version=_observed_source_version(parsed))
+                _append_event(
+                    conn,
+                    work_id=work_id,
+                    event_type="sync-observed",
+                    from_status=str(current["status"]),
+                    to_status=str(current["status"]),
+                    actor_type="adapter",
+                    actor_id=actor_id,
+                    now=now,
+                    node_id=owner_node,
+                    detail=detail,
+                )
+                if parsed["stale"]:
+                    _append_event(
+                        conn,
+                        work_id=work_id,
+                        event_type="sync-stale",
+                        from_status=str(current["status"]),
+                        to_status=str(current["status"]),
+                        actor_type="adapter",
+                        actor_id=actor_id,
+                        now=now,
+                        node_id=owner_node,
+                        detail=detail,
+                    )
+                _trim_adapter_events(conn, work_id)
+                updated += 1
+                continue
+            creation_reason = _revision_refusal(None, parsed.get("external_updated_at"), changed=True)
+            if creation_reason is not None:
+                # Creating an item is a mutation, so it is bought with a revision like any
+                # other. Without one the hub could not later tell a fresh observation from
+                # a replay of this one, which is how an unguarded identity gets rolled
+                # back. Refusing here keeps every projection in the ledger guarded from
+                # its first write, and the sibling observations in this batch still import.
+                _refuse(parsed, creation_reason)
+                continue
+            claim_headroom()
+            kind = "repo" if parsed["link_type"] == "github" else "other"
+            create_body: dict[str, Any] = {"title": parsed["title"], "kind": kind}
+            if parsed.get("description"):
+                create_body["description"] = parsed["description"]
+            item = _item_from_create(parse_create(create_body), work_id=_mint_id("wl-"), now=now)
+            _insert_item(conn, item)
+            link = _link_from_observation(parsed, work_id=item["work_id"], link_id=_mint_id("lnk-"), now=now)
+            _insert_link(
+                conn,
+                link,
+                adapter_id=adapter,
+                owner_node=owner_node,
+                source_version=_observed_source_version(parsed),
+            )
+            _append_event(
+                conn,
+                work_id=item["work_id"],
+                event_type="created",
+                from_status=None,
+                to_status=item["status"],
+                actor_type="adapter",
+                actor_id=actor_id,
+                now=now,
+                node_id=owner_node,
+                detail=detail,
+            )
+            _append_event(
+                conn,
+                work_id=item["work_id"],
+                event_type="linked",
+                from_status=item["status"],
+                to_status=item["status"],
+                actor_type="adapter",
+                actor_id=actor_id,
+                now=now,
+                node_id=owner_node,
+                detail=detail,
+            )
+            _append_event(
+                conn,
+                work_id=item["work_id"],
+                event_type="sync-observed",
+                from_status=item["status"],
+                to_status=item["status"],
+                actor_type="adapter",
+                actor_id=actor_id,
+                now=now,
+                node_id=owner_node,
+                detail=detail,
+            )
+            if parsed["stale"]:
+                _append_event(
+                    conn,
+                    work_id=item["work_id"],
+                    event_type="sync-stale",
+                    from_status=item["status"],
+                    to_status=item["status"],
+                    actor_type="adapter",
+                    actor_id=actor_id,
+                    now=now,
+                    node_id=owner_node,
+                    detail=detail,
+                )
+            _trim_adapter_events(conn, item["work_id"])
+            created += 1
+        conn.execute(
+            "INSERT INTO work_import_keys (adapter_id, idempotency_key, fingerprint, created, updated, unchanged, "
+            "refused, received_at, owner_node) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (adapter, key, fingerprint, created, updated, unchanged, refused, now, owner_node),
+        )
+        _trim_import_keys(conn, adapter_id=adapter, owner_node=owner_node)
+        _touch_cursor(
+            conn,
+            adapter_id=adapter,
+            source_type=source_type,
+            owner_node=owner_node,
+            now=now,
+        )
+        return {
+            "created": created,
+            "updated": updated,
+            "unchanged": unchanged,
+            "refused": refused,
+            "refused_details": refused_details,
+            "items": _items_for_observations(conn, parsed_observations),
+        }
+
+    return _in_transaction(conn, _write)

--- a/src/brigade/worklore_validate.py
+++ b/src/brigade/worklore_validate.py
@@ -1,0 +1,320 @@
+"""Field bounds and lifecycle edges for Worklore items.
+
+Burn-queue eligibility lives only in ``worklore_store.exclusion_bucket`` so the
+queue rules and their exclusion buckets cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+KINDS = frozenset({"repo", "fleet", "research", "writing", "admin", "experiment", "idea", "other"})
+PRIORITIES = frozenset({"low", "normal", "high", "urgent"})
+TOKEN_APPETITES = frozenset({"small", "medium", "large", "max"})
+EXECUTION_MODES = frozenset({"manual", "agent", "agent-with-review"})
+
+TITLE_MAX = 240
+DESCRIPTION_MAX = 8000
+SCOPE_MAX = 128
+BLOCKER_MAX = 2000
+ACCEPTANCE_ITEM_MAX = 400
+ACCEPTANCE_MAX_ITEMS = 20
+DEPENDENCIES_MAX_ITEMS = 50
+EVIDENCE_REFS_MAX_ITEMS = 20
+BURN_RANK_MAX = 10000
+TIMESTAMP_MAX = 64
+URL_MAX = 2048
+
+CREATE_FIELDS = frozenset(
+    {
+        "title",
+        "kind",
+        "description",
+        "scope",
+        "priority",
+        "burn_eligible",
+        "burn_rank",
+        "token_appetite",
+        "execution_mode",
+        "acceptance",
+        "blocker",
+        "review_after",
+        "spend_by",
+    }
+)
+
+TRANSITIONS: dict[str, frozenset[str]] = {
+    "captured": frozenset({"defining", "ready", "canceled"}),
+    "defining": frozenset({"ready", "deferred", "canceled"}),
+    "ready": frozenset({"claimed", "deferred", "canceled"}),
+    "claimed": frozenset({"running", "blocked", "canceled"}),
+    "running": frozenset({"verifying", "blocked", "canceled"}),
+    "verifying": frozenset({"completed", "blocked", "canceled"}),
+    "deferred": frozenset({"ready", "canceled"}),
+    "blocked": frozenset({"ready", "canceled"}),
+    "completed": frozenset({"archived"}),
+    "canceled": frozenset({"archived"}),
+}
+
+
+class WorkloreValidationError(Exception):
+    """A Worklore field or lifecycle check failed."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def contains_controls(value: str) -> bool:
+    """True when ``value`` contains a C0 or C1 control character (including DEL).
+
+    Terminal escapes start with ESC (0x1B), so this is also the terminal-control check.
+    """
+    return any(ord(ch) < 0x20 or 0x7F <= ord(ch) <= 0x9F for ch in value)
+
+
+def _field_bound(message: str) -> WorkloreValidationError:
+    return WorkloreValidationError(message, code="field-bound")
+
+
+def _private_data(message: str) -> WorkloreValidationError:
+    return WorkloreValidationError(message, code="private-data")
+
+
+# A private home path is matched as a whole path segment, so an ordinary repo
+# name (``escoffier-labs/homelab#4``), a public URL path
+# (``https://github.com/users/octocat``), or a neutral workspace path
+# (``/workspace/alice``) stays importable. User-profile directory spellings do not.
+_PRIVATE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:[A-Za-z]:)?[\\/](?:home|users|root)(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)
+_PRIVATE_ENV_MARKERS = (
+    "%userprofile%",
+    "%homepath%",
+    "%homedrive%",
+    "%appdata%",
+    "%localappdata%",
+    "$env:userprofile",
+)
+# Credential shapes, not entropy heuristics: a provider token prefix, a PEM
+# private key header, a JWT, an assignment whose value is long enough to be a
+# real secret, or URL userinfo.
+_CREDENTIAL_RES = (
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{16,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"xox[abopsr]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{30,}"),
+    re.compile(r"\bglpat-[0-9A-Za-z_-]{16,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
+    re.compile(
+        r"(?:api[_-]?key|secret|password|passwd|access[_-]?token|auth[_-]?token|token)"
+        r"[\"']?\s*[:=]\s*[\"']?[A-Za-z0-9_\-./+=]{16,}",
+        re.IGNORECASE,
+    ),
+    re.compile(r"//[^\s/@]+:[^\s/@]+@"),
+)
+_HOST_RE = re.compile(r"^[A-Za-z0-9._:\[\]-]+$")
+
+
+def contains_private_path(value: str) -> bool:
+    """True when ``value`` embeds an operator home directory or user-profile path."""
+    lowered = value.lower()
+    return bool(_PRIVATE_PATH_RE.search(value)) or any(marker in lowered for marker in _PRIVATE_ENV_MARKERS)
+
+
+def contains_credential(value: str) -> bool:
+    """True when ``value`` embeds a credential-shaped token, key, or URL userinfo."""
+    return any(pattern.search(value) for pattern in _CREDENTIAL_RES)
+
+
+def assert_no_private_data(value: str, field: str) -> str:
+    """Raise ``private-data`` when ``value`` carries a home path or a credential."""
+    if contains_private_path(value):
+        raise _private_data(f"{field} must not contain a private home path")
+    if contains_credential(value):
+        raise _private_data(f"{field} must not contain a credential-shaped value")
+    return value
+
+
+def safe_text(value: object, field: str, *, max_len: int, min_len: int = 1) -> str:
+    """Canonical string check: type, control characters, and length are ``field-bound``;
+    a home path or credential is ``private-data``."""
+    return assert_no_private_data(_require_str(value, field, max_len=max_len, min_len=min_len), field)
+
+
+def safe_optional_text(value: object, field: str, *, max_len: int, min_len: int = 1) -> str | None:
+    """``safe_text`` for a field that may be absent. ``min_len=0`` keeps a field whose
+    contract already accepts the empty string accepting it."""
+    if value is None:
+        return None
+    return safe_text(value, field, max_len=max_len, min_len=min_len)
+
+
+def safe_https_url(value: object, field: str = "url") -> str | None:
+    """Accept only a well-formed https URL with no userinfo and no private data."""
+    if value is None:
+        return None
+    text = _require_str(value, field, max_len=URL_MAX, min_len=1)
+    try:
+        parsed = urlsplit(text)
+    except ValueError:
+        raise _field_bound(f"{field} must be an https URL") from None
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise _field_bound(f"{field} must be an https URL")
+    if "@" in parsed.netloc:
+        raise _private_data(f"{field} must not embed URL credentials")
+    try:
+        port = parsed.port
+    except ValueError:
+        raise _field_bound(f"{field} must be an https URL") from None
+    if port is None and parsed.netloc.endswith(":"):
+        raise _field_bound(f"{field} must be an https URL")
+    if not parsed.hostname or not _HOST_RE.fullmatch(parsed.netloc):
+        raise _field_bound(f"{field} must be an https URL")
+    return assert_no_private_data(text, field)
+
+
+def _require_str(value: object, field: str, *, max_len: int, min_len: int = 0) -> str:
+    if not isinstance(value, str):
+        raise _field_bound(f"{field} must be a string")
+    if contains_controls(value):
+        raise _field_bound(f"{field} must not contain control characters")
+    if len(value) < min_len or len(value) > max_len:
+        raise _field_bound(f"{field} must be {min_len} to {max_len} characters")
+    return value
+
+
+def _choice(value: object, field: str, allowed: frozenset[str]) -> str:
+    if not isinstance(value, str) or value not in allowed or contains_controls(value):
+        raise _field_bound(f"{field} must be one of {sorted(allowed)}")
+    return value
+
+
+def _int_flag(value: object, field: str) -> int:
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if value in (0, 1):
+        return int(value)
+    raise _field_bound(f"{field} must be a boolean")
+
+
+def _burn_rank(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _field_bound("burn_rank must be an integer")
+    if value < 0 or value > BURN_RANK_MAX:
+        raise _field_bound(f"burn_rank must be 0 to {BURN_RANK_MAX}")
+    return value
+
+
+def _acceptance_items(value: object, *, required: bool) -> list[str]:
+    if value is None:
+        items: list[object] = []
+    elif not isinstance(value, list):
+        raise _field_bound("acceptance must be an array of strings")
+    else:
+        items = value
+    if required and not items:
+        raise WorkloreValidationError("acceptance is required", code="acceptance-required")
+    if len(items) > ACCEPTANCE_MAX_ITEMS:
+        if required:
+            raise WorkloreValidationError(
+                f"acceptance must have at most {ACCEPTANCE_MAX_ITEMS} items",
+                code="acceptance-required",
+            )
+        raise _field_bound(f"acceptance must have at most {ACCEPTANCE_MAX_ITEMS} items")
+    parsed: list[str] = []
+    for index, item in enumerate(items):
+        text = safe_text(
+            item,
+            f"acceptance[{index}]",
+            max_len=ACCEPTANCE_ITEM_MAX,
+            min_len=1,
+        )
+        if not text.strip():
+            raise _field_bound(f"acceptance[{index}] must be a non-empty string")
+        parsed.append(text)
+    if required and not parsed:
+        raise WorkloreValidationError("acceptance is required", code="acceptance-required")
+    return parsed
+
+
+def as_datetime(value: str) -> datetime:
+    """Parse an accepted Worklore timestamp, normalizing a trailing ``Z`` and naive input to UTC."""
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(text)
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def parse_timestamp(value: object, field: str) -> str | None:
+    """Return an ISO-8601 timestamp, or None for an absent one, so malformed input fails loudly."""
+    if value is None:
+        return None
+    text = _require_str(value, field, max_len=TIMESTAMP_MAX)
+    if not text:
+        return None
+    try:
+        as_datetime(text)
+    except ValueError:
+        raise _field_bound(f"{field} must be an ISO-8601 timestamp") from None
+    return text
+
+
+def parse_create(raw: object) -> dict[str, Any]:
+    """Normalize a native create body and apply Worklore defaults.
+
+    Every durable text field runs through ``safe_text`` / ``safe_optional_text``, so a
+    native create, and the patch that reuses this function, are held to the same
+    private-path and credential rules as an imported observation.
+    """
+    if not isinstance(raw, Mapping):
+        raise _field_bound("create body must be an object")
+    unknown = [name for name in raw if name not in CREATE_FIELDS]
+    if unknown:
+        raise WorkloreValidationError(f"unknown field: {unknown[0]}", code="unknown-field")
+    if "title" not in raw or "kind" not in raw:
+        raise _field_bound("title and kind are required")
+    payload = dict(raw)
+    return {
+        "title": safe_text(payload["title"], "title", max_len=TITLE_MAX, min_len=1),
+        "kind": _choice(payload["kind"], "kind", KINDS),
+        "description": safe_optional_text(
+            payload.get("description", ""), "description", max_len=DESCRIPTION_MAX, min_len=0
+        )
+        or "",
+        "scope": safe_optional_text(payload.get("scope"), "scope", max_len=SCOPE_MAX, min_len=0),
+        "status": "captured",
+        "priority": _choice(payload.get("priority", "normal"), "priority", PRIORITIES),
+        "burn_eligible": _int_flag(payload.get("burn_eligible", 0), "burn_eligible"),
+        "burn_rank": _burn_rank(payload.get("burn_rank", 1000)),
+        "token_appetite": _choice(
+            payload.get("token_appetite", "medium"),
+            "token_appetite",
+            TOKEN_APPETITES,
+        ),
+        "execution_mode": _choice(
+            payload.get("execution_mode", "manual"),
+            "execution_mode",
+            EXECUTION_MODES,
+        ),
+        "acceptance": _acceptance_items(payload.get("acceptance", []), required=False),
+        "blocker": safe_optional_text(payload.get("blocker"), "blocker", max_len=BLOCKER_MAX, min_len=0),
+        "review_after": parse_timestamp(payload.get("review_after"), "review_after"),
+        "spend_by": parse_timestamp(payload.get("spend_by"), "spend_by"),
+    }
+
+
+def assert_ready(item: Mapping[str, Any]) -> None:
+    """Raise when a ready item is missing a valid acceptance list."""
+    _acceptance_items(item.get("acceptance"), required=True)
+
+
+def can_transition(current: str, target: str) -> bool:
+    """True when ``current`` may move to ``target`` on the Worklore lifecycle."""
+    return target in TRANSITIONS.get(current, frozenset())

--- a/tests/test_fleet_cloud.py
+++ b/tests/test_fleet_cloud.py
@@ -211,6 +211,7 @@ def test_v4_migration_preserves_existing_rows(tmp_path):
         assert migrated.execute("SELECT run_id FROM events").fetchone()[0] == "run-a"
         assert migrated.execute("SELECT COUNT(*) FROM cloud_leases").fetchone()[0] == 0
         assert migrated.execute("SELECT COUNT(*) FROM grokbot_jobs").fetchone()[0] == 0
+        assert migrated.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 0
         assert migrated.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION
     finally:
         migrated.close()
@@ -292,12 +293,22 @@ def _hub(tmp_path):
         thread.join(timeout=5)
 
 
-def _request(hub, method: str, path: str, *, token: str | None = None, body: dict[str, object] | None = None):
+def _request(
+    hub,
+    method: str,
+    path: str,
+    *,
+    token: str | None = None,
+    body: dict[str, object] | None = None,
+    extra_headers: dict[str, str] | None = None,
+):
     host, port, _db = hub
     connection = http.client.HTTPConnection(host, port, timeout=5)
     headers = {"Content-Type": "application/json"} if body is not None else {}
     if token is not None:
         headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
     connection.request(
         method, path, body=json.dumps(body).encode("utf-8") if body is not None else None, headers=headers
     )
@@ -344,6 +355,7 @@ def test_cloud_http_routes_require_valid_auth_and_keep_dashboard_read_only(tmp_p
         assert "mac" not in models
         # Dashboard routes stay GET-only and cannot turn a bearer into a cloud write.
         assert _request(hub, "POST", "/", token=ADMIN_TOKEN, body={})[0] == 404
+        assert _request(hub, "GET", "/work/items", token=ADMIN_TOKEN) == (404, {"error": "not found"})
 
 
 def test_legacy_dashboard_start_map_uses_global_grokbot_start_for_latest_claimant(conn):

--- a/tests/test_mypy_override_ratchet.py
+++ b/tests/test_mypy_override_ratchet.py
@@ -32,7 +32,7 @@ def _ignored_module_patterns() -> list[str]:
 
 
 def _ignored_module_patterns_from_text(text: str) -> list[str]:
-    """Python 3.10 path: tomllib is 3.11+ and toml_compat cannot read multiline arrays."""
+    """Python 3.10 path: keep this ratchet independent from the TOML parser."""
     patterns: list[str] = []
     blocks = text.split("[[tool.mypy.overrides]]")[1:]
     for block in blocks:

--- a/tests/test_toml_compat.py
+++ b/tests/test_toml_compat.py
@@ -53,6 +53,69 @@ def test_fallback_preserves_hash_inside_quoted_values(monkeypatch):
     assert payload["label"] == "value # not comment"
 
 
+def test_fallback_loads_multiline_array_of_inline_tables(monkeypatch):
+    monkeypatch.setattr(toml_compat, "_stdlib_tomllib", None)
+
+    payload = toml_compat.loads(
+        """
+        [fleet.worklore.brigade]
+        targets = [
+          # Keep this comment between values.
+          { name = "primary", path = "/tmp/primary" },
+          { name = "secondary", path = "/tmp/secondary" }, # trailing comment
+        ]
+        """
+    )
+
+    assert payload["fleet"]["worklore"]["brigade"]["targets"] == [
+        {"name": "primary", "path": "/tmp/primary"},
+        {"name": "secondary", "path": "/tmp/secondary"},
+    ]
+
+
+def test_fallback_reports_incomplete_multiline_value_at_start_line(monkeypatch):
+    monkeypatch.setattr(toml_compat, "_stdlib_tomllib", None)
+    payload = '[fleet]\ntargets = [\n  { name = "primary" },\n'
+
+    with pytest.raises(toml_compat.TOMLDecodeError, match="incomplete TOML value on line 2"):
+        toml_compat.loads(payload)
+
+
+def test_fallback_scans_each_multiline_fragment_once(monkeypatch):
+    monkeypatch.setattr(toml_compat, "_stdlib_tomllib", None)
+    original_scan = toml_compat._CollectionState.scan
+    scanned_characters = 0
+
+    def counting_scan(self, fragment, line_number, *, preceded_by_newline=False):
+        nonlocal scanned_characters
+        scanned_characters += len(fragment) + preceded_by_newline
+        return original_scan(
+            self,
+            fragment,
+            line_number,
+            preceded_by_newline=preceded_by_newline,
+        )
+
+    monkeypatch.setattr(toml_compat._CollectionState, "scan", counting_scan)
+    fragments = ["  0," for _ in range(10_000)]
+    payload = "values = [\n" + "\n".join(fragments)
+
+    with pytest.raises(toml_compat.TOMLDecodeError, match="incomplete TOML value on line 1"):
+        toml_compat.loads(payload)
+
+    stripped_characters = len("[") + sum(len(fragment.strip()) for fragment in fragments)
+    assert scanned_characters == stripped_characters + len(fragments)
+
+
+@pytest.mark.parametrize(("opening", "closer"), [("[", "}"), ("{", "]")])
+def test_fallback_rejects_mismatched_multiline_closer_at_start_line(monkeypatch, opening, closer):
+    monkeypatch.setattr(toml_compat, "_stdlib_tomllib", None)
+    payload = f'[fleet]\ntargets = {opening}\n  name = "primary",\n{closer}\n'
+
+    with pytest.raises(toml_compat.TOMLDecodeError, match="mismatched closing delimiter on line 2"):
+        toml_compat.loads(payload)
+
+
 def test_fallback_reports_invalid_values(monkeypatch):
     monkeypatch.setattr(toml_compat, "_stdlib_tomllib", None)
 

--- a/tests/test_worklore_brigade.py
+++ b/tests/test_worklore_brigade.py
@@ -1,0 +1,1867 @@
+# Synthetic rejection fixtures retain private paths to exercise redaction.
+# content-guard: allow home-path file
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from brigade import cli
+from brigade import worklore_brigade as adapter
+from brigade import worklore_brigade_sync as sync
+from brigade.cli import fleet as fleet_cli
+from tests.support import PRIVATE_DIRECTORY_MODE, PRIVATE_FILE_MODE, assert_private_mode
+
+IDENTITY = "escoffier-labs/brigade"
+
+
+def _pending_task(**overrides: object) -> dict[str, object]:
+    task: dict[str, object] = {
+        "id": "abc123",
+        "text": "Add Worklore store",
+        "status": "pending",
+        "priority": "high",
+        "acceptance": ["pytest tests/test_worklore_store.py passes"],
+        "metadata": {
+            "verify_run_id": "run-xyz",
+            "receipt_id": "rec-1",
+            "run_path": "/var/lib/brigade/targets/brigade/.brigade/runs/run-xyz",
+        },
+    }
+    task.update(overrides)
+    return task
+
+
+def test_normalize_pending_task_strips_paths_and_keeps_acceptance() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(),
+        identity=IDENTITY,
+        edges=[{"source": "abc123", "target": "def456", "type": "blocks"}],
+    )
+    assert observation["external_key"] == "escoffier-labs/brigade#abc123"
+    assert observation["link_type"] == "brigade"
+    assert observation["title"] == "Add Worklore store"
+    assert "description" not in observation
+    assert observation["acceptance"] == ["pytest tests/test_worklore_store.py passes"]
+    assert observation["external_state"] == "pending"
+    assert observation["priority"] == "high"
+    assert observation["dependencies"] == [{"type": "blocks", "id": "def456"}]
+    assert observation["evidence_refs"] == ["run-xyz", "rec-1"]
+    assert observation["source_policy"] == "eligible"
+    assert observation["proposed_status"] is None
+    dumped = json.dumps(observation)
+    assert "/var/lib" not in dumped
+    assert "tasks_path" not in observation
+    assert "status" not in observation
+    assert "transition" not in observation
+
+
+def test_title_is_trimmed_and_capped_at_240() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(text=f"  {'x' * 300}  "),
+        identity=IDENTITY,
+        edges=[],
+    )
+    assert observation["title"] == "x" * 240
+    assert len(observation["title"]) == 240
+
+
+def test_done_task_proposes_completed_without_transition_fields() -> None:
+    observation = adapter.normalize_task(
+        {
+            "id": "done-1",
+            "text": "Finished",
+            "status": "done",
+            "acceptance": ["shipped"],
+            "metadata": {},
+        },
+        identity=IDENTITY,
+        edges=[],
+    )
+    assert observation["source_policy"] == "completed"
+    assert observation["proposed_status"] == "completed"
+    assert observation["external_state"] == "done"
+    assert "status" not in observation
+    assert "transition" not in observation
+
+
+@pytest.mark.parametrize("status", ["cancelled", "dismissed"])
+def test_cancelled_and_dismissed_complete_source_without_claiming_success(status: str) -> None:
+    observation = adapter.normalize_task(
+        {
+            "id": "term-1",
+            "text": "Stopped",
+            "status": status,
+            "acceptance": ["closed out"],
+            "metadata": {},
+        },
+        identity=IDENTITY,
+        edges=[],
+    )
+    assert observation["source_policy"] == "completed"
+    assert observation["proposed_status"] is None
+    assert observation["external_state"] == status
+    assert "status" not in observation
+    assert "transition" not in observation
+
+
+def test_dependencies_keep_outgoing_edges_and_dedupe() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(),
+        identity=IDENTITY,
+        edges=[
+            {"source": "other", "target": "abc123", "type": "blocks"},
+            {"source": "abc123", "target": "def456", "type": "blocks"},
+            {"source": "abc123", "target": "def456", "type": "blocks"},
+            {"source": "abc123", "target": "ghi789", "type": "parent-child"},
+            {"source": "abc123", "target": "def456", "type": "discovered-from"},
+        ],
+    )
+    assert observation["dependencies"] == [
+        {"type": "blocks", "id": "def456"},
+        {"type": "discovered-from", "id": "def456"},
+        {"type": "parent-child", "id": "ghi789"},
+    ]
+
+
+def test_normalize_task_sorts_deduped_dependencies_by_type_and_id() -> None:
+    edges = [
+        {"source": "abc123", "target": "ghi789", "type": "parent-child"},
+        {"source": "abc123", "target": "def456", "type": "discovered-from"},
+        {"source": "abc123", "target": "aaa000", "type": "blocks"},
+        {"source": "abc123", "target": "def456", "type": "blocks"},
+        {"source": "abc123", "target": "ghi789", "type": "parent-child"},
+    ]
+    reversed_edges = list(reversed(edges))
+    first = adapter.normalize_task(
+        _pending_task(acceptance=["second-check", "first-check"]),
+        identity=IDENTITY,
+        edges=edges,
+    )
+    second = adapter.normalize_task(
+        _pending_task(acceptance=["second-check", "first-check"]),
+        identity=IDENTITY,
+        edges=reversed_edges,
+    )
+    expected = [
+        {"type": "blocks", "id": "aaa000"},
+        {"type": "blocks", "id": "def456"},
+        {"type": "discovered-from", "id": "def456"},
+        {"type": "parent-child", "id": "ghi789"},
+    ]
+    assert first["dependencies"] == expected
+    assert second["dependencies"] == expected
+    assert first["acceptance"] == ["second-check", "first-check"]
+    assert second["acceptance"] == ["second-check", "first-check"]
+
+
+def test_malformed_and_path_shaped_dependencies_are_dropped_without_leaking() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(),
+        identity=IDENTITY,
+        edges=[
+            {"source": "abc123", "target": "/var/lib/secret-task", "type": "blocks"},
+            {"source": "abc123", "target": r"C:\Users\operator\task", "type": "blocks"},
+            {"source": "abc123", "target": "ok-dep", "type": "/home/operator/type"},
+            {"source": "abc123", "target": "bad#id", "type": "blocks"},
+            {"source": "abc123", "target": "has/slash", "type": "blocks"},
+            {"source": "abc123", "target": "has\\slash", "type": "blocks"},
+            {"source": "abc123", "target": "has space", "type": "blocks"},
+            {"source": "abc123", "target": "keep-me", "type": "blocks"},
+            {"source": "abc123", "type": "blocks"},
+            "not-an-edge",
+        ],
+    )
+    dumped = json.dumps(observation)
+    assert observation["dependencies"] == [{"type": "blocks", "id": "keep-me"}]
+    assert "/var/lib" not in dumped
+    assert "/home/" not in dumped
+    assert "C:\\Users\\" not in dumped
+    assert "secret-task" not in dumped
+
+
+def test_normalize_rejects_home_paths_and_receipt_bodies() -> None:
+    with pytest.raises(adapter.BrigadeObservationError, match="unknown-field"):
+        adapter.normalize_task(
+            {
+                "id": "bad",
+                "text": "Nope",
+                "status": "pending",
+                "acceptance": ["x"],
+                "receipt_body": {"stdout": "secret"},
+            },
+            identity=IDENTITY,
+            edges=[],
+        )
+    with pytest.raises(adapter.BrigadeObservationError, match="private-data"):
+        adapter.normalize_task(
+            {
+                "id": "bad2",
+                "text": "See /home/operator/secret",
+                "status": "pending",
+                "acceptance": ["x"],
+            },
+            identity=IDENTITY,
+            edges=[],
+        )
+    with pytest.raises(adapter.BrigadeObservationError, match="private-data"):
+        adapter.normalize_task(
+            {
+                "id": "bad3",
+                "text": r"notes in C:\Users\operator",
+                "status": "pending",
+                "acceptance": ["x"],
+            },
+            identity=IDENTITY,
+            edges=[],
+        )
+    with pytest.raises(adapter.BrigadeObservationError, match="private-data"):
+        adapter.normalize_task(
+            {
+                "id": "bad4",
+                "text": "Safe title",
+                "status": "pending",
+                "acceptance": ["see /home/operator/secret"],
+            },
+            identity=IDENTITY,
+            edges=[],
+        )
+    with pytest.raises(adapter.BrigadeObservationError, match="private-data"):
+        adapter.normalize_task(
+            {
+                "id": "bad5",
+                "text": "Safe title",
+                "status": "pending",
+                "acceptance": [r"notes in C:\Users\operator"],
+            },
+            identity=IDENTITY,
+            edges=[],
+        )
+
+
+@pytest.mark.parametrize(
+    "blocked_key",
+    ["receipt_body", "prompt", "transcript", "token", "secret", "password", "tasks_path"],
+)
+def test_blocked_keys_are_rejected_at_top_level_and_nested(blocked_key: str) -> None:
+    with pytest.raises(adapter.BrigadeObservationError, match="unknown-field"):
+        adapter.normalize_task(_pending_task(**{blocked_key: "leak"}), identity=IDENTITY, edges=[])
+    with pytest.raises(adapter.BrigadeObservationError, match="unknown-field"):
+        adapter.normalize_task(
+            _pending_task(metadata={"verify_run_id": "run-xyz", blocked_key: "leak"}),
+            identity=IDENTITY,
+            edges=[],
+        )
+
+
+def test_unselected_metadata_is_dropped_and_never_appears_in_json() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(
+            metadata={
+                "verify_run_id": "run-xyz",
+                "receipt_id": "rec-1",
+                "footprint": {"files": ["/var/lib/brigade/src/brigade/worklore_store.py"]},
+                "run_path": "/var/lib/brigade/targets/brigade/.brigade/runs/run-xyz",
+                "session_path": "/var/lib/brigade/targets/brigade/.brigade/sessions/s1",
+                "files": ["/var/lib/brigade/src/a.py"],
+                "symbols": ["brigade.worklore_store._parse_observation"],
+            }
+        ),
+        identity=IDENTITY,
+        edges=[],
+    )
+    dumped = json.dumps(observation)
+    assert "footprint" not in dumped
+    assert "run_path" not in dumped
+    assert "session_path" not in dumped
+    assert "files" not in dumped
+    assert "symbols" not in dumped
+    assert "/var/lib" not in dumped
+    assert "receipt_body" not in dumped
+    assert observation["evidence_refs"] == ["run-xyz", "rec-1"]
+
+
+def test_invalid_evidence_refs_are_omitted_without_receipt_bodies() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(
+            metadata={
+                "verify_run_id": "/var/lib/brigade/runs/run-xyz",
+                "receipt_id": "ok-receipt",
+                "receipt_path": "/var/lib/brigade/receipts/rec.json",
+            }
+        ),
+        identity=IDENTITY,
+        edges=[],
+    )
+    dumped = json.dumps(observation)
+    assert observation["evidence_refs"] == ["ok-receipt"]
+    assert "/var/lib" not in dumped
+    assert "receipt_body" not in dumped
+    assert "stdout" not in dumped
+
+
+def test_campaign_qualified_task_ids_are_accepted() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(id="brigade:20260829-120000-add-store-abc123"),
+        identity=IDENTITY,
+        edges=[
+            {
+                "source": "brigade:20260829-120000-add-store-abc123",
+                "target": "opsdeck:def456",
+                "type": "blocks",
+            }
+        ],
+    )
+    assert observation["external_key"] == "escoffier-labs/brigade#brigade:20260829-120000-add-store-abc123"
+    assert observation["dependencies"] == [{"type": "blocks", "id": "opsdeck:def456"}]
+
+
+@pytest.mark.parametrize(
+    "task_id",
+    ["", "#hash", "has/slash", r"has\slash", "has space", "/abs/path", r"C:\Users\task"],
+)
+def test_invalid_task_ids_are_rejected(task_id: str) -> None:
+    with pytest.raises(adapter.BrigadeObservationError, match="field-bound"):
+        adapter.normalize_task(_pending_task(id=task_id), identity=IDENTITY, edges=[])
+
+
+@pytest.mark.parametrize("identity", ["", "x", "/abs/path", "has space", "#bad"])
+def test_invalid_identities_are_rejected(identity: str) -> None:
+    with pytest.raises(adapter.BrigadeObservationError, match="field-bound"):
+        adapter.normalize_task(_pending_task(), identity=identity, edges=[])
+
+
+def test_acceptance_follows_live_worklore_bounds() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(acceptance=["ok"]),
+        identity=IDENTITY,
+        edges=[],
+    )
+    assert observation["acceptance"] == ["ok"]
+    with pytest.raises(adapter.BrigadeObservationError, match="field-bound"):
+        adapter.normalize_task(_pending_task(acceptance=["x"] * 21), identity=IDENTITY, edges=[])
+    with pytest.raises(adapter.BrigadeObservationError, match="field-bound"):
+        adapter.normalize_task(_pending_task(acceptance=[""]), identity=IDENTITY, edges=[])
+    with pytest.raises(adapter.BrigadeObservationError, match="field-bound"):
+        adapter.normalize_task(_pending_task(acceptance=["x" * 401]), identity=IDENTITY, edges=[])
+
+
+def _toml_string(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _write_brigade_fleet(home: Path, targets: list[tuple[str, str]]) -> None:
+    rows = ",\n".join(
+        f"  {{ path = {_toml_string(path)}, identity = {_toml_string(identity)} }}" for path, identity in targets
+    )
+    (home / "fleet.toml").write_text(
+        f"[fleet.worklore.brigade]\ntargets = [\n{rows}\n]\n",
+        encoding="utf-8",
+    )
+
+
+def _assert_bounded_sync_error(
+    exc: BaseException,
+    *,
+    code: str,
+    forbidden: list[str],
+) -> None:
+    message = str(exc)
+    assert getattr(exc, "code", None) == code
+    assert code in message
+    for item in forbidden:
+        assert item not in message
+    assert "/home/" not in message
+    assert "C:\\Users\\" not in message
+
+
+def test_load_config_requires_explicit_targets(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "fleet.toml").write_text("[fleet.worklore.brigade]\n")
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.BrigadeSyncError, match="targets") as excinfo:
+        sync.load_brigade_config()
+    _assert_bounded_sync_error(excinfo.value, code="field-bound", forbidden=[str(home)])
+
+
+def test_load_config_reads_explicit_target_tables(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    home.mkdir()
+    repo.mkdir()
+    _write_brigade_fleet(home, [(str(repo), IDENTITY)])
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    config = sync.load_brigade_config()
+    assert list(config) == ["targets"]
+    assert len(config["targets"]) == 1
+    target = config["targets"][0]
+    assert isinstance(target, sync.Target)
+    assert target.path == repo.resolve()
+    assert target.identity == IDENTITY
+
+
+def test_load_config_keeps_shared_identity_across_different_paths(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    first = tmp_path / "node-a"
+    second = tmp_path / "node-b"
+    home.mkdir()
+    first.mkdir()
+    second.mkdir()
+    _write_brigade_fleet(home, [(str(first), IDENTITY), (str(second), IDENTITY)])
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    config = sync.load_brigade_config()
+    assert [(target.path, target.identity) for target in config["targets"]] == [
+        (first.resolve(), IDENTITY),
+        (second.resolve(), IDENTITY),
+    ]
+
+
+def test_load_config_rejects_exact_duplicate_path_and_identity(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    home.mkdir()
+    repo.mkdir()
+    _write_brigade_fleet(home, [(str(repo), IDENTITY), (str(repo), IDENTITY)])
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.BrigadeSyncError, match="field-bound") as excinfo:
+        sync.load_brigade_config()
+    _assert_bounded_sync_error(excinfo.value, code="field-bound", forbidden=[str(repo), str(home)])
+
+
+@pytest.mark.parametrize(
+    "writer",
+    [
+        lambda home, _repo: None,
+        lambda home, _repo: (home / "fleet.toml").write_text("fleet = [", encoding="utf-8"),
+        lambda home, _repo: (home / "fleet.toml").write_text("[fleet.worklore.brigade]\n", encoding="utf-8"),
+        lambda home, _repo: (home / "fleet.toml").write_text(
+            "[fleet.worklore.brigade]\ntargets = []\n",
+            encoding="utf-8",
+        ),
+        lambda home, _repo: (home / "fleet.toml").write_text(
+            '[fleet.worklore.brigade]\ntargets = "escoffier-labs/brigade"\n',
+            encoding="utf-8",
+        ),
+    ],
+)
+def test_load_config_missing_and_malformed_toml_are_field_bound(tmp_path, monkeypatch, writer) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    home.mkdir()
+    repo.mkdir()
+    writer(home, repo)
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.BrigadeSyncError, match="field-bound") as excinfo:
+        sync.load_brigade_config()
+    _assert_bounded_sync_error(excinfo.value, code="field-bound", forbidden=[str(home), str(repo)])
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        'targets = ["escoffier-labs/brigade"]\n',
+        "targets = [{ identity = " + f'"{IDENTITY}"' + " }]\n",
+        "targets = [{ path = 12, identity = " + f'"{IDENTITY}"' + " }]\n",
+        "targets = [{ path = " + '""' + f', identity = "{IDENTITY}"' + " }]\n",
+        "targets = [{ path = " + f'"/missing-brigade-target", identity = "{IDENTITY}"' + " }]\n",
+    ],
+)
+def test_load_config_malformed_and_missing_paths_are_field_bound(tmp_path, monkeypatch, body: str) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "fleet.toml").write_text("[fleet.worklore.brigade]\n" + body, encoding="utf-8")
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.BrigadeSyncError, match="field-bound") as excinfo:
+        sync.load_brigade_config()
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code="field-bound",
+        forbidden=[str(home), "/missing-brigade-target"],
+    )
+
+
+def test_load_config_non_directory_path_is_field_bound(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    target_file = tmp_path / "not-a-dir"
+    home.mkdir()
+    target_file.write_text("nope", encoding="utf-8")
+    _write_brigade_fleet(home, [(str(target_file), IDENTITY)])
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.BrigadeSyncError, match="field-bound") as excinfo:
+        sync.load_brigade_config()
+    _assert_bounded_sync_error(excinfo.value, code="field-bound", forbidden=[str(target_file), str(home)])
+
+
+@pytest.mark.parametrize("identity", ["", "x", "/abs/path", "has space", "#bad"])
+def test_load_config_invalid_identity_is_field_bound(tmp_path, monkeypatch, identity: str) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    home.mkdir()
+    repo.mkdir()
+    _write_brigade_fleet(home, [(str(repo), identity)])
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.BrigadeSyncError, match="field-bound") as excinfo:
+        sync.load_brigade_config()
+    leaked = [str(repo), str(home)]
+    if identity:
+        leaked.append(identity)
+    _assert_bounded_sync_error(excinfo.value, code="field-bound", forbidden=leaked)
+
+
+def test_read_tasks_uses_public_command_and_drops_tasks_path(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    recorded: dict[str, object] = {}
+    payload = {
+        "tasks_path": str(target / ".brigade" / "work" / "tasks.json"),
+        "ready": [{"id": "abc123"}],
+        "tasks": [
+            {
+                "id": "abc123",
+                "text": "Add store",
+                "status": "pending",
+                "acceptance": ["tests pass"],
+                "metadata": {},
+            }
+        ],
+        "edges": [{"source": "abc123", "target": "def456", "type": "blocks"}],
+        "extra": "ignore-me",
+    }
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        recorded["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    tasks, edges = sync.read_public_tasks(target)
+    assert recorded["argv"] == ["brigade", "work", "tasks", "--target", str(target), "--all", "--json"]
+    kwargs = recorded["kwargs"]
+    assert kwargs["timeout"] == 30
+    assert kwargs["text"] is True
+    assert kwargs["stdout"] is subprocess.PIPE
+    assert kwargs["stderr"] is subprocess.PIPE
+    assert kwargs["check"] is False
+    assert kwargs.get("shell", False) is False
+    assert tasks[0]["id"] == "abc123"
+    assert edges[0]["source"] == "abc123"
+    dumped = json.dumps({"tasks": tasks, "edges": edges})
+    assert "tasks_path" not in dumped
+    assert "ready" not in dumped
+    assert "extra" not in dumped
+    assert str(target / ".brigade" / "work" / "tasks.json") not in dumped
+
+
+@pytest.mark.parametrize(
+    "fake_run",
+    [
+        lambda argv, **kwargs: subprocess.CompletedProcess(
+            argv,
+            2,
+            stdout="token=abc prompt=secret",
+            stderr="authorization bearer /home/operator Add store",
+        ),
+        lambda argv, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(argv, 30)),
+        lambda argv, **kwargs: (_ for _ in ()).throw(OSError("Permission denied: /home/operator/secret")),
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout="not-json", stderr="tasks_path=/tmp/x"),
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout="[]", stderr=""),
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout='{"edges":[]}', stderr=""),
+        lambda argv, **kwargs: subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout='{"tasks":{},"edges":[]}',
+            stderr="",
+        ),
+        lambda argv, **kwargs: subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout='{"tasks":[],"edges":{}}',
+            stderr="",
+        ),
+    ],
+)
+def test_read_tasks_failures_are_retryable_and_bounded(tmp_path, monkeypatch, fake_run) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.BrigadeSyncError, match="retryable-adapter-failure") as excinfo:
+        sync.read_public_tasks(target)
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code="retryable-adapter-failure",
+        forbidden=[
+            str(target),
+            "token",
+            "prompt",
+            "secret",
+            "authorization",
+            "bearer",
+            "Add store",
+            "not-json",
+            "stdout",
+            "stderr",
+            "tasks_path",
+            "Permission denied",
+            "TimeoutExpired",
+        ],
+    )
+
+
+def test_two_nodes_same_identity_share_one_external_key() -> None:
+    task = {
+        "id": "abc123",
+        "text": "Shared",
+        "status": "pending",
+        "acceptance": ["ok"],
+        "metadata": {},
+    }
+    first = sync.observations_for_target(task, edges=[], identity=IDENTITY)
+    second = sync.observations_for_target(task, edges=[], identity=IDENTITY)
+    assert first[0]["external_key"] == second[0]["external_key"] == f"{IDENTITY}#abc123"
+
+
+def test_observations_for_target_normalizes_one_or_many_tasks() -> None:
+    first = _pending_task()
+    second = _pending_task(id="def456", text="Second")
+    edges = [{"source": "abc123", "target": "def456", "type": "blocks"}]
+    single = sync.observations_for_target(first, edges=edges, identity=IDENTITY)
+    many = sync.observations_for_target([first, second], edges=edges, identity=IDENTITY)
+    assert single == [adapter.normalize_task(first, identity=IDENTITY, edges=edges)]
+    assert many == [
+        adapter.normalize_task(first, identity=IDENTITY, edges=edges),
+        adapter.normalize_task(second, identity=IDENTITY, edges=edges),
+    ]
+
+
+def test_read_tasks_uses_resolved_absolute_path_from_relative_cwd(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "repo"
+    other = tmp_path / "other"
+    target.mkdir()
+    other.mkdir()
+    monkeypatch.chdir(other)
+    recorded: dict[str, object] = {}
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0, stdout='{"tasks":[],"edges":[]}', stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    relative = Path("..") / "repo"
+    assert not relative.is_absolute()
+    tasks, edges = sync.read_public_tasks(relative)
+    resolved = str(target.resolve())
+    assert recorded["argv"] == ["brigade", "work", "tasks", "--target", resolved, "--all", "--json"]
+    assert Path(recorded["argv"][4]).is_absolute()
+    assert recorded["argv"][4] == resolved
+    assert tasks == []
+    assert edges == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tasks": ["Add store /home/operator/secret"], "edges": []},
+        {"tasks": [12], "edges": []},
+        {"tasks": [None], "edges": []},
+        {"tasks": [], "edges": ["not-an-edge /var/lib/secret-task"]},
+        {"tasks": [], "edges": [{"target": "def456", "type": "blocks"}]},
+        {"tasks": [], "edges": [{"source": "abc123", "type": "blocks"}]},
+        {"tasks": [], "edges": [{"source": "abc123", "target": "def456"}]},
+        {"tasks": [], "edges": [{"source": "", "target": "def456", "type": "blocks"}]},
+        {"tasks": [], "edges": [{"source": "abc123", "target": "", "type": "blocks"}]},
+        {"tasks": [], "edges": [{"source": "abc123", "target": "def456", "type": ""}]},
+        {"tasks": [], "edges": [{"source": "   ", "target": "def456", "type": "blocks"}]},
+        {"tasks": [], "edges": [{"source": 1, "target": "def456", "type": "blocks"}]},
+        {
+            "tasks": [{"id": "abc123", "text": "Add store /tmp/secret-task"}],
+            "edges": [{"source": "abc123", "target": None, "type": "blocks"}],
+        },
+    ],
+)
+def test_read_tasks_malformed_items_are_retryable_and_bounded(tmp_path, monkeypatch, payload) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.BrigadeSyncError, match="retryable-adapter-failure") as excinfo:
+        sync.read_public_tasks(target)
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code="retryable-adapter-failure",
+        forbidden=[
+            str(target),
+            "Add store",
+            "secret-task",
+            "not-an-edge",
+            "/tmp/",
+            "/var/lib",
+            "abc123",
+            "def456",
+            "blocks",
+        ],
+    )
+
+
+@pytest.mark.parametrize("payload", ["not-a-task", 12, None, ("tuple",)])
+def test_observations_for_target_rejects_non_mapping_non_list(payload) -> None:
+    with pytest.raises(sync.BrigadeSyncError) as excinfo:
+        sync.observations_for_target(payload, edges=[], identity=IDENTITY)
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code=excinfo.value.code,
+        forbidden=["not-a-task", "tuple", "TypeError"],
+    )
+    assert excinfo.value.code in {"field-bound", "retryable-adapter-failure"}
+
+
+UNSAFE_TASKS = [
+    _pending_task(text="See /home/operator/secret"),
+    {
+        "id": "bad",
+        "text": "Nope",
+        "status": "pending",
+        "acceptance": ["x"],
+        "receipt_body": {"stdout": "secret-token"},
+    },
+]
+UNSAFE_TASK_LEAKS = [
+    "See /home/operator/secret",
+    "receipt_body",
+    "secret-token",
+    "Nope",
+]
+
+
+@pytest.mark.parametrize("task", UNSAFE_TASKS)
+def test_observations_for_target_skips_and_counts_unsafe_tasks_without_leaking(task) -> None:
+    observations = sync.observations_for_target(task, edges=[], identity=IDENTITY)
+    assert observations == []
+    assert observations.skipped == 1
+    dumped = json.dumps({"observations": list(observations), "skipped": observations.skipped})
+    for fragment in UNSAFE_TASK_LEAKS:
+        assert fragment not in dumped
+
+
+def test_observations_for_target_keeps_healthy_tasks_beside_a_skipped_one() -> None:
+    observations = sync.observations_for_target(
+        [UNSAFE_TASKS[0], _pending_task(id="healthy", text="Add Worklore store")],
+        edges=[],
+        identity=IDENTITY,
+    )
+    assert [obs["external_key"] for obs in observations] == [f"{IDENTITY}#healthy"]
+    assert observations.skipped == 1
+
+
+FINGERPRINT_FIELDS = (
+    "acceptance",
+    "dependencies",
+    "evidence_refs",
+    "external_key",
+    "external_state",
+    "external_updated_at",
+    "priority",
+    "proposed_status",
+    "source_policy",
+    "title",
+)
+OTHER_IDENTITY = "other-org/other-repo"
+
+
+def _public_task(**overrides: object) -> dict[str, object]:
+    task: dict[str, object] = {
+        "id": "abc123",
+        "text": "Shared",
+        "status": "pending",
+        "priority": "high",
+        "acceptance": ["ok"],
+        "metadata": {},
+    }
+    task.update(overrides)
+    return task
+
+
+def _fingerprint(observation: dict[str, object]) -> str:
+    payload = {field: observation.get(field) for field in FINGERPRINT_FIELDS}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _batch_key(identity: str, observations: list[dict[str, object]]) -> str:
+    fingerprints = sorted(_fingerprint(item) for item in observations)
+    digest = hashlib.sha256(
+        json.dumps(fingerprints, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"brigade:{identity}:{digest}"
+
+
+def _recording_hub(posts: list[dict[str, object]], seen: dict[str, bool] | None = None):
+    store = {} if seen is None else seen
+
+    def fake_import_batch(payload):
+        posts.append(payload)
+        created = 0
+        updated = 0
+        for obs in payload["observations"]:
+            key = str(obs["external_key"])
+            if key in store:
+                updated += 1
+            else:
+                store[key] = True
+                created += 1
+        return {"created": created, "updated": updated, "unchanged": 0}
+
+    return fake_import_batch
+
+
+def _install_public_reader(monkeypatch, payloads: dict[Path, tuple[list[object], list[object]]]) -> list[object]:
+    read_targets: list[object] = []
+
+    def fake_read(target):
+        read_targets.append(target)
+        path = target.path if isinstance(target, sync.Target) else Path(target)
+        return payloads[path]
+
+    monkeypatch.setattr(sync, "read_public_tasks", fake_read)
+    return read_targets
+
+
+def _assert_no_hub_leak(message: str) -> None:
+    lowered = message.lower()
+    for fragment in (
+        "https://",
+        "http://",
+        "token",
+        "authorization",
+        "bearer",
+        "add store",
+        "shared",
+        "/work/imports",
+        "payload",
+        "exception",
+        "permission denied",
+    ):
+        assert fragment not in lowered
+
+
+def test_sync_reads_every_target_and_does_not_write_local_ledger(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    normalized: list[tuple[str, list[dict[str, object]]]] = []
+    node_a = tmp_path / "node-a"
+    node_b = tmp_path / "node-b"
+    node_a.mkdir()
+    node_b.mkdir()
+    ledger_a = node_a / ".brigade" / "work" / "tasks.json"
+    ledger_b = node_b / ".brigade" / "work" / "tasks.json"
+    ledger_a.parent.mkdir(parents=True)
+    ledger_b.parent.mkdir(parents=True)
+    original_a = '{"tasks":[{"id":"local-a"}]}'
+    original_b = '{"tasks":[{"id":"local-b"}]}'
+    ledger_a.write_text(original_a, encoding="utf-8")
+    ledger_b.write_text(original_b, encoding="utf-8")
+    before_a = {path: path.stat().st_mtime_ns for path in node_a.rglob("*")}
+    before_b = {path: path.stat().st_mtime_ns for path in node_b.rglob("*")}
+    read_targets = _install_public_reader(
+        monkeypatch,
+        {
+            node_a: ([_public_task()], []),
+            node_b: ([_public_task()], []),
+        },
+    )
+    real_observations = sync.observations_for_target
+
+    def spy_observations(tasks, *, edges=None, identity):
+        result = real_observations(tasks, edges=edges, identity=identity)
+        normalized.append((identity, result))
+        return result
+
+    monkeypatch.setattr(sync, "observations_for_target", spy_observations)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=node_a, identity=IDENTITY),
+            sync.Target(path=node_b, identity=IDENTITY),
+        ]
+    )
+    assert [target.path for target in read_targets] == [node_a, node_b]
+    assert [identity for identity, _obs in normalized] == [IDENTITY, IDENTITY]
+    assert ledger_a.read_text(encoding="utf-8") == original_a
+    assert ledger_b.read_text(encoding="utf-8") == original_b
+    assert {path: path.stat().st_mtime_ns for path in node_a.rglob("*")} == before_a
+    assert {path: path.stat().st_mtime_ns for path in node_b.rglob("*")} == before_b
+    assert result["targets"] == 2
+    assert result["identities"] == 1
+
+
+def test_sync_merges_targets_that_share_identity(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    (tmp_path / "node-a").mkdir()
+    (tmp_path / "node-b").mkdir()
+    _install_public_reader(
+        monkeypatch,
+        {
+            tmp_path / "node-a": ([_public_task()], []),
+            tmp_path / "node-b": ([_public_task()], []),
+        },
+    )
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=tmp_path / "node-a", identity=IDENTITY),
+            sync.Target(path=tmp_path / "node-b", identity=IDENTITY),
+        ]
+    )
+    assert len(posts) == 1
+    assert posts[0]["source_type"] == "brigade"
+    assert posts[0]["adapter_id"] == f"brigade:{IDENTITY}"
+    assert set(posts[0]) == {"adapter_id", "source_type", "idempotency_key", "observations"}
+    assert [obs["external_key"] for obs in posts[0]["observations"]] == [f"{IDENTITY}#abc123"]
+    assert result["created"] == 1
+    assert result["posted"] == 1
+    assert result["observation_count"] == 1
+    assert result["identities"] == 1
+
+
+def test_sync_two_nodes_post_same_external_key(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    seen: dict[str, bool] = {}
+    (tmp_path / "node-a").mkdir()
+    (tmp_path / "node-b").mkdir()
+    _install_public_reader(
+        monkeypatch,
+        {
+            tmp_path / "node-a": ([_public_task()], []),
+            tmp_path / "node-b": ([_public_task()], []),
+        },
+    )
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts, seen))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    first = sync.sync_brigade(targets=[sync.Target(path=tmp_path / "node-a", identity=IDENTITY)])
+    second = sync.sync_brigade(targets=[sync.Target(path=tmp_path / "node-b", identity=IDENTITY)])
+    keys = [obs["external_key"] for payload in posts for obs in payload["observations"]]
+    assert keys == [f"{IDENTITY}#abc123", f"{IDENTITY}#abc123"]
+    assert posts[0]["idempotency_key"] == posts[1]["idempotency_key"]
+    assert posts[0]["idempotency_key"] == _batch_key(IDENTITY, posts[0]["observations"])
+    assert first["created"] == 1
+    assert second["created"] == 0
+    assert second["updated"] == 1
+    receipt = tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json"
+    assert json.loads(receipt.read_text(encoding="utf-8"))["last_error_code"] is None
+    assert_private_mode(receipt, PRIVATE_FILE_MODE)
+
+
+@pytest.mark.parametrize("order", [("node-a", "node-b"), ("node-b", "node-a")])
+def test_identity_conflict_fails_closed_before_hub_regardless_of_order(
+    tmp_path, monkeypatch, order: tuple[str, str]
+) -> None:
+    posts: list[dict[str, object]] = []
+    first_name, second_name = order
+    first = tmp_path / first_name
+    second = tmp_path / second_name
+    first.mkdir()
+    second.mkdir()
+    payloads = {
+        tmp_path / "node-a": ([_public_task(text="Alpha title")], []),
+        tmp_path / "node-b": ([_public_task(text="Beta title")], []),
+    }
+    _install_public_reader(monkeypatch, payloads)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError, match="identity-conflict") as excinfo:
+        sync.sync_brigade(
+            targets=[
+                sync.Target(path=first, identity=IDENTITY),
+                sync.Target(path=second, identity=IDENTITY),
+            ]
+        )
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code="identity-conflict",
+        forbidden=[
+            IDENTITY,
+            "abc123",
+            f"{IDENTITY}#abc123",
+            "Alpha title",
+            "Beta title",
+            str(first),
+            str(second),
+            "payload",
+            "observations",
+        ],
+    )
+    assert posts == []
+    assert not (tmp_path / "worklore" / "brigade").exists()
+
+
+def test_identity_conflict_blocks_other_identities_before_any_post(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    other = tmp_path / "other"
+    node_a = tmp_path / "node-a"
+    node_b = tmp_path / "node-b"
+    other.mkdir()
+    node_a.mkdir()
+    node_b.mkdir()
+    _install_public_reader(
+        monkeypatch,
+        {
+            other: ([_public_task(id="other1", text="Other work")], []),
+            node_a: ([_public_task(text="Alpha title")], []),
+            node_b: ([_public_task(text="Beta title")], []),
+        },
+    )
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError, match="identity-conflict") as excinfo:
+        sync.sync_brigade(
+            targets=[
+                sync.Target(path=other, identity=OTHER_IDENTITY),
+                sync.Target(path=node_a, identity=IDENTITY),
+                sync.Target(path=node_b, identity=IDENTITY),
+            ]
+        )
+    assert excinfo.value.code == "identity-conflict"
+    assert posts == []
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code="identity-conflict",
+        forbidden=[IDENTITY, OTHER_IDENTITY, "Alpha title", "Other work", str(other)],
+    )
+
+
+def test_target_and_task_order_do_not_change_batch_or_keys(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    node_a = tmp_path / "node-a"
+    node_b = tmp_path / "node-b"
+    node_a.mkdir()
+    node_b.mkdir()
+    first = _public_task(id="zzz9", text="Last")
+    second = _public_task(id="aaa1", text="First")
+    sequence = [
+        {node_a: ([first, second], []), node_b: ([], [])},
+        {node_b: ([second, first], []), node_a: ([], [])},
+    ]
+
+    def fake_read(target):
+        payloads = sequence[len(posts)]
+        return payloads[target.path]
+
+    monkeypatch.setattr(sync, "read_public_tasks", fake_read)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    first_result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=node_a, identity=IDENTITY),
+            sync.Target(path=node_b, identity=IDENTITY),
+        ]
+    )
+    second_result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=node_b, identity=IDENTITY),
+            sync.Target(path=node_a, identity=IDENTITY),
+        ]
+    )
+    expected_obs = sync.observations_for_target([second, first], edges=[], identity=IDENTITY)
+    expected_obs = sorted(expected_obs, key=lambda item: str(item["external_key"]))
+    expected_key = _batch_key(IDENTITY, expected_obs)
+    assert [obs["external_key"] for obs in posts[0]["observations"]] == [
+        f"{IDENTITY}#aaa1",
+        f"{IDENTITY}#zzz9",
+    ]
+    assert posts[0]["observations"] == posts[1]["observations"] == expected_obs
+    assert posts[0]["idempotency_key"] == posts[1]["idempotency_key"] == expected_key
+    assert first_result["observation_count"] == second_result["observation_count"] == 2
+
+
+@pytest.mark.parametrize("order", [("node-a", "node-b"), ("node-b", "node-a")])
+def test_reordered_equivalent_edges_are_identical_regardless_of_target_order(
+    tmp_path, monkeypatch, order: tuple[str, str]
+) -> None:
+    posts: list[dict[str, object]] = []
+    first_name, second_name = order
+    first = tmp_path / first_name
+    second = tmp_path / second_name
+    first.mkdir()
+    second.mkdir()
+    edges_a = [
+        {"source": "abc123", "target": "ghi789", "type": "parent-child"},
+        {"source": "abc123", "target": "def456", "type": "blocks"},
+    ]
+    edges_b = [
+        {"source": "abc123", "target": "def456", "type": "blocks"},
+        {"source": "abc123", "target": "ghi789", "type": "parent-child"},
+    ]
+    payloads = {
+        tmp_path / "node-a": ([_public_task()], edges_a),
+        tmp_path / "node-b": ([_public_task()], edges_b),
+    }
+    _install_public_reader(monkeypatch, payloads)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=first, identity=IDENTITY),
+            sync.Target(path=second, identity=IDENTITY),
+        ]
+    )
+    expected_deps = [
+        {"type": "blocks", "id": "def456"},
+        {"type": "parent-child", "id": "ghi789"},
+    ]
+    assert len(posts) == 1
+    assert result["posted"] == 1
+    assert result["observation_count"] == 1
+    assert result["identities"] == 1
+    assert posts[0]["observations"][0]["dependencies"] == expected_deps
+    assert posts[0]["idempotency_key"] == _batch_key(IDENTITY, posts[0]["observations"])
+
+
+def test_sync_splits_501_observations_into_two_batches(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    tasks = [_public_task(id=f"t{index:04d}", text=f"Task {index:04d}") for index in range(1, 502)]
+    target = tmp_path / "repo"
+    target.mkdir()
+    _install_public_reader(monkeypatch, {target: (tasks, [])})
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    observations = sync.observations_for_target(tasks, edges=[], identity=IDENTITY)
+    observations = sorted(observations, key=lambda item: str(item["external_key"]))
+    assert result["posted"] == 2
+    assert result["observation_count"] == 501
+    assert [len(post["observations"]) for post in posts] == [500, 1]
+    assert posts[0]["observations"] == observations[:500]
+    assert posts[1]["observations"] == observations[500:]
+    assert posts[0]["idempotency_key"] == _batch_key(IDENTITY, observations[:500])
+    assert posts[1]["idempotency_key"] == _batch_key(IDENTITY, observations[500:])
+    assert posts[0]["idempotency_key"] != posts[1]["idempotency_key"]
+
+
+def test_empty_discovery_posts_one_empty_batch_per_identity(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    first = tmp_path / "node-a"
+    second = tmp_path / "node-b"
+    first.mkdir()
+    second.mkdir()
+    _install_public_reader(monkeypatch, {first: ([], []), second: ([], [])})
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=first, identity=IDENTITY),
+            sync.Target(path=second, identity=OTHER_IDENTITY),
+        ]
+    )
+    assert result["posted"] == 2
+    assert result["observation_count"] == 0
+    assert result["identities"] == 2
+    assert result["targets"] == 2
+    assert [post["observations"] for post in posts] == [[], []]
+    assert [post["adapter_id"] for post in posts] == [f"brigade:{IDENTITY}", f"brigade:{OTHER_IDENTITY}"]
+    assert posts[0]["idempotency_key"] == _batch_key(IDENTITY, [])
+    assert posts[1]["idempotency_key"] == _batch_key(OTHER_IDENTITY, [])
+
+
+def test_envelope_is_exactly_adapter_fields(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    target = tmp_path / "repo"
+    target.mkdir()
+    _install_public_reader(monkeypatch, {target: ([_public_task()], [])})
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    assert set(posts[0]) == {"adapter_id", "source_type", "idempotency_key", "observations"}
+    assert posts[0]["source_type"] == "brigade"
+    assert posts[0]["adapter_id"] == f"brigade:{IDENTITY}"
+
+
+def test_fingerprint_covers_every_source_authoritative_field(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    target = tmp_path / "repo"
+    target.mkdir()
+    baseline = {
+        "external_key": f"{IDENTITY}#abc123",
+        "link_type": "brigade",
+        "title": "Shared",
+        "acceptance": ["ok"],
+        "external_state": "pending",
+        "priority": "high",
+        "dependencies": [],
+        "evidence_refs": ["run-1"],
+        "source_policy": "eligible",
+        "proposed_status": None,
+        "external_updated_at": "2026-02-01T00:00:00+00:00",
+    }
+    variants = {
+        "external_key": f"{IDENTITY}#other",
+        "title": "Changed title",
+        "acceptance": ["changed"],
+        "external_state": "done",
+        "external_updated_at": "2026-03-01T00:00:00+00:00",
+        "priority": "low",
+        "dependencies": [{"type": "blocks", "id": "other"}],
+        "evidence_refs": ["run-other"],
+        "source_policy": "completed",
+        "proposed_status": "completed",
+    }
+    queue = [dict(baseline)]
+    for field, value in variants.items():
+        changed = dict(baseline)
+        changed[field] = value
+        queue.append(changed)
+
+    def fake_observations(tasks, *, edges=None, identity):
+        return [queue.pop(0)]
+
+    monkeypatch.setattr(sync, "read_public_tasks", lambda target: ([], []))
+    monkeypatch.setattr(sync, "observations_for_target", fake_observations)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    for _ in range(len(variants) + 1):
+        sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    baseline_key = posts[0]["idempotency_key"]
+    assert baseline_key == _batch_key(IDENTITY, [baseline])
+    changed_keys = [post["idempotency_key"] for post in posts[1:]]
+    assert all(key != baseline_key for key in changed_keys)
+    assert len(set(changed_keys)) == len(variants)
+
+
+def test_batch_key_uses_sorted_fingerprints(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    target = tmp_path / "repo"
+    target.mkdir()
+    first = {
+        "external_key": f"{IDENTITY}#aaa",
+        "title": "Alpha",
+        "acceptance": ["ok"],
+        "external_state": "pending",
+        "priority": "high",
+        "dependencies": [],
+        "evidence_refs": [],
+        "source_policy": "eligible",
+        "proposed_status": None,
+    }
+    second = {
+        "external_key": f"{IDENTITY}#zzz",
+        "title": "Zeta",
+        "acceptance": ["ok"],
+        "external_state": "pending",
+        "priority": "low",
+        "dependencies": [],
+        "evidence_refs": [],
+        "source_policy": "eligible",
+        "proposed_status": None,
+    }
+    sequence = [[second, first], [first, second]]
+
+    def fake_observations(tasks, *, edges=None, identity):
+        return [dict(item) for item in sequence.pop(0)]
+
+    monkeypatch.setattr(sync, "read_public_tasks", lambda target: ([], []))
+    monkeypatch.setattr(sync, "observations_for_target", fake_observations)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    expected = _batch_key(IDENTITY, [first, second])
+    assert posts[0]["idempotency_key"] == expected
+    assert posts[1]["idempotency_key"] == expected
+    assert posts[0]["idempotency_key"].startswith(f"brigade:{IDENTITY}:")
+    assert len(posts[0]["idempotency_key"].rsplit(":", 1)[1]) == 24
+    assert [obs["external_key"] for obs in posts[0]["observations"]] == [
+        f"{IDENTITY}#aaa",
+        f"{IDENTITY}#zzz",
+    ]
+
+
+def test_result_sums_bounded_hub_counts(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    tasks = [_public_task(id=f"t{index:04d}", text=f"Task {index:04d}") for index in range(1, 502)]
+    target = tmp_path / "repo"
+    target.mkdir()
+    _install_public_reader(monkeypatch, {target: (tasks, [])})
+
+    def leaky_hub(payload):
+        posts.append(payload)
+        return {
+            "created": 2,
+            "updated": 3,
+            "unchanged": 4,
+            "items": [{"title": "Add store", "path": str(target)}],
+            "secret": "token=abc",
+            "created_text": "1",
+        }
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", leaky_hub)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    assert set(result) == {
+        "targets",
+        "identities",
+        "posted",
+        "observation_count",
+        "refused",
+        "skipped",
+        "created",
+        "updated",
+        "unchanged",
+    }
+    assert result["refused"] == 0
+    assert result == {
+        "targets": 1,
+        "identities": 1,
+        "posted": 2,
+        "observation_count": 501,
+        "refused": 0,
+        "skipped": 0,
+        "created": 4,
+        "updated": 6,
+        "unchanged": 8,
+    }
+    dumped = json.dumps(result)
+    assert "Add store" not in dumped
+    assert "token" not in dumped
+    assert str(target) not in dumped
+    assert "items" not in dumped
+
+
+def test_hub_counts_ignore_negative_bool_float_and_numeric_strings(tmp_path, monkeypatch) -> None:
+    tasks = [_public_task(id=f"t{index:04d}", text=f"Task {index:04d}") for index in range(1, 502)]
+    target = tmp_path / "repo"
+    target.mkdir()
+    _install_public_reader(monkeypatch, {target: (tasks, [])})
+    responses = [
+        {"created": -2, "updated": True, "unchanged": "3"},
+        {"created": 1.5, "updated": 4, "unchanged": False},
+    ]
+
+    def typed_hub(_payload):
+        return responses.pop(0)
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", typed_hub)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    assert result["created"] == 0
+    assert result["updated"] == 4
+    assert result["unchanged"] == 0
+
+
+def test_receipt_path_fields_and_private_modes(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    target = tmp_path / "repo"
+    target.mkdir()
+    _install_public_reader(monkeypatch, {target: ([_public_task()], [])})
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    receipt_path = tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert set(receipt) == {
+        "adapter_id",
+        "idempotency_key",
+        "observation_count",
+        "refused",
+        "skipped",
+        "last_error_code",
+        "updated_at",
+    }
+    assert receipt["refused"] == 0
+    assert receipt["skipped"] == 0
+    assert receipt["adapter_id"] == f"brigade:{IDENTITY}"
+    assert receipt["idempotency_key"] == posts[0]["idempotency_key"]
+    assert receipt["observation_count"] == 1
+    assert receipt["last_error_code"] is None
+    assert receipt["updated_at"].endswith("Z")
+    dumped = json.dumps(receipt)
+    assert "Shared" not in dumped
+    assert "abc123" not in dumped
+    assert str(target) not in dumped
+    assert "payload" not in dumped
+    assert_private_mode(receipt_path, PRIVATE_FILE_MODE)
+    assert_private_mode(receipt_path.parent, PRIVATE_DIRECTORY_MODE)
+
+
+def test_sync_skips_unsafe_task_and_reports_bounded_count(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    target = tmp_path / "repo"
+    target.mkdir()
+    _install_public_reader(
+        monkeypatch,
+        {target: ([UNSAFE_TASKS[0], _public_task(id="healthy")], [])},
+    )
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    assert result["skipped"] == 1
+    assert result["observation_count"] == 1
+    assert [obs["external_key"] for obs in posts[0]["observations"]] == [f"{IDENTITY}#healthy"]
+    receipt = json.loads((tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json").read_text())
+    assert receipt["skipped"] == 1
+    dumped = json.dumps({"posts": posts, "receipt": receipt})
+    for fragment in UNSAFE_TASK_LEAKS:
+        assert fragment not in dumped
+
+
+def test_receipt_skips_are_scoped_to_the_identity(tmp_path, monkeypatch) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    _install_public_reader(
+        monkeypatch,
+        {
+            first: ([UNSAFE_TASKS[0]], []),
+            second: ([_public_task(id="healthy", text="Healthy work")], []),
+        },
+    )
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda _payload: {})
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+
+    result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=first, identity=IDENTITY),
+            sync.Target(path=second, identity=OTHER_IDENTITY),
+        ]
+    )
+
+    first_receipt = json.loads((tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json").read_text())
+    second_receipt = json.loads((tmp_path / "worklore" / "brigade" / "other-org-other-repo.json").read_text())
+    assert result["skipped"] == 1
+    assert first_receipt["skipped"] == 1
+    assert second_receipt["skipped"] == 0
+
+
+def test_hub_refusals_do_not_stop_later_brigade_identities(tmp_path, monkeypatch) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    posts: list[dict[str, object]] = []
+    _install_public_reader(
+        monkeypatch,
+        {
+            first: ([_public_task()], []),
+            second: ([_public_task(id="other-task", text="Other work")], []),
+        },
+    )
+
+    def fake_import(payload):
+        posts.append(payload)
+        return {"refused": 1} if payload["adapter_id"] == f"brigade:{IDENTITY}" else {"created": 1}
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+
+    result = sync.sync_brigade(
+        targets=[
+            sync.Target(path=first, identity=IDENTITY),
+            sync.Target(path=second, identity=OTHER_IDENTITY),
+        ]
+    )
+
+    assert [post["adapter_id"] for post in posts] == [f"brigade:{IDENTITY}", f"brigade:{OTHER_IDENTITY}"]
+    assert result["refused"] == 1
+    assert result["skipped"] == 0
+    first_receipt = json.loads((tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json").read_text())
+    second_receipt = json.loads((tmp_path / "worklore" / "brigade" / "other-org-other-repo.json").read_text())
+    assert (first_receipt["refused"], first_receipt["last_error_code"]) == (1, "hub-partial")
+    assert (second_receipt["refused"], second_receipt["last_error_code"]) == (0, None)
+
+
+BRIGADE_HUB_REFUSALS = [
+    ("fleet hub work failed: HTTP 400: title must be 1 to 240 characters", "hub-rejected"),
+    ("fleet hub work failed: HTTP 404", "hub-rejected"),
+    ("fleet hub work failed: HTTP 422", "hub-rejected"),
+    ("fleet hub work failed: HTTP 401", "hub-unauthorized"),
+    ("fleet hub work failed: HTTP 403: adapter is owned by another node", "hub-unauthorized"),
+    ("fleet hub work failed: HTTP 409: idempotency key reused with a different payload", "hub-conflict"),
+    ("fleet hub work failed: HTTP 500", "hub-unavailable"),
+    ("fleet hub work failed: HTTP 503: https://hub.example/work/imports token=abc", "hub-unavailable"),
+    ("fleet hub work failed: invalid JSON", "hub-unavailable"),
+    ("hub-unavailable", "hub-unavailable"),
+]
+
+
+@pytest.mark.parametrize(("message", "code"), BRIGADE_HUB_REFUSALS)
+def test_import_refusals_keep_stable_non_transient_codes(tmp_path, monkeypatch, message: str, code: str) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _install_public_reader(monkeypatch, {target: ([_public_task()], [])})
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(sync.worklore_client.FleetClientError(message)),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError) as excinfo:
+        sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code=code,
+        forbidden=[IDENTITY, "Shared", "token", "https://hub.example", str(target)],
+    )
+    _assert_no_hub_leak(str(excinfo.value))
+    receipt = json.loads((tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json").read_text())
+    assert receipt["last_error_code"] == code
+    _assert_no_hub_leak(json.dumps(receipt))
+
+
+def test_receipt_filename_sanitizes_reserved_characters() -> None:
+    raw = 'escoffier:labs/brigade\\x<y>"z|a?b*c'
+    safe = sync._safe_identity(raw)
+    for character in ':/\\<>"|?*':
+        assert character not in safe
+    assert safe == "escoffier-labs-brigade-x-y--z-a-b-c"
+
+
+def test_hub_unavailable_is_bounded_and_writes_best_effort_receipt(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    ledger = target / ".brigade" / "work" / "tasks.json"
+    ledger.parent.mkdir(parents=True)
+    original = '{"tasks":[{"id":"local-keep"}]}'
+    ledger.write_text(original, encoding="utf-8")
+    before = ledger.stat().st_mtime_ns
+    _install_public_reader(monkeypatch, {target: ([_public_task()], [])})
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(
+            sync.worklore_client.FleetClientError(
+                "fleet hub work failed: HTTP 503: https://hub.example/work/imports token=abc title=Add store"
+            )
+        ),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError, match="hub-unavailable") as excinfo:
+        sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code="hub-unavailable",
+        forbidden=[
+            IDENTITY,
+            "Add store",
+            "token",
+            "https://hub.example",
+            str(target),
+            "Shared",
+            "abc123",
+        ],
+    )
+    _assert_no_hub_leak(str(excinfo.value))
+    assert ledger.read_text(encoding="utf-8") == original
+    assert ledger.stat().st_mtime_ns == before
+    receipt_path = tmp_path / "worklore" / "brigade" / "escoffier-labs-brigade.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["last_error_code"] == "hub-unavailable"
+    assert receipt["adapter_id"] == f"brigade:{IDENTITY}"
+    assert "Add store" not in json.dumps(receipt)
+    assert "https://hub.example" not in json.dumps(receipt)
+    assert_private_mode(receipt_path, PRIVATE_FILE_MODE)
+    assert_private_mode(receipt_path.parent, PRIVATE_DIRECTORY_MODE)
+
+
+def _leaky_receipt_oserror(tmp_path: Path) -> OSError:
+    leaky_path = tmp_path / "home" / "operator" / "worklore" / "brigade" / "escoffier-labs-brigade.json"
+    return OSError(13, f"Permission denied: '{leaky_path}'")
+
+
+def test_successful_post_receipt_write_failure_is_bounded_and_replay_safe(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    target = tmp_path / "repo"
+    target.mkdir()
+    expected_obs = sync.observations_for_target([_public_task()], edges=[], identity=IDENTITY)
+    expected_key = _batch_key(IDENTITY, expected_obs)
+    leak = _leaky_receipt_oserror(tmp_path)
+
+    def failing_write(*args, **kwargs):
+        raise leak
+
+    _install_public_reader(monkeypatch, {target: ([_public_task()], [])})
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setattr(sync, "_write_receipt", failing_write)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError, match="receipt-write-failed") as excinfo:
+        sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    assert excinfo.value.code == "receipt-write-failed"
+    assert str(excinfo.value) == "receipt-write-failed: receipt-write-failed"
+    message = str(excinfo.value)
+    _assert_no_hub_leak(message)
+    _assert_bounded_sync_error(
+        excinfo.value,
+        code="receipt-write-failed",
+        forbidden=[IDENTITY, str(tmp_path), "Permission denied", "escoffier-labs-brigade.json"],
+    )
+    assert leak.strerror not in message
+    assert len(posts) == 1
+    assert posts[0]["idempotency_key"] == expected_key
+
+
+def test_hub_unavailable_receipt_write_failure_stays_hub_unavailable(tmp_path, monkeypatch) -> None:
+    leak = _leaky_receipt_oserror(tmp_path)
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    def failing_write(*args, **kwargs):
+        raise leak
+
+    _install_public_reader(monkeypatch, {target: ([_public_task()], [])})
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(
+            sync.worklore_client.FleetClientError(
+                "fleet hub work failed: HTTP 503: https://hub.example/work/imports token=abc title=Add store"
+            )
+        ),
+    )
+    monkeypatch.setattr(sync, "_write_receipt", failing_write)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError, match="hub-unavailable") as excinfo:
+        sync.sync_brigade(targets=[sync.Target(path=target, identity=IDENTITY)])
+    assert excinfo.value.code == "hub-unavailable"
+    message = str(excinfo.value)
+    _assert_no_hub_leak(message)
+    assert IDENTITY not in message
+    assert str(tmp_path) not in message
+    assert "Permission denied" not in message
+    assert "OSError" not in message
+    assert leak.strerror not in message
+
+
+def test_sync_rejects_empty_targets_before_hub(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    monkeypatch.setattr(sync.worklore_client, "import_batch", _recording_hub(posts))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.BrigadeSyncError, match="field-bound") as excinfo:
+        sync.sync_brigade(targets=[])
+    assert excinfo.value.code == "field-bound"
+    assert posts == []
+
+
+CLI_TARGETS: list[object] = [{"path": "not-a-real-checkout", "identity": IDENTITY}]
+CLI_CONFIG = {"targets": CLI_TARGETS}
+CLI_COUNT_FIELDS = (
+    "targets",
+    "identities",
+    "posted",
+    "observation_count",
+    "created",
+    "refused",
+    "skipped",
+    "updated",
+    "unchanged",
+)
+CLI_LEAKY_RESULT = {
+    "targets": 1,
+    "identities": 1,
+    "posted": 1,
+    "observation_count": 3,
+    "created": 1,
+    "updated": 0,
+    "unchanged": 2,
+    "refused": 0,
+    "skipped": 0,
+    "title": "Add Worklore store",
+    "url": "https://hub.example/work/imports",
+    "token": "brigade_secret",
+    "observations": [{"title": "Add Worklore store", "item": "hub-item-1"}],
+    "identity": IDENTITY,
+    "path": "/tmp/not-a-real-checkout",
+}
+
+
+def test_worklore_brigade_sync_is_imported_at_fleet_module_scope() -> None:
+    assert hasattr(fleet_cli, "worklore_brigade_sync")
+    assert fleet_cli.worklore_brigade_sync is sync
+
+
+def test_sync_brigade_cli_json(monkeypatch, capsys) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_sync(targets):
+        captured["targets"] = targets
+        return dict(CLI_LEAKY_RESULT)
+
+    monkeypatch.setattr(fleet_cli.worklore_brigade_sync, "load_brigade_config", lambda: CLI_CONFIG)
+    monkeypatch.setattr(fleet_cli.worklore_brigade_sync, "sync_brigade", fake_sync)
+    assert fleet_cli._dispatch_work_sync_brigade(argparse.Namespace(json=True)) == 0
+    captured_io = capsys.readouterr()
+    assert captured_io.err == ""
+    payload = json.loads(captured_io.out)
+    assert captured_io.out == json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    assert captured["targets"] is CLI_CONFIG["targets"]
+    assert set(payload) == set(CLI_COUNT_FIELDS)
+    assert all(isinstance(payload[field], int) and payload[field] >= 0 for field in CLI_COUNT_FIELDS)
+    assert payload == {
+        "created": 1,
+        "identities": 1,
+        "observation_count": 3,
+        "posted": 1,
+        "refused": 0,
+        "skipped": 0,
+        "targets": 1,
+        "unchanged": 2,
+        "updated": 0,
+    }
+    _assert_no_hub_leak(captured_io.out)
+    assert IDENTITY not in captured_io.out
+    assert "Add Worklore store" not in captured_io.out
+    assert "not-a-real-checkout" not in captured_io.out
+    assert "brigade_secret" not in captured_io.out
+    assert "hub-item-1" not in captured_io.out
+
+
+def test_sync_brigade_cli_default_reports_counts_only(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(fleet_cli.worklore_brigade_sync, "load_brigade_config", lambda: CLI_CONFIG)
+    monkeypatch.setattr(
+        fleet_cli.worklore_brigade_sync,
+        "sync_brigade",
+        lambda targets: dict(CLI_LEAKY_RESULT),
+    )
+    assert fleet_cli._dispatch_work_sync_brigade(argparse.Namespace(json=False)) == 0
+    captured_io = capsys.readouterr()
+    assert captured_io.err == ""
+    lines = [line for line in captured_io.out.splitlines() if line.strip()]
+    assert len(lines) == 1
+    line = lines[0]
+    assert "1" in line
+    assert "3" in line
+    assert "2" in line
+    assert "posted" in line.lower()
+    assert "observation" in line.lower()
+    assert "created" in line.lower()
+    assert IDENTITY not in captured_io.out
+    assert "Add Worklore store" not in captured_io.out
+    assert "not-a-real-checkout" not in captured_io.out
+    assert "brigade_secret" not in captured_io.out
+    assert "https://" not in captured_io.out
+    assert "hub-item-1" not in captured_io.out
+    assert "title" not in line.lower()
+    _assert_no_hub_leak(captured_io.out)
+
+
+def test_sync_brigade_cli_surfaces_refusals_after_printing_counts(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(fleet_cli.worklore_brigade_sync, "load_brigade_config", lambda: CLI_CONFIG)
+    monkeypatch.setattr(
+        fleet_cli.worklore_brigade_sync,
+        "sync_brigade",
+        lambda targets: {
+            "targets": 2,
+            "identities": 2,
+            "posted": 2,
+            "observation_count": 2,
+            "created": 1,
+            "updated": 0,
+            "unchanged": 0,
+            "refused": 1,
+            "skipped": 3,
+        },
+    )
+
+    assert fleet_cli._dispatch_work_sync_brigade(argparse.Namespace(json=True)) == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "created": 1,
+        "identities": 2,
+        "observation_count": 2,
+        "posted": 2,
+        "refused": 1,
+        "skipped": 3,
+        "targets": 2,
+        "unchanged": 0,
+        "updated": 0,
+    }
+    assert fleet_cli._dispatch_work_sync_brigade(argparse.Namespace(json=False)) == 1
+    assert capsys.readouterr().out == (
+        "targets 2, identities 2, posted 2, 2 observation(s), created 1, updated 0, unchanged 0, refused 1, skipped 3\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        "Brigade Worklore config is missing targets",
+        "targets must be a non-empty list",
+    ),
+)
+def test_sync_brigade_cli_config_error_returns_2(monkeypatch, capsys, message: str) -> None:
+    def missing_config() -> dict[str, object]:
+        raise sync.BrigadeSyncError(message, code="field-bound")
+
+    monkeypatch.setattr(fleet_cli.worklore_brigade_sync, "load_brigade_config", missing_config)
+    assert fleet_cli._dispatch_work_sync_brigade(argparse.Namespace(json=False)) == 2
+    captured_io = capsys.readouterr()
+    assert captured_io.out == ""
+    err_lines = [line for line in captured_io.err.splitlines() if line.strip()]
+    assert err_lines == [f"field-bound: {message}"]
+    _assert_no_hub_leak(captured_io.err)
+    assert IDENTITY not in captured_io.err
+    assert "/home/" not in captured_io.err
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    (
+        ("hub-unavailable", "hub-unavailable"),
+        ("hub-rejected", "hub-rejected"),
+        ("hub-unauthorized", "hub-unauthorized"),
+        ("hub-conflict", "hub-conflict"),
+        ("retryable-adapter-failure", "adapter command failed"),
+        ("receipt-write-failed", "receipt-write-failed"),
+        ("identity-conflict", "identity-conflict"),
+    ),
+)
+def test_sync_brigade_cli_adapter_failures_return_1(monkeypatch, capsys, code: str, message: str) -> None:
+    monkeypatch.setattr(fleet_cli.worklore_brigade_sync, "load_brigade_config", lambda: CLI_CONFIG)
+
+    def boom(targets):
+        raise sync.BrigadeSyncError(message, code=code)
+
+    monkeypatch.setattr(fleet_cli.worklore_brigade_sync, "sync_brigade", boom)
+    assert fleet_cli._dispatch_work_sync_brigade(argparse.Namespace(json=False)) == 1
+    captured_io = capsys.readouterr()
+    assert captured_io.out == ""
+    err_lines = [line for line in captured_io.err.splitlines() if line.strip()]
+    assert err_lines == [f"{code}: {message}"]
+    _assert_no_hub_leak(captured_io.err)
+    assert IDENTITY not in captured_io.err
+    assert "/home/" not in captured_io.err
+    assert "Add Worklore store" not in captured_io.err
+    assert "not-a-real-checkout" not in captured_io.err
+
+
+def test_fleet_work_parser_accepts_sync_brigade() -> None:
+    parser = cli._build_parser()
+    parsed = parser.parse_args(["fleet", "work", "sync-brigade", "--json"])
+    assert parsed.func is fleet_cli._dispatch_work_sync_brigade
+    assert parsed.json is True
+    default = parser.parse_args(["fleet", "work", "sync-brigade"])
+    assert default.func is fleet_cli._dispatch_work_sync_brigade
+    assert default.json is False
+
+
+def test_a_normalized_task_carries_the_source_revision_the_hub_guard_needs() -> None:
+    observation = adapter.normalize_task(
+        _pending_task(updated_at="2026-02-01T00:00:00+00:00"), identity=IDENTITY, edges=[]
+    )
+    assert observation["external_updated_at"] == "2026-02-01T00:00:00+00:00"
+
+
+def test_a_task_without_a_usable_revision_reports_none_rather_than_a_guess() -> None:
+    for value in (None, "", "   ", 17, "x" * 200):
+        task = _pending_task()
+        if value is not None:
+            task["updated_at"] = value
+        observation = adapter.normalize_task(task, identity=IDENTITY, edges=[])
+        assert "external_updated_at" not in observation
+
+
+def test_the_source_revision_is_part_of_the_batch_fingerprint() -> None:
+    assert "external_updated_at" in sync.FINGERPRINT_FIELDS

--- a/tests/test_worklore_client.py
+++ b/tests/test_worklore_client.py
@@ -1,0 +1,658 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from brigade import cli, worklore_client
+from brigade.cli import fleet as fleet_cli
+
+
+def test_client_fails_closed_when_hub_is_configured_and_down(monkeypatch):
+    monkeypatch.setattr(
+        worklore_client,
+        "load_fleet_settings",
+        lambda: {
+            "hub_url": "http://127.0.0.1:9",
+            "admin_token": "admin",
+            "node_token": "node",
+        },  # content-guard: allow loopback-ipv4
+    )
+    with pytest.raises(worklore_client.FleetClientError, match="hub-unavailable"):
+        worklore_client.create_item({"title": "Native", "kind": "fleet"})
+
+
+def test_fleet_work_create_and_burn_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        worklore_client,
+        "create_item",
+        lambda body, idempotency_key=None: {
+            "item": {"work_id": "wl-aaa", "title": body["title"], "status": "captured"}
+        },
+    )
+    paging: dict[str, object] = {}
+
+    def fake_burn_queue(*, limit=None, cursor=None):
+        paging.update({"limit": limit, "cursor": cursor})
+        return {"items": [], "exclusions": {"acceptance-required": 1, "source-policy": 0}, "next_cursor": None}
+
+    monkeypatch.setattr(worklore_client, "burn_queue", fake_burn_queue)
+    assert (
+        fleet_cli._dispatch_work_create(argparse.Namespace(title="X", kind="fleet", json=True, idempotency_key=None))
+        == 0
+    )
+    assert '"wl-aaa"' in capsys.readouterr().out
+    assert fleet_cli._dispatch_work_burn(argparse.Namespace(json=True, limit=10, cursor="cur-1")) == 0
+    assert "acceptance-required" in capsys.readouterr().out
+    assert paging == {"limit": 10, "cursor": "cur-1"}
+
+
+def test_public_client_exports_required_operations():
+    for name in (
+        "create_item",
+        "get_item",
+        "list_items",
+        "list_events",
+        "list_all_events",
+        "burn_queue",
+        "patch_item",
+        "transition",
+        "record_attempt",
+        "add_link",
+        "delete_link",
+        "import_batch",
+        "link_execution",
+    ):
+        assert callable(getattr(worklore_client, name))
+
+
+def test_fleet_work_parser_registers_public_commands():
+    parser = cli._build_parser()
+    create = parser.parse_args(
+        [
+            "fleet",
+            "work",
+            "create",
+            "--title",
+            "X",
+            "--kind",
+            "fleet",
+            "--idempotency-key",
+            "create-1",
+            "--json",
+        ]
+    )
+    assert create.func is fleet_cli._dispatch_work_create
+    assert create.title == "X"
+    assert create.kind == "fleet"
+    assert create.idempotency_key == "create-1"
+    assert create.json is True
+    omitted = parser.parse_args(["fleet", "work", "create", "--title", "X", "--kind", "fleet"])
+    assert omitted.idempotency_key is None
+
+    show = parser.parse_args(["fleet", "work", "show", "wl-aaa", "--json"])
+    assert show.func is fleet_cli._dispatch_work_show
+    assert show.work_id == "wl-aaa"
+
+    listed = parser.parse_args(["fleet", "work", "list", "--source", "github", "--json"])
+    assert listed.func is fleet_cli._dispatch_work_list
+    assert listed.source == "github"
+
+    burn = parser.parse_args(["fleet", "work", "burn", "--json"])
+    assert burn.func is fleet_cli._dispatch_work_burn
+
+    patch = parser.parse_args(["fleet", "work", "patch", "wl-aaa", "--if-match", "1", "--priority", "high", "--json"])
+    assert patch.func is fleet_cli._dispatch_work_patch
+    assert patch.work_id == "wl-aaa"
+    assert patch.if_match == "1"
+    assert patch.priority == "high"
+    assert patch.burn_eligible is None
+
+    burn_eligible = parser.parse_args(["fleet", "work", "patch", "wl-aaa", "--if-match", "1", "--burn-eligible"])
+    assert burn_eligible.burn_eligible is True
+    burn_ineligible = parser.parse_args(["fleet", "work", "patch", "wl-aaa", "--if-match", "1", "--no-burn-eligible"])
+    assert burn_ineligible.burn_eligible is False
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "fleet",
+                "work",
+                "patch",
+                "wl-aaa",
+                "--if-match",
+                "1",
+                "--burn-eligible",
+                "--no-burn-eligible",
+            ]
+        )
+
+    transitioned = parser.parse_args(
+        ["fleet", "work", "transition", "wl-aaa", "--to-status", "ready", "--if-match", "2", "--json"]
+    )
+    assert transitioned.func is fleet_cli._dispatch_work_transition
+    assert transitioned.to_status == "ready"
+    assert transitioned.if_match == "2"
+
+    attempt = parser.parse_args(
+        ["fleet", "work", "attempt", "wl-aaa", "--action", "reset", "--if-match", "3", "--json"]
+    )
+    assert attempt.func is fleet_cli._dispatch_work_attempt
+    assert attempt.action == "reset"
+
+    link = parser.parse_args(
+        [
+            "fleet",
+            "work",
+            "link",
+            "wl-aaa",
+            "--link-type",
+            "url",
+            "--external-key",
+            "https://example.invalid/a",
+            "--json",
+        ]
+    )
+    assert link.func is fleet_cli._dispatch_work_link
+    assert link.link_type == "url"
+    assert link.external_key == "https://example.invalid/a"
+
+    unlink = parser.parse_args(["fleet", "work", "unlink", "wl-aaa", "lnk-bbb", "--json"])
+    assert unlink.func is fleet_cli._dispatch_work_unlink
+    assert unlink.work_id == "wl-aaa"
+    assert unlink.link_id == "lnk-bbb"
+
+
+def test_fleet_work_show_list_and_patch_dispatch_json(monkeypatch, capsys):
+    patch_bodies: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        worklore_client,
+        "get_item",
+        lambda work_id: {"item": {"work_id": work_id, "title": "Shown"}},
+    )
+    monkeypatch.setattr(
+        worklore_client,
+        "list_items",
+        lambda source=None: {"items": [{"work_id": "wl-src", "source": source}]},
+    )
+    monkeypatch.setattr(
+        worklore_client,
+        "patch_item",
+        lambda work_id, body, if_match=None: (
+            patch_bodies.append(body)
+            or {"item": {"work_id": work_id, "priority": body.get("priority"), "version": if_match}}
+        ),
+    )
+    assert fleet_cli._dispatch_work_show(argparse.Namespace(work_id="wl-show", json=True)) == 0
+    assert '"wl-show"' in capsys.readouterr().out
+    assert fleet_cli._dispatch_work_list(argparse.Namespace(source="native", json=True)) == 0
+    assert '"wl-src"' in capsys.readouterr().out
+    assert (
+        fleet_cli._dispatch_work_patch(
+            argparse.Namespace(
+                work_id="wl-patch",
+                if_match="1",
+                title=None,
+                description=None,
+                scope=None,
+                priority="high",
+                burn_rank=None,
+                burn_eligible=True,
+                token_appetite=None,
+                execution_mode=None,
+                acceptance=None,
+                blocker=None,
+                review_after=None,
+                spend_by=None,
+                json=True,
+            )
+        )
+        == 0
+    )
+    assert '"wl-patch"' in capsys.readouterr().out
+    assert patch_bodies == [{"priority": "high", "burn_eligible": True}]
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self, amt: int | None = None) -> bytes:
+        return self._payload if amt is None else self._payload[:amt]
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+
+def _capture_urlopen(monkeypatch, captured: dict[str, object], payload: dict[str, object] | None = None) -> None:
+    monkeypatch.setattr(
+        worklore_client,
+        "load_fleet_settings",
+        lambda: {
+            "hub_url": "http://127.0.0.1:9",
+            "admin_token": "admin-secret",
+            "node_token": "node-secret",
+        },  # content-guard: allow loopback-ipv4
+    )
+
+    def fake_open(request, timeout=None):
+        captured["url"] = request.full_url
+        captured["method"] = request.get_method()
+        captured["headers"] = {key.lower(): value for key, value in request.header_items()}
+        captured["timeout"] = timeout
+        return _FakeResponse(payload or {"item": {"work_id": "wl-1"}})
+
+    monkeypatch.setattr(worklore_client, "_hub_open", fake_open)
+
+
+def test_create_item_uses_node_auth_and_idempotency_key(monkeypatch):
+    captured: dict[str, object] = {}
+    _capture_urlopen(monkeypatch, captured)
+    payload = worklore_client.create_item({"title": "Native", "kind": "fleet"}, idempotency_key="create-1")
+    assert payload["item"]["work_id"] == "wl-1"
+    headers = captured["headers"]
+    assert captured["method"] == "POST"
+    assert headers["authorization"] == "Bearer node-secret"
+    assert headers["idempotency-key"] == "create-1"
+    assert "admin-secret" not in headers.values()
+
+
+def test_create_item_generates_bounded_idempotency_key(monkeypatch):
+    captured: dict[str, object] = {}
+    _capture_urlopen(monkeypatch, captured)
+    worklore_client.create_item({"title": "Native", "kind": "fleet"})
+    headers = captured["headers"]
+    key = headers["idempotency-key"]
+    assert isinstance(key, str) and 1 <= len(key) <= 256
+    assert headers["authorization"] == "Bearer node-secret"
+
+
+def test_patch_and_reset_use_node_auth(monkeypatch):
+    captured: dict[str, object] = {}
+    _capture_urlopen(monkeypatch, captured, {"item": {"work_id": "wl-1", "version": 2}})
+    worklore_client.patch_item("wl-1", {"priority": "high"}, if_match=1)
+    headers = captured["headers"]
+    assert headers["authorization"] == "Bearer node-secret"
+    assert headers["if-match"] == "1"
+    worklore_client.record_attempt("wl-1", {"action": "reset"}, if_match=2)
+    headers = captured["headers"]
+    assert headers["authorization"] == "Bearer node-secret"
+
+
+def test_fleet_work_create_passes_idempotency_key(monkeypatch, capsys):
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        worklore_client,
+        "create_item",
+        lambda body, idempotency_key=None: (
+            seen.update({"body": body, "idempotency_key": idempotency_key})
+            or {"item": {"work_id": "wl-key", "title": body["title"]}}
+        ),
+    )
+    assert (
+        fleet_cli._dispatch_work_create(
+            argparse.Namespace(title="Keyed", kind="fleet", json=True, idempotency_key="cli-1")
+        )
+        == 0
+    )
+    assert seen == {"body": {"title": "Keyed", "kind": "fleet"}, "idempotency_key": "cli-1"}
+    assert '"wl-key"' in capsys.readouterr().out
+
+
+def _paging_urlopen(monkeypatch, pages: list[dict[str, object]], urls: list[str]) -> None:
+    monkeypatch.setattr(
+        worklore_client,
+        "load_fleet_settings",
+        lambda: {
+            "hub_url": "http://127.0.0.1:9",
+            "admin_token": "admin-secret",
+            "node_token": "node-secret",
+        },  # content-guard: allow loopback-ipv4
+    )
+    remaining = list(pages)
+
+    def fake_open(request, timeout=None):
+        urls.append(request.full_url)
+        return _FakeResponse(remaining.pop(0) if remaining else {"items": [], "next_cursor": None})
+
+    monkeypatch.setattr(worklore_client, "_hub_open", fake_open)
+
+
+def test_list_items_all_follows_every_page(monkeypatch):
+    urls: list[str] = []
+    _paging_urlopen(
+        monkeypatch,
+        [
+            {"items": [{"work_id": "wl-1"}, {"work_id": "wl-2"}], "next_cursor": "cur-1"},
+            {"items": [{"work_id": "wl-3"}], "next_cursor": "cur-2"},
+            {"items": [{"work_id": "wl-4"}], "next_cursor": None},
+        ],
+        urls,
+    )
+    items = worklore_client.list_items_all(source="github", page_size=2)
+    assert [item["work_id"] for item in items] == ["wl-1", "wl-2", "wl-3", "wl-4"]
+    assert len(urls) == 3
+    assert "cursor" not in urls[0] and "limit=2" in urls[0] and "source=github" in urls[0]
+    assert "cursor=cur-1" in urls[1]
+    assert "cursor=cur-2" in urls[2]
+
+
+def test_list_items_all_refuses_a_cursor_cycle(monkeypatch):
+    urls: list[str] = []
+    _paging_urlopen(
+        monkeypatch,
+        [
+            {"items": [{"work_id": "wl-1"}], "next_cursor": "loop"},
+            {"items": [{"work_id": "wl-2"}], "next_cursor": "loop"},
+        ],
+        urls,
+    )
+    with pytest.raises(worklore_client.WorkloreListingError, match="did not advance"):
+        worklore_client.list_items_all(source="github", page_size=1)
+    assert len(urls) == 2
+
+
+def test_list_items_all_is_bounded_by_pages_and_items(monkeypatch):
+    urls: list[str] = []
+    _paging_urlopen(
+        monkeypatch,
+        [{"items": [{"work_id": f"wl-{index}"}], "next_cursor": f"cur-{index}"} for index in range(10)],
+        urls,
+    )
+    with pytest.raises(worklore_client.WorkloreListingError, match="exceeded 3 pages"):
+        worklore_client.list_items_all(page_size=1, max_pages=3)
+    urls.clear()
+    _paging_urlopen(
+        monkeypatch,
+        [{"items": [{"work_id": f"wl-{index}"}], "next_cursor": f"cur-{index}"} for index in range(10)],
+        urls,
+    )
+    with pytest.raises(worklore_client.WorkloreListingError, match="exceeded 2 items"):
+        worklore_client.list_items_all(page_size=1, max_items=2)
+
+
+def test_list_items_all_rejects_a_malformed_page(monkeypatch):
+    urls: list[str] = []
+    _paging_urlopen(monkeypatch, [{"items": "not-a-list"}], urls)
+    with pytest.raises(worklore_client.WorkloreListingError, match="items must be an array"):
+        worklore_client.list_items_all()
+    urls.clear()
+    _paging_urlopen(monkeypatch, [{"items": [], "next_cursor": 7}], urls)
+    with pytest.raises(worklore_client.WorkloreListingError, match="next_cursor must be a string"):
+        worklore_client.list_items_all()
+
+
+def test_list_item_links_all_follows_every_page_under_listing_bounds(monkeypatch):
+    urls: list[str] = []
+    _paging_urlopen(
+        monkeypatch,
+        [
+            {"item": {"work_id": "wl-1"}, "links": [{"link_id": "one"}], "links_next_cursor": "cur-1"},
+            {"item": {"work_id": "wl-1"}, "links": [{"link_id": "two"}], "links_next_cursor": None},
+        ],
+        urls,
+    )
+
+    links = worklore_client.list_item_links_all("wl-1", page_size=1)
+
+    assert [link["link_id"] for link in links] == ["one", "two"]
+    assert len(urls) == 2
+    assert "links_limit=1" in urls[0] and "links_cursor" not in urls[0]
+    assert "links_cursor=cur-1" in urls[1]
+
+
+def test_worklore_listing_error_stays_a_fleet_client_error():
+    assert issubclass(worklore_client.WorkloreListingError, worklore_client.FleetClientError)
+
+
+# --- transport hardening (Daybreak finding 1) --------------------------------
+
+_LOOPBACK = "127.0.0.1"  # content-guard: allow loopback-ipv4
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    """Records every request it sees; replies with the class's scripted response."""
+
+    seen: list[tuple[str, dict[str, str]]] = []
+    redirect_to: str | None = None
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        type(self).seen.append((self.path, {key.lower(): value for key, value in self.headers.items()}))
+        if type(self).redirect_to is not None:
+            self.send_response(302)
+            self.send_header("Location", type(self).redirect_to)
+            self.end_headers()
+            return
+        body = json.dumps({"items": [], "next_cursor": None}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args: object) -> None:
+        return
+
+
+@contextlib.contextmanager
+def _recording_server(*, redirect_to: str | None = None):
+    handler = type("_Handler", (_RecordingHandler,), {"seen": [], "redirect_to": redirect_to})
+    server = ThreadingHTTPServer((_LOOPBACK, 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{_LOOPBACK}:{server.server_address[1]}", handler.seen
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _settings(monkeypatch, hub_url: str, **overrides: str) -> None:
+    settings = {"hub_url": hub_url, "admin_token": "admin-secret", "node_token": "node-secret"}
+    settings.update(overrides)
+    monkeypatch.setattr(worklore_client, "load_fleet_settings", lambda: dict(settings))
+
+
+@pytest.mark.parametrize(
+    "hub_url",
+    [
+        "http://hub.example",
+        "http://hub.example:8080",
+        "http://192.0.2.10:8080",
+        "ftp://hub.example",
+        "file:///tmp/hub",
+        "hub.example",
+    ],
+)
+def test_cleartext_remote_hub_is_refused_before_the_token_is_sent(monkeypatch, hub_url):
+    _settings(monkeypatch, hub_url)
+
+    def unreachable(*_args, **_kwargs):
+        raise AssertionError("a refused hub URL must never be opened")
+
+    monkeypatch.setattr(worklore_client, "_hub_open", unreachable)
+    with pytest.raises(worklore_client.FleetClientError, match="must use https"):
+        worklore_client.list_items()
+    with pytest.raises(worklore_client.FleetClientError, match="must use https"):
+        worklore_client.create_item({"title": "Native", "kind": "fleet"})
+
+
+@pytest.mark.parametrize("hub_url", ["https://hub.example", "http://127.0.0.1:8787", "http://localhost:8787"])
+def test_https_and_loopback_http_hubs_are_allowed(monkeypatch, hub_url):
+    _settings(monkeypatch, hub_url)
+    seen: list[str] = []
+
+    def fake_open(request, timeout=None):
+        seen.append(request.full_url)
+        return _FakeResponse({"items": []})
+
+    monkeypatch.setattr(worklore_client, "_hub_open", fake_open)
+    assert worklore_client.list_items() == {"items": []}
+    assert seen == [f"{hub_url}/work/items"]
+
+
+def test_worklore_reuses_the_fleet_hub_opener():
+    """Worklore shares the fleet opener: an empty ProxyHandler (build_opener drops it
+    from ``handlers`` because it resolves nothing) and the origin-pinned redirect
+    handler, rather than bare ``urllib.request.urlopen``."""
+    from brigade import fleet_client
+
+    assert worklore_client._hub_open is fleet_client._hub_open
+    handlers = fleet_client._HUB_OPENER.handlers
+    assert not [h for h in handlers if isinstance(h, urllib.request.ProxyHandler)]
+    assert [h for h in handlers if isinstance(h, fleet_client._HubRedirectHandler)]
+
+
+def test_hub_traffic_ignores_proxy_environment(monkeypatch):
+    with _recording_server() as (hub_url, hub_seen), _recording_server() as (proxy_url, proxy_seen):
+        for name in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy"):
+            monkeypatch.setenv(name, proxy_url)
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        _settings(monkeypatch, hub_url)
+        assert worklore_client.list_items() == {"items": [], "next_cursor": None}
+    assert [path for path, _ in hub_seen] == ["/work/items"]
+    assert proxy_seen == [], "hub traffic reached a configured proxy"
+
+
+def test_cross_origin_redirect_is_refused_and_never_replays_the_token():
+    with _recording_server() as (other_url, other_seen):
+        with _recording_server(redirect_to=f"{other_url}/work/items") as (hub_url, hub_seen):
+            settings = {"hub_url": hub_url, "admin_token": "admin-secret", "node_token": "node-secret"}
+            original = worklore_client.load_fleet_settings
+            worklore_client.load_fleet_settings = lambda: dict(settings)  # type: ignore[assignment]
+            try:
+                with pytest.raises(worklore_client.FleetClientError, match="HTTP 302"):
+                    worklore_client.list_items()
+            finally:
+                worklore_client.load_fleet_settings = original  # type: ignore[assignment]
+        assert [path for path, _ in hub_seen] == ["/work/items"]
+    assert other_seen == [], "the bearer token followed a cross-origin redirect"
+
+
+def test_reads_prefer_the_node_token_and_admin_writes_stay_explicit(monkeypatch):
+    captured: dict[str, object] = {}
+    _capture_urlopen(monkeypatch, captured)
+    worklore_client.list_items()
+    assert captured["headers"]["authorization"] == "Bearer node-secret"
+    worklore_client.get_item("wl-1")
+    assert captured["headers"]["authorization"] == "Bearer node-secret"
+    worklore_client.burn_queue()
+    assert captured["headers"]["authorization"] == "Bearer node-secret"
+    assert worklore_client._token(admin=True) == "admin-secret"
+    assert worklore_client._token(admin=False) == "node-secret"
+
+
+def test_reads_fall_back_to_the_admin_token_only_when_no_node_token_exists(monkeypatch):
+    _settings(monkeypatch, f"http://{_LOOPBACK}:9", node_token="")
+    seen: list[str] = []
+
+    def fake_open(request, timeout=None):
+        seen.append(dict(request.header_items())["Authorization"])
+        return _FakeResponse({"items": []})
+
+    monkeypatch.setattr(worklore_client, "_hub_open", fake_open)
+    worklore_client.list_items()
+    assert seen == ["Bearer admin-secret"]
+    with pytest.raises(worklore_client.FleetClientError, match="no fleet node token"):
+        worklore_client.create_item({"title": "Native", "kind": "fleet"})
+
+
+def test_oversized_success_response_is_refused(monkeypatch):
+    _settings(monkeypatch, f"http://{_LOOPBACK}:9")
+    oversized = b"x" * (worklore_client.MAX_RESPONSE_BYTES + 1)
+
+    class _Flood:
+        def read(self, amt=None):
+            return oversized if amt is None else oversized[:amt]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(worklore_client, "_hub_open", lambda request, timeout=None: _Flood())
+    with pytest.raises(worklore_client.FleetClientError, match="response exceeded"):
+        worklore_client.list_items()
+
+
+def test_oversized_http_error_body_still_maps_to_a_stable_refusal(monkeypatch):
+    _settings(monkeypatch, f"http://{_LOOPBACK}:9")
+    oversized = io.BytesIO(b"{" + b"x" * (worklore_client.MAX_ERROR_RESPONSE_BYTES + 1))
+
+    def fake_open(request, timeout=None):
+        raise urllib.error.HTTPError(request.full_url, 500, "Server Error", {}, oversized)
+
+    monkeypatch.setattr(worklore_client, "_hub_open", fake_open)
+    with pytest.raises(worklore_client.FleetClientError) as excinfo:
+        worklore_client.list_items()
+    message = str(excinfo.value)
+    assert message == "fleet hub work failed: HTTP 500"
+    assert "x" * 100 not in message
+
+
+def test_hub_error_text_is_sanitized_and_preserves_its_error_code(monkeypatch):
+    _settings(monkeypatch, f"http://{_LOOPBACK}:9")
+    refusal = io.BytesIO(json.dumps({"code": "version-conflict", "error": "stale\r\n\x1b[2J version"}).encode())
+
+    def fake_open(request, timeout=None):
+        raise urllib.error.HTTPError(request.full_url, 409, "Conflict", {}, refusal)
+
+    monkeypatch.setattr(worklore_client, "_hub_open", fake_open)
+    with pytest.raises(worklore_client.WorkloreClientError) as excinfo:
+        worklore_client.list_items()
+    assert excinfo.value.code == "version-conflict"
+    assert str(excinfo.value) == "fleet hub work failed: HTTP 409: stale [2J version"
+
+
+def test_fleet_work_json_error_sanitizes_terminal_controls_and_keeps_code(monkeypatch, capsys):
+    monkeypatch.setattr(
+        worklore_client,
+        "list_items",
+        lambda source=None: (_ for _ in ()).throw(
+            worklore_client.WorkloreClientError("fleet hub work failed: stale\x1b[2J version", code="version-conflict")
+        ),
+    )
+
+    assert fleet_cli._dispatch_work_list(argparse.Namespace(source=None, json=True)) == 1
+    assert json.loads(capsys.readouterr().err) == {
+        "code": "version-conflict",
+        "error": "fleet hub work failed: stale [2J version",
+    }
+
+
+def test_a_response_without_a_bounded_read_is_refused(monkeypatch):
+    _settings(monkeypatch, f"http://{_LOOPBACK}:9")
+
+    class _Unbounded:
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(worklore_client, "_hub_open", lambda request, timeout=None: _Unbounded())
+    with pytest.raises(worklore_client.FleetClientError, match="bounded reads"):
+        worklore_client.list_items()
+
+
+def test_burn_queue_passes_paging_through_and_omits_it_by_default(monkeypatch):
+    captured: dict[str, object] = {}
+    _capture_urlopen(monkeypatch, captured, {"items": [], "exclusions": {}, "next_cursor": None})
+    worklore_client.burn_queue()
+    assert captured["url"] == "http://127.0.0.1:9/work/queue/burn"  # content-guard: allow loopback-ipv4
+    worklore_client.burn_queue(limit=10, cursor="cur-1")
+    assert "limit=10" in str(captured["url"]) and "cursor=cur-1" in str(captured["url"])

--- a/tests/test_worklore_github.py
+++ b/tests/test_worklore_github.py
@@ -1,0 +1,1568 @@
+# Synthetic rejection fixtures retain private paths to exercise redaction.
+# content-guard: allow home-path file
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import types
+
+import pytest
+from brigade import cli, fleet_hub, worklore_store, worklore_validate
+from brigade import worklore_github as gh
+from brigade import worklore_github_sync as sync
+from brigade.cli import fleet as fleet_cli
+from tests.support import PRIVATE_DIRECTORY_MODE, PRIVATE_FILE_MODE, assert_private_mode
+
+PUBLIC_ORG = [{"name": "escoffier-labs", "visibility": "public"}]
+EXISTING_LINKED_ITEM = {
+    "title": "Existing title",
+    "acceptance": ["operator acceptance"],
+    "links": [
+        {
+            "link_type": "github",
+            "external_key": "escoffier-labs/brigade#12",
+            "source_acceptance": ["existing acceptance"],
+            "source_policy": "eligible",
+            "url": "https://github.com/escoffier-labs/brigade/issues/12",
+            "external_updated_at": "2026-08-28T12:00:00Z",
+        }
+    ],
+}
+
+
+def test_normalize_open_labeled_issue() -> None:
+    observation = gh.normalize_issue(
+        {
+            "number": 12,
+            "title": "Rotate restic password",
+            "body": "## Acceptance\n- restic snapshots --latest 1 succeeds\n",
+            "labels": [{"name": "burn-queue"}, {"name": "ops"}],
+            "state": "OPEN",
+            "url": "https://github.com/Escoffier-Labs/brigade/issues/12",
+            "updatedAt": "2026-08-29T12:00:00Z",
+            "repository": {"nameWithOwner": "Escoffier-Labs/brigade"},
+        }
+    )
+    assert observation["external_key"] == "escoffier-labs/brigade#12"
+    assert observation["link_type"] == "github"
+    assert observation["title"] == "Rotate restic password"
+    assert observation["acceptance"] == ["restic snapshots --latest 1 succeeds"]
+    assert observation["source_policy"] == "eligible"
+    assert observation["proposed_status"] is None
+    assert observation["url"] == "https://github.com/Escoffier-Labs/brigade/issues/12"
+    assert observation["external_updated_at"] == "2026-08-29T12:00:00Z"
+    assert "body" not in observation
+    assert "labels" not in observation
+    assert "source_type" not in observation
+
+
+def test_label_removal_and_close_are_observations_not_transitions() -> None:
+    closed = gh.normalize_issue(
+        {
+            "number": 3,
+            "title": "Done work",
+            "body": "",
+            "labels": [{"name": "burn-queue"}],
+            "state": "CLOSED",
+            "url": "https://github.com/escoffier-labs/brigade/issues/3",
+            "updatedAt": "2026-08-29T12:00:00Z",
+            "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+        }
+    )
+    assert closed["source_policy"] == "closed"
+    assert closed["proposed_status"] == "completed"
+    unlabeled = gh.normalize_issue(
+        {
+            "number": 4,
+            "title": "Still open",
+            "body": "",
+            "labels": [{"name": "docs"}],
+            "state": "OPEN",
+            "url": "https://github.com/escoffier-labs/brigade/issues/4",
+            "updatedAt": "2026-08-29T12:00:00Z",
+            "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+        }
+    )
+    assert unlabeled["source_policy"] == "label-removed"
+    assert unlabeled["proposed_status"] is None
+
+
+def test_normalize_rejects_tokens_home_paths_and_http_urls() -> None:
+    base = {
+        "number": 1,
+        "title": "Bad",
+        "body": "",
+        "labels": [{"name": "burn-queue"}],
+        "state": "OPEN",
+        "updatedAt": "2026-08-29T12:00:00Z",
+        "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+    }
+    private_keys = (
+        "token",
+        "secret",
+        "password",
+        "authorization",
+        "prompt",
+        "transcript",
+        "receipt",
+        "path",
+    )
+    for key in private_keys:
+        with pytest.raises(gh.GitHubObservationError, match="unknown-field"):
+            gh.normalize_issue(
+                {
+                    **base,
+                    "url": "https://github.com/escoffier-labs/brigade/issues/1",
+                    key: "abc",
+                }
+            )
+    with pytest.raises(gh.GitHubObservationError, match="field-bound"):
+        gh.normalize_issue({**base, "url": "http://github.com/escoffier-labs/brigade/issues/1"})
+    with pytest.raises(gh.GitHubObservationError, match="private-data"):
+        gh.normalize_issue(
+            {
+                **base,
+                "url": "https://github.com/escoffier-labs/brigade/issues/1",
+                "body": "see /home/operator/secret",
+            }
+        )
+    with pytest.raises(gh.GitHubObservationError, match="private-data"):
+        gh.normalize_issue(
+            {
+                **base,
+                "url": "https://github.com/escoffier-labs/brigade/issues/1",
+                "title": r"notes in C:\Users\operator",
+            }
+        )
+    with pytest.raises(gh.GitHubObservationError, match="private-data"):
+        gh.normalize_issue(
+            {
+                **base,
+                "url": "https://github.com/escoffier-labs/brigade/issues/1",
+                "body": r"see C:\Users\operator\secret",
+            }
+        )
+
+
+def _oversized_issue(**overrides: object) -> dict[str, object]:
+    body = "## Acceptance\n" + "".join(f"- criterion {index} {'x' * 500}\n" for index in range(25))
+    issue: dict[str, object] = {
+        "number": 12,
+        "title": f"  {'T' * 400}  ",
+        "body": body,
+        "labels": [{"name": "burn-queue"}],
+        "state": "OPEN",
+        "url": "https://github.com/escoffier-labs/brigade/issues/12",
+        "updatedAt": "2026-08-29T12:00:00Z",
+        "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+    }
+    issue.update(overrides)
+    return issue
+
+
+def test_normalize_bounds_title_and_acceptance_to_the_hub_contract() -> None:
+    observation = gh.normalize_issue(_oversized_issue())
+    assert observation["title"] == "T" * worklore_validate.TITLE_MAX
+    assert len(observation["acceptance"]) == worklore_validate.ACCEPTANCE_MAX_ITEMS
+    assert all(item.strip() for item in observation["acceptance"])
+    assert all(len(item) <= worklore_validate.ACCEPTANCE_ITEM_MAX for item in observation["acceptance"])
+
+
+def test_normalize_rejects_control_characters_the_hub_refuses() -> None:
+    with pytest.raises(gh.GitHubObservationError, match="field-bound"):
+        gh.normalize_issue(_oversized_issue(title="Rotate\x07restic"))
+
+
+def test_bounded_issue_observation_is_accepted_by_the_real_store(tmp_path) -> None:
+    conn = fleet_hub.init_db(tmp_path / "hub.db")
+
+    worklore_store.ensure_schema(conn)
+    result = worklore_store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="github:escoffier-labs:bounded",
+        observations=[gh.normalize_issue(_oversized_issue())],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    assert result["created"] == 1
+
+
+def test_load_config_requires_explicit_orgs(tmp_path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "fleet.toml").write_text('[fleet.worklore.github]\nlabel = "burn-queue"\n')
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    with pytest.raises(sync.GitHubSyncError, match="orgs"):
+        sync.load_github_config()
+
+
+def test_discover_uses_octopool_when_present(monkeypatch) -> None:
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/octopool" if name == "octopool" else None)
+    recorded = {}
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        recorded["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+    assert recorded["argv"][:3] == ["octopool", "gh", "search"]
+    assert recorded["env"]["OCTOPOOL_NO_FALLBACK"] == "1"
+    assert "--token" not in recorded["argv"]
+    assert "--state" not in recorded["argv"]
+    assert "--limit" in recorded["argv"]
+    assert recorded["argv"][recorded["argv"].index("--limit") + 1] == "500"
+
+
+def test_discover_refuses_a_search_that_hits_the_hard_result_ceiling(monkeypatch) -> None:
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    issues = [
+        {
+            "number": number,
+            "title": "Queued work",
+            "body": "",
+            "labels": [{"name": "burn-queue"}],
+            "state": "OPEN",
+            "url": f"https://github.com/escoffier-labs/brigade/issues/{number}",
+            "updatedAt": "2026-08-29T12:00:00Z",
+            "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+        }
+        for number in range(sync.BATCH_SIZE)
+    ]
+    monkeypatch.setattr(
+        sync.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=json.dumps(issues), stderr=""),
+    )
+
+    with pytest.raises(sync.GitHubSyncError) as excinfo:
+        sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+
+    assert excinfo.value.code == "search-truncated"
+    assert str(excinfo.value) == "search-truncated: search result limit reached"
+
+
+def test_discover_falls_back_to_gh_and_rejects_non_json(monkeypatch) -> None:
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/gh" if name == "gh" else None)
+    recorded = {}
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0, stdout="not-json", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.GitHubSyncError, match="retryable-adapter-failure") as excinfo:
+        sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+    assert recorded["argv"][0] == "gh"
+    assert "not-json" not in str(excinfo.value)
+
+
+def test_discover_rejects_non_array_json(monkeypatch) -> None:
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.GitHubSyncError, match="retryable-adapter-failure"):
+        sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+
+
+def test_discover_subprocess_failure_is_bounded(monkeypatch) -> None:
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(
+            argv,
+            2,
+            stdout="token=abc",
+            stderr="authorization bearer /home/operator",
+        )
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.GitHubSyncError, match="retryable-adapter-failure") as excinfo:
+        sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+    message = str(excinfo.value)
+    assert "token" not in message
+    assert "authorization" not in message
+    assert "bearer" not in message
+    assert "/home/" not in message
+    assert "abc" not in message
+
+
+def test_private_org_never_uses_octopool(monkeypatch) -> None:
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/octopool")
+    recorded = {}
+
+    def fake_run(argv, **kwargs):
+        recorded["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    sync.discover_issues(
+        [{"name": "escoffier-labs", "visibility": "private"}],
+        label="burn-queue",
+        state="all",
+    )
+    assert recorded["argv"][0] == "gh"
+
+
+def test_discover_maps_explicit_state_flags(monkeypatch) -> None:
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    recorded: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        recorded.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="open")
+    sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="closed")
+    assert recorded[0][recorded[0].index("--state") + 1] == "open"
+    assert recorded[1][recorded[1].index("--state") + 1] == "closed"
+
+
+def test_discover_rejects_unknown_state(monkeypatch) -> None:
+    with pytest.raises(sync.GitHubSyncError, match="state"):
+        sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="merged")
+
+
+def test_reconcile_refreshes_previously_linked_issue_missing_from_label_search(monkeypatch) -> None:
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=json.dumps(
+                {
+                    "number": 12,
+                    "title": "Removed label",
+                    "body": "",
+                    "labels": [],
+                    "state": "OPEN",
+                    "url": "https://github.com/escoffier-labs/brigade/issues/12",
+                    "updatedAt": "2026-08-29T12:00:00Z",
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        sync.shutil,
+        "which",
+        lambda name: "/usr/bin/octopool" if name == "octopool" else "/usr/bin/gh",
+    )
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[
+            {
+                "title": "Removed label",
+                "links": [
+                    {
+                        "link_type": "github",
+                        "external_key": "escoffier-labs/brigade#12",
+                        "source_acceptance": [],
+                        "source_policy": "eligible",
+                        "url": "https://github.com/escoffier-labs/brigade/issues/12",
+                        "external_updated_at": "2026-08-28T12:00:00Z",
+                    }
+                ],
+            }
+        ],
+    )
+    assert observations[0]["source_policy"] == "label-removed"
+    assert observations[0]["external_key"] == "escoffier-labs/brigade#12"
+    assert observations[0]["title"] == "Removed label"
+    assert "body" not in observations[0]
+    assert "labels" not in observations[0]
+    view_calls = [argv for argv in calls if "view" in argv]
+    assert view_calls
+    assert all("repository" not in argv for argv in view_calls)
+    assert "--repo" in view_calls[0]
+    assert view_calls[0][view_calls[0].index("--repo") + 1] == "escoffier-labs/brigade"
+
+
+def test_pooled_404_is_inconclusive(monkeypatch) -> None:
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="HTTP 404")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: "/usr/bin/octopool" if name == "octopool" else None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[EXISTING_LINKED_ITEM],
+    )
+    assert observations == []
+
+
+def test_direct_gh_exact_http_404_emits_stale_tombstone(monkeypatch) -> None:
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="HTTP 404")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[EXISTING_LINKED_ITEM],
+    )
+    assert len(observations) == 1
+    observation = observations[0]
+    assert observation["stale"] is True
+    assert observation["title"] == "Existing title"
+    assert observation["acceptance"] == ["existing acceptance"]
+    assert observation["source_policy"] == "eligible"
+    assert observation["url"] == "https://github.com/escoffier-labs/brigade/issues/12"
+    assert observation["external_updated_at"] == "2026-08-28T12:00:00Z"
+    assert observation["acceptance"] != EXISTING_LINKED_ITEM["acceptance"]
+
+
+@pytest.mark.parametrize(
+    ("stdout", "stderr"),
+    [
+        ("", "temporary adapter failure for project404"),
+        ("upstream error message mentions 404", ""),
+    ],
+)
+def test_direct_gh_incidental_404_text_is_retryable(monkeypatch, stdout: str, stderr: str) -> None:
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.GitHubSyncError, match="retryable-adapter-failure"):
+        sync.discover_and_reconcile(
+            PUBLIC_ORG,
+            label="burn-queue",
+            state="all",
+            existing_items=[EXISTING_LINKED_ITEM],
+        )
+
+
+def test_http_404_classifier_accepts_exact_signal_or_structured_status() -> None:
+    assert sync._is_http_404(subprocess.CompletedProcess([], 1, stdout="", stderr="HTTP 404"))
+    assert sync._is_http_404(subprocess.CompletedProcess([], 1, stdout='{"status": 404}', stderr=""))
+
+
+def test_reconcile_skips_existing_link_outside_configured_orgs(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[
+            {
+                "title": "Foreign linked",
+                "links": [
+                    {
+                        "link_type": "github",
+                        "external_key": "another-org/repo#9",
+                        "source_acceptance": [],
+                        "source_policy": "eligible",
+                        "url": "https://github.com/another-org/repo/issues/9",
+                    }
+                ],
+            }
+        ],
+    )
+    assert observations == []
+    assert len(calls) == 1
+    assert "search" in calls[0]
+    assert "view" not in calls[0]
+    assert calls[0][calls[0].index("--owner") + 1] == "escoffier-labs"
+
+
+def test_discover_rejects_foreign_owner_from_org_search(monkeypatch) -> None:
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "title": "Foreign",
+                        "body": "",
+                        "labels": [{"name": "burn-queue"}],
+                        "state": "OPEN",
+                        "url": "https://github.com/another-org/repo/issues/1",
+                        "updatedAt": "2026-08-29T12:00:00Z",
+                        "repository": {"nameWithOwner": "another-org/repo"},
+                    }
+                ]
+            ),
+            stderr="search stderr leaked",
+        )
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    with pytest.raises(sync.GitHubSyncError, match="retryable-adapter-failure") as excinfo:
+        sync.discover_issues(PUBLIC_ORG, label="burn-queue", state="all")
+    message = str(excinfo.value)
+    assert "another-org" not in message
+    assert "payload" not in message
+    assert "https://" not in message
+    assert "github.com" not in message
+    assert "stdout" not in message
+    assert "stderr" not in message
+    assert "search stderr leaked" not in message
+
+
+def _linked_item(link: dict[str, object], *, title: str = "Existing title") -> dict[str, object]:
+    return {"title": title, "links": [link]}
+
+
+def test_tombstone_skips_and_counts_mismatched_or_non_https_url(monkeypatch) -> None:
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="HTTP 404")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    mismatched = _linked_item(
+        {
+            "link_type": "github",
+            "external_key": "escoffier-labs/brigade#12",
+            "source_acceptance": ["existing acceptance"],
+            "source_policy": "eligible",
+            "url": "https://github.com/other-org/other-repo/issues/12",
+        }
+    )
+    http_url = _linked_item(
+        {
+            "link_type": "github",
+            "external_key": "escoffier-labs/brigade#13",
+            "source_acceptance": ["existing acceptance"],
+            "source_policy": "eligible",
+            "url": "http://github.com/escoffier-labs/brigade/issues/13",
+        }
+    )
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[mismatched, http_url],
+    )
+    assert observations == []
+    assert observations.skipped == 2
+
+
+def test_tombstone_bounds_title_and_acceptance_to_the_hub_contract(monkeypatch) -> None:
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="HTTP 404")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[
+            _linked_item(
+                {
+                    "link_type": "github",
+                    "external_key": "escoffier-labs/brigade#12",
+                    "source_acceptance": [f"criterion {index} {'x' * 500}" for index in range(25)],
+                    "source_policy": "eligible",
+                    "url": "https://github.com/escoffier-labs/brigade/issues/12",
+                },
+                title="T" * 400,
+            )
+        ],
+    )
+    tombstone = observations[0]
+    assert tombstone["stale"] is True
+    assert tombstone["title"] == "T" * worklore_validate.TITLE_MAX
+    assert len(tombstone["acceptance"]) == worklore_validate.ACCEPTANCE_MAX_ITEMS
+    assert all(len(item) <= worklore_validate.ACCEPTANCE_ITEM_MAX for item in tombstone["acceptance"])
+
+
+def test_malformed_existing_github_links_are_skipped_and_counted(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[
+            "not-an-item",
+            {"title": "Bad links", "links": "not-a-list"},
+            {"title": "Bad link", "links": ["not-a-link"]},
+            {"title": "Bad key", "links": [{"link_type": "github", "external_key": "escoffier-labs/brigade"}]},
+            {"title": "Bad number", "links": [{"link_type": "github", "external_key": "escoffier-labs/brigade#0"}]},
+            {"title": "Other source", "links": [{"link_type": "brigade", "external_key": "not-parsed"}]},
+        ],
+    )
+    assert observations == []
+    assert observations.skipped == 5
+    assert all("view" not in argv for argv in calls)
+
+
+def test_reconcile_pages_a_truncated_link_projection_before_refreshing(monkeypatch) -> None:
+    existing = {"work_id": "wl-hidden-link", "links": [], "links_truncated": True}
+    hidden_link = {
+        "link_type": "github",
+        "external_key": "escoffier-labs/brigade#12",
+        "source_acceptance": ["existing acceptance"],
+        "source_policy": "eligible",
+        "url": "https://github.com/escoffier-labs/brigade/issues/12",
+    }
+    calls: list[object] = []
+    monkeypatch.setattr(sync, "discover_issues", lambda *args, **kwargs: sync._DiscoveryResult())
+    monkeypatch.setattr(
+        sync.worklore_client, "list_item_links_all", lambda work_id: calls.append(work_id) or [hidden_link]
+    )
+    monkeypatch.setattr(sync, "_refresh_missing_link", lambda **kwargs: calls.append(kwargs) or dict(SYNC_OBSERVATION))
+
+    observations = sync.discover_and_reconcile(PUBLIC_ORG, label="burn-queue", state="all", existing_items=[existing])
+
+    assert calls[0] == "wl-hidden-link"
+    assert calls[1]["number"] == 12
+    assert [item["external_key"] for item in observations] == [SYNC_OBSERVATION["external_key"]]
+
+
+def test_malformed_link_does_not_block_healthy_issues(tmp_path, monkeypatch) -> None:
+    healthy = {
+        "number": 7,
+        "title": "Healthy",
+        "body": "",
+        "labels": [{"name": "burn-queue"}],
+        "state": "OPEN",
+        "url": "https://github.com/escoffier-labs/brigade/issues/7",
+        "updatedAt": "2026-08-29T12:00:00Z",
+        "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+    }
+    posts: list[dict[str, object]] = []
+    monkeypatch.setattr(sync.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        sync.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=json.dumps([healthy]), stderr=""),
+    )
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "list_items",
+        lambda source=None, **_page: {
+            "items": [{"title": "Bad key", "links": [{"link_type": "github", "external_key": 7}]}]
+        },
+    )
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: posts.append(payload) or {})
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_github(orgs=PUBLIC_ORG)
+    assert result["skipped"] == 1
+    assert [obs["external_key"] for obs in posts[0]["observations"]] == ["escoffier-labs/brigade#7"]
+    receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    assert receipt["skipped"] == 1
+
+
+SYNC_OBSERVATION = {
+    "external_key": "escoffier-labs/brigade#12",
+    "link_type": "github",
+    "title": "Rotate restic password",
+    "acceptance": ["restic snapshots --latest 1 succeeds"],
+    "source_policy": "eligible",
+    "proposed_status": None,
+    "url": "https://github.com/escoffier-labs/brigade/issues/12",
+    "external_updated_at": "2026-08-29T12:00:00Z",
+}
+
+
+def _observation(*, number: int, org: str = "escoffier-labs", title: str | None = None) -> dict[str, object]:
+    owner = org.lower()
+    return {
+        "external_key": f"{owner}/brigade#{number}",
+        "link_type": "github",
+        "title": title or f"Issue {number}",
+        "acceptance": [f"check {number}"],
+        "source_policy": "eligible",
+        "proposed_status": None,
+        "url": f"https://github.com/{owner}/brigade/issues/{number}",
+        "external_updated_at": "2026-08-29T12:00:00Z",
+    }
+
+
+def _batch_key(org: str, observations: list[dict[str, object]]) -> str:
+    digest = worklore_store.observation_fingerprint(observations)
+    return f"github:{org.lower()}:{digest}"
+
+
+def _assert_no_leak(message: str) -> None:
+    lowered = message.lower()
+    for fragment in (
+        "https://",
+        "http://",
+        "token",
+        "authorization",
+        "bearer",
+        "rotate restic",
+        "/work/imports",
+        "payload",
+        "exception",
+    ):
+        assert fragment not in lowered
+
+
+def test_sync_posts_one_batch_and_skips_duplicate_revision(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    list_calls: list[str | None] = []
+    discover_calls: list[dict[str, object]] = []
+    hub_items = [EXISTING_LINKED_ITEM]
+
+    def fake_import_batch(payload):
+        posts.append(payload)
+        return {"created": 1 if len(posts) == 1 else 0, "updated": 0 if len(posts) == 1 else 1}
+
+    def fake_list_items(source=None, **_page):
+        list_calls.append(source)
+        return {"items": hub_items}
+
+    def fake_discover(orgs, *, label, state, existing_items, budget=None):
+        discover_calls.append({"orgs": orgs, "label": label, "state": state, "existing_items": existing_items})
+        return [dict(SYNC_OBSERVATION)]
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import_batch)
+    monkeypatch.setattr(sync.worklore_client, "list_items", fake_list_items)
+    monkeypatch.setattr(sync, "discover_and_reconcile", fake_discover)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    first = sync.sync_github(orgs=PUBLIC_ORG)
+    second = sync.sync_github(orgs=PUBLIC_ORG)
+    assert first["posted"] == 1 and second["posted"] == 1
+    assert first["observation_count"] == 1
+    assert list_calls == ["github", "github"]
+    assert discover_calls[0]["orgs"] == [{"name": "escoffier-labs", "visibility": "public"}]
+    assert discover_calls[0]["existing_items"] == hub_items
+    assert discover_calls[0]["label"] == "burn-queue"
+    assert discover_calls[0]["state"] == "all"
+    assert posts[0]["adapter_id"] == "github:escoffier-labs"
+    assert posts[0]["source_type"] == "github"
+    assert set(posts[0]) == {"adapter_id", "source_type", "idempotency_key", "observations"}
+    assert posts[0]["idempotency_key"] == posts[1]["idempotency_key"]
+    assert posts[0]["idempotency_key"] == _batch_key("escoffier-labs", [SYNC_OBSERVATION])
+    assert posts[0]["idempotency_key"].startswith("github:escoffier-labs:")
+    receipt_path = tmp_path / "worklore" / "github" / "github-escoffier-labs.json"
+    receipt = json.loads(receipt_path.read_text())
+    assert set(receipt) == {
+        "adapter_id",
+        "idempotency_key",
+        "observation_count",
+        "refused",
+        "skipped",
+        "last_error_code",
+        "updated_at",
+    }
+    assert receipt["refused"] == 0
+    assert receipt["adapter_id"] == "github:escoffier-labs"
+    assert receipt["idempotency_key"] == posts[0]["idempotency_key"]
+    assert receipt["observation_count"] == 1
+    assert receipt["skipped"] == 0
+    assert receipt["last_error_code"] is None
+    assert "Rotate restic" not in json.dumps(receipt)
+    assert_private_mode(receipt_path, PRIVATE_FILE_MODE)
+    assert_private_mode(receipt_path.parent, PRIVATE_DIRECTORY_MODE)
+
+
+def test_empty_discovery_posts_one_empty_batch(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: posts.append(payload) or {})
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: [],
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_github(orgs=PUBLIC_ORG)
+    assert result["posted"] == 1
+    assert result["observation_count"] == 0
+    assert len(posts) == 1
+    assert posts[0]["observations"] == []
+    assert posts[0]["adapter_id"] == "github:escoffier-labs"
+    assert posts[0]["idempotency_key"] == _batch_key("escoffier-labs", [])
+    receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    assert receipt["observation_count"] == 0
+
+
+def test_sync_splits_501_observations_into_two_batches(tmp_path, monkeypatch) -> None:
+    observations = [_observation(number=index) for index in range(1, 502)]
+    posts: list[dict[str, object]] = []
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: posts.append(payload) or {})
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: list(observations),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_github(orgs=PUBLIC_ORG)
+    assert result["posted"] == 2
+    assert result["observation_count"] == 501
+    assert [len(post["observations"]) for post in posts] == [500, 1]
+    canonical = sorted(observations, key=lambda item: item["external_key"])
+    assert posts[0]["observations"] == canonical[:500]
+    assert posts[1]["observations"] == canonical[500:]
+    assert posts[0]["idempotency_key"] == _batch_key("escoffier-labs", canonical[:500])
+    assert posts[1]["idempotency_key"] == _batch_key("escoffier-labs", canonical[500:])
+    assert all(len(post["idempotency_key"]) <= 256 for post in posts)
+    assert posts[0]["idempotency_key"] != posts[1]["idempotency_key"]
+
+
+def test_sync_posts_configured_orgs_independently(tmp_path, monkeypatch) -> None:
+    orgs = [
+        {"name": "escoffier-labs", "visibility": "public"},
+        {"name": "Lidless-Labs", "visibility": "public"},
+    ]
+    posts: list[dict[str, object]] = []
+    discover_orgs: list[object] = []
+    list_calls: list[str | None] = []
+    first_obs = _observation(number=1, org="escoffier-labs", title="First org only")
+    second_obs = _observation(number=2, org="Lidless-Labs", title="Second org only")
+
+    def fake_list_items(source=None, **_page):
+        list_calls.append(source)
+        return {"items": []}
+
+    def fake_discover(discovered, *, label, state, existing_items, budget=None):
+        discover_orgs.append(discovered)
+        name = discovered[0]["name"].lower()
+        if name == "escoffier-labs":
+            return [first_obs]
+        return [second_obs]
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: posts.append(payload) or {})
+    monkeypatch.setattr(sync.worklore_client, "list_items", fake_list_items)
+    monkeypatch.setattr(sync, "discover_and_reconcile", fake_discover)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_github(orgs=orgs)
+    assert list_calls == ["github"]
+    assert discover_orgs == [
+        [{"name": "escoffier-labs", "visibility": "public"}],
+        [{"name": "Lidless-Labs", "visibility": "public"}],
+    ]
+    assert [post["adapter_id"] for post in posts] == ["github:escoffier-labs", "github:lidless-labs"]
+    assert posts[0]["observations"] == [first_obs]
+    assert posts[1]["observations"] == [second_obs]
+    assert first_obs not in posts[1]["observations"]
+    assert second_obs not in posts[0]["observations"]
+    assert result["posted"] == 2
+    first_receipt = tmp_path / "worklore" / "github" / "github-escoffier-labs.json"
+    second_receipt = tmp_path / "worklore" / "github" / "github-lidless-labs.json"
+    assert json.loads(first_receipt.read_text())["adapter_id"] == "github:escoffier-labs"
+    assert json.loads(second_receipt.read_text())["adapter_id"] == "github:lidless-labs"
+    assert_private_mode(first_receipt, PRIVATE_FILE_MODE)
+    assert_private_mode(second_receipt, PRIVATE_FILE_MODE)
+    assert_private_mode(first_receipt.parent, PRIVATE_DIRECTORY_MODE)
+
+
+def test_multi_org_sync_completes_link_projections_once(tmp_path, monkeypatch) -> None:
+    orgs = [
+        {"name": "escoffier-labs", "visibility": "public"},
+        {"name": "lidless-labs", "visibility": "public"},
+    ]
+    items = [{"work_id": "wl-1", "links": [], "links_truncated": True}]
+    completed = [{"work_id": "wl-1", "links": [], "links_truncated": False}]
+    completion_calls: list[object] = []
+    discovery_items: list[object] = []
+
+    def complete(existing_items):
+        completion_calls.append(existing_items)
+        return completed
+
+    def discover(_orgs, *, label, state, existing_items, budget=None):
+        discovery_items.append(existing_items)
+        return []
+
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": items})
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda _payload: {})
+    monkeypatch.setattr(sync, "_complete_link_projections", complete)
+    monkeypatch.setattr(sync, "discover_and_reconcile", discover)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+
+    sync.sync_github(orgs=orgs)
+
+    assert completion_calls == [items]
+    assert discovery_items == [completed, completed]
+
+
+def test_hub_refusals_do_not_stop_later_github_chunks_or_orgs(tmp_path, monkeypatch) -> None:
+    orgs = [
+        {"name": "escoffier-labs", "visibility": "public"},
+        {"name": "lidless-labs", "visibility": "public"},
+    ]
+    first = [_observation(number=number, org="escoffier-labs") for number in range(1, 502)]
+    second = [_observation(number=1, org="lidless-labs")]
+    posts: list[dict[str, object]] = []
+
+    def fake_discover(discovered, **_kwargs):
+        return first if discovered[0]["name"] == "escoffier-labs" else second
+
+    def fake_import(payload):
+        posts.append(payload)
+        return {"refused": 1} if len(posts) == 1 else {"created": len(payload["observations"])}
+
+    monkeypatch.setattr(sync, "discover_and_reconcile", fake_discover)
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+
+    result = sync.sync_github(orgs=orgs)
+
+    assert [post["adapter_id"] for post in posts] == [
+        "github:escoffier-labs",
+        "github:escoffier-labs",
+        "github:lidless-labs",
+    ]
+    assert result["posted"] == 3
+    assert result["observation_count"] == 502
+    assert result["refused"] == 1
+    assert result["skipped"] == 0
+    first_receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    second_receipt = json.loads((tmp_path / "worklore" / "github" / "github-lidless-labs.json").read_text())
+    assert (first_receipt["refused"], first_receipt["last_error_code"]) == (1, "hub-partial")
+    assert (second_receipt["refused"], second_receipt["last_error_code"]) == (0, None)
+
+
+def test_sync_sorts_before_fingerprinting_the_full_posted_chunk(tmp_path, monkeypatch) -> None:
+    first = _observation(number=1, title="Alpha title must not change the key")
+    second = _observation(number=2, title="Beta title must not change the key")
+    posts: list[dict[str, object]] = []
+    sequence = [[first, second], [second, first]]
+
+    def fake_discover(orgs, *, label, state, existing_items, budget=None):
+        return [dict(item) for item in sequence.pop(0)]
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: posts.append(payload) or {})
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(sync, "discover_and_reconcile", fake_discover)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    sync.sync_github(orgs=PUBLIC_ORG)
+    sync.sync_github(orgs=PUBLIC_ORG)
+    canonical = sorted([first, second], key=lambda item: item["external_key"])
+    expected = _batch_key("escoffier-labs", canonical)
+    assert posts[0]["idempotency_key"] == expected
+    assert posts[1]["idempotency_key"] == expected
+    extra = dict(first)
+    extra["title"] = "Different title changes the posted chunk"
+    extra["url"] = "https://github.com/escoffier-labs/brigade/issues/99"
+    assert _batch_key("escoffier-labs", [extra, second]) != expected
+    assert len(expected) <= 256
+
+
+def test_sync_canonicalizes_full_chunks_and_real_store_accepts_source_changes(tmp_path, monkeypatch) -> None:
+    conn = fleet_hub.init_db(tmp_path / "hub.db")
+    from brigade import worklore_store as store
+
+    store.ensure_schema(conn)
+    first = [_observation(number=2, title="Second"), _observation(number=1, title="First")]
+    changed = [dict(first[0]), dict(first[1])]
+    changed[1]["acceptance"] = ["new source acceptance"]
+    # A real source stamps a changed issue with a newer updatedAt, and the hub's rollback
+    # guard requires exactly that before it applies the change.
+    changed[1]["external_updated_at"] = "2026-08-30T12:00:00Z"
+    posted: list[dict[str, object]] = []
+
+    def fake_import(payload):
+        posted.append(payload)
+        return store.import_batch(conn, actor_id="node-a", owner_node="node-a", **payload)
+
+    sequence = [first, list(reversed(changed))]
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import)
+    monkeypatch.setattr(
+        sync.worklore_client, "list_items", lambda source=None, **_page: store.list_items(conn, source=source)
+    )
+    monkeypatch.setattr(sync, "discover_and_reconcile", lambda *args, **kwargs: sequence.pop(0))
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    sync.sync_github(orgs=PUBLIC_ORG)
+    sync.sync_github(orgs=PUBLIC_ORG)
+    assert [post["observations"] for post in posted] == [
+        sorted(first, key=lambda item: item["external_key"]),
+        sorted(changed, key=lambda item: item["external_key"]),
+    ]
+    assert posted[0]["idempotency_key"] != posted[1]["idempotency_key"]
+    imported = store.list_items(conn, source="github")["items"]
+    changed_item = next(item for item in imported if item["links"][0]["external_key"] == "escoffier-labs/brigade#1")
+    assert changed_item["links"][0]["source_acceptance"] == ["new source acceptance"]
+
+
+def test_sync_skips_unsafe_provider_body_and_reports_bounded_count(tmp_path, monkeypatch) -> None:
+    unsafe = {
+        "number": 1,
+        "title": "Safe title",
+        "body": "see /home/operator/secret",
+        "labels": [{"name": "burn-queue"}],
+        "state": "OPEN",
+        "url": "https://github.com/escoffier-labs/brigade/issues/1",
+        "updatedAt": "2026-08-29T12:00:00Z",
+        "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+    }
+    monkeypatch.setattr(sync.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        sync.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=json.dumps([unsafe]), stderr=""),
+    )
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    posts: list[dict[str, object]] = []
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: posts.append(payload) or {})
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    result = sync.sync_github(orgs=PUBLIC_ORG)
+    assert result["skipped"] == 1 and posts[0]["observations"] == []
+    assert "see /home/operator/secret" not in json.dumps(posts)
+    receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    assert receipt["skipped"] == 1
+
+
+def test_sync_retry_receipt_includes_skipped_unsafe_provider_issues(tmp_path, monkeypatch) -> None:
+    unsafe = {
+        "number": 1,
+        "title": "Safe title",
+        "body": "see /home/operator/secret",
+        "labels": [{"name": "burn-queue"}],
+        "state": "OPEN",
+        "url": "https://github.com/escoffier-labs/brigade/issues/1",
+        "updatedAt": "2026-08-29T12:00:00Z",
+        "repository": {"nameWithOwner": "escoffier-labs/brigade"},
+    }
+    monkeypatch.setattr(sync.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        sync.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=json.dumps([unsafe]), stderr=""),
+    )
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(sync.worklore_client.FleetClientError("hub unavailable")),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError, match="hub-unavailable"):
+        sync.sync_github(orgs=PUBLIC_ORG)
+    receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    assert receipt["skipped"] == 1
+    assert "see /home/operator/secret" not in json.dumps(receipt)
+
+
+def test_hub_unavailable_writes_retry_receipt_and_does_not_raise_raw_url(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(
+            sync.worklore_client.FleetClientError(
+                "fleet hub work failed: HTTP 503: https://hub.example/work/imports token=abc title=Rotate restic"
+            )
+        ),
+    )
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: [dict(SYNC_OBSERVATION)],
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError, match="hub-unavailable") as excinfo:
+        sync.sync_github(orgs=PUBLIC_ORG)
+    _assert_no_leak(str(excinfo.value))
+    receipt_path = tmp_path / "worklore" / "github" / "github-escoffier-labs.json"
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["last_error_code"] == "hub-unavailable"
+    assert receipt["adapter_id"] == "github:escoffier-labs"
+    assert "Rotate restic" not in json.dumps(receipt)
+    assert "https://hub.example" not in json.dumps(receipt)
+    assert_private_mode(receipt_path, PRIVATE_FILE_MODE)
+    assert_private_mode(receipt_path.parent, PRIVATE_DIRECTORY_MODE)
+
+
+def test_list_items_fleet_error_is_bounded_and_writes_retry_receipt(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "list_items",
+        lambda source=None, **_page: (_ for _ in ()).throw(
+            sync.worklore_client.FleetClientError(
+                "fleet hub work failed: HTTP 503: https://hub.example/work/items token=abc title=Rotate restic"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(AssertionError("import_batch must not run")),
+    )
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: (_ for _ in ()).throw(
+            AssertionError("discover must not run")
+        ),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError, match="hub-unavailable") as excinfo:
+        sync.sync_github(orgs=PUBLIC_ORG)
+    _assert_no_leak(str(excinfo.value))
+    receipt_path = tmp_path / "worklore" / "github" / "github-escoffier-labs.json"
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["last_error_code"] == "hub-unavailable"
+    assert receipt["adapter_id"] == "github:escoffier-labs"
+    assert "Rotate restic" not in json.dumps(receipt)
+    assert_private_mode(receipt_path, PRIVATE_FILE_MODE)
+
+
+HUB_REFUSALS = [
+    ("fleet hub work failed: HTTP 400: title must be 1 to 240 characters", "hub-rejected"),
+    ("fleet hub work failed: HTTP 404", "hub-rejected"),
+    ("fleet hub work failed: HTTP 422", "hub-rejected"),
+    ("fleet hub work failed: HTTP 401", "hub-unauthorized"),
+    ("fleet hub work failed: HTTP 403: adapter is owned by another node", "hub-unauthorized"),
+    ("fleet hub work failed: HTTP 409: idempotency key reused with a different payload", "hub-conflict"),
+    ("fleet hub work failed: HTTP 500", "hub-unavailable"),
+    ("fleet hub work failed: HTTP 503: https://hub.example/work/imports token=abc", "hub-unavailable"),
+    ("fleet hub work failed: invalid JSON", "hub-unavailable"),
+    ("hub-unavailable", "hub-unavailable"),
+]
+
+
+@pytest.mark.parametrize(("message", "code"), HUB_REFUSALS)
+def test_import_refusals_keep_stable_non_transient_codes(tmp_path, monkeypatch, message: str, code: str) -> None:
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(sync.worklore_client.FleetClientError(message)),
+    )
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: [dict(SYNC_OBSERVATION)],
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError) as excinfo:
+        sync.sync_github(orgs=PUBLIC_ORG)
+    assert excinfo.value.code == code
+    _assert_no_leak(str(excinfo.value))
+    receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    assert receipt["last_error_code"] == code
+    _assert_no_leak(json.dumps(receipt))
+
+
+@pytest.mark.parametrize(("message", "code"), HUB_REFUSALS)
+def test_list_items_refusals_keep_stable_non_transient_codes(tmp_path, monkeypatch, message: str, code: str) -> None:
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "list_items",
+        lambda source=None, **_page: (_ for _ in ()).throw(sync.worklore_client.FleetClientError(message)),
+    )
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(AssertionError("import_batch must not run")),
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError) as excinfo:
+        sync.sync_github(orgs=PUBLIC_ORG)
+    assert excinfo.value.code == code
+    _assert_no_leak(str(excinfo.value))
+    receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    assert receipt["last_error_code"] == code
+
+
+def test_receipt_filename_sanitizes_reserved_characters() -> None:
+    raw = 'github:org/name\\x<y>"z|a?b*c'
+    safe = sync._safe_adapter_id(raw)
+    for character in ':/\\<>"|?*':
+        assert character not in safe
+    assert safe == "github-org-name-x-y--z-a-b-c"
+
+
+def test_sync_rejects_case_insensitive_duplicate_orgs_before_hub_or_github(tmp_path, monkeypatch) -> None:
+    list_calls: list[str | None] = []
+    posts: list[dict[str, object]] = []
+    discover_calls: list[object] = []
+    github_calls: list[list[str]] = []
+
+    def fake_list_items(source=None, **_page):
+        list_calls.append(source)
+        return {"items": []}
+
+    def fake_import_batch(payload):
+        posts.append(payload)
+        return {}
+
+    def fake_discover(orgs, *, label, state, existing_items, budget=None):
+        discover_calls.append(orgs)
+        return [dict(SYNC_OBSERVATION)]
+
+    def fake_run(argv, **kwargs):
+        github_calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(sync.worklore_client, "list_items", fake_list_items)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import_batch)
+    monkeypatch.setattr(sync, "discover_and_reconcile", fake_discover)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError, match="field-bound") as excinfo:
+        sync.sync_github(
+            orgs=[
+                {"name": "Escoffier-Labs", "visibility": "public"},
+                {"name": "escoffier-labs", "visibility": "public"},
+            ]
+        )
+    assert excinfo.value.code == "field-bound"
+    _assert_no_leak(str(excinfo.value))
+    assert list_calls == []
+    assert posts == []
+    assert discover_calls == []
+    assert github_calls == []
+
+
+def _leaky_receipt_oserror(tmp_path) -> OSError:
+    leaky_path = tmp_path / "home" / "operator" / "worklore" / "github" / "github-escoffier-labs.json"
+    return OSError(13, f"Permission denied: '{leaky_path}'")
+
+
+def test_successful_post_receipt_write_failure_is_bounded_and_replay_safe(tmp_path, monkeypatch) -> None:
+    posts: list[dict[str, object]] = []
+    expected_key = _batch_key("escoffier-labs", [SYNC_OBSERVATION])
+    leak = _leaky_receipt_oserror(tmp_path)
+
+    def fake_import_batch(payload):
+        posts.append(payload)
+        return {"created": 1, "updated": 0}
+
+    def failing_write(*args, **kwargs):
+        raise leak
+
+    monkeypatch.setattr(sync.worklore_client, "import_batch", fake_import_batch)
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: [dict(SYNC_OBSERVATION)],
+    )
+    monkeypatch.setattr(sync, "_write_receipt", failing_write)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError, match="receipt-write-failed") as excinfo:
+        sync.sync_github(orgs=PUBLIC_ORG)
+    assert excinfo.value.code == "receipt-write-failed"
+    assert str(excinfo.value) == "receipt-write-failed: receipt-write-failed"
+    message = str(excinfo.value)
+    _assert_no_leak(message)
+    assert str(tmp_path) not in message
+    assert "/home/" not in message
+    assert "Permission denied" not in message
+    assert "github-escoffier-labs.json" not in message
+    assert leak.strerror not in message
+    assert len(posts) == 1
+    assert posts[0]["idempotency_key"] == expected_key
+
+
+def test_hub_import_refusal_is_reported_as_a_partial_failure(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: {"created": 1, "refused": 1})
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: [dict(SYNC_OBSERVATION)],
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+
+    result = sync.sync_github(orgs=PUBLIC_ORG)
+
+    assert result["refused"] == 1
+    receipt = json.loads((tmp_path / "worklore" / "github" / "github-escoffier-labs.json").read_text())
+    assert receipt["last_error_code"] == "hub-partial"
+    assert receipt["refused"] == 1
+
+
+def test_hub_unavailable_receipt_write_failure_stays_hub_unavailable(tmp_path, monkeypatch) -> None:
+    leak = _leaky_receipt_oserror(tmp_path)
+
+    def failing_write(*args, **kwargs):
+        raise leak
+
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "import_batch",
+        lambda payload: (_ for _ in ()).throw(
+            sync.worklore_client.FleetClientError(
+                "fleet hub work failed: HTTP 503: https://hub.example/work/imports token=abc title=Rotate restic"
+            )
+        ),
+    )
+    monkeypatch.setattr(sync.worklore_client, "list_items", lambda source=None, **_page: {"items": []})
+    monkeypatch.setattr(
+        sync,
+        "discover_and_reconcile",
+        lambda orgs, *, label, state, existing_items, budget=None: [dict(SYNC_OBSERVATION)],
+    )
+    monkeypatch.setattr(sync, "_write_receipt", failing_write)
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    with pytest.raises(sync.GitHubSyncError, match="hub-unavailable") as excinfo:
+        sync.sync_github(orgs=PUBLIC_ORG)
+    assert excinfo.value.code == "hub-unavailable"
+    message = str(excinfo.value)
+    _assert_no_leak(message)
+    assert str(tmp_path) not in message
+    assert "/home/" not in message
+    assert "Permission denied" not in message
+    assert "github-escoffier-labs.json" not in message
+    assert leak.strerror not in message
+    assert "OSError" not in message
+
+
+CLI_CONFIG = {
+    "orgs": [{"name": "escoffier-labs", "visibility": "public"}],
+    "label": "burn-queue",
+    "state": "all",
+}
+
+
+def test_sync_github_cli_json(monkeypatch, capsys) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_sync(orgs=None, *, label, state):
+        captured["orgs"] = orgs
+        captured["label"] = label
+        captured["state"] = state
+        return {
+            "posted": 1,
+            "observation_count": 3,
+            "title": "Rotate restic password",
+            "url": "https://github.com/escoffier-labs/brigade/issues/12",
+            "token": "ghp_secret",
+            "observations": [{"title": "Rotate restic password"}],
+        }
+
+    monkeypatch.setattr(fleet_cli.worklore_github_sync, "load_github_config", lambda: CLI_CONFIG)
+    monkeypatch.setattr(fleet_cli.worklore_github_sync, "sync_github", fake_sync)
+    assert fleet_cli._dispatch_work_sync_github(argparse.Namespace(json=True)) == 0
+    captured_io = capsys.readouterr()
+    assert captured_io.err == ""
+    payload = json.loads(captured_io.out)
+    assert payload == json.loads(json.dumps(payload, sort_keys=True))
+    assert captured_io.out == json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    assert payload["orgs"] == ["escoffier-labs"]
+    assert payload["posted"] == 1
+    assert payload["observation_count"] == 3
+    assert payload["refused"] == payload["skipped"] == 0
+    assert captured["orgs"] == CLI_CONFIG["orgs"]
+    assert captured["label"] == "burn-queue"
+    assert captured["state"] == "all"
+    assert set(payload) == {"orgs", "posted", "observation_count", "refused", "skipped"}
+    _assert_no_leak(captured_io.out)
+    assert "ghp_secret" not in captured_io.out
+    assert "Rotate restic" not in captured_io.out
+
+
+def test_sync_github_cli_default_reports_counts_only(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(fleet_cli.worklore_github_sync, "load_github_config", lambda: CLI_CONFIG)
+    monkeypatch.setattr(
+        fleet_cli.worklore_github_sync,
+        "sync_github",
+        lambda orgs=None, *, label, state: {
+            "posted": 2,
+            "observation_count": 7,
+            "title": "Rotate restic password",
+            "observations": [{"title": "Rotate restic password"}],
+        },
+    )
+    assert fleet_cli._dispatch_work_sync_github(argparse.Namespace(json=False)) == 0
+    captured_io = capsys.readouterr()
+    assert captured_io.err == ""
+    lines = [line for line in captured_io.out.splitlines() if line.strip()]
+    assert len(lines) == 1
+    line = lines[0]
+    assert "2" in line
+    assert "7" in line
+    assert "posted" in line.lower()
+    assert "observation" in line.lower()
+    assert "Rotate restic" not in captured_io.out
+    assert "title" not in line.lower()
+    _assert_no_leak(captured_io.out)
+
+
+def test_sync_github_cli_surfaces_refusals_after_printing_counts(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(fleet_cli.worklore_github_sync, "load_github_config", lambda: CLI_CONFIG)
+    monkeypatch.setattr(
+        fleet_cli.worklore_github_sync,
+        "sync_github",
+        lambda orgs=None, *, label, state: {"posted": 2, "observation_count": 7, "refused": 1, "skipped": 3},
+    )
+
+    assert fleet_cli._dispatch_work_sync_github(argparse.Namespace(json=True)) == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "observation_count": 7,
+        "orgs": ["escoffier-labs"],
+        "posted": 2,
+        "refused": 1,
+        "skipped": 3,
+    }
+    assert fleet_cli._dispatch_work_sync_github(argparse.Namespace(json=False)) == 1
+    assert capsys.readouterr().out == "posted 2 batch(es), 7 observation(s), refused 1, skipped 3\n"
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        "GitHub Worklore config is missing orgs",
+        "orgs must be a non-empty list",
+    ),
+)
+def test_sync_github_cli_config_error_returns_2(monkeypatch, capsys, message: str) -> None:
+    def missing_config() -> dict[str, object]:
+        raise sync.GitHubSyncError(message, code="field-bound")
+
+    monkeypatch.setattr(fleet_cli.worklore_github_sync, "load_github_config", missing_config)
+    assert fleet_cli._dispatch_work_sync_github(argparse.Namespace(json=False)) == 2
+    captured_io = capsys.readouterr()
+    assert captured_io.out == ""
+    err_lines = [line for line in captured_io.err.splitlines() if line.strip()]
+    assert err_lines == [f"field-bound: {message}"]
+    _assert_no_leak(captured_io.err)
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    (
+        ("hub-unavailable", "hub-unavailable"),
+        ("hub-rejected", "hub-rejected"),
+        ("hub-unauthorized", "hub-unauthorized"),
+        ("hub-conflict", "hub-conflict"),
+        ("retryable-adapter-failure", "adapter command failed"),
+        ("receipt-write-failed", "receipt-write-failed"),
+    ),
+)
+def test_sync_github_cli_adapter_failures_return_1(monkeypatch, capsys, code: str, message: str) -> None:
+    monkeypatch.setattr(fleet_cli.worklore_github_sync, "load_github_config", lambda: CLI_CONFIG)
+
+    def boom(orgs=None, *, label, state):
+        raise sync.GitHubSyncError(message, code=code)
+
+    monkeypatch.setattr(fleet_cli.worklore_github_sync, "sync_github", boom)
+    assert fleet_cli._dispatch_work_sync_github(argparse.Namespace(json=False)) == 1
+    captured_io = capsys.readouterr()
+    assert captured_io.out == ""
+    err_lines = [line for line in captured_io.err.splitlines() if line.strip()]
+    assert err_lines == [f"{code}: {message}"]
+    _assert_no_leak(captured_io.err)
+    assert "/home/" not in captured_io.err
+    assert "Rotate restic" not in captured_io.err
+
+
+def test_fleet_work_parser_accepts_sync_github() -> None:
+    parser = cli._build_parser()
+    parsed = parser.parse_args(["fleet", "work", "sync-github", "--json"])
+    assert parsed.func is fleet_cli._dispatch_work_sync_github
+    assert parsed.json is True
+    default = parser.parse_args(["fleet", "work", "sync-github"])
+    assert default.func is fleet_cli._dispatch_work_sync_github
+    assert default.json is False
+
+
+def _stale_link(number):
+    return _linked_item(
+        {
+            "link_type": "github",
+            "external_key": f"escoffier-labs/brigade#{number}",
+            "source_acceptance": ["existing acceptance"],
+            "source_policy": "eligible",
+            "url": f"https://github.com/escoffier-labs/brigade/issues/{number}",
+        }
+    )
+
+
+def _reconcile_views(monkeypatch, views):
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        views.append(argv)
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="HTTP 404")
+
+    monkeypatch.setattr(sync.shutil, "which", lambda name: None)
+    monkeypatch.setattr(sync.subprocess, "run", fake_run)
+
+
+def test_reconcile_refreshes_stop_at_the_run_refresh_ceiling(monkeypatch) -> None:
+    views: list[list[str]] = []
+    _reconcile_views(monkeypatch, views)
+    monkeypatch.setattr(sync, "RECONCILE_MAX_REFRESHES", 2)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[_stale_link(number) for number in range(10, 20)],
+    )
+    assert len(views) == 2
+    assert len(observations) == 2
+    assert observations.skipped == 8
+
+
+def test_reconcile_refreshes_stop_when_the_wall_clock_budget_is_spent(monkeypatch) -> None:
+    views: list[list[str]] = []
+    _reconcile_views(monkeypatch, views)
+    clock = iter([0.0, 0.0, 5.0])
+    monkeypatch.setattr(sync, "time", types.SimpleNamespace(monotonic=lambda: next(clock, 5.0)))
+    monkeypatch.setattr(sync, "RECONCILE_BUDGET_SECONDS", 1.0)
+    observations = sync.discover_and_reconcile(
+        PUBLIC_ORG,
+        label="burn-queue",
+        state="all",
+        existing_items=[_stale_link(number) for number in range(10, 15)],
+    )
+    assert len(views) == 1
+    assert observations.skipped == 4
+
+
+def test_one_refresh_budget_spans_every_configured_org(monkeypatch, tmp_path) -> None:
+    views: list[list[str]] = []
+    _reconcile_views(monkeypatch, views)
+    monkeypatch.setattr(sync, "RECONCILE_MAX_REFRESHES", 1)
+    monkeypatch.setattr(sync.worklore_client, "import_batch", lambda payload: {})
+    monkeypatch.setattr(
+        sync.worklore_client,
+        "list_items",
+        lambda source=None, **_page: {"items": [_stale_link(10), _stale_link(11)]},
+    )
+    monkeypatch.setenv("BRIGADE_HOME", str(tmp_path))
+    sync.sync_github(
+        orgs=[
+            {"name": "escoffier-labs", "visibility": "public"},
+            {"name": "lidless-labs", "visibility": "public"},
+        ]
+    )
+    assert len(views) == 1

--- a/tests/test_worklore_http.py
+++ b/tests/test_worklore_http.py
@@ -1,0 +1,1316 @@
+# Synthetic rejection fixtures retain private paths to exercise redaction.
+# content-guard: allow home-path file
+import importlib.util
+import json
+import sqlite3
+import subprocess
+from base64 import urlsafe_b64encode
+from pathlib import Path
+
+from brigade import fleet_hub
+from brigade import fleet_hub_http
+from brigade import worklore_github_sync as github_sync
+from brigade import worklore_http
+from brigade import worklore_http as http
+from brigade import worklore_store as store
+
+_CLOUD = importlib.util.spec_from_file_location(
+    "worklore_http_fleet_cloud_helpers", Path(__file__).with_name("test_fleet_cloud.py")
+)
+assert _CLOUD is not None and _CLOUD.loader is not None
+_cloud = importlib.util.module_from_spec(_CLOUD)
+_CLOUD.loader.exec_module(_cloud)
+ADMIN_TOKEN = _cloud.ADMIN_TOKEN
+_hub = _cloud._hub
+_request = _cloud._request
+
+
+def _req(
+    method,
+    path,
+    *,
+    admin=False,
+    node=None,
+    operator=False,
+    operator_authorization_resolved=None,
+    body=None,
+    headers=None,
+):
+    return http.Request(
+        method=method,
+        path=path,
+        is_admin=admin,
+        node_id=node,
+        is_operator=operator,
+        operator_authorization_resolved=(
+            operator if operator_authorization_resolved is None else operator_authorization_resolved
+        ),
+        body=body or {},
+        headers=headers or {},
+    )
+
+
+def _http_conn(tmp_path):
+    conn = fleet_hub.init_db(tmp_path / "db")
+    store.ensure_schema(conn)
+    return conn
+
+
+def test_cookie_caller_cannot_read_or_write(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, body = http.handle(conn, _req("GET", "/work/items"))
+    assert status == 401 and body["code"] == "unauthorized"
+
+
+def test_node_can_read_and_import_but_cannot_transition(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Native", "kind": "fleet"}),
+    )
+    assert status == 201
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}", node="node-a"))
+    assert status == 200 and body["item"]["title"] == "Native"
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            node="node-a",
+            body={"to_status": "defining"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 403 and body["code"] == "forbidden"
+
+
+def test_patch_and_transition_require_if_match(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Edit me", "kind": "admin"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(
+        conn,
+        _req("PATCH", f"/work/items/{work_id}", admin=True, body={"priority": "high"}),
+    )
+    assert status == 400 and body["code"] == "if-match-required"
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "defining"},
+        ),
+    )
+    assert status == 400 and body["code"] == "if-match-required"
+    status, ok = http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"priority": "high"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 200 and ok["item"]["version"] == 2
+    status, ready = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "defining"},
+            headers={"If-Match": "2"},
+        ),
+    )
+    assert status == 200 and ready["item"]["status"] == "defining"
+    status, conflict = http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"priority": "low"},
+            headers={"If-Match": "2"},
+        ),
+    )
+    assert status == 409 and conflict["code"] == "version-conflict"
+
+
+def test_invalid_transition_and_missing_item_use_stable_codes(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "X", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "running"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 400 and body["code"] == "invalid-transition"
+    status, body = http.handle(conn, _req("GET", "/work/items/wl-missing", admin=True))
+    assert status == 404 and body["code"] == "not-found"
+
+
+def test_attempts_body_is_action_and_optional_run_id(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Try", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/attempts",
+            node="node-a",
+            body={"action": "failed"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 403 and body["code"] == "attempt-forbidden"
+
+
+def test_attempt_run_id_uses_canonical_safe_text_validation(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Try", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+    cases = [
+        ("x" * (store.ATTEMPT_RUN_ID_MAX + 1), "field-bound"),
+        ("run\x1b[31m", "field-bound"),
+        ("/home/example/run", "private-data"),
+        (1, "field-bound"),
+    ]
+    for run_id, code in cases:
+        status, body = http.handle(
+            conn,
+            _req(
+                "POST",
+                f"/work/items/{work_id}/attempts",
+                admin=True,
+                body={"action": "started", "run_id": run_id},
+                headers={"If-Match": "1"},
+            ),
+        )
+        assert status == 400 and body["code"] == code
+
+
+def test_attempt_reset_discards_a_run_id_over_http(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Try", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+
+    status, _ = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/attempts",
+            admin=True,
+            body={"action": "reset", "run_id": "run-do-not-persist"},
+            headers={"If-Match": "1"},
+        ),
+    )
+
+    assert status == 200 and store.list_events(conn, work_id)[-1]["run_id"] is None
+
+
+def test_authenticated_node_attempt_replay_is_idempotent_over_http(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Try", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    status, _ = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/execution",
+            node="node-a",
+            body={"node_id": "node-a", "run_id": "run-1"},
+        ),
+    )
+    assert status == 201
+    request = _req(
+        "POST",
+        f"/work/items/{work_id}/attempts",
+        node="node-a",
+        body={"action": "failed", "run_id": "run-1"},
+        headers={"If-Match": "1"},
+    )
+
+    first_status, first = http.handle(conn, request)
+    replay_status, replay = http.handle(conn, request)
+
+    assert (first_status, replay_status) == (200, 200)
+    assert replay["item"] == first["item"]
+    assert [event["event_type"] for event in store.list_events(conn, work_id)].count("attempt-failed") == 1
+
+
+def test_worklore_enabled_is_fail_closed_and_reads_fleet_config(tmp_path):
+    config = tmp_path / "fleet.toml"
+    assert worklore_http.enabled(environ={}, config_path=config) is False
+    config.write_text("[fleet.worklore]\nenabled = true\n")
+    assert worklore_http.enabled(environ={}, config_path=config) is True
+    assert worklore_http.enabled(environ={"BRIGADE_WORKLORE_ENABLED": "0"}, config_path=config) is False
+    assert worklore_http.enabled(environ={"BRIGADE_WORKLORE_ENABLED": "1"}, config_path=config) is True
+
+
+def test_worklore_enabled_uses_brigade_home_config(monkeypatch, tmp_path):
+    home = tmp_path / "brigade-home"
+    home.mkdir()
+    (home / "fleet.toml").write_text("[fleet.worklore]\nenabled = true\n")
+    monkeypatch.setenv("BRIGADE_HOME", str(home))
+    assert worklore_http.enabled(environ={}) is True
+
+
+def test_worklore_list_query_validation_and_pagination(tmp_path):
+    conn = _http_conn(tmp_path)
+    for index in range(3):
+        http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": f"Item {index}", "kind": "fleet"}))
+    status, body = http.handle(conn, _req("GET", "/work/items?kind=fleet&burn_eligible=false&limit=2", admin=True))
+    assert status == 200 and len(body["items"]) == 2 and body["next_cursor"]
+    status, body = http.handle(conn, _req("GET", "/work/items?unknown=x", admin=True))
+    assert status == 400 and body["code"] == "unknown-field"
+    status, body = http.handle(conn, _req("GET", "/work/events?limit=0", admin=True))
+    assert status == 400 and body["code"] == "field-bound"
+    status, body = http.handle(conn, _req("GET", "/work/events?unknown=x", admin=True))
+    assert status == 400 and body["code"] == "unknown-field"
+    work_id = store.list_items(conn, kind="fleet")["items"][0]["work_id"]
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}/events?limit=1", admin=True))
+    assert status == 200 and len(body["events"]) == 1
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}/events?status=ready", admin=True))
+    assert status == 400 and body["code"] == "unknown-field"
+
+
+def test_worklore_admin_link_routes_call_store_directly(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Links", "kind": "admin"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, added = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/links",
+            admin=True,
+            body={"link_type": "url", "external_key": "https://example.invalid/runbook"},
+        ),
+    )
+    assert status == 201
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/links",
+            admin=True,
+            body={"link_type": "fleet-run", "external_key": "node/run"},
+        ),
+    )
+    assert status == 403 and body["code"] == "link-forbidden"
+    status, body = http.handle(
+        conn,
+        _req("DELETE", f"/work/items/{work_id}/links/{added['link']['link_id']}", admin=True),
+    )
+    assert status == 200 and body == {"ok": True}
+
+
+def test_link_delete_honors_if_match_and_keeps_the_link_on_conflict(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": "Links", "kind": "admin"}))
+    work_id = created["item"]["work_id"]
+    _, added = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/links",
+            admin=True,
+            body={"link_type": "url", "external_key": "https://example.invalid/runbook"},
+        ),
+    )
+    http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"priority": "high"},
+            headers={"If-Match": "1"},
+        ),
+    )
+
+    status, body = http.handle(
+        conn,
+        _req(
+            "DELETE",
+            f"/work/items/{work_id}/links/{added['link']['link_id']}",
+            admin=True,
+            headers={"If-Match": "1"},
+        ),
+    )
+
+    assert (status, body["code"]) == (409, "version-conflict")
+    assert store.list_links(conn, work_id)[0]["link_id"] == added["link"]["link_id"]
+
+
+def test_worklore_routes_are_absent_when_disabled(tmp_path):
+    with _hub(tmp_path) as hub:
+        status, body = _request(hub, "GET", "/work/items", token=ADMIN_TOKEN)
+        assert status == 404
+        assert body["error"] == "not found"
+
+
+def test_worklore_native_create_to_burn_on_enabled_hub(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "1")
+    with _hub(tmp_path) as hub:
+        status, created = _request(
+            hub, "POST", "/work/items", token=ADMIN_TOKEN, body={"title": "NAS restic", "kind": "fleet"}
+        )
+        assert status == 201
+        work_id = created["item"]["work_id"]
+        _request(
+            hub,
+            "PATCH",
+            f"/work/items/{work_id}",
+            token=ADMIN_TOKEN,
+            body={
+                "acceptance": ["restic snapshots --latest 1 succeeds"],
+                "burn_eligible": True,
+                "execution_mode": "agent",
+            },
+            extra_headers={"If-Match": "1"},
+        )
+        _request(
+            hub,
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            token=ADMIN_TOKEN,
+            body={"to_status": "ready"},
+            extra_headers={"If-Match": "2"},
+        )
+        status, queue = _request(hub, "GET", "/work/queue/burn", token=ADMIN_TOKEN)
+        assert status == 200
+        assert queue["items"][0]["work_id"] == work_id
+
+
+def test_admin_worklore_patch_succeeds_without_allow_admin_writes(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "1")
+    with _hub(tmp_path) as hub:
+        _, created = _request(
+            hub, "POST", "/work/items", token=ADMIN_TOKEN, body={"title": "Admin write", "kind": "admin"}
+        )
+        status, patched = _request(
+            hub,
+            "PATCH",
+            f"/work/items/{created['item']['work_id']}",
+            token=ADMIN_TOKEN,
+            body={"priority": "high"},
+            extra_headers={"If-Match": "1"},
+        )
+        assert status == 200
+        assert patched["item"]["priority"] == "high"
+
+
+def test_existing_claim_and_dashboard_routes_stay_unchanged(tmp_path):
+    with _hub(tmp_path) as hub:
+        assert _request(hub, "GET", "/claims", token=ADMIN_TOKEN)[0] == 200
+        assert _request(hub, "GET", "/health")[0] == 200
+
+
+def test_operator_nodes_reads_toml_and_bounded_env(tmp_path):
+    config = tmp_path / "fleet.toml"
+    assert worklore_http.operator_nodes(environ={}, config_path=config) == ()
+    config.write_text(
+        '[fleet.worklore]\noperator_nodes = ["rocinante", "unknown", "bad id", "rocinante", "shadowfax"]\n'
+    )
+    assert worklore_http.operator_nodes(environ={}, config_path=config) == ("rocinante", "shadowfax")
+    config.write_text('[fleet.worklore]\noperator_nodes = "rocinante"\n')
+    assert worklore_http.operator_nodes(environ={}, config_path=config) == ()
+    env = {"BRIGADE_WORKLORE_OPERATOR_NODES": "gandalf, unknown, n1"}
+    config.write_text('[fleet.worklore]\noperator_nodes = ["rocinante"]\n')
+    assert worklore_http.operator_nodes(environ=env, config_path=config) == ("gandalf", "n1")
+    assert worklore_http.operator_nodes(environ={"BRIGADE_WORKLORE_OPERATOR_NODES": ""}, config_path=config) == ()
+    too_long = "a" * 129
+    env = {"BRIGADE_WORKLORE_OPERATOR_NODES": f"rocinante,{too_long},shadowfax"}
+    assert worklore_http.operator_nodes(environ=env, config_path=config) == ("rocinante", "shadowfax")
+    many = ",".join(f"n{index}" for index in range(40))
+    nodes = worklore_http.operator_nodes(environ={"BRIGADE_WORKLORE_OPERATOR_NODES": many}, config_path=config)
+    assert len(nodes) == 32
+    assert nodes[0] == "n0" and nodes[-1] == "n31"
+
+
+def test_operator_authorization_is_snapshotted_once_per_request(tmp_path, monkeypatch):
+    conn = _http_conn(tmp_path)
+    decisions = []
+
+    def rotating_operator_nodes():
+        decisions.append("read")
+        return ("ops-node",) if len(decisions) == 1 else ()
+
+    monkeypatch.setattr(http, "operator_nodes", rotating_operator_nodes)
+    status, created = http.handle(
+        conn,
+        _req("POST", "/work/items", node="ops-node", body={"title": "Native", "kind": "fleet"}),
+    )
+
+    assert status == 201
+    assert decisions == ["read"]
+    assert store.list_events(conn, created["item"]["work_id"])[0]["actor_type"] == "operator"
+
+
+def test_direct_request_can_supply_a_resolved_non_operator_snapshot(tmp_path, monkeypatch):
+    conn = _http_conn(tmp_path)
+    decisions = []
+    monkeypatch.setattr(http, "operator_nodes", lambda: decisions.append("read") or ("ops-node",))
+
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/items",
+            node="node-a",
+            operator_authorization_resolved=True,
+            body={"title": "No config read", "kind": "fleet"},
+        ),
+    )
+
+    assert (status, body["code"]) == (403, "forbidden")
+    assert decisions == []
+
+
+def test_fleet_hub_reads_operator_configuration_once_for_a_non_operator_node(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "1")
+    decisions = []
+    monkeypatch.setattr(worklore_http, "operator_nodes", lambda: decisions.append("read") or ())
+
+    with _hub(tmp_path) as hub:
+        conn = fleet_hub.open_db(hub[2])
+        try:
+            _node, node_token = fleet_hub.add_node(conn, "node-a", "node-a")
+        finally:
+            conn.close()
+        status, _body = _request(hub, "GET", "/work/items", token=node_token)
+
+    assert status == 200
+    assert decisions == ["read"]
+
+
+def test_operator_node_can_create_patch_transition_reset_and_link(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, created = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/items",
+            node="ops-node",
+            operator=True,
+            body={"title": "Native", "kind": "fleet"},
+            headers={"Idempotency-Key": "create-1"},
+        ),
+    )
+    assert status == 201
+    work_id = created["item"]["work_id"]
+    events = store.list_events(conn, work_id)
+    assert [event["event_type"] for event in events] == ["created"]
+    assert events[0]["actor_type"] == "operator"
+    assert events[0]["actor_id"] == "ops-node"
+    assert events[0]["node_id"] == "ops-node"
+    status, patched = http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            node="ops-node",
+            operator=True,
+            body={"priority": "high"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 200 and patched["item"]["priority"] == "high"
+    assert store.list_events(conn, work_id)[-1]["actor_type"] == "operator"
+    status, moved = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            node="ops-node",
+            operator=True,
+            body={"to_status": "defining"},
+            headers={"If-Match": "2"},
+        ),
+    )
+    assert status == 200 and moved["item"]["status"] == "defining"
+    status, reset = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/attempts",
+            node="ops-node",
+            operator=True,
+            body={"action": "reset"},
+            headers={"If-Match": "3"},
+        ),
+    )
+    assert status == 200 and reset["item"]["attempt_count"] == 0
+    reset_event = store.list_events(conn, work_id)[-1]
+    assert reset_event["event_type"] == "attempt-reset"
+    assert reset_event["actor_type"] == "operator"
+    assert reset_event["node_id"] == "ops-node"
+    status, added = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/links",
+            node="ops-node",
+            operator=True,
+            body={"link_type": "url", "external_key": "https://example.invalid/runbook"},
+        ),
+    )
+    assert status == 201
+    status, body = http.handle(
+        conn,
+        _req(
+            "DELETE",
+            f"/work/items/{work_id}/links/{added['link']['link_id']}",
+            node="ops-node",
+            operator=True,
+        ),
+    )
+    assert status == 200 and body == {"ok": True}
+
+
+def test_ordinary_node_keeps_read_but_cannot_mutate_or_import(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Native", "kind": "fleet"}),
+    )
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}", node="node-a"))
+    assert status == 200
+    status, body = http.handle(
+        conn,
+        _req("POST", "/work/items", node="node-a", body={"title": "Nope", "kind": "fleet"}),
+    )
+    assert status == 403 and body["code"] == "forbidden"
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/attempts",
+            node="node-a",
+            body={"action": "reset"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    assert status == 403 and body["code"] == "forbidden"
+    import_body = {
+        "adapter_id": "github:escoffier-labs",
+        "source_type": "github",
+        "idempotency_key": "imp-1",
+        "observations": [
+            {
+                "external_key": "escoffier-labs/brigade#1",
+                "link_type": "github",
+                "title": "Imported",
+                "source_policy": "eligible",
+                "url": "https://github.com/escoffier-labs/brigade/issues/1",
+                "external_updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+    }
+    status, body = http.handle(conn, _req("POST", "/work/imports", node="node-a", body=import_body))
+    assert status == 403 and body["code"] == "forbidden"
+    assert conn.execute("SELECT COUNT(*) FROM work_sync_cursors").fetchone()[0] == 0
+    status, imported = http.handle(
+        conn,
+        _req("POST", "/work/imports", node="ops-node", operator=True, body=import_body),
+    )
+    assert status == 200 and imported["created"] == 1
+
+
+def test_native_create_idempotency_replays_and_conflicts(tmp_path):
+    conn = _http_conn(tmp_path)
+    body = {"title": "Retry me", "kind": "fleet"}
+    first_status, first = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/items",
+            node="ops-node",
+            operator=True,
+            body=body,
+            headers={"Idempotency-Key": "native-1"},
+        ),
+    )
+    assert first_status == 201
+    work_id = first["item"]["work_id"]
+    second_status, second = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/items",
+            node="ops-node",
+            operator=True,
+            body=body,
+            headers={"Idempotency-Key": "native-1"},
+        ),
+    )
+    assert second_status == 201
+    assert second["item"]["work_id"] == work_id
+    assert [event["event_type"] for event in store.list_events(conn, work_id)] == ["created"]
+    conflict_status, conflict = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/items",
+            node="ops-node",
+            operator=True,
+            body={"title": "Different", "kind": "fleet"},
+            headers={"Idempotency-Key": "native-1"},
+        ),
+    )
+    assert conflict_status == 409 and conflict["code"] == "import-conflict"
+    other_status, other = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/items",
+            admin=True,
+            body=body,
+            headers={"Idempotency-Key": "native-1"},
+        ),
+    )
+    assert other_status == 201
+    assert other["item"]["work_id"] != work_id
+
+
+def test_hub_marks_configured_operator_node_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "1")
+    monkeypatch.setenv("BRIGADE_WORKLORE_OPERATOR_NODES", "ops-node")
+    with _hub(tmp_path) as hub:
+        db = fleet_hub.open_db(hub[2])
+        try:
+            _, operator_token = fleet_hub.add_node(db, "ops-node")
+            _, worker_token = fleet_hub.add_node(db, "worker-node")
+        finally:
+            db.close()
+        status, created = _request(
+            hub,
+            "POST",
+            "/work/items",
+            token=operator_token,
+            body={"title": "From node", "kind": "fleet"},
+            extra_headers={"Idempotency-Key": "hub-create-1"},
+        )
+        assert status == 201
+        work_id = created["item"]["work_id"]
+        status, shown = _request(hub, "GET", f"/work/items/{work_id}", token=operator_token)
+        assert status == 200
+        created_event = shown["recent_events"][0]
+        assert created_event["actor_type"] == "operator"
+        assert created_event["actor_id"] == "ops-node"
+        assert created_event["node_id"] == "ops-node"
+        status, refused = _request(
+            hub,
+            "POST",
+            "/work/items",
+            token=worker_token,
+            body={"title": "From worker", "kind": "fleet"},
+        )
+        assert status == 403 and refused["code"] == "forbidden"
+        status, listed = _request(hub, "GET", "/work/items", token=worker_token)
+        assert status == 200 and listed["items"][0]["work_id"] == work_id
+        status, admin_created = _request(
+            hub, "POST", "/work/items", token=ADMIN_TOKEN, body={"title": "Admin still works", "kind": "admin"}
+        )
+        assert status == 201
+
+
+def test_worklore_open_db_error_does_not_leak_sqlite_text(tmp_path, monkeypatch):
+    marker = "SECRET_MARKER_/tmp/fake-worklore.db"
+
+    def _boom(*_args, **_kwargs):
+        raise sqlite3.OperationalError(f"unable to open database file: {marker}")
+
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "1")
+    monkeypatch.setattr(fleet_hub_http, "open_db", _boom)
+    with _hub(tmp_path) as hub:
+        status, body = _request(hub, "GET", "/work/items", token=ADMIN_TOKEN)
+    assert status == 500
+    assert body["error"] == "hub database error"
+    assert marker not in str(body)
+
+
+def test_sqlite_failure_maps_to_a_stable_internal_error(tmp_path, monkeypatch):
+    conn = _http_conn(tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise sqlite3.OperationalError("no such column: /tmp/secret-worklore.db")
+
+    monkeypatch.setattr(store, "list_items", _boom)
+    status, body = http.handle(conn, _req("GET", "/work/items", admin=True))
+    assert status == 500
+    assert body == {"error": "internal error", "code": "internal-error"}
+    assert "secret-worklore" not in str(body)
+    assert http._STATUS_BY_CODE["internal-error"] == 500
+
+
+def test_item_detail_uses_the_documented_recent_events_key(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, created = http.handle(
+        conn, _req("POST", "/work/items", admin=True, body={"title": "Detail", "kind": "fleet"})
+    )
+    assert status == 201
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}", admin=True))
+    assert status == 200
+    assert set(body) == {"item", "links", "links_next_cursor", "recent_events"}
+    assert [event["event_type"] for event in body["recent_events"]] == ["created"]
+    assert body["links"] == [] and body["links_next_cursor"] is None
+
+
+def test_execution_link_returns_201_and_passes_admin_authority(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": "Run", "kind": "fleet"}))
+    work_id = created["item"]["work_id"]
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    status, body = http.handle(
+        conn,
+        _req("POST", f"/work/items/{work_id}/execution", admin=True, body={"node_id": "node-a", "run_id": "run-1"}),
+    )
+    assert status == 201 and body["link"]["link_type"] == "fleet-run"
+    assert store.list_events(conn, work_id)[-1]["actor_type"] == "operator"
+
+
+def test_node_cannot_link_another_nodes_run_through_the_route(tmp_path):
+    conn = _http_conn(tmp_path)
+    _, created = http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": "Run", "kind": "fleet"}))
+    work_id = created["item"]["work_id"]
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/execution",
+            node="node-b",
+            body={"node_id": "node-a", "run_id": "run-1"},
+        ),
+    )
+    assert status == 403 and body["code"] == "execution-mismatch"
+
+
+def test_operator_can_unlink_a_retired_source_link_but_not_an_eligible_one(tmp_path):
+    conn = _http_conn(tmp_path)
+    observation = {
+        "external_key": "escoffier-labs/brigade#31",
+        "link_type": "github",
+        "title": "Retire me",
+        "source_policy": "eligible",
+        "external_updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    status, imported = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/imports",
+            node="ops-node",
+            operator=True,
+            body={
+                "adapter_id": "github:escoffier-labs",
+                "source_type": "github",
+                "idempotency_key": "http-1",
+                "observations": [observation],
+            },
+        ),
+    )
+    assert status == 200
+    work_id = imported["items"][0]["work_id"]
+    link_id = store.list_links(conn, work_id)[0]["link_id"]
+    status, refused = http.handle(conn, _req("DELETE", f"/work/items/{work_id}/links/{link_id}", admin=True))
+    assert status == 403 and refused["code"] == "link-forbidden"
+    http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/imports",
+            node="ops-node",
+            operator=True,
+            body={
+                "adapter_id": "github:escoffier-labs",
+                "source_type": "github",
+                "idempotency_key": "http-2",
+                "observations": [
+                    {
+                        **observation,
+                        "source_policy": "closed",
+                        "external_updated_at": "2026-01-02T00:00:00+00:00",
+                    }
+                ],
+            },
+        ),
+    )
+    status, body = http.handle(
+        conn, _req("DELETE", f"/work/items/{work_id}/links/{link_id}", node="ops-node", operator=True)
+    )
+    assert status == 200 and body == {"ok": True}
+    assert store.list_links(conn, work_id) == []
+    assert store.list_items(conn, source="native")["items"][0]["work_id"] == work_id
+
+
+# --- numeric field bounds (Daybreak finding 6) -------------------------------
+
+_WIDE = "9" * 5000
+
+
+def _seeded_item(conn) -> str:
+    status, created = http.handle(
+        conn,
+        _req("POST", "/work/items", admin=True, body={"title": "Native", "kind": "fleet"}),
+    )
+    assert status == 201
+    return created["item"]["work_id"]
+
+
+def _cursor(kind: str, values: dict[str, str]) -> str:
+    payload = json.dumps({"kind": kind, "values": values}, sort_keys=True, separators=(",", ":"))
+    return urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def test_oversized_limit_is_a_field_bound_refusal(tmp_path):
+    conn = _http_conn(tmp_path)
+    work_id = _seeded_item(conn)
+    for path in ("/work/items", "/work/events", f"/work/items/{work_id}/events"):
+        status, body = http.handle(conn, _req("GET", f"{path}?limit={_WIDE}", admin=True))
+        assert (status, body["code"]) == (400, "field-bound"), path
+        assert "1 to 100" in body["error"]
+
+
+def test_ordinary_limits_still_reach_the_store(tmp_path):
+    conn = _http_conn(tmp_path)
+    _seeded_item(conn)
+    status, body = http.handle(conn, _req("GET", "/work/items?limit=1", admin=True))
+    assert status == 200 and len(body["items"]) == 1
+    status, body = http.handle(conn, _req("GET", "/work/items?limit=0", admin=True))
+    assert (status, body["code"]) == (400, "field-bound")
+    status, body = http.handle(conn, _req("GET", "/work/items?limit=abc", admin=True))
+    assert (status, body["code"]) == (400, "field-bound")
+
+
+def test_oversized_cursor_is_refused_before_it_is_decoded(tmp_path):
+    conn = _http_conn(tmp_path)
+    work_id = _seeded_item(conn)
+    cases = [
+        ("/work/items", _cursor("items", {"created_at": "2026-01-01T00:00:00Z", "work_id": "wl-" + _WIDE})),
+        ("/work/events", _cursor("events", {"occurred_at": "2026-01-01T00:00:00Z", "seq": _WIDE})),
+        (f"/work/items/{work_id}/events", _cursor("item-events", {"seq": _WIDE})),
+    ]
+    for path, cursor in cases:
+        status, body = http.handle(conn, _req("GET", f"{path}?cursor={cursor}", admin=True))
+        assert (status, body["code"]) == (400, "field-bound"), path
+        assert body["error"] == "cursor is invalid"
+
+
+def test_a_cursor_sequence_wider_than_sqlite_is_a_field_bound_refusal(tmp_path):
+    """A short cursor can still carry an integer SQLite cannot bind; the overflow
+    becomes the ordinary refusal instead of a traceback."""
+    conn = _http_conn(tmp_path)
+    work_id = _seeded_item(conn)
+    cases = [
+        ("/work/events", _cursor("events", {"occurred_at": "2026-01-01T00:00:00Z", "seq": "9" * 40})),
+        (f"/work/items/{work_id}/events", _cursor("item-events", {"seq": "9" * 40})),
+    ]
+    for path, cursor in cases:
+        status, body = http.handle(conn, _req("GET", f"{path}?cursor={cursor}", admin=True))
+        assert (status, body["code"]) == (400, "field-bound"), path
+        assert body["error"] == "request field is out of bounds"
+
+
+def test_paging_cursors_still_round_trip(tmp_path):
+    conn = _http_conn(tmp_path)
+    _seeded_item(conn)
+    _seeded_item(conn)
+    status, first = http.handle(conn, _req("GET", "/work/items?limit=1", admin=True))
+    assert status == 200 and first["next_cursor"]
+    status, second = http.handle(conn, _req("GET", f"/work/items?limit=1&cursor={first['next_cursor']}", admin=True))
+    assert status == 200 and len(second["items"]) == 1
+    assert second["items"][0]["work_id"] != first["items"][0]["work_id"]
+
+
+def test_oversized_if_match_is_refused_without_a_traceback(tmp_path):
+    conn = _http_conn(tmp_path)
+    work_id = _seeded_item(conn)
+    routes = [
+        ("PATCH", f"/work/items/{work_id}", {"priority": "high"}),
+        ("POST", f"/work/items/{work_id}/transitions", {"to_status": "ready"}),
+        ("POST", f"/work/items/{work_id}/attempts", {"action": "start"}),
+    ]
+    for method, path, body in routes:
+        status, payload = http.handle(conn, _req(method, path, admin=True, body=body, headers={"If-Match": _WIDE}))
+        assert (status, payload["code"]) == (400, "if-match-required"), path
+
+
+def test_ordinary_if_match_values_still_work(tmp_path):
+    conn = _http_conn(tmp_path)
+    work_id = _seeded_item(conn)
+    status, body = http.handle(
+        conn,
+        _req("PATCH", f"/work/items/{work_id}", admin=True, body={"priority": "high"}, headers={"If-Match": "1"}),
+    )
+    assert status == 200 and body["item"]["priority"] == "high"
+    status, body = http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"priority": "low"},
+            headers={"If-Match": "9999999999"},
+        ),
+    )
+    assert (status, body["code"]) == (409, "version-conflict")
+
+
+# --- import authz and private data (Daybreak findings 2 and 3) ---------------
+
+
+def _import_body(**overrides):
+    body = {
+        "adapter_id": "github:escoffier-labs",
+        "source_type": "github",
+        "idempotency_key": "imp-x",
+        "observations": [
+            {
+                "external_key": "escoffier-labs/brigade#41",
+                "link_type": "github",
+                "title": "Imported",
+                "source_policy": "eligible",
+                "url": "https://github.com/escoffier-labs/brigade/issues/41",
+                # The hub refuses to project an observation whose source reports no
+                # revision, so the ordinary import body carries one.
+                "external_updated_at": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+    }
+    body.update(overrides)
+    return body
+
+
+def test_direct_github_404_through_hub_marks_the_link_stale_and_excludes_it_from_burn(tmp_path, monkeypatch):
+    conn = _http_conn(tmp_path)
+    status, imported = http.handle(conn, _req("POST", "/work/imports", admin=True, body=_import_body()))
+    assert status == 200 and imported["created"] == 1
+    work_id = imported["items"][0]["work_id"]
+    http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"acceptance": ["done"], "burn_eligible": True, "execution_mode": "agent"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "ready"},
+            headers={"If-Match": "2"},
+        ),
+    )
+
+    def fake_run(argv, **kwargs):
+        if "search" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="HTTP 404")
+
+    monkeypatch.setattr(github_sync.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(github_sync.subprocess, "run", fake_run)
+    tombstone = github_sync.discover_and_reconcile(
+        [{"name": "escoffier-labs", "visibility": "public"}],
+        label="burn-queue",
+        state="all",
+        existing_items=store.list_items(conn, source="github")["items"],
+    )
+    status, reconciled = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/imports",
+            admin=True,
+            body=_import_body(idempotency_key="direct-404", observations=tombstone),
+        ),
+    )
+    assert status == 200 and (reconciled["updated"], reconciled["refused"]) == (1, 0)
+    assert store.list_links(conn, work_id)[0]["stale_at"] is not None
+    queue = store.burn_queue(conn)
+    assert queue["items"] == []
+    assert queue["exclusions"]["source-policy"] == 1
+
+
+def test_imports_need_a_configured_operator_node(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, body = http.handle(conn, _req("POST", "/work/imports", node="node-a", body=_import_body()))
+    assert status == 403 and body["code"] == "forbidden"
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 0
+    status, admin_import = http.handle(conn, _req("POST", "/work/imports", admin=True, body=_import_body()))
+    assert status == 200 and admin_import["created"] == 1
+
+
+def test_an_ordinary_node_cannot_squat_an_adapter_namespace_over_http(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, body = http.handle(
+        conn,
+        _req("POST", "/work/imports", node="node-squatter", body=_import_body(observations=[])),
+    )
+    assert status == 403 and body["code"] == "forbidden"
+    status, empty = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/imports",
+            node="ops-squatter",
+            operator=True,
+            body=_import_body(observations=[], idempotency_key="empty-1"),
+        ),
+    )
+    assert status == 200 and empty == {
+        "created": 0,
+        "updated": 0,
+        "unchanged": 0,
+        "refused": 0,
+        "refused_details": [],
+        "items": [],
+    }
+    assert conn.execute("SELECT COUNT(*) FROM work_sync_cursors").fetchone()[0] == 0
+    status, imported = http.handle(
+        conn,
+        _req("POST", "/work/imports", node="ops-node", operator=True, body=_import_body()),
+    )
+    assert status == 200 and imported["created"] == 1
+    assert conn.execute("SELECT owner_node FROM work_sync_cursors").fetchone()[0] == "ops-node"
+
+
+def test_adapter_prefix_and_private_data_are_bad_requests(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/imports",
+            node="ops-node",
+            operator=True,
+            body=_import_body(adapter_id="brigade:escoffier-labs"),
+        ),
+    )
+    assert status == 400 and body["code"] == "field-bound"
+    leaky = dict(_import_body()["observations"][0], title="see /home/operator/notes")
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/imports",
+            node="ops-node",
+            operator=True,
+            body=_import_body(observations=[leaky]),
+        ),
+    )
+    assert status == 400 and body["code"] == "private-data"
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 0
+
+
+def _ready(conn, title):
+    created = http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": title, "kind": "fleet"}))[1]
+    work_id = created["item"]["work_id"]
+    http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"acceptance": ["done"], "burn_eligible": True, "execution_mode": "agent"},
+            headers={"If-Match": "1"},
+        ),
+    )
+    http.handle(
+        conn,
+        _req(
+            "POST",
+            f"/work/items/{work_id}/transitions",
+            admin=True,
+            body={"to_status": "ready"},
+            headers={"If-Match": "2"},
+        ),
+    )
+    return work_id
+
+
+def test_burn_queue_is_paged_and_rejects_unknown_query_fields(tmp_path):
+    conn = _http_conn(tmp_path)
+    ready = [_ready(conn, f"Ready {index}") for index in range(3)]
+    status, first = http.handle(conn, _req("GET", "/work/queue/burn?limit=2", admin=True))
+    assert status == 200
+    assert set(first) == {"items", "exclusions", "next_cursor"}
+    assert [item["work_id"] for item in first["items"]] == ready[:2]
+    assert first["next_cursor"]
+    cursor = urlsafe_b64encode(b"x").decode("ascii")
+    status, last = http.handle(conn, _req("GET", f"/work/queue/burn?limit=2&cursor={first['next_cursor']}", admin=True))
+    assert status == 200
+    assert [item["work_id"] for item in last["items"]] == ready[2:]
+    assert last["next_cursor"] is None
+    status, body = http.handle(conn, _req("GET", "/work/queue/burn?state=ready", admin=True))
+    assert status == 400 and body["code"] == "unknown-field"
+    status, body = http.handle(conn, _req("GET", "/work/queue/burn?limit=0", admin=True))
+    assert status == 400 and body["code"] == "field-bound"
+    status, body = http.handle(conn, _req("GET", f"/work/queue/burn?cursor={cursor}", admin=True))
+    assert status == 400 and body["code"] == "field-bound"
+
+
+def test_burn_queue_default_page_is_bounded(tmp_path):
+    conn = _http_conn(tmp_path)
+    for index in range(store.BURN_PAGE_DEFAULT + 2):
+        _ready(conn, f"Ready {index:03d}")
+    status, body = http.handle(conn, _req("GET", "/work/queue/burn", admin=True))
+    assert status == 200
+    assert len(body["items"]) == store.BURN_PAGE_DEFAULT
+    assert body["next_cursor"]
+
+
+def test_item_detail_reads_only_the_recent_events_it_returns(tmp_path):
+    conn = _http_conn(tmp_path)
+    created = http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": "Chatty", "kind": "fleet"}))[1]
+    work_id = created["item"]["work_id"]
+    for version in range(1, 25):
+        http.handle(
+            conn,
+            _req(
+                "PATCH",
+                f"/work/items/{work_id}",
+                admin=True,
+                body={"scope": f"scope-{version}"},
+                headers={"If-Match": str(version)},
+            ),
+        )
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}", admin=True))
+    assert status == 200
+    assert len(body["recent_events"]) == store.DETAIL_RECENT_EVENTS
+    assert body["recent_events"] == store.list_events(conn, work_id)[-store.DETAIL_RECENT_EVENTS :]
+
+
+def test_native_create_and_patch_reject_private_data_over_http(tmp_path):
+    conn = _http_conn(tmp_path)
+    status, body = http.handle(
+        conn,
+        _req(
+            "POST",
+            "/work/items",
+            admin=True,
+            body={"title": "Leaky", "kind": "fleet", "description": "see /home/operator/notes"},
+        ),
+    )
+    assert status == 400 and body["code"] == "private-data"
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 0
+    created = http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": "Clean", "kind": "fleet"}))[1]
+    work_id = created["item"]["work_id"]
+    status, body = http.handle(
+        conn,
+        _req(
+            "PATCH",
+            f"/work/items/{work_id}",
+            admin=True,
+            body={"acceptance": ["paste " + "ghp_" + "a" * 36]},
+            headers={"if-match": "1"},
+        ),
+    )
+    assert status == 400 and body["code"] == "private-data"
+    assert http.handle(conn, _req("GET", f"/work/items/{work_id}", admin=True))[1]["item"]["version"] == 1
+
+
+def test_item_detail_pages_links_and_rejects_unknown_query_keys(tmp_path):
+    conn = _http_conn(tmp_path)
+    created = http.handle(conn, _req("POST", "/work/items", admin=True, body={"title": "Linked", "kind": "fleet"}))[1]
+    work_id = created["item"]["work_id"]
+    for number in range(3):
+        status, _ = http.handle(
+            conn,
+            _req(
+                "POST",
+                f"/work/items/{work_id}/links",
+                admin=True,
+                body={"link_type": "url", "external_key": f"https://example.com/{number}"},
+            ),
+        )
+        assert status == 201
+    seen = []
+    cursor = None
+    for _ in range(4):
+        suffix = "?links_limit=2" + (f"&links_cursor={cursor}" if cursor else "")
+        status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}{suffix}", admin=True))
+        assert status == 200 and len(body["links"]) <= 2
+        seen.extend(link["link_id"] for link in body["links"])
+        cursor = body["links_next_cursor"]
+        if cursor is None:
+            break
+    assert cursor is None
+    assert seen == [link["link_id"] for link in store.list_links(conn, work_id)]
+    status, body = http.handle(conn, _req("GET", f"/work/items/{work_id}?limit=2", admin=True))
+    assert status == 400 and body["code"] == "unknown-field"
+
+
+def test_a_node_may_not_present_the_reserved_admin_node_id(tmp_path):
+    conn = _http_conn(tmp_path)
+    for request in (
+        _req("GET", "/work/items", node="admin"),
+        _req("GET", "/work/items", node="admin", operator=True),
+        _req(
+            "POST",
+            "/work/imports",
+            node="admin",
+            operator=True,
+            body={"adapter_id": "github:x", "source_type": "github", "idempotency_key": "k", "observations": []},
+        ),
+    ):
+        status, body = http.handle(conn, request)
+        assert (status, body["code"]) == (403, "forbidden")
+
+
+def test_the_admin_node_id_is_never_a_configured_operator_node(monkeypatch):
+    monkeypatch.setenv("BRIGADE_WORKLORE_OPERATOR_NODES", "admin,node-a")
+    assert worklore_http.operator_nodes() == ("node-a",)

--- a/tests/test_worklore_store.py
+++ b/tests/test_worklore_store.py
@@ -1,0 +1,2729 @@
+# Synthetic rejection fixtures retain private paths and credential-like emails.
+# content-guard: allow home-path file
+# content-guard: allow email file
+import sqlite3
+
+import pytest
+from brigade import fleet_hub
+from brigade import worklore_store as store
+
+# The hub refuses to project an observation whose source will not say which revision it is
+# speaking for, so a revision is part of the ordinary shape of a test observation rather
+# than something only the replay tests bother with.
+_BASE_REVISION = "2026-01-01T00:00:00+00:00"
+
+
+def _conn(tmp_path):
+    conn = fleet_hub.init_db(tmp_path / "worklore.db")
+    store.ensure_schema(conn)
+    return conn
+
+
+def _legacy_items(conn, count, *, prefix="legacy"):
+    """Insert old rows directly so a listing test can exercise a large ledger cheaply."""
+    rows = [
+        (
+            f"wl-{prefix}-{index:06d}",
+            f"{prefix} {index}",
+            None,
+            "fleet",
+            None,
+            "captured",
+            "normal",
+            0,
+            0,
+            "small",
+            "manual",
+            "[]",
+            None,
+            None,
+            None,
+            None,
+            0,
+            1,
+            f"{index:020d}",
+            f"{index:020d}",
+            None,
+        )
+        for index in range(count)
+    ]
+    conn.executemany(
+        "INSERT INTO work_items (work_id, title, description, kind, scope, status, priority, burn_eligible, "
+        "burn_rank, token_appetite, execution_mode, acceptance_json, blocker, review_after, spend_by, ready_at, "
+        "attempt_count, version, created_at, updated_at, archived_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+
+def _within_sqlite_budget(conn, read):
+    callbacks = 0
+
+    def stop_after_fixed_work():
+        nonlocal callbacks
+        callbacks += 1
+        return 1 if callbacks > 80 else 0
+
+    conn.set_progress_handler(stop_after_fixed_work, 100)
+    try:
+        return read()
+    finally:
+        conn.set_progress_handler(None, 0)
+
+
+def _legacy_events(conn, work_id, count, *, event_type="legacy"):
+    rows = [
+        (
+            work_id,
+            f"evt-{event_type}-{index:06d}",
+            event_type,
+            None,
+            None,
+            "operator",
+            "admin",
+            None,
+            None,
+            "{}",
+            f"{index:020d}",
+            f"{index:020d}",
+            100_000 + index,
+        )
+        for index in range(count)
+    ]
+    conn.executemany(
+        "INSERT INTO work_events (work_id, event_id, event_type, from_status, to_status, actor_type, actor_id, "
+        "node_id, run_id, detail_json, occurred_at, received_at, seq) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+
+
+def test_fresh_hub_applies_worklore_schema_after_model_roster_v15(tmp_path):
+    assert fleet_hub.SCHEMA_VERSION > 15
+    conn = fleet_hub.init_db(tmp_path / "hub.db")
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION
+        assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM work_create_keys").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_create_and_transition_share_one_transaction(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Fleet maintenance", "kind": "fleet"}, actor_id="admin")
+    assert item["work_id"].startswith("wl-")
+    assert item["status"] == "captured"
+    assert item["version"] == 1
+    events = store.list_events(conn, item["work_id"])
+    assert [event["event_type"] for event in events] == ["created"]
+    updated = store.transition(
+        conn,
+        item["work_id"],
+        to_status="defining",
+        expected_version=1,
+        actor_type="operator",
+        actor_id="admin",
+    )
+    assert updated["status"] == "defining" and updated["version"] == 2
+    assert [event["event_type"] for event in store.list_events(conn, item["work_id"])] == [
+        "created",
+        "transitioned",
+    ]
+
+
+def test_ready_sets_ready_at_and_burn_order_is_stable(tmp_path):
+    conn = _conn(tmp_path)
+    first = store.create_item(conn, {"title": "A", "kind": "fleet"}, actor_id="admin")
+    second = store.create_item(conn, {"title": "B", "kind": "fleet"}, actor_id="admin")
+    for work_id, rank, spend_by in (
+        (second["work_id"], 10, "2026-09-01T00:00:00+00:00"),
+        (first["work_id"], 10, "2026-08-30T00:00:00+00:00"),
+    ):
+        store.patch_item(
+            conn,
+            work_id,
+            {
+                "acceptance": ["done"],
+                "burn_eligible": True,
+                "execution_mode": "agent",
+                "burn_rank": rank,
+                "spend_by": spend_by,
+            },
+            expected_version=1,
+            actor_id="admin",
+        )
+        store.transition(conn, work_id, to_status="ready", expected_version=2, actor_id="admin")
+    queue = store.burn_queue(conn)
+    assert [item["title"] for item in queue["items"]] == ["A", "B"]
+    assert queue["exclusions"]["attempt-limit"] == 0
+    assert queue["exclusions"]["source-policy"] == 0
+
+
+def test_exclusion_bucket_is_first_match(tmp_path):
+    conn = _conn(tmp_path)
+    store.create_item(conn, {"title": "Not ready", "kind": "fleet"}, actor_id="admin")
+    queue = store.burn_queue(conn)
+    assert queue["exclusions"]["not-ready"] == 1
+    assert queue["exclusions"]["acceptance-required"] == 0
+
+
+def test_work_links_require_existing_work_id(tmp_path):
+    conn = _conn(tmp_path)
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO work_links (link_id, work_id, link_type, external_key, "
+            "source_policy, source_acceptance_json, synced_at) VALUES "
+            "('lnk-missing', 'wl-missing', 'url', 'https://example.com/a', "
+            "'eligible', '[]', '2026-08-29T00:00:00+00:00')"
+        )
+        conn.commit()
+
+
+def test_stale_version_does_not_write_an_event(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Conflict", "kind": "admin"}, actor_id="admin")
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.patch_item(conn, item["work_id"], {"priority": "high"}, expected_version=0, actor_id="admin")
+    assert excinfo.value.code == "version-conflict"
+    assert store.list_events(conn, item["work_id"])[0]["event_type"] == "created"
+    assert store.get_item(conn, item["work_id"])["version"] == 1
+
+
+def test_unlink_advances_item_version_and_rejects_a_stale_writer(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Unlink race", "kind": "fleet"}, actor_id="admin")
+    link = store.add_link(
+        conn,
+        item["work_id"],
+        {"link_type": "url", "external_key": "https://example.invalid/unlink-race"},
+        actor_id="admin",
+    )
+    conn.execute(
+        "UPDATE work_items SET updated_at = ? WHERE work_id = ?", ("2000-01-01T00:00:00+00:00", item["work_id"])
+    )
+    conn.commit()
+
+    unlinked = store.delete_link(
+        conn,
+        item["work_id"],
+        link["link_id"],
+        expected_version=item["version"],
+        actor_id="admin",
+    )
+
+    assert unlinked["version"] == item["version"] + 1
+    assert unlinked["updated_at"] != "2000-01-01T00:00:00+00:00"
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.patch_item(
+            conn, item["work_id"], {"priority": "high"}, expected_version=item["version"], actor_id="admin"
+        )
+    assert excinfo.value.code == "version-conflict"
+    assert store.list_links(conn, item["work_id"]) == []
+
+
+def test_import_batch_is_idempotent_and_keeps_scheduling(tmp_path):
+    conn = _conn(tmp_path)
+    observation = {
+        "external_key": "escoffier-labs/brigade#1",
+        "link_type": "github",
+        "title": "Burn queue item",
+        "description": "Do the work",
+        "acceptance": ["tests pass"],
+        "external_state": "open",
+        "external_updated_at": "2026-08-29T00:00:00+00:00",
+        "url": "https://github.com/escoffier-labs/brigade/issues/1",
+        "display_ref": "escoffier-labs/brigade#1",
+        "source_policy": "eligible",
+    }
+    first = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    store.patch_item(
+        conn,
+        first["items"][0]["work_id"],
+        {"burn_rank": 5, "token_appetite": "large", "acceptance": ["operator override"]},
+        expected_version=1,
+        actor_id="admin",
+    )
+    conn.execute(
+        "UPDATE work_sync_cursors SET last_success_at = '2026-01-01T00:00:00+00:00', "
+        "updated_at = '2026-01-01T00:00:00+00:00' WHERE adapter_id = ?",
+        ("github:escoffier-labs",),
+    )
+    conn.commit()
+    second = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    replay_cursor = conn.execute(
+        "SELECT last_success_at, updated_at FROM work_sync_cursors WHERE adapter_id = ?",
+        ("github:escoffier-labs",),
+    ).fetchone()
+    assert replay_cursor[0] > "2026-01-01T00:00:00+00:00"
+    assert replay_cursor[1] > "2026-01-01T00:00:00+00:00"
+    later = dict(observation)
+    later["acceptance"] = ["source refreshed"]
+    later["external_updated_at"] = "2026-08-30T00:00:00+00:00"
+    store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1b",
+        observations=[later],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    replay = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-1",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    item = store.get_item(conn, first["items"][0]["work_id"])
+    links = store.list_links(conn, item["work_id"])
+    assert second["created"] == 1 and second["updated"] == 0
+    assert replay["created"] == second["created"]
+    assert replay["updated"] == 0
+    assert [entry["external_key"] for entry in replay["items"]] == [observation["external_key"]]
+    assert item["burn_rank"] == 5
+    assert item["token_appetite"] == "large"
+    assert item["acceptance"] == ["operator override"]
+    assert item["effective_acceptance"] == ["operator override"]
+    assert links[0]["source_acceptance"] == ["source refreshed"]
+    types = [event["event_type"] for event in store.list_events(conn, item["work_id"])]
+    assert types.count("sync-observed") == 2
+
+
+def test_import_rejects_secrets_paths_duplicate_keys_and_foreign_nodes(tmp_path):
+    conn = _conn(tmp_path)
+    with pytest.raises(store.WorkloreValidationError) as excinfo:
+        store.import_batch(
+            conn,
+            adapter_id="github:escoffier-labs",
+            source_type="github",
+            idempotency_key="batch-bad",
+            observations=[
+                {
+                    "external_key": "a/b#1",
+                    "link_type": "github",
+                    "title": "x",
+                    "source_policy": "eligible",
+                    "prompt": "secret",
+                }
+            ],
+            actor_id="node-a",
+            owner_node="node-a",
+        )
+    assert excinfo.value.code == "unknown-field"
+    store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="batch-2",
+        observations=[
+            {
+                "external_key": "a/b#2",
+                "link_type": "github",
+                "title": "One",
+                "url": "https://github.com/a/b/issues/2",
+                "external_state": "open",
+                "external_updated_at": "2026-01-01T00:00:00+00:00",
+                "source_policy": "eligible",
+            }
+        ],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    collision = store.import_batch(
+        conn,
+        adapter_id="github:other",
+        source_type="github",
+        idempotency_key="batch-3",
+        observations=[
+            {
+                "external_key": "a/b#2",
+                "link_type": "github",
+                "title": "Two",
+                "url": "https://github.com/a/b/issues/2",
+                "external_state": "open",
+                "external_updated_at": "2026-01-02T00:00:00+00:00",
+                "source_policy": "eligible",
+            }
+        ],
+        actor_id="node-b",
+        owner_node="node-b",
+    )
+    assert collision["refused_details"][0]["reason"] == store.REFUSED_ADAPTER_IDENTITY_CONFLICT
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.import_batch(
+            conn,
+            adapter_id="github:escoffier-labs",
+            source_type="github",
+            idempotency_key="batch-4",
+            observations=[
+                {
+                    "external_key": "a/b#3",
+                    "link_type": "github",
+                    "title": "Three",
+                    "url": "https://github.com/a/b/issues/3",
+                    "external_state": "open",
+                    "external_updated_at": "2026-01-01T00:00:00+00:00",
+                    "source_policy": "eligible",
+                }
+            ],
+            actor_id="node-b",
+            owner_node="node-b",
+        )
+    assert excinfo.value.code == "adapter-owner-mismatch"
+
+
+def test_execution_link_requires_existing_run_for_caller_node(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Join run", "kind": "fleet"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    linked = store.link_execution(conn, item["work_id"], node_id="node-a", run_id="run-1", actor_id="node-a")
+    assert linked["link_type"] == "fleet-run"
+    assert linked["external_key"] == "node-a/run-1"
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.link_execution(conn, item["work_id"], node_id="node-b", run_id="run-1", actor_id="node-a")
+    assert excinfo.value.code == "execution-mismatch"
+
+
+def test_execution_link_is_idempotent_and_conflicts_across_work_items(tmp_path):
+    conn = _conn(tmp_path)
+    first = store.create_item(conn, {"title": "First", "kind": "fleet"}, actor_id="admin")
+    second = store.create_item(conn, {"title": "Second", "kind": "fleet"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    linked = store.link_execution(conn, first["work_id"], node_id="node-a", run_id="run-1", actor_id="node-a")
+    replay = store.link_execution(conn, first["work_id"], node_id="node-a", run_id="run-1", actor_id="node-a")
+    assert replay == linked
+    assert [event["event_type"] for event in store.list_events(conn, first["work_id"])] == [
+        "created",
+        "execution-linked",
+    ]
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.link_execution(conn, second["work_id"], node_id="node-a", run_id="run-1", actor_id="node-a")
+    assert excinfo.value.code == "link-conflict"
+
+
+def test_admin_links_are_validated_and_emit_stable_events(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Manual links", "kind": "admin"}, actor_id="admin")
+    link = store.add_link(
+        conn,
+        item["work_id"],
+        {"link_type": "url", "external_key": "https://example.invalid/runbook", "display_ref": "Runbook"},
+        actor_id="admin",
+    )
+    assert link["url"] == "https://example.invalid/runbook"
+    assert link["synced_at"]
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.add_link(
+            conn,
+            item["work_id"],
+            {"link_type": "url", "external_key": "https://example.invalid/runbook"},
+            actor_id="admin",
+        )
+    assert excinfo.value.code == "link-conflict"
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.add_link(
+            conn,
+            item["work_id"],
+            {"link_type": "fleet-run", "external_key": "node/run"},
+            actor_id="admin",
+        )
+    assert excinfo.value.code == "link-forbidden"
+    for link_type, external_key in (
+        ("github", "escoffier-labs/brigade#99"),
+        ("brigade", "receipt-99"),
+    ):
+        added = store.add_link(
+            conn,
+            item["work_id"],
+            {"link_type": link_type, "external_key": external_key},
+            actor_id="admin",
+        )
+        with pytest.raises(store.WorkloreConflict) as excinfo:
+            store.add_link(
+                conn,
+                item["work_id"],
+                {"link_type": link_type, "external_key": external_key},
+                actor_id="admin",
+            )
+        assert excinfo.value.code == "link-conflict"
+        store.delete_link(conn, item["work_id"], added["link_id"], actor_id="admin")
+    store.delete_link(conn, item["work_id"], link["link_id"], actor_id="admin")
+    assert store.list_links(conn, item["work_id"]) == []
+    assert [event["event_type"] for event in store.list_events(conn, item["work_id"])] == [
+        "created",
+        "linked",
+        "linked",
+        "unlinked",
+        "linked",
+        "unlinked",
+        "unlinked",
+    ]
+
+
+def test_import_counts_unchanged_without_events_and_replays_them(tmp_path):
+    conn = _conn(tmp_path)
+    observation = {
+        "external_key": "escoffier-labs/brigade#10",
+        "link_type": "github",
+        "title": "Observed",
+        "source_policy": "eligible",
+        "url": "https://github.com/escoffier-labs/brigade/issues/10",
+        "external_updated_at": _BASE_REVISION,
+    }
+    first = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="first",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    work_id = first["items"][0]["work_id"]
+    unchanged = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="same-state",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    assert unchanged["created"] == 0 and unchanged["updated"] == 0 and unchanged["unchanged"] == 1
+    assert [event["event_type"] for event in store.list_events(conn, work_id)] == ["created", "linked", "sync-observed"]
+    assert (
+        store.import_batch(
+            conn,
+            adapter_id="github:escoffier-labs",
+            source_type="github",
+            idempotency_key="same-state",
+            observations=[observation],
+            actor_id="node-a",
+            owner_node="node-a",
+        )
+        == unchanged
+    )
+
+
+def test_list_keysets_filter_and_page_deterministically(tmp_path):
+    conn = _conn(tmp_path)
+    items = [
+        store.create_item(conn, {"title": f"Item {index}", "kind": "fleet"}, actor_id="admin") for index in range(3)
+    ]
+    first = store.list_items(conn, kind="fleet", burn_eligible=False, limit=2)
+    second = store.list_items(conn, kind="fleet", burn_eligible=False, limit=2, cursor=first["next_cursor"])
+    assert [item["work_id"] for item in first["items"] + second["items"]] == [item["work_id"] for item in items]
+    assert store.list_all_events(conn, event_type="created", limit=1)["next_cursor"]
+    with pytest.raises(store.WorkloreValidationError) as excinfo:
+        store.list_items(conn, limit=101)
+    assert excinfo.value.code == "field-bound"
+
+
+def test_record_attempt_failed_excludes_after_two(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Burn me", "kind": "fleet"}, actor_id="admin")
+    store.patch_item(
+        conn,
+        item["work_id"],
+        {"acceptance": ["done"], "burn_eligible": True, "execution_mode": "agent"},
+        expected_version=1,
+        actor_id="admin",
+    )
+    store.transition(conn, item["work_id"], to_status="ready", expected_version=2, actor_id="admin")
+    store.record_attempt(conn, item["work_id"], action="failed", expected_version=3, actor_id="admin")
+    store.record_attempt(conn, item["work_id"], action="failed", expected_version=4, actor_id="admin")
+    queue = store.burn_queue(conn)
+    assert queue["items"] == []
+    assert queue["exclusions"]["attempt-limit"] == 1
+    reset = store.record_attempt(conn, item["work_id"], action="reset", expected_version=5, actor_id="admin")
+    assert reset["attempt_count"] == 0
+
+
+def test_record_attempt_started_bumps_version_without_count(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Start me", "kind": "fleet"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    store.link_execution(conn, item["work_id"], node_id="node-a", run_id="run-1", actor_id="node-a")
+    started = store.record_attempt(
+        conn,
+        item["work_id"],
+        action="started",
+        expected_version=1,
+        actor_id="node-a",
+        node_id="node-a",
+        run_id="run-1",
+    )
+    assert started["attempt_count"] == 0
+    assert started["version"] == 2
+
+
+def test_node_attempt_replays_are_idempotent_even_with_a_stale_version(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Replay", "kind": "fleet"}, actor_id="admin")
+    _run_row(conn, run_id="run-replay")
+    store.link_execution(conn, item["work_id"], node_id="node-a", run_id="run-replay", actor_id="node-a")
+
+    started = store.record_attempt(
+        conn,
+        item["work_id"],
+        action="started",
+        expected_version=1,
+        actor_id="node-a",
+        node_id="node-a",
+        run_id="run-replay",
+    )
+    replayed_start = store.record_attempt(
+        conn,
+        item["work_id"],
+        action="started",
+        expected_version=1,
+        actor_id="node-a",
+        node_id="node-a",
+        run_id="run-replay",
+    )
+    failed = store.record_attempt(
+        conn,
+        item["work_id"],
+        action="failed",
+        expected_version=2,
+        actor_id="node-a",
+        node_id="node-a",
+        run_id="run-replay",
+    )
+    replayed_failure = store.record_attempt(
+        conn,
+        item["work_id"],
+        action="failed",
+        expected_version=2,
+        actor_id="node-a",
+        node_id="node-a",
+        run_id="run-replay",
+    )
+
+    assert replayed_start == started
+    assert replayed_failure == failed
+    assert failed["attempt_count"] == 1 and failed["version"] == 3
+    assert [event["event_type"] for event in store.list_events(conn, item["work_id"])] == [
+        "created",
+        "execution-linked",
+        "attempt-started",
+        "attempt-failed",
+    ]
+
+
+def test_attempt_event_ceiling_refuses_new_unique_actions(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ITEM_MAX_ATTEMPT_EVENTS", 2)
+    item = store.create_item(conn, {"title": "Bounded", "kind": "fleet"}, actor_id="admin")
+    first = store.record_attempt(
+        conn, item["work_id"], action="started", expected_version=1, actor_id="admin", run_id="run-1"
+    )
+    store.record_attempt(
+        conn, item["work_id"], action="failed", expected_version=first["version"], actor_id="admin", run_id="run-2"
+    )
+
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.record_attempt(
+            conn, item["work_id"], action="started", expected_version=3, actor_id="admin", run_id="run-3"
+        )
+
+    assert excinfo.value.code == "attempt-conflict"
+    assert [event["event_type"] for event in store.list_events(conn, item["work_id"])] == [
+        "created",
+        "attempt-started",
+        "attempt-failed",
+    ]
+
+
+def test_attempt_event_ceiling_uses_a_bounded_index_probe_for_legacy_events(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Legacy attempts", "kind": "fleet"}, actor_id="admin")
+    recorded = store.record_attempt(
+        conn,
+        item["work_id"],
+        action="started",
+        expected_version=1,
+        actor_id="admin",
+        run_id="existing-run",
+    )
+    _legacy_events(conn, item["work_id"], 25_000, event_type="attempt-started")
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+    try:
+        with pytest.raises(store.WorkloreConflict) as excinfo:
+            _within_sqlite_budget(
+                conn,
+                lambda: store.record_attempt(
+                    conn,
+                    item["work_id"],
+                    action="started",
+                    expected_version=2,
+                    actor_id="admin",
+                    run_id="new-unique-run",
+                ),
+            )
+    finally:
+        conn.set_trace_callback(None)
+
+    assert excinfo.value.code == "attempt-conflict"
+    probe_reads = [statement for statement in statements if "work_events_attempt_work_seq" in statement]
+    assert len(probe_reads) == 1
+    assert "SELECT 1 FROM work_events INDEXED BY work_events_attempt_work_seq" in probe_reads[0]
+    assert f"LIMIT 1 OFFSET {store.ITEM_MAX_ATTEMPT_EVENTS - 1}" in probe_reads[0]
+    assert (
+        store.record_attempt(
+            conn,
+            item["work_id"],
+            action="started",
+            expected_version=2,
+            actor_id="admin",
+            run_id="existing-run",
+        )
+        == recorded
+    )
+
+
+def test_reset_discards_its_run_id(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Reset", "kind": "fleet"}, actor_id="admin")
+
+    store.record_attempt(
+        conn, item["work_id"], action="reset", expected_version=1, actor_id="admin", run_id="run-do-not-persist"
+    )
+
+    assert store.list_events(conn, item["work_id"])[-1]["run_id"] is None
+
+
+def test_node_failed_without_owned_fleet_run_is_forbidden(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "No run", "kind": "fleet"}, actor_id="admin")
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.record_attempt(
+            conn,
+            item["work_id"],
+            action="failed",
+            expected_version=1,
+            actor_id="node-a",
+            node_id="node-a",
+            run_id="run-missing",
+        )
+    assert excinfo.value.code == "attempt-forbidden"
+
+
+def test_list_items_source_filters_include_links(tmp_path):
+    conn = _conn(tmp_path)
+    native = store.create_item(conn, {"title": "Native only", "kind": "fleet"}, actor_id="admin")
+    imported = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="list-1",
+        observations=[
+            {
+                "external_key": "escoffier-labs/brigade#9",
+                "link_type": "github",
+                "title": "Linked issue",
+                "source_policy": "eligible",
+                "url": "https://github.com/escoffier-labs/brigade/issues/9",
+                "external_updated_at": _BASE_REVISION,
+            }
+        ],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    github_items = store.list_items(conn, source="github")
+    native_items = store.list_items(conn, source="native")
+    assert [item["work_id"] for item in github_items["items"]] == [imported["items"][0]["work_id"]]
+    assert github_items["items"][0]["links"][0]["external_key"] == "escoffier-labs/brigade#9"
+    assert [item["work_id"] for item in native_items["items"]] == [native["work_id"]]
+    assert native_items["items"][0]["links"] == []
+    events = store.list_all_events(conn)
+    assert {event["event_type"] for event in events["events"]} >= {"created", "sync-observed"}
+
+
+def test_filtered_item_listing_stops_at_its_candidate_budget_and_paginates_past_sparse_rows(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    _legacy_items(conn, 25_000)
+    conn.execute("UPDATE work_items SET status = 'ready', burn_eligible = 1")
+    conn.commit()
+    monkeypatch.setattr(store, "LIST_SCAN_MAX", 13, raising=False)
+
+    sparse = _within_sqlite_budget(
+        conn,
+        lambda: store.list_items(conn, status="ready", kind="fleet", burn_eligible=True, source="github", limit=1),
+    )
+    assert sparse["items"] == []
+    assert sparse["next_cursor"]
+
+    conn.execute(
+        "INSERT INTO work_links (link_id, work_id, link_type, external_key, source_policy, "
+        "source_acceptance_json, synced_at) VALUES ('lnk-sparse', 'wl-legacy-000003', 'github', "
+        "'example/repo#3', 'eligible', '[]', '00000000000000000003')"
+    )
+    conn.commit()
+    monkeypatch.setattr(store, "LIST_SCAN_MAX", 2, raising=False)
+
+    first = store.list_items(conn, status="ready", burn_eligible=True, source="github", limit=1)
+    second = store.list_items(
+        conn, status="ready", burn_eligible=True, source="github", limit=1, cursor=first["next_cursor"]
+    )
+    assert first["items"] == [] and first["next_cursor"]
+    assert [item["work_id"] for item in second["items"]] == ["wl-legacy-000003"]
+    assert second["next_cursor"]
+
+
+def test_missing_source_sets_stale_and_appends_sync_stale(tmp_path):
+    conn = _conn(tmp_path)
+    observation = {
+        "external_key": "escoffier-labs/brigade#8",
+        "link_type": "github",
+        "title": "Vanished",
+        "source_policy": "eligible",
+        "url": "https://github.com/escoffier-labs/brigade/issues/8",
+        "external_updated_at": _BASE_REVISION,
+    }
+    first = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="stale-1",
+        observations=[observation],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    missing = dict(observation)
+    missing["stale"] = True
+    # Marking an identity stale changes the projection, so it is held to the same rule as
+    # any other change: the observation has to advance the revision to be applied.
+    missing["external_updated_at"] = "2026-01-02T00:00:00+00:00"
+    store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="stale-2",
+        observations=[missing],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    work_id = first["items"][0]["work_id"]
+    links = store.list_links(conn, work_id)
+    assert links[0]["stale_at"] is not None
+    assert "sync-stale" in [event["event_type"] for event in store.list_events(conn, work_id)]
+
+
+def test_stale_source_does_not_exclude_an_item_with_another_eligible_non_stale_source(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_github_observation(81, acceptance=["done"])], key="k1")["items"][0]["work_id"]
+    store.patch_item(
+        conn,
+        work_id,
+        {"burn_eligible": True, "execution_mode": "agent"},
+        expected_version=1,
+        actor_id="admin",
+    )
+    store.transition(conn, work_id, to_status="ready", expected_version=2, actor_id="admin")
+    conn.execute(
+        "INSERT INTO work_links (link_id, work_id, link_type, external_key, display_ref, url, external_state, "
+        "external_updated_at, source_policy, source_acceptance_json, synced_at, stale_at) "
+        "VALUES ('lnk-eligible-sibling', ?, 'brigade', 'brigade#81', 'brigade#81', NULL, NULL, NULL, "
+        "'eligible', '[]', '2999-01-01T00:00:00+00:00', NULL)",
+        (work_id,),
+    )
+    conn.commit()
+    stale = _github_observation(81, acceptance=["done"], stale=True)
+    assert _import(conn, [stale], key="k2")["updated"] == 1
+
+    queue = store.burn_queue(conn)
+
+    assert [item["work_id"] for item in queue["items"]] == [work_id]
+    assert queue["exclusions"]["source-policy"] == 0
+
+
+def test_create_item_idempotency_is_scoped_to_operator_and_preserves_node(tmp_path):
+    conn = _conn(tmp_path)
+    body = {"title": "Retry native", "kind": "fleet"}
+    first = store.create_item(
+        conn,
+        body,
+        actor_id="ops-node",
+        actor_type="operator",
+        node_id="ops-node",
+        idempotency_key="native-1",
+    )
+    replay = store.create_item(
+        conn,
+        body,
+        actor_id="ops-node",
+        actor_type="operator",
+        node_id="ops-node",
+        idempotency_key="native-1",
+    )
+    assert replay["work_id"] == first["work_id"]
+    events = store.list_events(conn, first["work_id"])
+    assert [event["event_type"] for event in events] == ["created"]
+    assert events[0]["actor_type"] == "operator"
+    assert events[0]["actor_id"] == "ops-node"
+    assert events[0]["node_id"] == "ops-node"
+    with pytest.raises(store.WorkloreConflict) as excinfo:
+        store.create_item(
+            conn,
+            {"title": "Different payload", "kind": "fleet"},
+            actor_id="ops-node",
+            actor_type="operator",
+            node_id="ops-node",
+            idempotency_key="native-1",
+        )
+    assert excinfo.value.code == "import-conflict"
+    other = store.create_item(
+        conn,
+        body,
+        actor_id="admin",
+        actor_type="operator",
+        idempotency_key="native-1",
+    )
+    assert other["work_id"] != first["work_id"]
+    stored = conn.execute(
+        "SELECT actor_id, idempotency_key, work_id FROM work_create_keys ORDER BY actor_id"
+    ).fetchall()
+    assert [(row[0], row[1]) for row in stored] == [("admin", "native-1"), ("ops-node", "native-1")]
+
+
+def _github_observation(number: int, **overrides):
+    observation = {
+        "external_key": f"escoffier-labs/brigade#{number}",
+        "link_type": "github",
+        "title": f"Issue {number}",
+        "source_policy": "eligible",
+        "url": f"https://github.com/escoffier-labs/brigade/issues/{number}",
+        "external_updated_at": _BASE_REVISION,
+    }
+    observation.update(overrides)
+    return observation
+
+
+def _import(conn, observations, *, key, adapter="github:escoffier-labs"):
+    return store.import_batch(
+        conn,
+        adapter_id=adapter,
+        source_type="github",
+        idempotency_key=key,
+        observations=observations,
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+
+
+def test_item_events_page_in_insertion_order_when_a_batch_shares_one_timestamp(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_github_observation(1)], key="k1")["items"][0]["work_id"]
+    expected = [event["event_id"] for event in store.list_events(conn, work_id)]
+    assert [event["event_type"] for event in store.list_events(conn, work_id)] == [
+        "created",
+        "linked",
+        "sync-observed",
+    ]
+    occurred = {row[0] for row in conn.execute("SELECT occurred_at FROM work_events WHERE work_id = ?", (work_id,))}
+    assert len(occurred) == 1, "the batch must share one timestamp for this test to mean anything"
+    paged: list[str] = []
+    cursor = None
+    while True:
+        page = store.list_events_page(conn, work_id, limit=1, cursor=cursor)
+        paged.extend(event["event_id"] for event in page["events"])
+        cursor = page["next_cursor"]
+        if not cursor:
+            break
+    assert paged == expected
+    assert all("seq" not in event for event in store.list_events_page(conn, work_id, limit=10)["events"])
+
+
+def test_item_event_cursor_replay_is_stable(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_github_observation(2)], key="k1")["items"][0]["work_id"]
+    first = store.list_events_page(conn, work_id, limit=2)
+    replay = store.list_events_page(conn, work_id, limit=2, cursor=first["next_cursor"])
+    assert replay == store.list_events_page(conn, work_id, limit=2, cursor=first["next_cursor"])
+    assert [event["event_id"] for event in first["events"] + replay["events"]] == [
+        event["event_id"] for event in store.list_events(conn, work_id)
+    ]
+
+
+def test_fleet_wide_events_break_shared_timestamp_ties_by_insertion_order(tmp_path):
+    conn = _conn(tmp_path)
+    _import(conn, [_github_observation(3)], key="k1")
+    newest_first = [event["event_id"] for event in store.list_all_events(conn, limit=100)["events"]]
+    assert newest_first == list(
+        reversed([row[0] for row in conn.execute("SELECT event_id FROM work_events ORDER BY seq")])
+    )
+    paged: list[str] = []
+    cursor = None
+    while True:
+        page = store.list_all_events(conn, limit=1, cursor=cursor)
+        paged.extend(event["event_id"] for event in page["events"])
+        cursor = page["next_cursor"]
+        if not cursor:
+            break
+    assert paged == newest_first
+
+
+def test_filtered_event_listing_stops_at_its_candidate_budget_and_paginates_past_sparse_rows(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Event ledger", "kind": "fleet"}, actor_id="admin")
+    _legacy_events(conn, item["work_id"], 25_000)
+    monkeypatch.setattr(store, "LIST_SCAN_MAX", 13, raising=False)
+
+    sparse = _within_sqlite_budget(
+        conn,
+        lambda: store.list_all_events(conn, work_id=item["work_id"], event_type="missing", limit=1),
+    )
+    assert sparse["events"] == []
+    assert sparse["next_cursor"]
+
+    conn.execute(
+        "UPDATE work_events SET event_type = 'target' WHERE work_id = ? AND event_id = 'evt-legacy-024997'",
+        (item["work_id"],),
+    )
+    conn.commit()
+    monkeypatch.setattr(store, "LIST_SCAN_MAX", 2, raising=False)
+
+    first = store.list_all_events(conn, work_id=item["work_id"], event_type="target", limit=1)
+    second = store.list_all_events(
+        conn, work_id=item["work_id"], event_type="target", limit=1, cursor=first["next_cursor"]
+    )
+    assert first["events"] == [] and first["next_cursor"]
+    assert [event["event_id"] for event in second["events"]] == ["evt-legacy-024997"]
+    assert second["next_cursor"]
+
+
+def test_event_pagination_rejects_a_cursor_that_lost_its_sequence(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Cursor", "kind": "fleet"}, actor_id="admin")
+    stale = store._encode_cursor("item-events", {"occurred_at": "t", "event_id": "evt-1"})
+    with pytest.raises(store.WorkloreValidationError) as excinfo:
+        store.list_events_page(conn, item["work_id"], limit=1, cursor=stale)
+    assert excinfo.value.code == "field-bound"
+
+
+def test_unchanged_observation_refreshes_synced_at_without_events_or_version_churn(tmp_path):
+    conn = _conn(tmp_path)
+    observation = _github_observation(4)
+    first = _import(conn, [observation], key="k1")
+    work_id = first["items"][0]["work_id"]
+    before_item = store.get_item(conn, work_id)
+    before_link = store.list_links(conn, work_id)[0]
+    conn.execute(
+        "UPDATE work_links SET synced_at = ? WHERE link_id = ?", ("2000-01-01T00:00:00+00:00", before_link["link_id"])
+    )
+    conn.commit()
+    events_before = store.list_events(conn, work_id)
+    result = _import(conn, [observation], key="k2")
+    after_link = store.list_links(conn, work_id)[0]
+    assert result["created"] == 0 and result["updated"] == 0 and result["unchanged"] == 1
+    assert after_link["synced_at"] > "2000-01-01T00:00:00+00:00"
+    assert store.list_events(conn, work_id) == events_before
+    assert store.get_item(conn, work_id)["version"] == before_item["version"]
+    assert store.get_item(conn, work_id)["updated_at"] == before_item["updated_at"]
+
+
+def test_oldest_eligible_link_is_authoritative_even_with_empty_acceptance(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_github_observation(5, acceptance=[])], key="k1")["items"][0]["work_id"]
+    conn.execute(
+        "INSERT INTO work_links (link_id, work_id, link_type, external_key, display_ref, url, external_state, "
+        "external_updated_at, source_policy, source_acceptance_json, synced_at, stale_at) "
+        "VALUES ('lnk-younger', ?, 'brigade', 'other#1', 'other#1', NULL, NULL, NULL, 'eligible', "
+        "'[\"younger criterion\"]', '2999-01-01T00:00:00+00:00', NULL)",
+        (work_id,),
+    )
+    conn.commit()
+    assert store.get_item(conn, work_id)["effective_acceptance"] == []
+    with pytest.raises(store.WorkloreValidationError) as excinfo:
+        store.transition(
+            conn,
+            work_id,
+            to_status="ready",
+            expected_version=store.get_item(conn, work_id)["version"],
+            actor_id="admin",
+        )
+    assert excinfo.value.code == "acceptance-required"
+
+
+def test_eligible_adapter_link_stays_protected_from_operator_unlink(tmp_path):
+    conn = _conn(tmp_path)
+    imported = _import(conn, [_github_observation(6)], key="k1")
+    work_id = imported["items"][0]["work_id"]
+    link_id = store.list_links(conn, work_id)[0]["link_id"]
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.delete_link(conn, work_id, link_id, actor_id="admin")
+    assert excinfo.value.code == "link-forbidden"
+    assert len(store.list_links(conn, work_id)) == 1
+
+
+def test_retired_adapter_link_unlinks_to_native_with_one_event_and_kept_schedule(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_github_observation(7)], key="k1")["items"][0]["work_id"]
+    store.patch_item(
+        conn,
+        work_id,
+        {
+            "acceptance": ["stays put"],
+            "burn_rank": 42,
+            "burn_eligible": True,
+            "execution_mode": "agent",
+            "review_after": "2026-01-01T00:00:00+00:00",
+            "spend_by": "2027-01-01T00:00:00+00:00",
+        },
+        expected_version=store.get_item(conn, work_id)["version"],
+        actor_id="admin",
+    )
+    _import(
+        conn,
+        [_github_observation(7, source_policy="label-removed", external_updated_at="2026-01-02T00:00:00+00:00")],
+        key="k2",
+    )
+    scheduled = store.get_item(conn, work_id)
+    link_id = store.list_links(conn, work_id)[0]["link_id"]
+    before = len(store.list_events(conn, work_id))
+    store.delete_link(conn, work_id, link_id, actor_id="ops-node", actor_type="operator", node_id="ops-node")
+    events = store.list_events(conn, work_id)
+    assert len(events) == before + 1
+    unlinked = events[-1]
+    assert unlinked["event_type"] == "unlinked"
+    assert unlinked["actor_type"] == "operator" and unlinked["actor_id"] == "ops-node"
+    assert unlinked["detail"]["source_policy"] == "label-removed"
+    assert unlinked["detail"]["became_native"] is True
+    assert unlinked["detail"]["adapter_id"] == "github:escoffier-labs"
+    assert store.list_links(conn, work_id) == []
+    assert store.list_items(conn, source="native")["items"][0]["work_id"] == work_id
+    assert store.list_items(conn, source="github")["items"] == []
+    after = store.get_item(conn, work_id)
+    for field in ("burn_rank", "review_after", "spend_by", "ready_at", "attempt_count"):
+        assert after[field] == scheduled[field], field
+    assert after["version"] == scheduled["version"] + 1
+
+
+def test_unlinking_one_of_two_source_links_does_not_claim_native(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_github_observation(8)], key="k1")["items"][0]["work_id"]
+    conn.execute(
+        "INSERT INTO work_links (link_id, work_id, link_type, external_key, display_ref, url, external_state, "
+        "external_updated_at, source_policy, source_acceptance_json, synced_at, stale_at) "
+        "VALUES ('lnk-second', ?, 'brigade', 'repo#2', 'repo#2', NULL, NULL, NULL, 'eligible', '[]', "
+        "'2999-01-01T00:00:00+00:00', NULL)",
+        (work_id,),
+    )
+    conn.commit()
+    _import(
+        conn,
+        [_github_observation(8, source_policy="closed", external_updated_at="2026-01-02T00:00:00+00:00")],
+        key="k2",
+    )
+    github_link = next(link for link in store.list_links(conn, work_id) if link["link_type"] == "github")
+    store.delete_link(conn, work_id, github_link["link_id"], actor_id="admin")
+    unlinked = store.list_events(conn, work_id)[-1]
+    assert "became_native" not in unlinked["detail"]
+    assert [link["link_type"] for link in store.list_links(conn, work_id)] == ["brigade"]
+
+
+def test_execution_link_authority_comes_from_the_admin_flag_not_the_actor_id(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Join run", "kind": "fleet"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('node-a', 'run-1', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    with pytest.raises(store.WorkloreForbidden) as excinfo:
+        store.link_execution(conn, item["work_id"], node_id="node-a", run_id="run-1", actor_id="admin")
+    assert excinfo.value.code == "execution-mismatch"
+    linked = store.link_execution(
+        conn,
+        item["work_id"],
+        node_id="node-a",
+        run_id="run-1",
+        actor_id="admin",
+        actor_type="operator",
+        is_admin=True,
+    )
+    assert linked["external_key"] == "node-a/run-1"
+    assert store.list_events(conn, item["work_id"])[-1]["actor_type"] == "operator"
+
+
+def test_operator_node_execution_link_is_recorded_as_operator(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Join run", "kind": "fleet"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES ('ops-node', 'run-9', 1, 'd', 'run.created', 't', 't')"
+    )
+    conn.commit()
+    store.link_execution(
+        conn,
+        item["work_id"],
+        node_id="ops-node",
+        run_id="run-9",
+        actor_id="ops-node",
+        actor_type="operator",
+    )
+    event = store.list_events(conn, item["work_id"])[-1]
+    assert event["event_type"] == "execution-linked"
+    assert event["actor_type"] == "operator" and event["actor_id"] == "ops-node"
+
+
+def test_exclusion_bucket_is_the_only_burn_rule_and_matches_the_queue(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Burnable", "kind": "fleet"}, actor_id="admin")
+    work_id = item["work_id"]
+    store.patch_item(
+        conn,
+        work_id,
+        {"acceptance": ["done"], "burn_eligible": True, "execution_mode": "agent"},
+        expected_version=1,
+        actor_id="admin",
+    )
+    store.transition(conn, work_id, to_status="ready", expected_version=2, actor_id="admin")
+    ready = store.get_item(conn, work_id)
+    assert store.exclusion_bucket(ready, []) is None
+    assert store.burn_queue(conn)["items"][0]["work_id"] == work_id
+    assert store.exclusion_bucket(ready, ["label-removed"]) == "source-policy"
+    assert store.exclusion_bucket({**ready, "attempt_count": 2}, []) == "attempt-limit"
+    assert store.exclusion_bucket({**ready, "review_after": "2999-01-01T00:00:00Z"}, []) == "review-after"
+    assert store.exclusion_bucket({**ready, "status": "captured"}, []) == "not-ready"
+
+
+# --- adapter namespace ownership (Daybreak finding 2) ------------------------
+
+
+def _cursor_owners(conn):
+    return [tuple(row) for row in conn.execute("SELECT adapter_id, owner_node FROM work_sync_cursors")]
+
+
+def test_empty_first_batch_does_not_reserve_the_adapter_namespace(tmp_path):
+    conn = _conn(tmp_path)
+    squat = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="squat-1",
+        observations=[],
+        actor_id="node-squatter",
+        owner_node="node-squatter",
+    )
+    assert squat == {"created": 0, "updated": 0, "unchanged": 0, "refused": 0, "refused_details": [], "items": []}
+    assert conn.execute("SELECT COUNT(*) FROM work_sync_cursors").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM work_import_keys").fetchone()[0] == 0
+    real = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="real-1",
+        observations=[_github_observation(1)],
+        actor_id="node-a",
+        owner_node="node-a",
+    )
+    assert real["created"] == 1
+    assert _cursor_owners(conn) == [("github:escoffier-labs", "node-a")]
+
+
+def test_empty_batch_from_the_owning_node_still_records_liveness(tmp_path):
+    conn = _conn(tmp_path)
+    _import(conn, [_github_observation(2)], key="k1")
+    result = _import(conn, [], key="k2")
+    assert result == {"created": 0, "updated": 0, "unchanged": 0, "refused": 0, "refused_details": [], "items": []}
+    assert _cursor_owners(conn) == [("github:escoffier-labs", "node-a")]
+    stored = conn.execute("SELECT COUNT(*) FROM work_import_keys WHERE idempotency_key = 'k2'").fetchone()
+    assert stored[0] == 1
+
+
+def test_adapter_id_must_be_namespaced_by_its_source_type(tmp_path):
+    conn = _conn(tmp_path)
+    for adapter_id, source_type in (
+        ("brigade:escoffier-labs", "github"),
+        ("github:escoffier-labs", "brigade"),
+        ("escoffier-labs", "github"),
+        ("github:", "github"),
+        ("github:-bad", "github"),
+    ):
+        with pytest.raises(store.WorkloreValidationError) as excinfo:
+            store.import_batch(
+                conn,
+                adapter_id=adapter_id,
+                source_type=source_type,
+                idempotency_key="ns-1",
+                observations=[],
+                actor_id="node-a",
+                owner_node="node-a",
+            )
+        assert excinfo.value.code == "field-bound", adapter_id
+    assert conn.execute("SELECT COUNT(*) FROM work_sync_cursors").fetchone()[0] == 0
+
+
+def test_observation_link_type_must_match_the_batch_source_type(tmp_path):
+    conn = _conn(tmp_path)
+    with pytest.raises(store.WorkloreValidationError) as excinfo:
+        store.import_batch(
+            conn,
+            adapter_id="brigade:escoffier-labs",
+            source_type="brigade",
+            idempotency_key="mix-1",
+            observations=[_github_observation(3)],
+            actor_id="node-a",
+            owner_node="node-a",
+        )
+    assert excinfo.value.code == "field-bound"
+    assert conn.execute("SELECT COUNT(*) FROM work_links").fetchone()[0] == 0
+
+
+def test_adapter_cannot_adopt_an_operator_managed_link(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Operator owned", "kind": "repo"}, actor_id="admin")
+    store.add_link(
+        conn,
+        item["work_id"],
+        {"link_type": "github", "external_key": "escoffier-labs/brigade#4"},
+        actor_id="admin",
+    )
+    before = store.list_links(conn, item["work_id"])
+    result = _import(conn, [_github_observation(4, title="Adapter takeover")], key="takeover-1")
+    # The identity is refused, not adopted, and the refusal is named rather than inferred.
+    assert (result["created"], result["updated"], result["unchanged"], result["refused"]) == (0, 0, 0, 1)
+    assert result["refused_details"][0]["reason"] == store.REFUSED_OPERATOR_MANAGED
+    assert store.list_links(conn, item["work_id"]) == before
+    assert store.get_item(conn, item["work_id"])["title"] == "Operator owned"
+
+
+def test_imported_identity_owner_node_mismatch_is_refused(tmp_path):
+    conn = _conn(tmp_path)
+    _import(conn, [_github_observation(5)], key="own-1")
+    conn.execute(
+        "UPDATE work_sync_cursors SET owner_node = 'node-b' WHERE adapter_id = ?",
+        ("github:escoffier-labs",),
+    )
+    conn.commit()
+    result = store.import_batch(
+        conn,
+        adapter_id="github:escoffier-labs",
+        source_type="github",
+        idempotency_key="own-2",
+        observations=[_github_observation(5, title="Moved node")],
+        actor_id="node-b",
+        owner_node="node-b",
+    )
+    assert result["refused_details"][0]["reason"] == store.REFUSED_OWNER_NODE_MISMATCH
+    assert store.list_items(conn)["items"][0]["title"] == "Issue 5"
+
+
+# --- canonical observation validator (Daybreak finding 3) --------------------
+
+
+def _rejects(conn, observation, *, code, key):
+    with pytest.raises((store.WorkloreValidationError, store.WorkloreConflict)) as excinfo:
+        _import(conn, [observation], key=key)
+    assert excinfo.value.code == code, observation
+
+
+def test_observation_validator_rejects_controls_private_paths_and_credentials(tmp_path):
+    conn = _conn(tmp_path)
+    many_deps = [{"type": "task", "id": str(index)} for index in range(51)]
+    cases = (
+        (_github_observation(10, title="bell \x07 title"), "field-bound"),
+        (_github_observation(11, title="reset \x1b[2J title"), "field-bound"),
+        (_github_observation(12, title="see /home/operator/notes"), "private-data"),
+        (_github_observation(13, title="see /Users/operator/notes"), "private-data"),
+        (_github_observation(14, title=r"see C:\Users\operator\notes"), "private-data"),
+        (_github_observation(15, description="%USERPROFILE%\\secrets"), "private-data"),
+        (_github_observation(16, display_ref="ghp_" + "a" * 36), "private-data"),
+        (_github_observation(17, description="api_key=" + "A" * 24), "private-data"),
+        (_github_observation(18, acceptance=["x" * 401]), "field-bound"),
+        (_github_observation(19, acceptance=["ok"] * 21), "field-bound"),
+        (_github_observation(20, url="https://user:pass@github.com/a/b/issues/20"), "private-data"),
+        (_github_observation(21, url="http://github.com/a/b/issues/21"), "field-bound"),
+        (_github_observation(22, url="https:///a/b/issues/22"), "field-bound"),
+        (_github_observation(23, dependencies=many_deps), "field-bound"),
+        (_github_observation(24, evidence_refs=[f"ref-{index}" for index in range(21)]), "field-bound"),
+    )
+    for index, (observation, code) in enumerate(cases):
+        _rejects(conn, observation, code=code, key=f"bad-{index}")
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 0
+
+
+def test_a_safe_link_cannot_be_updated_by_an_unsafe_observation(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_github_observation(25)], key="safe-1")["items"][0]["work_id"]
+    before_item = store.get_item(conn, work_id)
+    before_links = store.list_links(conn, work_id)
+    unsafe = (
+        (_github_observation(25, title="now at /home/operator/notes"), "private-data"),
+        (_github_observation(25, title="now with \x1b]0;title\x07"), "field-bound"),
+        (_github_observation(25, acceptance=["y" * 401]), "field-bound"),
+        (_github_observation(25, url="https://operator:token@github.com/a/b/issues/25"), "private-data"),
+    )
+    for index, (observation, code) in enumerate(unsafe):
+        _rejects(conn, observation, code=code, key=f"unsafe-{index}")
+    assert store.get_item(conn, work_id) == before_item
+    assert store.list_links(conn, work_id) == before_links
+
+
+# --- bounded reads (burn pages, page-scoped links, storage ceilings) ---------
+
+
+def _ready_item(conn, title, **patch):
+    item = store.create_item(conn, {"title": title, "kind": "fleet"}, actor_id="admin")
+    store.patch_item(
+        conn,
+        item["work_id"],
+        {"acceptance": ["done"], "burn_eligible": True, "execution_mode": "agent", **patch},
+        expected_version=1,
+        actor_id="admin",
+    )
+    store.transition(conn, item["work_id"], to_status="ready", expected_version=2, actor_id="admin")
+    return item["work_id"]
+
+
+def _walk_burn(conn, **kwargs):
+    seen: list[str] = []
+    exclusions = {name: 0 for name in store.EXCLUSION_BUCKETS}
+    cursor = None
+    pages = 0
+    while pages < 50:
+        page = store.burn_queue(conn, cursor=cursor, **kwargs)
+        pages += 1
+        seen.extend(item["work_id"] for item in page["items"])
+        for bucket, count in page["exclusions"].items():
+            exclusions[bucket] += count
+        cursor = page["next_cursor"]
+        if cursor is None:
+            return seen, exclusions, pages
+    raise AssertionError("burn pagination did not terminate")
+
+
+def test_burn_queue_pages_a_high_cardinality_ledger_without_losing_rows(tmp_path):
+    conn = _conn(tmp_path)
+    ready = {_ready_item(conn, f"Ready {index:03d}") for index in range(60)}
+    for index in range(5):
+        store.create_item(conn, {"title": f"Captured {index}", "kind": "fleet"}, actor_id="admin")
+    first = store.burn_queue(conn)
+    assert len(first["items"]) == store.BURN_PAGE_DEFAULT
+    assert first["next_cursor"] is not None
+    seen, exclusions, pages = _walk_burn(conn)
+    assert sorted(seen) == sorted(ready)
+    assert len(seen) == len(set(seen))
+    assert exclusions["not-ready"] == 5
+    assert pages > 1
+
+
+def test_burn_page_size_is_bounded_and_the_cursor_is_validated(tmp_path):
+    conn = _conn(tmp_path)
+    for index in range(4):
+        _ready_item(conn, f"Ready {index}")
+    page = store.burn_queue(conn, limit=2)
+    assert len(page["items"]) == 2 and page["next_cursor"] is not None
+    rest = store.burn_queue(conn, limit=2, cursor=page["next_cursor"])
+    assert len(rest["items"]) == 2 and rest["next_cursor"] is None
+    for bad_limit in (0, 101, "many"):
+        with pytest.raises(store.WorkloreValidationError):
+            store.burn_queue(conn, limit=bad_limit)
+    with pytest.raises(store.WorkloreValidationError):
+        store.burn_queue(conn, cursor="not-a-cursor")
+    with pytest.raises(store.WorkloreValidationError):
+        store.burn_queue(conn, cursor=store.list_items(conn, limit=1)["next_cursor"])
+
+
+def test_burn_scan_budget_stops_a_page_of_excluded_rows_and_hands_back_a_cursor(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "BURN_SCAN_MAX", 6)
+    monkeypatch.setattr(store, "_BURN_SCAN_CHUNK", 4)
+    for index in range(20):
+        store.create_item(conn, {"title": f"Captured {index}", "kind": "fleet"}, actor_id="admin")
+    page = store.burn_queue(conn)
+    assert page["items"] == []
+    assert sum(page["exclusions"].values()) == 6
+    assert page["next_cursor"] is not None
+
+
+def _link_reads(conn, read):
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+    try:
+        result = read()
+    finally:
+        conn.set_trace_callback(None)
+    return result, [statement for statement in statements if "FROM work_links" in statement]
+
+
+def _assert_page_scoped_link_reads(reads, page_ids, off_page_ids):
+    assert reads, "page read never consulted links"
+    assert all("GROUP BY" not in statement and "work_id IN (" not in statement for statement in reads)
+    assert all("WHERE work_id =" in statement and "LIMIT" in statement for statement in reads)
+    assert all(any(f"work_id = '{work_id}'" in statement for work_id in page_ids) for statement in reads)
+    assert all(work_id not in statement for statement in reads for work_id in off_page_ids)
+
+
+def test_page_reads_load_links_only_for_the_current_page(tmp_path):
+    conn = _conn(tmp_path)
+    work_ids = [_ready_item(conn, f"Ready {index}") for index in range(6)]
+    for read in (lambda: store.list_items(conn, limit=2), lambda: store.burn_queue(conn, limit=2)):
+        page, reads = _link_reads(conn, read)
+        page_ids = [item["work_id"] for item in page["items"]]
+        _assert_page_scoped_link_reads(reads, page_ids, set(work_ids) - set(page_ids))
+
+
+def test_recent_events_are_cut_by_sql_not_by_slicing_every_event(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Chatty", "kind": "fleet"}, actor_id="admin")
+    work_id = item["work_id"]
+    for version in range(1, 25):
+        store.patch_item(conn, work_id, {"scope": f"scope-{version}"}, expected_version=version, actor_id="admin")
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+    try:
+        recent = store.recent_events(conn, work_id)
+    finally:
+        conn.set_trace_callback(None)
+    assert len(recent) == store.DETAIL_RECENT_EVENTS
+    assert recent == store.list_events(conn, work_id)[-store.DETAIL_RECENT_EVENTS :]
+    reads = [statement for statement in statements if "FROM work_events" in statement]
+    assert reads and all("ORDER BY seq DESC LIMIT" in statement for statement in reads)
+
+
+def _observation(number, *, title="Observed", updated_at=_BASE_REVISION):
+    """One observation from a source that reports which revision it is speaking for.
+
+    A revision is the ordinary case, because the hub will not write a projection without
+    one. ``updated_at=None`` builds the unproven observation the guard refuses.
+    """
+    observation = {
+        "external_key": f"escoffier-labs/brigade#{number}",
+        "link_type": "github",
+        "title": title,
+        "source_policy": "eligible",
+        "url": f"https://github.com/escoffier-labs/brigade/issues/{number}",
+    }
+    if updated_at is not None:
+        observation["external_updated_at"] = updated_at
+    return observation
+
+
+def _import(conn, observations, *, key, adapter="github:escoffier-labs", node="node-a"):
+    return store.import_batch(
+        conn,
+        adapter_id=adapter,
+        source_type="github",
+        idempotency_key=key,
+        observations=observations,
+        actor_id=node,
+        owner_node=node,
+    )
+
+
+def test_adapter_storage_ceiling_refuses_new_identities_and_still_accepts_updates(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ADAPTER_IMPORT_MAX_LINKS", 1)
+    assert _import(conn, [_observation(1)], key="first")["created"] == 1
+    with pytest.raises(store.WorkloreConflict) as refused:
+        _import(conn, [_observation(2)], key="second")
+    assert refused.value.code == "import-conflict"
+    renamed = _observation(1, title="Renamed", updated_at="2026-01-02T00:00:00+00:00")
+    assert _import(conn, [renamed], key="third")["updated"] == 1
+    assert conn.execute("SELECT COUNT(*) FROM work_links").fetchone()[0] == 1
+
+
+def test_owner_storage_ceiling_bounds_every_adapter_one_node_owns(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "OWNER_IMPORT_MAX_LINKS", 1)
+    assert _import(conn, [_observation(1)], key="first")["created"] == 1
+    with pytest.raises(store.WorkloreConflict) as refused:
+        _import(conn, [_observation(2)], key="second", adapter="github:lidless-labs")
+    assert refused.value.code == "import-conflict"
+
+
+def test_link_owner_columns_are_backfilled_from_the_event_log_on_migration(tmp_path):
+    if sqlite3.sqlite_version_info < (3, 35):
+        pytest.skip("ALTER TABLE DROP COLUMN needs SQLite 3.35")
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_observation(7)], key="first")["items"][0]["work_id"]
+    conn.execute("DROP INDEX work_links_adapter")
+    conn.execute("DROP INDEX work_links_owner")
+    conn.execute("ALTER TABLE work_links DROP COLUMN adapter_id")
+    conn.execute("ALTER TABLE work_links DROP COLUMN owner_node")
+    conn.commit()
+    store.ensure_schema(conn)
+    conn.commit()
+    assert conn.execute("SELECT adapter_id, owner_node FROM work_links").fetchone() == (
+        "github:escoffier-labs",
+        "node-a",
+    )
+    assert store._owning_adapter(conn, work_id, "github", "escoffier-labs/brigade#7") == (
+        "github:escoffier-labs",
+        "node-a",
+    )
+    with pytest.raises(store.WorkloreForbidden):
+        _import(conn, [_observation(7)], key="other-node", node="node-b")
+
+
+# --- native text validation (Daybreak finding 1) -----------------------------
+
+
+_LEAKS = (
+    ("private path", "/home/operator/notes"),
+    ("credential", "ghp_" + "a" * 36),
+)
+
+
+def _create_bodies(leak):
+    return [
+        {"title": f"Fleet {leak}", "kind": "fleet", "description": f"see {leak}"},
+        {"title": f"see {leak}", "kind": "fleet"},
+        {"title": "Scoped", "kind": "fleet", "scope": leak},
+        {"title": "Accepting", "kind": "fleet", "acceptance": ["ok", f"paste {leak}"]},
+        {"title": "Blocked", "kind": "fleet", "blocker": f"waiting on {leak}"},
+    ]
+
+
+@pytest.mark.parametrize("label,leak", _LEAKS)
+def test_native_create_rejects_private_data_in_every_durable_text_field(tmp_path, label, leak):
+    conn = _conn(tmp_path)
+    for body in _create_bodies(leak):
+        with pytest.raises(store.WorkloreValidationError) as refused:
+            store.create_item(conn, body, actor_id="admin")
+        assert refused.value.code == "private-data", (label, body)
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("label,leak", _LEAKS)
+def test_native_patch_rejects_private_data_in_every_durable_text_field(tmp_path, label, leak):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Clean", "kind": "fleet"}, actor_id="admin")
+    work_id = item["work_id"]
+    patches = [
+        {"title": f"see {leak}"},
+        {"description": f"see {leak}"},
+        {"scope": leak},
+        {"acceptance": ["ok", f"paste {leak}"]},
+        {"blocker": f"waiting on {leak}"},
+    ]
+    for patch in patches:
+        with pytest.raises(store.WorkloreValidationError) as refused:
+            store.patch_item(conn, work_id, patch, expected_version=1, actor_id="admin")
+        assert refused.value.code == "private-data", (label, patch)
+    after = store.get_item(conn, work_id)
+    assert after["version"] == 1 and after["title"] == "Clean"
+
+
+def test_native_text_keeps_its_existing_length_and_required_semantics(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(
+        conn,
+        {"title": "Empty optionals", "kind": "fleet", "description": "", "scope": "", "blocker": ""},
+        actor_id="admin",
+    )
+    assert item["description"] == "" and item["scope"] == "" and item["blocker"] == ""
+    patched = store.patch_item(conn, item["work_id"], {"scope": ""}, expected_version=1, actor_id="admin")
+    assert patched["scope"] == ""
+    for body, code in (
+        ({"title": "", "kind": "fleet"}, "field-bound"),
+        ({"title": "A" * (store.TITLE_MAX + 1), "kind": "fleet"}, "field-bound"),
+        ({"kind": "fleet"}, "field-bound"),
+        ({"title": "Long acceptance", "kind": "fleet", "acceptance": ["A" * 401]}, "field-bound"),
+    ):
+        with pytest.raises(store.WorkloreValidationError) as refused:
+            store.create_item(conn, body, actor_id="admin")
+        assert refused.value.code == code, body
+
+
+# --- per-item link cardinality (Daybreak finding 2) --------------------------
+
+
+def _run_row(conn, node_id="node-a", run_id="run-1", sequence=1):
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (node_id, run_id, sequence, "d", "run.created", "t", "t"),
+    )
+    conn.commit()
+
+
+def _url_link(conn, work_id, number):
+    return store.add_link(
+        conn,
+        work_id,
+        {"link_type": "url", "external_key": f"https://example.com/{number}"},
+        actor_id="admin",
+    )
+
+
+def test_item_link_ceiling_is_shared_by_operator_and_fleet_run_links(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ITEM_MAX_LINKS", 2)
+    work_id = store.create_item(conn, {"title": "Linked", "kind": "fleet"}, actor_id="admin")["work_id"]
+    _url_link(conn, work_id, 1)
+    _url_link(conn, work_id, 2)
+    with pytest.raises(store.WorkloreConflict) as refused:
+        _url_link(conn, work_id, 3)
+    assert refused.value.code == "link-conflict"
+    assert "2 link ceiling" in str(refused.value)
+    _run_row(conn)
+    with pytest.raises(store.WorkloreConflict) as run_refused:
+        store.link_execution(conn, work_id, node_id="node-a", run_id="run-1", actor_id="node-a")
+    assert run_refused.value.code == "link-conflict"
+    assert conn.execute("SELECT COUNT(*) FROM work_links WHERE work_id = ?", (work_id,)).fetchone()[0] == 2
+
+
+def test_the_link_ceiling_is_per_item_not_per_ledger(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ITEM_MAX_LINKS", 1)
+    first = store.create_item(conn, {"title": "First", "kind": "fleet"}, actor_id="admin")["work_id"]
+    second = store.create_item(conn, {"title": "Second", "kind": "fleet"}, actor_id="admin")["work_id"]
+    _url_link(conn, first, 1)
+    _url_link(conn, second, 2)
+    with pytest.raises(store.WorkloreConflict):
+        _url_link(conn, first, 3)
+
+
+def test_link_pages_walk_a_high_cardinality_item_with_a_stable_cursor(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = store.create_item(conn, {"title": "Many links", "kind": "fleet"}, actor_id="admin")["work_id"]
+    for number in range(7):
+        _url_link(conn, work_id, number)
+    seen = []
+    cursor = None
+    pages = 0
+    while pages < 10:
+        page = store.list_links_page(conn, work_id, limit=3, cursor=cursor)
+        pages += 1
+        assert len(page["links"]) <= 3
+        seen.extend(link["link_id"] for link in page["links"])
+        cursor = page["next_cursor"]
+        if cursor is None:
+            break
+    assert cursor is None and pages == 3
+    assert seen == [link["link_id"] for link in store.list_links(conn, work_id)]
+    assert len(set(seen)) == 7
+
+
+def test_link_page_rejects_a_bad_limit_or_cursor_and_an_unknown_item(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = store.create_item(conn, {"title": "Paged", "kind": "fleet"}, actor_id="admin")["work_id"]
+    for value in (0, 101, "many"):
+        with pytest.raises(store.WorkloreValidationError):
+            store.list_links_page(conn, work_id, limit=value)
+    with pytest.raises(store.WorkloreValidationError) as refused:
+        store.list_links_page(conn, work_id, cursor="not-a-cursor")
+    assert refused.value.code == "field-bound"
+    with pytest.raises(store.WorkloreNotFound):
+        store.list_links_page(conn, "wl-missing")
+
+
+def test_list_items_bounds_projected_links_and_reports_truncation(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ITEM_LINK_PROJECTION_MAX", 2)
+    crowded = store.create_item(conn, {"title": "Crowded", "kind": "fleet"}, actor_id="admin")["work_id"]
+    for number in range(5):
+        _url_link(conn, crowded, number)
+    quiet = store.create_item(conn, {"title": "Quiet", "kind": "fleet"}, actor_id="admin")["work_id"]
+    _url_link(conn, quiet, 99)
+    by_id = {item["work_id"]: item for item in store.list_items(conn)["items"]}
+    assert len(by_id[crowded]["links"]) == 2 and by_id[crowded]["links_truncated"] is True
+    assert len(by_id[quiet]["links"]) == 1 and by_id[quiet]["links_truncated"] is False
+    assert [link["link_id"] for link in by_id[crowded]["links"]] == [
+        link["link_id"] for link in store.list_links(conn, crowded)[:2]
+    ]
+
+
+def test_burn_and_detail_reads_summarize_links_instead_of_loading_them(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _ready_item(conn, "Crowded but burnable")
+    for number in range(40):
+        _url_link(conn, work_id, number)
+    for read in (lambda: store.burn_queue(conn), lambda: store.get_item(conn, work_id)):
+        _, reads = _link_reads(conn, read)
+        assert reads, "read never consulted links"
+        assert all("GROUP BY" not in statement and "work_id IN (" not in statement for statement in reads)
+        assert all(f"WHERE work_id = '{work_id}'" in statement and "LIMIT 1" in statement for statement in reads)
+
+
+def test_burn_policy_and_effective_acceptance_survive_a_crowded_item(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_observation(1)], key="first")["items"][0]["work_id"]
+    store.patch_item(
+        conn,
+        work_id,
+        {"burn_eligible": True, "execution_mode": "agent"},
+        expected_version=1,
+        actor_id="admin",
+    )
+    second = dict(_observation(1, updated_at="2026-01-02T00:00:00+00:00"), acceptance=["from source"])
+    _import(conn, [second], key="second")
+    for number in range(30):
+        _url_link(conn, work_id, number)
+    store.transition(conn, work_id, to_status="defining", expected_version=2, actor_id="admin")
+    store.transition(conn, work_id, to_status="ready", expected_version=3, actor_id="admin")
+    assert store.get_item(conn, work_id)["effective_acceptance"] == ["from source"]
+    assert store.burn_queue(conn)["items"][0]["work_id"] == work_id
+    store.patch_item(conn, work_id, {"acceptance": ["own"]}, expected_version=4, actor_id="admin")
+    third = dict(
+        _observation(1, updated_at="2026-01-03T00:00:00+00:00"),
+        acceptance=["from source"],
+        source_policy="closed",
+    )
+    _import(conn, [third], key="third")
+    queue = store.burn_queue(conn)
+    assert queue["items"] == [] and queue["exclusions"]["source-policy"] == 1
+
+
+# --- adapter and owner storage beyond links (Daybreak finding 3) -------------
+
+
+def _import_key_rows(conn, adapter="github:escoffier-labs"):
+    return [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT idempotency_key, owner_node FROM work_import_keys WHERE adapter_id = ? "
+            "ORDER BY received_at ASC, rowid ASC",
+            (adapter,),
+        )
+    ]
+
+
+def test_repeated_unchanged_imports_expire_keys_past_the_adapter_window(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ADAPTER_IMPORT_KEY_RETENTION", 3)
+    assert _import(conn, [_observation(1)], key="create")["created"] == 1
+    events_after_create = conn.execute("SELECT COUNT(*) FROM work_events").fetchone()[0]
+    for index in range(10):
+        result = _import(conn, [_observation(1)], key=f"unchanged-{index}")
+        assert (result["created"], result["updated"], result["unchanged"]) == (0, 0, 1)
+    rows = _import_key_rows(conn)
+    assert [key for key, _ in rows] == ["unchanged-7", "unchanged-8", "unchanged-9"]
+    assert {owner for _, owner in rows} == {"node-a"}
+    assert conn.execute("SELECT COUNT(*) FROM work_events").fetchone()[0] == events_after_create
+
+
+def test_a_replay_inside_the_retention_window_is_still_exact(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ADAPTER_IMPORT_KEY_RETENTION", 3)
+    first = _import(conn, [_observation(1), _observation(2)], key="batch")
+    assert first["created"] == 2
+    events = conn.execute("SELECT COUNT(*) FROM work_events").fetchone()[0]
+    for index in range(2):
+        _import(conn, [_observation(3 + index)], key=f"filler-{index}")
+    replay = _import(conn, [_observation(1), _observation(2)], key="batch")
+    assert replay["created"] == 2 and replay["updated"] == 0 and replay["unchanged"] == 0
+    assert {item["external_key"] for item in replay["items"]} == {
+        "escoffier-labs/brigade#1",
+        "escoffier-labs/brigade#2",
+    }
+    assert conn.execute("SELECT COUNT(*) FROM work_events").fetchone()[0] == events + 6
+
+
+def test_import_keys_expire_per_owner_across_every_adapter_it_owns(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "OWNER_IMPORT_KEY_RETENTION", 2)
+    _import(conn, [_observation(1)], key="one", adapter="github:escoffier-labs")
+    _import(conn, [_observation(2)], key="two", adapter="github:lidless-labs")
+    _import(conn, [_observation(3)], key="three", adapter="github:solomonneas")
+    remaining = [
+        tuple(row)
+        for row in conn.execute("SELECT adapter_id, idempotency_key FROM work_import_keys ORDER BY received_at ASC")
+    ]
+    assert remaining == [("github:lidless-labs", "two"), ("github:solomonneas", "three")]
+    other = store.import_batch(
+        conn,
+        adapter_id="github:other-node",
+        source_type="github",
+        idempotency_key="kept",
+        observations=[_observation(9)],
+        actor_id="node-b",
+        owner_node="node-b",
+    )
+    assert other["created"] == 1
+    assert conn.execute("SELECT COUNT(*) FROM work_import_keys WHERE owner_node = 'node-b'").fetchone()[0] == 1
+
+
+def test_changed_observations_expire_old_adapter_sync_events_only(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ADAPTER_SYNC_EVENT_RETENTION", 3)
+    work_id = _import(conn, [_observation(1)], key="create")["items"][0]["work_id"]
+    store.add_link(
+        conn,
+        work_id,
+        {"link_type": "url", "external_key": "https://example.com/kept"},
+        actor_id="admin",
+    )
+    for index in range(12):
+        renamed = _observation(1, title=f"Renamed {index}", updated_at=f"2026-01-{index + 2:02d}T00:00:00+00:00")
+        assert _import(conn, [renamed], key=f"change-{index}")["updated"] == 1
+    types = [event["event_type"] for event in store.list_events(conn, work_id)]
+    assert types.count("sync-observed") == 3
+    assert types[:3] == ["created", "linked", "linked"]
+    assert store.get_item(conn, work_id)["title"] == "Renamed 11"
+    events = store.list_events(conn, work_id)
+    assert [event["detail"]["adapter_id"] for event in events if event["event_type"] == "sync-observed"] == [
+        "github:escoffier-labs"
+    ] * 3
+
+
+def test_adapter_event_retention_leaves_the_ownership_backfill_intact(tmp_path, monkeypatch):
+    if sqlite3.sqlite_version_info < (3, 35):
+        pytest.skip("ALTER TABLE DROP COLUMN needs SQLite 3.35")
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ADAPTER_SYNC_EVENT_RETENTION", 1)
+    work_id = _import(conn, [_observation(7)], key="create")["items"][0]["work_id"]
+    for index in range(5):
+        _import(conn, [_observation(7, title=f"Renamed {index}")], key=f"change-{index}")
+    conn.execute("DROP INDEX work_links_adapter")
+    conn.execute("DROP INDEX work_links_owner")
+    conn.execute("ALTER TABLE work_links DROP COLUMN adapter_id")
+    conn.execute("ALTER TABLE work_links DROP COLUMN owner_node")
+    conn.commit()
+    store.ensure_schema(conn)
+    conn.commit()
+    assert store._owning_adapter(conn, work_id, "github", "escoffier-labs/brigade#7") == (
+        "github:escoffier-labs",
+        "node-a",
+    )
+
+
+def test_import_key_owner_is_backfilled_from_the_adapter_cursor_on_migration(tmp_path):
+    if sqlite3.sqlite_version_info < (3, 35):
+        pytest.skip("ALTER TABLE DROP COLUMN needs SQLite 3.35")
+    conn = _conn(tmp_path)
+    _import(conn, [_observation(1)], key="legacy")
+    conn.execute("DROP INDEX work_import_keys_adapter")
+    conn.execute("DROP INDEX work_import_keys_owner")
+    conn.execute("ALTER TABLE work_import_keys DROP COLUMN owner_node")
+    conn.commit()
+    store.ensure_schema(conn)
+    conn.commit()
+    assert _import_key_rows(conn) == [("legacy", "node-a")]
+
+
+def test_unchanged_import_keeps_link_liveness_without_new_storage(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "ADAPTER_IMPORT_KEY_RETENTION", 2)
+    work_id = _import(conn, [_observation(1)], key="create")["items"][0]["work_id"]
+    baseline = store.list_links(conn, work_id)[0]
+    versions = store.get_item(conn, work_id)["version"]
+    for index in range(6):
+        _import(conn, [_observation(1)], key=f"unchanged-{index}")
+    refreshed = store.list_links(conn, work_id)[0]
+    assert refreshed["synced_at"] >= baseline["synced_at"]
+    assert {key: value for key, value in refreshed.items() if key != "synced_at"} == {
+        key: value for key, value in baseline.items() if key != "synced_at"
+    }
+    assert store.get_item(conn, work_id)["version"] == versions
+    assert conn.execute("SELECT COUNT(*) FROM work_import_keys").fetchone()[0] == 2
+
+
+def _timed_observation(number, *, updated_at, state="open", title="Observed"):
+    """One observation whose source reports when it last changed."""
+    return {
+        **_observation(number, title=title),
+        "external_state": state,
+        "external_updated_at": updated_at,
+    }
+
+
+def _expire_import_key(conn, key):
+    """Drop one import key the way retention would, without waiting for 500 batches."""
+    conn.execute("DELETE FROM work_import_keys WHERE idempotency_key = ?", (key,))
+    conn.commit()
+
+
+def _link_state(conn, work_id):
+    link = store.list_links(conn, work_id)[0]
+    return store.get_item(conn, work_id)["title"], link["external_state"], link["external_updated_at"]
+
+
+def test_expired_import_key_replay_never_rolls_back_a_newer_observation(tmp_path):
+    conn = _conn(tmp_path)
+    older = _timed_observation(1, updated_at="2026-01-01T00:00:00+00:00", state="open", title="Older")
+    newer = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="Newer")
+    work_id = _import(conn, [older], key="A")["items"][0]["work_id"]
+    _expire_import_key(conn, "A")
+    assert _import(conn, [newer], key="B")["updated"] == 1
+    replay = _import(conn, [older], key="A")
+    assert (replay["created"], replay["updated"], replay["unchanged"], replay["refused"]) == (0, 0, 0, 1)
+    assert replay["refused_details"][0]["reason"] == store.REFUSED_REVISION_STALE
+    assert _link_state(conn, work_id) == ("Newer", "closed", "2026-02-01T00:00:00+00:00")
+
+
+def test_a_refused_stale_replay_writes_nothing_at_all(tmp_path):
+    conn = _conn(tmp_path)
+    older = _timed_observation(1, updated_at="2026-01-01T00:00:00+00:00", state="open", title="Older")
+    newer = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="Newer")
+    work_id = _import(conn, [older], key="A")["items"][0]["work_id"]
+    _expire_import_key(conn, "A")
+    _import(conn, [newer], key="B")
+    before_link = store.list_links(conn, work_id)[0]
+    before_events = store.list_events(conn, work_id)
+    before_version = store.get_item(conn, work_id)["version"]
+    _import(conn, [older], key="A")
+    assert store.list_links(conn, work_id)[0] == before_link
+    assert store.list_events(conn, work_id) == before_events
+    assert store.get_item(conn, work_id)["version"] == before_version
+
+
+def test_an_exact_replay_of_the_newest_observation_is_applied_and_changes_nothing(tmp_path):
+    conn = _conn(tmp_path)
+    observation = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed")
+    work_id = _import(conn, [observation], key="A")["items"][0]["work_id"]
+    _expire_import_key(conn, "A")
+    replay = _import(conn, [observation], key="A")
+    assert (replay["created"], replay["updated"], replay["unchanged"]) == (0, 0, 1)
+    assert _link_state(conn, work_id) == ("Observed", "closed", "2026-02-01T00:00:00+00:00")
+    assert [event["event_type"] for event in store.list_events(conn, work_id)] == [
+        "created",
+        "linked",
+        "sync-observed",
+    ]
+
+
+def test_an_observation_without_a_timestamp_cannot_displace_a_high_water(tmp_path):
+    conn = _conn(tmp_path)
+    timed = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="Timed")
+    work_id = _import(conn, [timed], key="A")["items"][0]["work_id"]
+    untimed = _observation(1, title="Untimed", updated_at=None)
+    assert _import(conn, [untimed], key="B")["refused"] == 1
+    assert _link_state(conn, work_id) == ("Timed", "closed", "2026-02-01T00:00:00+00:00")
+
+
+def test_a_source_that_reports_no_revision_never_gets_a_projection_to_roll_back(tmp_path):
+    conn = _conn(tmp_path)
+    unproven = _observation(1, title="First", updated_at=None)
+    result = _import(conn, [unproven], key="A")
+    assert (result["created"], result["updated"], result["unchanged"], result["refused"]) == (0, 0, 0, 1)
+    assert result["refused_details"][0]["reason"] == store.REFUSED_REVISION_MISSING
+    assert store.list_items(conn)["items"] == []
+    assert conn.execute("SELECT COUNT(*) FROM work_links").fetchone()[0] == 0
+
+
+def test_an_unparseable_revision_never_gets_a_projection_to_roll_back(tmp_path):
+    conn = _conn(tmp_path)
+    garbage = _timed_observation(1, updated_at="not-a-timestamp", title="Garbage")
+    result = _import(conn, [garbage], key="A")
+    assert (result["created"], result["refused"]) == (0, 1)
+    assert result["refused_details"][0]["reason"] == store.REFUSED_REVISION_MISSING
+    assert store.list_items(conn)["items"] == []
+
+
+def test_replay_cannot_roll_back_an_identity_whose_replay_reports_no_revision(tmp_path):
+    conn = _conn(tmp_path)
+    # A -> expire -> B -> replay A, where the replayed batch carries no revision at all.
+    # Before the guard was made total this was the identity class that stayed
+    # last-write-wins, so the replay overwrote B with A.
+    first = _timed_observation(1, updated_at="2026-01-01T00:00:00+00:00", state="open", title="A")
+    work_id = _import(conn, [first], key="A")["items"][0]["work_id"]
+    _expire_import_key(conn, "A")
+    second = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="B")
+    assert _import(conn, [second], key="B")["updated"] == 1
+    replay = _import(conn, [_observation(1, title="A", updated_at=None)], key="A")
+    assert (replay["created"], replay["updated"], replay["unchanged"], replay["refused"]) == (0, 0, 0, 1)
+    assert replay["refused_details"][0]["reason"] == store.REFUSED_REVISION_MISSING
+    assert _link_state(conn, work_id) == ("B", "closed", "2026-02-01T00:00:00+00:00")
+
+
+def test_replay_cannot_roll_back_an_identity_whose_replay_reports_an_unparseable_revision(tmp_path):
+    conn = _conn(tmp_path)
+    first = _timed_observation(1, updated_at="2026-01-01T00:00:00+00:00", state="open", title="A")
+    work_id = _import(conn, [first], key="A")["items"][0]["work_id"]
+    _expire_import_key(conn, "A")
+    second = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="B")
+    assert _import(conn, [second], key="B")["updated"] == 1
+    garbage = _timed_observation(1, updated_at="not-a-timestamp", state="open", title="A")
+    replay = _import(conn, [garbage], key="A")
+    assert (replay["created"], replay["updated"], replay["unchanged"], replay["refused"]) == (0, 0, 0, 1)
+    assert replay["refused_details"][0]["reason"] == store.REFUSED_REVISION_MISSING
+    assert _link_state(conn, work_id) == ("B", "closed", "2026-02-01T00:00:00+00:00")
+
+
+def test_a_missing_revision_is_refused_per_identity_and_the_valid_sibling_imports(tmp_path):
+    conn = _conn(tmp_path)
+    unproven = _observation(1, title="Unproven", updated_at=None)
+    proven = _timed_observation(2, updated_at="2026-02-01T00:00:00+00:00", title="Proven")
+    result = _import(conn, [unproven, proven], key="A")
+    assert (result["created"], result["updated"], result["unchanged"], result["refused"]) == (1, 0, 0, 1)
+    assert result["refused_details"] == [
+        {"external_key": "escoffier-labs/brigade#1", "link_type": "github", "reason": store.REFUSED_REVISION_MISSING}
+    ]
+    titles = [item["title"] for item in store.list_items(conn)["items"]]
+    assert titles == ["Proven"]
+
+
+def _unguarded_legacy_link(conn, number, *, title="Legacy"):
+    """One imported identity as a database written before ``source_version`` holds it.
+
+    Its ``external_updated_at`` is NULL, so migration seeds it nothing and it is the only
+    identity class that can still meet an observation carrying no revision.
+    """
+    item = store.create_item(conn, {"title": title, "kind": "repo"}, actor_id="admin")
+    conn.execute(
+        "INSERT INTO work_links (link_id, work_id, link_type, external_key, display_ref, url, "
+        "external_state, external_updated_at, source_policy, source_acceptance_json, synced_at, "
+        "stale_at, adapter_id, owner_node, source_version) "
+        "VALUES (?, ?, 'github', ?, ?, ?, NULL, NULL, 'eligible', '[]', ?, NULL, ?, 'node-a', NULL)",
+        (
+            f"lnk-legacy-{number}",
+            item["work_id"],
+            f"escoffier-labs/brigade#{number}",
+            f"escoffier-labs/brigade#{number}",
+            f"https://github.com/escoffier-labs/brigade/issues/{number}",
+            "2026-01-01T00:00:00+00:00",
+            "github:escoffier-labs",
+        ),
+    )
+    conn.commit()
+    return item["work_id"]
+
+
+def test_an_unproven_observation_that_changes_nothing_is_unchanged_not_refused(tmp_path):
+    conn = _conn(tmp_path)
+    # The one place a missing revision survives: it writes no projection, so there is no
+    # state for a revision to protect, and refusing every re-poll of a settled legacy
+    # identity would be noise rather than a rollback the operator needs to see.
+    work_id = _unguarded_legacy_link(conn, 1, title="Legacy")
+    result = _import(conn, [_observation(1, title="Legacy", updated_at=None)], key="A")
+    assert (result["created"], result["updated"], result["unchanged"], result["refused"]) == (0, 0, 1, 0)
+    assert store.get_item(conn, work_id)["title"] == "Legacy"
+
+
+def test_an_unproven_observation_that_would_change_a_legacy_identity_is_refused(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _unguarded_legacy_link(conn, 1, title="Legacy")
+    result = _import(conn, [_observation(1, title="Rewritten", updated_at=None)], key="A")
+    assert (result["created"], result["updated"], result["unchanged"], result["refused"]) == (0, 0, 0, 1)
+    assert result["refused_details"][0]["reason"] == store.REFUSED_REVISION_MISSING
+    assert store.get_item(conn, work_id)["title"] == "Legacy"
+
+
+def test_the_high_water_refuses_the_stale_and_still_admits_the_eligible(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", title="Newer")], key="A")[
+        "items"
+    ][0]["work_id"]
+    stale = _timed_observation(1, updated_at="2026-01-01T00:00:00+00:00", title="Stale")
+    assert _import(conn, [stale], key="B")["refused"] == 1
+    eligible = _timed_observation(1, updated_at="2026-03-01T00:00:00+00:00", state="closed", title="Eligible")
+    assert _import(conn, [eligible], key="C")["updated"] == 1
+    assert _link_state(conn, work_id) == ("Eligible", "closed", "2026-03-01T00:00:00+00:00")
+    assert _import(conn, [stale], key="D")["refused"] == 1
+    assert store.get_item(conn, work_id)["title"] == "Eligible"
+
+
+def test_offset_and_zulu_timestamps_compare_as_instants_not_as_text(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_timed_observation(1, updated_at="2026-02-01T00:00:00Z", title="Newer")], key="A")[
+        "items"
+    ][0]["work_id"]
+    # 2026-01-31T23:00:00-05:00 is 04:00Z on the 1st: later than the high-water as an
+    # instant, earlier as a string. The guard must read it as the instant it is.
+    later = _timed_observation(1, updated_at="2026-01-31T23:00:00-05:00", title="Later")
+    assert _import(conn, [later], key="B")["updated"] == 1
+    assert store.get_item(conn, work_id)["title"] == "Later"
+
+
+def test_the_source_high_water_stays_out_of_the_link_projection(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_timed_observation(1, updated_at="2026-02-01T00:00:00+00:00")], key="A")["items"][0][
+        "work_id"
+    ]
+    link = store.list_links(conn, work_id)[0]
+    assert "source_version" not in link
+    assert "source_version" not in store.list_links_page(conn, work_id)["links"][0]
+    assert "source_version" not in store.list_items(conn)["items"][0]["links"][0]
+
+
+def test_the_high_water_column_is_bounded_by_the_links_it_rides_on(tmp_path):
+    conn = _conn(tmp_path)
+    for number in range(1, 6):
+        _import(conn, [_timed_observation(number, updated_at="2026-02-01T00:00:00+00:00")], key=f"k{number}")
+    links = conn.execute("SELECT COUNT(*) FROM work_links").fetchone()[0]
+    stamped = conn.execute("SELECT COUNT(*) FROM work_links WHERE source_version IS NOT NULL").fetchone()[0]
+    assert (links, stamped) == (5, 5)
+
+
+def _legacy_links(conn, work_id, count, *, start=0):
+    """Insert links straight into storage, the way a database written before ITEM_MAX_LINKS
+    was enforced on write already holds them."""
+    for index in range(start, start + count):
+        conn.execute(
+            "INSERT INTO work_links (link_id, work_id, link_type, external_key, display_ref, url, "
+            "external_state, external_updated_at, source_policy, source_acceptance_json, synced_at, "
+            "stale_at, adapter_id, owner_node, source_version) "
+            "VALUES (?, ?, 'url', ?, ?, NULL, NULL, NULL, 'eligible', '[]', ?, NULL, NULL, NULL, NULL)",
+            (f"lnk-legacy-{index:05d}", work_id, f"legacy-{index}", f"legacy-{index}", f"2026-01-01T00:{index:02d}:00"),
+        )
+    conn.commit()
+
+
+def test_detail_and_burn_reads_stop_within_a_fixed_sqlite_work_budget_for_legacy_links(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    work_id = _ready_item(conn, "Legacy")
+    _legacy_links(conn, work_id, 25_000)
+    monkeypatch.setattr(store, "ITEM_LINK_PROJECTION_MAX", 5)
+
+    def within_budget(read):
+        callbacks = 0
+
+        def stop_after_fixed_work():
+            nonlocal callbacks
+            callbacks += 1
+            return 1 if callbacks > 80 else 0
+
+        conn.set_progress_handler(stop_after_fixed_work, 100)
+        try:
+            return read()
+        finally:
+            conn.set_progress_handler(None, 0)
+
+    page = within_budget(lambda: store.list_items(conn, limit=1))
+    queue = within_budget(lambda: store.burn_queue(conn, limit=1))
+
+    item = page["items"][0]
+    assert len(item["links"]) == 5 and item["links_truncated"] is True
+    assert [item["work_id"] for item in queue["items"]] == [work_id]
+
+
+def test_an_item_inside_the_projection_budget_is_not_reported_as_truncated(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _ready_item(conn, "Small")
+    _legacy_links(conn, work_id, 3)
+    item = store.list_items(conn, limit=1)["items"][0]
+    assert len(item["links"]) == 3 and item["links_truncated"] is False
+
+
+def test_migration_prunes_import_keys_and_adapter_events_of_a_quiet_adapter(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_observation(1)], key="seed")["items"][0]["work_id"]
+    for index in range(8):
+        conn.execute(
+            "INSERT INTO work_import_keys (adapter_id, idempotency_key, fingerprint, created, updated, "
+            "unchanged, received_at, owner_node) VALUES ('github:quiet', ?, 'fp', 0, 0, 0, ?, 'node-a')",
+            (f"quiet-{index}", f"2026-01-0{index + 1}T00:00:00+00:00"),
+        )
+    for index in range(8):
+        conn.execute(
+            "INSERT INTO work_events (work_id, event_id, event_type, from_status, to_status, actor_type, "
+            "actor_id, node_id, run_id, detail_json, occurred_at, received_at, seq) "
+            "VALUES (?, ?, 'sync-observed', 'captured', 'captured', 'adapter', 'node-a', 'node-a', NULL, "
+            "'{}', '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00', ?)",
+            (work_id, f"legacy-event-{index}", 1000 + index),
+        )
+    conn.commit()
+    monkeypatch.setattr(store, "ADAPTER_IMPORT_KEY_RETENTION", 3)
+    monkeypatch.setattr(store, "ADAPTER_SYNC_EVENT_RETENTION", 2)
+    store.ensure_schema(conn)
+    quiet = [
+        row[0]
+        for row in conn.execute(
+            "SELECT idempotency_key FROM work_import_keys WHERE adapter_id = 'github:quiet' ORDER BY received_at ASC"
+        )
+    ]
+    assert quiet == ["quiet-5", "quiet-6", "quiet-7"]
+    kept = [event["event_type"] for event in store.list_events(conn, work_id)]
+    assert kept.count("sync-observed") == 2
+    assert kept[:2] == ["created", "linked"], "lifecycle events must survive the prune"
+
+
+def test_migration_prunes_import_keys_per_owner_across_adapters(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    for index in range(6):
+        conn.execute(
+            "INSERT INTO work_import_keys (adapter_id, idempotency_key, fingerprint, created, updated, "
+            "unchanged, received_at, owner_node) VALUES (?, ?, 'fp', 0, 0, 0, ?, 'node-a')",
+            (f"github:org-{index}", f"key-{index}", f"2026-01-0{index + 1}T00:00:00+00:00"),
+        )
+    conn.commit()
+    monkeypatch.setattr(store, "OWNER_IMPORT_KEY_RETENTION", 2)
+    store.ensure_schema(conn)
+    assert [row[0] for row in conn.execute("SELECT idempotency_key FROM work_import_keys ORDER BY received_at")] == [
+        "key-4",
+        "key-5",
+    ]
+
+
+def test_create_keys_are_one_identity_row_per_durable_item_and_cannot_grow_alone(tmp_path):
+    conn = _conn(tmp_path)
+    work_ids = []
+    for index in range(5):
+        item = store.create_item(
+            conn, {"title": f"Native {index}", "kind": "fleet"}, actor_id="admin", idempotency_key=f"key-{index}"
+        )
+        work_ids.append(item["work_id"])
+        # Every replay resolves to the same item and writes no second identity row.
+        for _ in range(3):
+            replay = store.create_item(
+                conn, {"title": f"Native {index}", "kind": "fleet"}, actor_id="admin", idempotency_key=f"key-{index}"
+            )
+            assert replay["work_id"] == item["work_id"]
+    keys = conn.execute("SELECT COUNT(*) FROM work_create_keys").fetchone()[0]
+    items = conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0]
+    assert keys == items == 5
+    assert [row[0] for row in conn.execute("SELECT work_id FROM work_create_keys ORDER BY received_at")] == work_ids
+
+
+def test_a_create_key_is_never_swept_because_expiring_it_would_permit_a_duplicate(tmp_path):
+    conn = _conn(tmp_path)
+    item = store.create_item(conn, {"title": "Native", "kind": "fleet"}, actor_id="admin", idempotency_key="once")
+    store.ensure_schema(conn)
+    assert conn.execute("SELECT COUNT(*) FROM work_create_keys").fetchone()[0] == 1
+    replay = store.create_item(conn, {"title": "Native", "kind": "fleet"}, actor_id="admin", idempotency_key="once")
+    assert replay["work_id"] == item["work_id"]
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 1
+    # The row is pinned to its item, so no sweep can quietly free the key either.
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("DELETE FROM work_items WHERE work_id = ?", (item["work_id"],))
+
+
+def test_creates_without_an_idempotency_key_write_no_create_key_row(tmp_path):
+    conn = _conn(tmp_path)
+    for index in range(4):
+        store.create_item(conn, {"title": f"Anonymous {index}", "kind": "fleet"}, actor_id="admin")
+    assert conn.execute("SELECT COUNT(*) FROM work_create_keys").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 4
+
+
+# --- final sendback regressions ---------------------------------------------
+
+
+def _v16_link_table(conn):
+    """Reshape work_links the way a v16 database holds it: no per-identity high-water."""
+    conn.execute(f"ALTER TABLE work_links DROP COLUMN {store._LINK_SOURCE_VERSION_COLUMN}")
+    conn.execute("DELETE FROM work_schema_meta")
+    conn.commit()
+
+
+def test_a_migrated_v16_identity_bootstraps_a_high_water_from_its_stored_timestamp(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(
+        conn, [_timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="Newer")], key="A"
+    )["items"][0]["work_id"]
+    _v16_link_table(conn)
+    store.ensure_schema(conn)
+    assert conn.execute("SELECT source_version FROM work_links").fetchone()[0] == "2026-02-01T00:00:00+00:00"
+    older = _timed_observation(1, updated_at="2026-01-01T00:00:00+00:00", state="open", title="Older")
+    assert _import(conn, [older], key="B")["refused"] == 1
+    assert _link_state(conn, work_id) == ("Newer", "closed", "2026-02-01T00:00:00+00:00")
+
+
+def test_a_migrated_identity_with_an_unparseable_timestamp_bootstraps_no_high_water(tmp_path):
+    conn = _conn(tmp_path)
+    # The hub no longer lets an unparseable revision into the ledger, so the only database
+    # holding one is a v16 database that accepted it before the guard existed. Migration
+    # must still seed nothing from it rather than storing text it cannot compare.
+    work_id = _import(conn, [_timed_observation(1, updated_at="2026-02-01T00:00:00+00:00")], key="A")["items"][0][
+        "work_id"
+    ]
+    conn.execute("UPDATE work_links SET external_updated_at = 'not-a-timestamp' WHERE work_id = ?", (work_id,))
+    conn.commit()
+    _v16_link_table(conn)
+    store.ensure_schema(conn)
+    assert conn.execute("SELECT source_version FROM work_links").fetchone()[0] is None
+
+
+def test_an_equal_source_revision_with_a_changed_payload_is_refused(tmp_path):
+    conn = _conn(tmp_path)
+    first = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="open", title="First")
+    work_id = _import(conn, [first], key="A")["items"][0]["work_id"]
+    forged = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="Forged")
+    result = _import(conn, [forged], key="B")
+    assert (result["created"], result["updated"], result["unchanged"], result["refused"]) == (0, 0, 0, 1)
+    assert _link_state(conn, work_id) == ("First", "open", "2026-02-01T00:00:00+00:00")
+
+
+def test_equal_source_poll_preserves_an_operator_title_edit(tmp_path):
+    conn = _conn(tmp_path)
+    observation = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", title="Source title")
+    work_id = _import(conn, [observation], key="A")["items"][0]["work_id"]
+    store.patch_item(conn, work_id, {"title": "Operator title"}, expected_version=1, actor_id="admin")
+
+    result = _import(conn, [observation], key="B")
+
+    assert (result["updated"], result["unchanged"], result["refused"]) == (0, 1, 0)
+    assert store.get_item(conn, work_id)["title"] == "Operator title"
+
+
+def test_newer_source_title_update_advances_the_item_version(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(
+        conn,
+        [_timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", title="First title")],
+        key="A",
+    )["items"][0]["work_id"]
+
+    result = _import(
+        conn,
+        [_timed_observation(1, updated_at="2026-02-02T00:00:00+00:00", title="Second title")],
+        key="B",
+    )
+
+    assert (result["updated"], result["refused"]) == (1, 0)
+    item = store.get_item(conn, work_id)
+    assert (item["title"], item["version"]) == ("Second title", 2)
+
+
+def test_newer_tombstone_keeps_the_last_known_external_state(tmp_path):
+    conn = _conn(tmp_path)
+    first = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="open")
+    work_id = _import(conn, [first], key="A")["items"][0]["work_id"]
+    missing = _timed_observation(1, updated_at="2026-02-02T00:00:00+00:00")
+    missing.pop("external_state")
+    missing["stale"] = True
+
+    result = _import(conn, [missing], key="B")
+
+    link = store.list_links(conn, work_id)[0]
+    assert (result["updated"], link["external_state"], link["external_updated_at"]) == (
+        1,
+        "open",
+        "2026-02-02T00:00:00+00:00",
+    )
+    assert link["stale_at"] is not None
+
+
+def test_source_acceptance_ignores_newer_url_and_execution_links_after_an_unchanged_resync(tmp_path):
+    conn = _conn(tmp_path)
+    source = dict(_timed_observation(1, updated_at="2026-02-01T00:00:00+00:00"), acceptance=["source check"])
+    work_id = _import(conn, [source], key="A")["items"][0]["work_id"]
+    store.patch_item(
+        conn,
+        work_id,
+        {"burn_eligible": True, "execution_mode": "agent"},
+        expected_version=1,
+        actor_id="admin",
+    )
+    store.transition(conn, work_id, to_status="defining", expected_version=2, actor_id="admin")
+    store.transition(conn, work_id, to_status="ready", expected_version=3, actor_id="admin")
+    source_link = store.list_links(conn, work_id)[0]
+    conn.execute(
+        "UPDATE work_links SET synced_at = ? WHERE link_id = ?", ("2000-01-01T00:00:00+00:00", source_link["link_id"])
+    )
+    conn.commit()
+    _url_link(conn, work_id, "source-acceptance")
+    _run_row(conn, run_id="source-acceptance")
+    store.link_execution(conn, work_id, node_id="node-a", run_id="source-acceptance", actor_id="node-a")
+
+    refreshed = _import(conn, [source], key="B")
+
+    links = {link["link_type"]: link for link in store.list_links(conn, work_id)}
+    assert refreshed["unchanged"] == 1
+    assert links["github"]["synced_at"] > links["url"]["synced_at"]
+    assert links["github"]["synced_at"] > links["fleet-run"]["synced_at"]
+    assert store.get_item(conn, work_id)["effective_acceptance"] == ["source check"]
+    assert [item["work_id"] for item in store.burn_queue(conn)["items"]] == [work_id]
+
+
+def test_cross_adapter_identity_collision_refuses_only_that_identity(tmp_path):
+    conn = _conn(tmp_path)
+    _import(conn, [_observation(1, title="First adapter")], key="A")
+
+    result = _import(
+        conn,
+        [_observation(1, title="Collides"), _observation(2, title="Sibling")],
+        key="B",
+        adapter="github:other",
+    )
+
+    assert (result["created"], result["refused"]) == (1, 1)
+    assert result["refused_details"] == [
+        {
+            "external_key": "escoffier-labs/brigade#1",
+            "link_type": "github",
+            "reason": store.REFUSED_ADAPTER_IDENTITY_CONFLICT,
+        }
+    ]
+    assert [item["title"] for item in store.list_items(conn)["items"]] == ["First adapter", "Sibling"]
+
+
+def test_owner_node_mismatch_refuses_only_that_identity(tmp_path):
+    conn = _conn(tmp_path)
+    _import(conn, [_observation(1, title="Owned by node a")], key="A")
+    conn.execute("UPDATE work_sync_cursors SET owner_node = 'node-b' WHERE adapter_id = ?", ("github:escoffier-labs",))
+    conn.commit()
+
+    result = _import(
+        conn,
+        [_observation(1, title="Node mismatch"), _observation(2, title="Sibling")],
+        key="B",
+        node="node-b",
+    )
+
+    assert (result["created"], result["refused"]) == (1, 1)
+    assert result["refused_details"] == [
+        {
+            "external_key": "escoffier-labs/brigade#1",
+            "link_type": "github",
+            "reason": store.REFUSED_OWNER_NODE_MISMATCH,
+        }
+    ]
+    assert [item["title"] for item in store.list_items(conn)["items"]] == ["Owned by node a", "Sibling"]
+
+
+def test_a_missing_source_revision_after_a_high_water_is_refused_with_a_reason(tmp_path):
+    conn = _conn(tmp_path)
+    timed = _timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", state="closed", title="Timed")
+    work_id = _import(conn, [timed], key="A")["items"][0]["work_id"]
+    result = _import(conn, [_observation(1, title="Untimed", updated_at=None)], key="B")
+    assert (result["unchanged"], result["refused"]) == (0, 1)
+    assert result["refused_details"] == [
+        {
+            "external_key": "escoffier-labs/brigade#1",
+            "link_type": "github",
+            "reason": "source-revision-missing",
+        }
+    ]
+    assert _link_state(conn, work_id) == ("Timed", "closed", "2026-02-01T00:00:00+00:00")
+
+
+def test_a_replayed_import_key_reports_the_refusals_it_originally_counted(tmp_path):
+    conn = _conn(tmp_path)
+    _import(conn, [_timed_observation(1, updated_at="2026-02-01T00:00:00+00:00", title="Timed")], key="A")
+    batch = [
+        _observation(1, title="Untimed", updated_at=None),
+        _timed_observation(2, updated_at="2026-02-01T00:00:00+00:00", title="Fresh"),
+    ]
+    first = _import(conn, batch, key="B")
+    assert (first["created"], first["refused"]) == (1, 1)
+    replay = _import(conn, batch, key="B")
+    assert (replay["created"], replay["updated"], replay["unchanged"], replay["refused"]) == (1, 0, 0, 1)
+
+
+def test_an_operator_identity_collision_refuses_only_that_observation(tmp_path):
+    conn = _conn(tmp_path)
+    native = store.create_item(conn, {"title": "Hand linked", "kind": "repo"}, actor_id="admin")
+    store.add_link(
+        conn,
+        native["work_id"],
+        {
+            "link_type": "github",
+            "external_key": "escoffier-labs/brigade#1",
+            "url": "https://github.com/escoffier-labs/brigade/issues/1",
+        },
+        actor_id="admin",
+    )
+    result = _import(conn, [_observation(1, title="Collides"), _observation(2, title="Sibling")], key="A")
+    assert (result["created"], result["refused"]) == (1, 1)
+    assert result["refused_details"] == [
+        {
+            "external_key": "escoffier-labs/brigade#1",
+            "link_type": "github",
+            "reason": "operator-managed-identity",
+        }
+    ]
+    assert store.get_item(conn, native["work_id"])["title"] == "Hand linked"
+    assert conn.execute("SELECT COUNT(*) FROM work_items").fetchone()[0] == 2
+
+
+def test_an_operator_url_link_is_not_owned_by_an_adapter_sharing_its_external_key(tmp_path):
+    conn = _conn(tmp_path)
+    work_id = _import(conn, [_observation(1)], key="A")["items"][0]["work_id"]
+    operator_link = store.add_link(
+        conn,
+        work_id,
+        {
+            "link_type": "url",
+            "external_key": "escoffier-labs/brigade#1",
+            "url": "https://example.invalid/tracker",
+        },
+        actor_id="admin",
+    )
+    # The github link with the same external_key is adapter owned and still eligible. That
+    # must not reach across link types and freeze the operator's own url link.
+    store.delete_link(conn, work_id, operator_link["link_id"], actor_id="admin")
+    assert [link["link_type"] for link in store.list_links(conn, work_id)] == ["github"]
+
+
+def test_an_operator_link_of_another_type_does_not_block_an_adapter_import(tmp_path):
+    conn = _conn(tmp_path)
+    native = store.create_item(conn, {"title": "Native", "kind": "repo"}, actor_id="admin")
+    store.add_link(
+        conn,
+        native["work_id"],
+        {
+            "link_type": "url",
+            "external_key": "escoffier-labs/brigade#1",
+            "url": "https://example.invalid/tracker",
+        },
+        actor_id="admin",
+    )
+    result = _import(conn, [_observation(1, title="Imported")], key="A")
+    assert (result["created"], result["refused"]) == (1, 0)
+
+
+def _hub_run(conn, node_id, run_id, *, sequence):
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, state, ts, received_at) "
+        "VALUES (?, ?, ?, 'd', 'run.created', 't', 't')",
+        (node_id, run_id, sequence),
+    )
+    conn.commit()
+
+
+def test_repeated_fleet_runs_cannot_freeze_an_item_at_the_link_ceiling(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "FLEET_RUN_LINK_RETENTION", 3)
+    work_id = store.create_item(conn, {"title": "Busy", "kind": "fleet"}, actor_id="admin")["work_id"]
+    for index in range(8):
+        _hub_run(conn, "node-a", f"run-{index}", sequence=index + 1)
+        store.link_execution(conn, work_id, node_id="node-a", run_id=f"run-{index}", actor_id="node-a")
+    keys = [link["external_key"] for link in store.list_links(conn, work_id)]
+    assert len(keys) == 3
+    assert set(keys) == {"node-a/run-5", "node-a/run-6", "node-a/run-7"}
+
+
+def test_fleet_run_retention_leaves_operator_links_alone(tmp_path, monkeypatch):
+    conn = _conn(tmp_path)
+    monkeypatch.setattr(store, "FLEET_RUN_LINK_RETENTION", 2)
+    work_id = store.create_item(conn, {"title": "Busy", "kind": "fleet"}, actor_id="admin")["work_id"]
+    store.add_link(conn, work_id, {"link_type": "url", "external_key": "https://example.invalid/a"}, actor_id="admin")
+    for index in range(5):
+        _hub_run(conn, "node-a", f"run-{index}", sequence=index + 1)
+        store.link_execution(conn, work_id, node_id="node-a", run_id=f"run-{index}", actor_id="node-a")
+    types = sorted(link["link_type"] for link in store.list_links(conn, work_id))
+    assert types == ["fleet-run", "fleet-run", "url"]
+
+
+def test_a_legacy_database_over_the_link_ceiling_starts_and_can_be_repaired(tmp_path, monkeypatch):
+    db = tmp_path / "legacy.db"
+    conn = fleet_hub.init_db(db)
+    work_id = store.create_item(conn, {"title": "Legacy", "kind": "fleet"}, actor_id="admin")["work_id"]
+    _legacy_links(conn, work_id, 6)
+    conn.close()
+    monkeypatch.setattr(store, "ITEM_MAX_LINKS", 4)
+    started = fleet_hub.init_db(db)
+    try:
+        assert started.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION
+        # Reads stay bounded by SQL rather than by trusting the ceiling.
+        monkeypatch.setattr(store, "ITEM_LINK_PROJECTION_MAX", 2)
+        item = store.list_items(started, limit=1)["items"][0]
+        assert len(item["links"]) == 2 and item["links_truncated"] is True
+        # New writes still enforce the ceiling.
+        with pytest.raises(store.WorkloreConflict) as refused:
+            store.add_link(
+                started, work_id, {"link_type": "url", "external_key": "https://example.invalid/x"}, actor_id="admin"
+            )
+        assert refused.value.code == "link-conflict"
+        # And the operator can delete back under it through the ordinary route.
+        for link in store.list_links(started, work_id)[:3]:
+            store.delete_link(started, work_id, link["link_id"], actor_id="admin")
+        store.add_link(
+            started, work_id, {"link_type": "url", "external_key": "https://example.invalid/x"}, actor_id="admin"
+        )
+        assert len(store.list_links(started, work_id)) == 4
+    finally:
+        started.close()
+
+
+def test_a_legacy_over_ceiling_database_starts_with_worklore_disabled(tmp_path, monkeypatch):
+    db = tmp_path / "disabled.db"
+    conn = fleet_hub.init_db(db)
+    work_id = store.create_item(conn, {"title": "Legacy", "kind": "fleet"}, actor_id="admin")["work_id"]
+    _legacy_links(conn, work_id, 6)
+    conn.close()
+    monkeypatch.setenv("BRIGADE_WORKLORE_ENABLED", "0")
+    monkeypatch.setattr(store, "ITEM_MAX_LINKS", 4)
+    started = fleet_hub.init_db(db)
+    try:
+        assert started.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION
+    finally:
+        started.close()
+
+
+def _plan(conn, sql, params=()):
+    return " ".join(str(row[3]) for row in conn.execute(f"EXPLAIN QUERY PLAN {sql}", params))
+
+
+def test_the_item_page_and_the_sprint_log_read_from_named_indexes(tmp_path):
+    conn = _conn(tmp_path)
+    store.create_item(conn, {"title": "Indexed", "kind": "fleet"}, actor_id="admin")
+    items_plan = _plan(conn, "SELECT work_id FROM work_items ORDER BY created_at ASC, work_id ASC LIMIT 1")
+    assert "work_items_created_order" in items_plan and "TEMP B-TREE" not in items_plan
+    events_plan = _plan(conn, "SELECT work_id FROM work_events ORDER BY occurred_at DESC, seq DESC LIMIT 1")
+    assert "work_events_recent" in events_plan and "TEMP B-TREE" not in events_plan
+    claim_plan = _plan(
+        conn,
+        "SELECT adapter_id FROM work_links WHERE work_id = ? AND link_type = ? AND external_key = ?",
+        ("w", "github", "k"),
+    )
+    # The identity lookup resolves through the UNIQUE (link_type, external_key) constraint,
+    # so ownership costs one indexed row read rather than a scan of the item's links.
+    assert "USING INDEX" in claim_plan and "SCAN work_links" not in claim_plan
+    retention_plan = _plan(
+        conn,
+        "SELECT seq FROM work_events INDEXED BY work_events_adapter_retention "
+        "WHERE work_id = ? AND actor_type = 'adapter' AND event_type IN (?, ?)",
+        ("w", "sync-observed", "sync-stale"),
+    )
+    assert "work_events_adapter_retention" in retention_plan
+    assert "SCAN work_events" not in retention_plan
+    attempt_plan = _plan(
+        conn,
+        "SELECT 1 FROM work_events INDEXED BY work_events_attempt_work_seq "
+        "WHERE work_id = ? AND event_type IN (?, ?, ?) LIMIT 1 OFFSET ?",
+        ("w", "attempt-started", "attempt-failed", "attempt-reset", store.ITEM_MAX_ATTEMPT_EVENTS - 1),
+    )
+    assert "work_events_attempt_work_seq" in attempt_plan
+    assert "SCAN work_events" not in attempt_plan
+
+
+def test_worklore_operations_are_explicitly_bound_by_the_store_facade():
+    from brigade import worklore_store_operations as operations
+
+    assert operations._core() is store
+
+
+def test_the_legacy_quota_reconciliation_runs_once_not_on_every_start(tmp_path):
+    conn = _conn(tmp_path)
+    _import(conn, [_observation(1)], key="seed")
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+    try:
+        store.ensure_schema(conn)
+    finally:
+        conn.set_trace_callback(None)
+    assert not [statement for statement in statements if "ROW_NUMBER() OVER (PARTITION BY" in statement]
+
+
+def test_fleet_hub_schema_is_v18_for_the_recoverable_link_ceiling(tmp_path):
+    assert fleet_hub.SCHEMA_VERSION == 18
+    conn = fleet_hub.init_db(tmp_path / "hub.db")
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 18
+        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(work_import_keys)")}
+        assert "refused" in columns
+        assert conn.execute("SELECT COUNT(*) FROM work_schema_meta").fetchone()[0] >= 1
+    finally:
+        conn.close()

--- a/tests/test_worklore_validate.py
+++ b/tests/test_worklore_validate.py
@@ -1,0 +1,175 @@
+# Synthetic rejection fixtures retain private paths, emails, and a dummy JWT.
+# content-guard: allow home-path file
+# content-guard: allow email file
+# content-guard: allow jwt-token file
+from __future__ import annotations
+
+import pytest
+from brigade import worklore_validate as v
+
+
+def test_create_payload_rejects_unknown_and_overlong_fields() -> None:
+    parsed = v.parse_create({"title": "Rotate NAS restic password", "kind": "fleet"})
+    assert parsed["title"] == "Rotate NAS restic password"
+    assert parsed["kind"] == "fleet"
+    assert parsed["status"] == "captured"
+    assert parsed["burn_rank"] == 1000
+    for raw, code in (
+        ({"title": "x", "kind": "fleet", "extra": True}, "unknown-field"),
+        ({"title": "", "kind": "fleet"}, "field-bound"),
+        ({"title": "x" * 241, "kind": "fleet"}, "field-bound"),
+        ({"title": "ok", "kind": "not-a-kind"}, "field-bound"),
+        ({"title": "ok\x00", "kind": "fleet"}, "field-bound"),
+    ):
+        with pytest.raises(v.WorkloreValidationError) as excinfo:
+            v.parse_create(raw)
+        assert excinfo.value.code == code
+
+
+def test_ready_requires_acceptance() -> None:
+    item = {"acceptance": ["restic snapshots --latest 1 succeeds"]}
+    v.assert_ready(item)
+    item["acceptance"] = []
+    with pytest.raises(v.WorkloreValidationError) as excinfo:
+        v.assert_ready(item)
+    assert excinfo.value.code == "acceptance-required"
+
+
+def test_burn_eligibility_has_no_second_home_in_the_validator() -> None:
+    """The queue rules live only in the store, so a duplicate helper cannot drift from them."""
+    assert not hasattr(v, "burn_eligible")
+
+
+def test_timestamps_are_validated_so_malformed_values_cannot_hide_work() -> None:
+    parsed = v.parse_create(
+        {
+            "title": "Rotate NAS restic password",
+            "kind": "fleet",
+            "review_after": "2026-09-01T00:00:00Z",
+            "spend_by": "2026-09-30T00:00:00+00:00",
+        }
+    )
+    assert parsed["review_after"] == "2026-09-01T00:00:00Z"
+    assert parsed["spend_by"] == "2026-09-30T00:00:00+00:00"
+    assert v.parse_create({"title": "x", "kind": "fleet", "review_after": ""})["review_after"] is None
+    assert v.parse_create({"title": "x", "kind": "fleet", "spend_by": None})["spend_by"] is None
+    for field in ("review_after", "spend_by"):
+        for bad in ("tomorrow", "2026-13-45", "2026-09-01T00:00:00Z\n", 17):
+            with pytest.raises(v.WorkloreValidationError) as excinfo:
+                v.parse_create({"title": "x", "kind": "fleet", field: bad})
+            assert excinfo.value.code == "field-bound"
+
+
+def test_as_datetime_normalizes_zulu_and_naive_input_to_utc() -> None:
+    assert v.as_datetime("2026-09-01T00:00:00Z") == v.as_datetime("2026-09-01T00:00:00+00:00")
+    assert v.as_datetime("2026-09-01T00:00:00") == v.as_datetime("2026-09-01T00:00:00+00:00")
+
+
+def test_lifecycle_edges_are_closed() -> None:
+    assert v.can_transition("captured", "ready") is True
+    assert v.can_transition("ready", "claimed") is True
+    assert v.can_transition("ready", "running") is False
+    assert v.can_transition("completed", "archived") is True
+    assert v.can_transition("archived", "ready") is False
+
+
+# --- canonical private-data primitives (Daybreak finding 3) ------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/home/operator/notes",
+        "/home",
+        "see /Users/operator/notes",
+        r"C:\Users\operator\notes",
+        "C:/Users/operator/notes",
+        "file:///home/operator/notes",
+        'path="/root/.ssh/id_ed25519"',
+        "%USERPROFILE%\\AppData",
+    ],
+)
+def test_private_paths_are_detected(value: str) -> None:
+    assert v.contains_private_path(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "escoffier-labs/homelab#4",
+        "escoffier-labs/home#4",
+        "https://github.com/users/octocat",
+        "Homeroom rotation",
+        "rootcause analysis",
+        "brigade/rooted#12",
+    ],
+)
+def test_ordinary_identities_are_not_private_paths(value: str) -> None:
+    assert v.contains_private_path(value) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ghp_" + "a" * 36,
+        "github_pat_" + "b" * 30,
+        "xoxb-1234567890-abcdef",
+        "sk-" + "c" * 32,
+        "AKIAIOSFODNN7EXAMPLE",
+        "-----BEGIN OPENSSH PRIVATE KEY-----",
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdefghij",
+        "password=" + "s" * 20,
+        "https://operator:" + "hunter2" + "@example.invalid/x",
+    ],
+)
+def test_credential_shapes_are_detected(value: str) -> None:
+    assert v.contains_credential(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "fix the token handling",
+        "rotate the api key next quarter",
+        "secret santa planning",
+        "https://github.com/escoffier-labs/brigade/issues/1",
+    ],
+)
+def test_ordinary_prose_is_not_a_credential(value: str) -> None:
+    assert v.contains_credential(value) is False
+
+
+def test_safe_text_separates_field_bound_from_private_data() -> None:
+    assert v.safe_text("plain title", "title", max_len=20) == "plain title"
+    for value, code in (
+        (42, "field-bound"),
+        ("bell \x07", "field-bound"),
+        ("x" * 61, "field-bound"),
+        ("/home/operator", "private-data"),
+        ("ghp_" + "a" * 36, "private-data"),
+    ):
+        with pytest.raises(v.WorkloreValidationError) as excinfo:
+            v.safe_text(value, "title", max_len=60)
+        assert excinfo.value.code == code, value
+
+
+def test_safe_https_url_rejects_userinfo_and_malformed_urls() -> None:
+    assert v.safe_https_url("https://github.com/a/b/issues/1") == "https://github.com/a/b/issues/1"
+    assert v.safe_https_url("https://example.invalid:443/path") == "https://example.invalid:443/path"
+    assert v.safe_https_url("https://[2001:db8::1]:8443/path") == "https://[2001:db8::1]:8443/path"
+    assert v.safe_https_url(None) is None
+    for value, code in (
+        ("http://github.com/a", "field-bound"),
+        ("https:///a", "field-bound"),
+        ("https://git hub.com/a", "field-bound"),
+        ("ftp://github.com/a", "field-bound"),
+        ("https://operator:token@github.com/a", "private-data"),
+        ("https://example.invalid:abc/path", "field-bound"),
+        ("https://2001:db8::1/path", "field-bound"),
+        ("https://example.invalid:/path", "field-bound"),
+        ("https://example.invalid:65536/path", "field-bound"),
+        ("https://example.invalid/redirect?to=/home/operator/notes", "private-data"),
+    ):
+        with pytest.raises(v.WorkloreValidationError) as excinfo:
+            v.safe_https_url(value)
+        assert excinfo.value.code == code, value


### PR DESCRIPTION
## Summary

- Add an opt-in Worklore ledger to Brigade Fleet Hub, including lifecycle events, links, exclusions, burn selection, and bounded reads.
- Add idempotent import adapters for labeled GitHub issues and Brigade task ledgers.
- Add `brigade fleet work` commands for ledger access and source synchronization.

## Why

Low-priority work needs a durable backlog that spans repositories and operational work without making any source adapter authoritative over operator-managed fields.

## Verification

- Exact-SHA focused gate: `20260901-125805-work-verify-4eefbb`
- GitHub CI run `33510867723`: all required checks passed on `5148278cbce7ba0775f37c0107e452bdaf89c093`, including Python 3.10, 3.11, and 3.12 shards, Windows native acceptance, lint, content guard, install matrices, and provenance
- Opus 5 adversarial review on `5148278cbce7ba0775f37c0107e452bdaf89c093`: PASS, no Critical or Important findings
- Daybreak Blue security scan on `5148278cbce7ba0775f37c0107e452bdaf89c093`: PASS, no Critical, Important, or Minor findings

## Risk

This advances the Fleet Hub schema to version 18. The migration adds Worklore tables, indexes, bounded legacy-row handling, and one-time migration metadata. Worklore stays disabled unless explicitly configured.
