### PR TITLE
fix(run): propagate explicit sandbox into direct-worker synthesis and handoff

### DIFF
--- a/src/brigade/aboyeur/planning.py
+++ b/src/brigade/aboyeur/planning.py
@@ -306,7 +306,7 @@ def resolve_run_sandbox(
     sandbox: str | None = None,
     roster_sandbox: str | None = None,
     read_only: bool = False,
-    health: Mapping[str, Any] | None = None,
+    health: object | None = None,
 ) -> str | None:
     """Resolve the sandbox every write-capable stage for a run must inherit.
 
@@ -314,7 +314,7 @@ def resolve_run_sandbox(
     the roster declaration, then the read-only default. A recorded ``None`` in
     health still falls through so a later explicit or roster value is not lost.
     """
-    if isinstance(health, Mapping):
+    if isinstance(health, dict):
         stored = health.get("effective_sandbox")
         if isinstance(stored, str) and stored:
             return stored

--- a/src/brigade/aboyeur/planning.py
+++ b/src/brigade/aboyeur/planning.py
@@ -301,6 +301,30 @@ def _orchestrator_failure_detail(
     return result.detail or ""
 
 
+def resolve_run_sandbox(
+    *,
+    sandbox: str | None = None,
+    roster_sandbox: str | None = None,
+    read_only: bool = False,
+    health: Mapping[str, Any] | None = None,
+) -> str | None:
+    """Resolve the sandbox every write-capable stage for a run must inherit.
+
+    Precedence: persisted ``health.effective_sandbox``, the explicit argument,
+    the roster declaration, then the read-only default. A recorded ``None`` in
+    health still falls through so a later explicit or roster value is not lost.
+    """
+    if isinstance(health, Mapping):
+        stored = health.get("effective_sandbox")
+        if isinstance(stored, str) and stored:
+            return stored
+    if sandbox is not None:
+        return sandbox
+    if roster_sandbox is not None:
+        return roster_sandbox
+    return "read-only" if read_only else None
+
+
 def _run_orchestrator(
     roster: Roster,
     prompt: str,
@@ -337,13 +361,22 @@ def _run_orchestrator(
             failure_phase="preflight",
             failure_kind="provider-config",
         )
+    effective_read_only = read_only if sandbox_read_only is None else sandbox_read_only
+    # Do not invent a sandbox kwarg from read_only alone: legacy run_agent
+    # doubles omit that parameter, and prompt-level read-only already
+    # travels as read_only=. Roster or an explicit flag still propagate.
+    effective_sandbox = resolve_run_sandbox(
+        sandbox=sandbox,
+        roster_sandbox=roster.sandbox,
+        read_only=False,
+    )
     kwargs: dict[str, object] = {
         "timeout": timeout_for(orchestrator, roster),
         "cwd": cwd,
-        "read_only": read_only if sandbox_read_only is None else sandbox_read_only,
+        "read_only": effective_read_only,
     }
-    if sandbox is not None:
-        kwargs["sandbox"] = sandbox
+    if effective_sandbox is not None:
+        kwargs["sandbox"] = effective_sandbox
     if orchestrator.model is not None:
         kwargs["model"] = orchestrator.model
     if orchestrator.reasoning is not None:

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -29,6 +29,7 @@ from . import (
     verification_contract,
     worker_events,
 )
+from .aboyeur.planning import resolve_run_sandbox
 from .roster import Agent, Roster, _as_bool, _as_capabilities, _as_command, _as_env
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
@@ -423,6 +424,41 @@ def _continuation_prompt(task: str) -> str:
     )
 
 
+def _finish_resume_receipt(run_dir: Path, run_meta: dict, final: agents.AgentResult) -> int:
+    now = datetime.now(timezone.utc).isoformat()
+    run_meta.setdefault("resumed_at", []).append(now)
+    if not final.ok:
+        bounded_detail = (final.detail or "orchestrator failed during synthesis")[:2000]
+        _archive_failure(run_meta)
+        run_meta["status"] = "failed"
+        run_meta["error"] = bounded_detail
+        run_meta["failure_phase"] = "synthesis"
+        run_meta["failure"] = {
+            "phase": "synthesis",
+            "kind": "agent-error",
+            "detail": bounded_detail,
+            "seat": run_meta.get("orchestrator"),
+        }
+        _refresh_run_timing(run_meta)
+        try:
+            aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
+        except run_lifecycle.LifecycleJournalError as exc:
+            raise runguard.RetainRunLockError(f"failed to write failed-synthesis run receipt: {exc}") from exc
+        print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
+        return 2
+    (run_dir / "final.txt").write_text(final.text + "\n")
+    run_meta["status"] = "ok"
+    run_meta.pop("error", None)
+    _archive_failure(run_meta)
+    _refresh_run_timing(run_meta)
+    try:
+        aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
+    except run_lifecycle.LifecycleJournalError as exc:
+        raise runguard.RetainRunLockError(f"failed to write successful-synthesis run receipt: {exc}") from exc
+    print(final.text)
+    return 0
+
+
 def resume(run_dir: Path) -> int:
     run_dir = run_dir.expanduser().resolve()
     run_meta = _load_json(run_dir, "run.json")
@@ -564,7 +600,13 @@ def _resume_locked(
         return 2
 
     read_only = bool(run_meta.get("read_only"))
-    sandbox = roster_snapshot.get("sandbox")
+    roster_sandbox = roster_snapshot.get("sandbox")
+    sandbox = resolve_run_sandbox(
+        sandbox=roster_sandbox if isinstance(roster_sandbox, str) else None,
+        roster_sandbox=roster.sandbox,
+        read_only=read_only,
+        health=run_meta.get("health") if isinstance(run_meta.get("health"), dict) else None,
+    )
     if approval_resume:
         from . import runs_cmd
 
@@ -718,6 +760,31 @@ def _resume_locked(
     )
 
     task = run_meta.get("task", "")
+    direct_worker = isinstance(run_meta.get("worker"), str) and bool(run_meta.get("worker"))
+    if direct_worker:
+        # A finished direct worker is already the user-visible result. Do not
+        # spawn a write-capable chef just to re-speak it, and do not reclassify
+        # a completed worker when a later chef seat would have dropped sandbox.
+        direct_result = (
+            worker_results[0]
+            if worker_results
+            else aboyeur.WorkerResult(
+                worker=str(run_meta.get("worker") or ""),
+                task=task,
+                text="",
+                ok=False,
+                detail="direct worker produced no result",
+            )
+        )
+        final = aboyeur._agent_result_from_worker(direct_result)
+        synthesis_payload = receipt_schema.synthesis_document(
+            mode="direct-worker",
+            worker=run_meta.get("worker") if isinstance(run_meta.get("worker"), str) else None,
+            result={"ok": final.ok, "detail": final.detail, "text": final.text},
+            ground_truth=ground_truth,
+        )
+        aboyeur.write_sidecar_revision(run_dir, "synthesis.json", synthesis_payload)
+        return _finish_resume_receipt(run_dir, run_meta, final)
     synth_prompt = aboyeur.build_synth_prompt(
         task,
         worker_results,
@@ -750,16 +817,21 @@ def _resume_locked(
             file=sys.stderr,
         )
         return 2
+    synth_kwargs: dict[str, object] = {
+        "timeout": orchestrator.timeout_seconds or roster.timeout_seconds,
+        "cwd": cwd,
+        "read_only": read_only,
+        "model": orchestrator.model,
+        "reasoning": orchestrator.reasoning,
+        "env": dict(orchestrator.env) if orchestrator.env is not None else None,
+        "command": orchestrator.command,
+    }
+    if sandbox is not None:
+        synth_kwargs["sandbox"] = sandbox
     final = agents.run_agent(
         orchestrator.cli,
         synth_prompt,
-        timeout=orchestrator.timeout_seconds or roster.timeout_seconds,
-        cwd=cwd,
-        read_only=read_only,
-        model=orchestrator.model,
-        reasoning=orchestrator.reasoning,
-        env=dict(orchestrator.env) if orchestrator.env is not None else None,
-        command=orchestrator.command,
+        **synth_kwargs,
     )
     synth_captured = message_envelope.emit(
         final.text,
@@ -790,35 +862,4 @@ def _resume_locked(
         "synthesis.json",
         synthesis_payload,
     )
-    now = datetime.now(timezone.utc).isoformat()
-    run_meta.setdefault("resumed_at", []).append(now)
-    if not final.ok:
-        bounded_detail = (final.detail or "orchestrator failed during synthesis")[:2000]
-        _archive_failure(run_meta)
-        run_meta["status"] = "failed"
-        run_meta["error"] = bounded_detail
-        run_meta["failure_phase"] = "synthesis"
-        run_meta["failure"] = {
-            "phase": "synthesis",
-            "kind": "agent-error",
-            "detail": bounded_detail,
-            "seat": roster.orchestrator,
-        }
-        _refresh_run_timing(run_meta)
-        try:
-            aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
-        except run_lifecycle.LifecycleJournalError as exc:
-            raise runguard.RetainRunLockError(f"failed to write failed-synthesis run receipt: {exc}") from exc
-        print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
-        return 2
-    (run_dir / "final.txt").write_text(final.text + "\n")
-    run_meta["status"] = "ok"
-    run_meta.pop("error", None)
-    _archive_failure(run_meta)
-    _refresh_run_timing(run_meta)
-    try:
-        aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
-    except run_lifecycle.LifecycleJournalError as exc:
-        raise runguard.RetainRunLockError(f"failed to write successful-synthesis run receipt: {exc}") from exc
-    print(final.text)
-    return 0
+    return _finish_resume_receipt(run_dir, run_meta, final)

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -466,6 +466,57 @@ def _finish_resume_receipt(
     return 0
 
 
+def _finish_direct_worker_resume_receipt(
+    run_dir: Path,
+    run_meta: dict,
+    final: agents.AgentResult,
+    *,
+    worker: str,
+) -> int:
+    """Terminalize a resumed ``--worker`` result without chef synthesis labels.
+
+    A failed direct worker is still the user-visible result: write ``final.txt``,
+    type ``failure_phase`` from the worker (or ``dispatch``), and attribute the
+    seat to the worker. Reusing ``_finish_resume_receipt`` would mislabel this
+    as a chef synthesis failure.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    run_meta.setdefault("resumed_at", []).append(now)
+    (run_dir / "final.txt").write_text(final.text + "\n")
+    if not final.ok:
+        bounded_detail = (final.detail or "worker failed")[:2000]
+        failure_phase = final.failure_phase or "dispatch"
+        _archive_failure(run_meta)
+        run_meta["status"] = "failed"
+        run_meta["error"] = bounded_detail
+        run_meta["failure_phase"] = failure_phase
+        run_meta["failure"] = {
+            "phase": failure_phase,
+            "kind": final.failure_kind or "agent-error",
+            "detail": bounded_detail,
+            "seat": worker,
+        }
+        _refresh_run_timing(run_meta)
+        try:
+            aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
+        except run_lifecycle.LifecycleJournalError as exc:
+            raise runguard.RetainRunLockError(f"failed to write failed-worker run receipt: {exc}") from exc
+        print(f"error: worker failed: {final.detail}", file=sys.stderr)
+        if final.text:
+            print(final.text)
+        return 2
+    run_meta["status"] = "ok"
+    run_meta.pop("error", None)
+    _archive_failure(run_meta)
+    _refresh_run_timing(run_meta)
+    try:
+        aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
+    except run_lifecycle.LifecycleJournalError as exc:
+        raise runguard.RetainRunLockError(f"failed to write successful-worker run receipt: {exc}") from exc
+    print(final.text)
+    return 0
+
+
 def resume(run_dir: Path) -> int:
     run_dir = run_dir.expanduser().resolve()
     run_meta = _load_json(run_dir, "run.json")
@@ -750,6 +801,9 @@ def _resume_locked(
             # observed byte count, the configured cap, and the output-limit
             # classification for every resumed run.
             failure_kind=r.get("failure_kind"),
+            failure_phase=(
+                r.get("failure_phase") if not r.get("ok") and isinstance(r.get("failure_phase"), str) else None
+            ),
             output_truncated=bool(r.get("output_truncated")),
             output_bytes=int(r.get("output_bytes") or 0),
             output_cap_bytes=int(r.get("output_cap_bytes") or 0),
@@ -781,17 +835,28 @@ def _resume_locked(
                 text="",
                 ok=False,
                 detail="direct worker produced no result",
+                failure_phase="dispatch",
             )
         )
         final = agent_result_from_worker(direct_result)
+        synthesis_result: dict[str, object] = {"ok": final.ok, "detail": final.detail, "text": final.text}
+        if final.failure_phase is not None:
+            synthesis_result["failure_phase"] = final.failure_phase
+        if final.failure_kind is not None:
+            synthesis_result["failure_kind"] = final.failure_kind
         synthesis_payload = receipt_schema.synthesis_document(
             mode="direct-worker",
             worker=run_meta.get("worker") if isinstance(run_meta.get("worker"), str) else None,
-            result={"ok": final.ok, "detail": final.detail, "text": final.text},
+            result=synthesis_result,
             ground_truth=ground_truth,
         )
         aboyeur.write_sidecar_revision(run_dir, "synthesis.json", synthesis_payload)
-        return _finish_resume_receipt(run_dir, run_meta, final, seat=roster.orchestrator)
+        return _finish_direct_worker_resume_receipt(
+            run_dir,
+            run_meta,
+            final,
+            worker=str(run_meta.get("worker") or direct_result.worker),
+        )
     synth_prompt = aboyeur.build_synth_prompt(
         task,
         worker_results,

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -31,6 +31,7 @@ from . import (
 )
 from .aboyeur.planning import resolve_run_sandbox
 from .roster import Agent, Roster, _as_bool, _as_capabilities, _as_command, _as_env
+from .run_receipts import agent_result_from_worker
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
 _NONTERMINAL_RUN_STATUSES = frozenset(
@@ -424,7 +425,13 @@ def _continuation_prompt(task: str) -> str:
     )
 
 
-def _finish_resume_receipt(run_dir: Path, run_meta: dict, final: agents.AgentResult) -> int:
+def _finish_resume_receipt(
+    run_dir: Path,
+    run_meta: dict,
+    final: agents.AgentResult,
+    *,
+    seat: str,
+) -> int:
     now = datetime.now(timezone.utc).isoformat()
     run_meta.setdefault("resumed_at", []).append(now)
     if not final.ok:
@@ -437,7 +444,7 @@ def _finish_resume_receipt(run_dir: Path, run_meta: dict, final: agents.AgentRes
             "phase": "synthesis",
             "kind": "agent-error",
             "detail": bounded_detail,
-            "seat": run_meta.get("orchestrator"),
+            "seat": seat,
         }
         _refresh_run_timing(run_meta)
         try:
@@ -605,7 +612,7 @@ def _resume_locked(
         sandbox=roster_sandbox if isinstance(roster_sandbox, str) else None,
         roster_sandbox=roster.sandbox,
         read_only=read_only,
-        health=run_meta.get("health") if isinstance(run_meta.get("health"), dict) else None,
+        health=run_meta.get("health"),
     )
     if approval_resume:
         from . import runs_cmd
@@ -770,13 +777,13 @@ def _resume_locked(
             if worker_results
             else aboyeur.WorkerResult(
                 worker=str(run_meta.get("worker") or ""),
-                task=task,
+                task=task if isinstance(task, str) else "",
                 text="",
                 ok=False,
                 detail="direct worker produced no result",
             )
         )
-        final = aboyeur._agent_result_from_worker(direct_result)
+        final = agent_result_from_worker(direct_result)
         synthesis_payload = receipt_schema.synthesis_document(
             mode="direct-worker",
             worker=run_meta.get("worker") if isinstance(run_meta.get("worker"), str) else None,
@@ -784,7 +791,7 @@ def _resume_locked(
             ground_truth=ground_truth,
         )
         aboyeur.write_sidecar_revision(run_dir, "synthesis.json", synthesis_payload)
-        return _finish_resume_receipt(run_dir, run_meta, final)
+        return _finish_resume_receipt(run_dir, run_meta, final, seat=roster.orchestrator)
     synth_prompt = aboyeur.build_synth_prompt(
         task,
         worker_results,
@@ -817,21 +824,17 @@ def _resume_locked(
             file=sys.stderr,
         )
         return 2
-    synth_kwargs: dict[str, object] = {
-        "timeout": orchestrator.timeout_seconds or roster.timeout_seconds,
-        "cwd": cwd,
-        "read_only": read_only,
-        "model": orchestrator.model,
-        "reasoning": orchestrator.reasoning,
-        "env": dict(orchestrator.env) if orchestrator.env is not None else None,
-        "command": orchestrator.command,
-    }
-    if sandbox is not None:
-        synth_kwargs["sandbox"] = sandbox
     final = agents.run_agent(
         orchestrator.cli,
         synth_prompt,
-        **synth_kwargs,
+        timeout=orchestrator.timeout_seconds or roster.timeout_seconds,
+        cwd=cwd,
+        read_only=read_only,
+        sandbox=sandbox,
+        model=orchestrator.model,
+        reasoning=orchestrator.reasoning,
+        env=dict(orchestrator.env) if orchestrator.env is not None else None,
+        command=orchestrator.command,
     )
     synth_captured = message_envelope.emit(
         final.text,
@@ -862,4 +865,4 @@ def _resume_locked(
         "synthesis.json",
         synthesis_payload,
     )
-    return _finish_resume_receipt(run_dir, run_meta, final)
+    return _finish_resume_receipt(run_dir, run_meta, final, seat=roster.orchestrator)

--- a/tests/test_run_transport.py
+++ b/tests/test_run_transport.py
@@ -1206,6 +1206,10 @@ def _interrupted_resume_run(
 class _SandboxRecordingServer:
     def __init__(self, *a, **k):
         self.resumed = []
+        self.turn_ok = True
+        self.turn_text = "finished now"
+        self.turn_detail = ""
+        self.turn_status = "complete"
 
     def start(self):
         pass
@@ -1217,6 +1221,7 @@ class _SandboxRecordingServer:
         from brigade import codex_appserver
 
         self.resumed.append({"thread_id": thread_id, "sandbox": sandbox, "model": model})
+        owner = self
 
         class _Thread:
             def __init__(self, thread_id):
@@ -1224,9 +1229,10 @@ class _SandboxRecordingServer:
 
             def run_turn(self, prompt, *, timeout, on_event=None):  # noqa: ARG002
                 return codex_appserver.TurnResult(
-                    text="finished now",
-                    ok=True,
-                    status="complete",
+                    text=owner.turn_text,
+                    ok=owner.turn_ok,
+                    status=owner.turn_status,
+                    detail=owner.turn_detail,
                     thread_id=self.thread_id,
                 )
 
@@ -1279,6 +1285,42 @@ def test_direct_worker_resume_skips_chef_and_keeps_worker_result(tmp_path, monke
     assert synthesis["result"]["text"] == "finished now"
     assert (run_dir / "final.txt").read_text().strip() == "finished now"
     assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+
+
+def test_direct_worker_resume_failed_worker_keeps_worker_failure_typing(tmp_path, monkeypatch, capsys):
+    from brigade import run_resume
+
+    run_dir = _interrupted_resume_run(tmp_path, worker="coder", direct_worker=True)
+    server = _SandboxRecordingServer()
+    server.turn_ok = False
+    server.turn_text = "partial worker output"
+    server.turn_detail = "provider hung up"
+    server.turn_status = "failed"
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", lambda *a, **k: server)
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        raise AssertionError("direct-worker resume must not invoke chef")
+
+    monkeypatch.setattr(run_resume.agents, "run_agent", fake_run_agent)
+    assert run_resume.resume(run_dir) == 2
+    captured = capsys.readouterr()
+    assert "error: worker failed: provider hung up" in captured.err
+    assert "orchestrator failed during synthesis" not in captured.err
+    assert captured.out.strip() == "partial worker output"
+    assert (run_dir / "final.txt").read_text().strip() == "partial worker output"
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "dispatch"
+    assert run_meta["failure"] == {
+        "phase": "dispatch",
+        "kind": "agent-error",
+        "detail": "provider hung up",
+        "seat": "coder",
+    }
+    synthesis = json.loads((run_dir / "synthesis.json").read_text())
+    assert synthesis["mode"] == "direct-worker"
+    assert synthesis["result"]["ok"] is False
+    assert synthesis["result"]["text"] == "partial worker output"
 
 
 def test_resume_read_only_sandbox_never_becomes_a_write(tmp_path, monkeypatch):

--- a/tests/test_run_transport.py
+++ b/tests/test_run_transport.py
@@ -944,3 +944,366 @@ def test_dispatch_does_not_run_when_versioned_custom_command_or_model_override_i
     assert override_results[0].ok is False
     assert override_results[0].failure_kind == "fleet-model-policy"
     assert override_calls == []
+
+
+def _direct_worker_roster(*, chef_cli: str = "claude", coder_cli: str = "codex") -> Roster:
+    return Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(name="chef", cli=chef_cli, role="plan"),
+            "coder": Agent(name="coder", cli=coder_cli, role="write"),
+        },
+        max_workers=2,
+    )
+
+
+def test_dispatch_passes_explicit_sandbox_to_direct_worker(monkeypatch, tmp_path):
+    captured: list[dict[str, object]] = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        captured.append({"cli": cli_ref, "sandbox": kwargs.get("sandbox"), "read_only": kwargs.get("read_only")})
+        return agents.AgentResult(text="implemented", ok=True)
+
+    monkeypatch.setattr(agents, "run_agent", fake_run_agent)
+    results = run_transport.dispatch(
+        [Assignment(worker="coder", task="implement it")],
+        _direct_worker_roster(),
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        cwd=tmp_path,
+        sandbox="danger-full-access",
+        output_dir=tmp_path,
+        direct=True,
+    )
+    assert results[0].ok is True
+    assert captured == [{"cli": "codex", "sandbox": "danger-full-access", "read_only": False}]
+
+
+def test_direct_worker_handoff_propagates_explicit_sandbox(monkeypatch, tmp_path):
+    from brigade import aboyeur
+    from brigade import verification_contract
+    from tests.run_test_helpers import run_aboyeur_guarded
+
+    calls: list[dict[str, object]] = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        calls.append(
+            {
+                "cli": cli_ref,
+                "sandbox": kwargs.get("sandbox"),
+                "read_only": kwargs.get("read_only"),
+            }
+        )
+        return agents.AgentResult(text="worker final output", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    output_dir = tmp_path / "run"
+    inbox = tmp_path / "handoffs"
+    contract = {
+        "schema": verification_contract.VERIFICATION_CONTRACT_SCHEMA,
+        "schema_version": verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION,
+        "verifier": {"source": "command", "command": "true"},
+        "rollback": {"policy": "none"},
+        "budget": {},
+    }
+
+    rc = run_aboyeur_guarded(
+        "implement the bounded fix",
+        _direct_worker_roster(),
+        worker="coder",
+        sandbox="danger-full-access",
+        handoff_inbox=inbox,
+        output_dir=output_dir,
+        cwd=tmp_path,
+        route_enabled=False,
+        code_graph_enabled=False,
+        evidence_enabled=False,
+        verification_contract_payload=contract,
+    )
+
+    assert rc == 0
+    assert [call["cli"] for call in calls] == ["codex"]
+    assert calls[0]["sandbox"] == "danger-full-access"
+    assert calls[0]["read_only"] is False
+    chef_calls = [call for call in calls if call["cli"] == "claude"]
+    assert chef_calls == []
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "ok"
+    assert run_meta["worker"] == "coder"
+    assert list(inbox.glob("*.md"))
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())
+    assert synthesis["mode"] == "direct-worker"
+    assert synthesis["result"]["text"] == "worker final output"
+
+
+def test_direct_worker_read_only_sandbox_never_becomes_a_write(monkeypatch, tmp_path):
+    from brigade import aboyeur
+    from tests.run_test_helpers import run_aboyeur_guarded
+
+    calls: list[dict[str, object]] = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        calls.append(
+            {
+                "cli": cli_ref,
+                "sandbox": kwargs.get("sandbox"),
+                "read_only": kwargs.get("read_only"),
+            }
+        )
+        return agents.AgentResult(text="read-only review", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    output_dir = tmp_path / "run"
+
+    rc = run_aboyeur_guarded(
+        "review the diff",
+        _direct_worker_roster(),
+        worker="coder",
+        read_only=True,
+        sandbox="read-only",
+        handoff_inbox=tmp_path / "handoffs",
+        output_dir=output_dir,
+        cwd=tmp_path,
+        route_enabled=False,
+        code_graph_enabled=False,
+        evidence_enabled=False,
+    )
+
+    assert rc == 0
+    assert calls
+    for call in calls:
+        write_invocation = call["sandbox"] not in {"read-only", None} or (
+            call["sandbox"] is None and call["read_only"] is False
+        )
+        assert write_invocation is False
+        assert call["sandbox"] == "read-only"
+        assert call["read_only"] is True
+    assert all(call["cli"] != "claude" for call in calls)
+
+
+def test_handoff_failure_preserves_direct_worker_result_and_verification(monkeypatch, tmp_path):
+    from brigade import aboyeur
+    from brigade import verification_contract
+    from tests.run_test_helpers import run_aboyeur_guarded
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        return agents.AgentResult(text="worker final output", ok=True)
+
+    def fail_handoff(*args, **kwargs):  # noqa: ARG001
+        raise OSError("cannot write handoff")
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur, "write_run_handoff", fail_handoff)
+    output_dir = tmp_path / "run"
+    contract = {
+        "schema": verification_contract.VERIFICATION_CONTRACT_SCHEMA,
+        "schema_version": verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION,
+        "verifier": {"source": "command", "command": "true"},
+        "rollback": {"policy": "none"},
+        "budget": {},
+    }
+
+    rc = run_aboyeur_guarded(
+        "implement the bounded fix",
+        _direct_worker_roster(),
+        worker="coder",
+        sandbox="danger-full-access",
+        handoff_inbox=tmp_path / "handoffs",
+        output_dir=output_dir,
+        cwd=tmp_path,
+        route_enabled=False,
+        code_graph_enabled=False,
+        evidence_enabled=False,
+        verification_contract_payload=contract,
+    )
+
+    assert rc == 2
+    worker_doc = json.loads((output_dir / "worker-results.json").read_text())
+    assert worker_doc["results"][0]["ok"] is True
+    assert worker_doc["results"][0]["text"] == "worker final output"
+    assert "failure_phase" not in worker_doc["results"][0]
+    plan = json.loads((output_dir / "plan.json").read_text())
+    assert plan["verification_contract"]["verifier"]["command"] == "true"
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())
+    assert synthesis["mode"] == "direct-worker"
+    assert synthesis["result"]["ok"] is True
+    assert synthesis["result"]["text"] == "worker final output"
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "handoff"
+    assert run_meta["failure"]["kind"] == "handoff-write-error"
+
+
+def _interrupted_resume_run(
+    tmp_path,
+    *,
+    worker: str = "cook",
+    direct_worker: bool = False,
+    sandbox: str | None = "danger-full-access",
+):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    run_meta = {
+        "task": "implement the bounded fix",
+        "cwd": str(tmp_path),
+        "orchestrator": "chef",
+        "read_only": False,
+        "status": "failed",
+        "started_at": "2026-08-31T00:00:00+00:00",
+        "error": "run owner process 99999999 is no longer active",
+        "failure_phase": "stale-lock-recovery",
+        "failure": {
+            "phase": "stale-lock-recovery",
+            "kind": "owner-process-exited",
+            "owner_pid": 99999999,
+        },
+        "health": {"effective_sandbox": sandbox},
+    }
+    if direct_worker:
+        run_meta["worker"] = worker
+        run_meta["run_mode"] = "direct-worker"
+    (run_dir / "run.json").write_text(json.dumps(run_meta))
+    (run_dir / "roster.json").write_text(
+        json.dumps(
+            {
+                "orchestrator": "chef",
+                "max_workers": 4,
+                "timeout_seconds": 600.0,
+                "allow_models": [],
+                "sandbox": None,
+                "agents": {
+                    "chef": {"cli": "claude", "model": None, "role": "plan", "timeout_seconds": None},
+                    worker: {"cli": "codex", "model": None, "role": "code", "timeout_seconds": None},
+                },
+            }
+        )
+    )
+    (run_dir / "plan.json").write_text(
+        json.dumps({"assignments": [{"stage": 1, "worker": worker, "task": "write the fix"}]})
+    )
+    (run_dir / "worker-results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "worker": worker,
+                        "task": "write the fix",
+                        "ok": False,
+                        "detail": "timeout",
+                        "text": "partial",
+                        "thread_id": "t-sandbox",
+                        "status": "interrupted",
+                    }
+                ],
+                "ground_truth": {"verify_receipt": "20260831-000147-work-verify-4b2d5d"},
+            }
+        )
+    )
+    return run_dir
+
+
+class _SandboxRecordingServer:
+    def __init__(self, *a, **k):
+        self.resumed = []
+
+    def start(self):
+        pass
+
+    def close(self):
+        pass
+
+    def resume_thread(self, thread_id, *, cwd, model=None, sandbox=None):
+        from brigade import codex_appserver
+
+        self.resumed.append({"thread_id": thread_id, "sandbox": sandbox, "model": model})
+
+        class _Thread:
+            def __init__(self, thread_id):
+                self.thread_id = thread_id
+
+            def run_turn(self, prompt, *, timeout, on_event=None):  # noqa: ARG002
+                return codex_appserver.TurnResult(
+                    text="finished now",
+                    ok=True,
+                    status="complete",
+                    thread_id=self.thread_id,
+                )
+
+        return _Thread(thread_id)
+
+
+def test_resume_synthesis_receives_explicit_sandbox(tmp_path, monkeypatch):
+    from brigade import run_resume
+
+    run_dir = _interrupted_resume_run(tmp_path, worker="cook", direct_worker=False)
+    server = _SandboxRecordingServer()
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", lambda *a, **k: server)
+    captured: dict[str, object] = {}
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        captured["cli"] = cli_ref
+        captured["sandbox"] = kwargs.get("sandbox")
+        captured["read_only"] = kwargs.get("read_only")
+        return agents.AgentResult(text="final synthesis", ok=True)
+
+    monkeypatch.setattr(run_resume.agents, "run_agent", fake_run_agent)
+    assert run_resume.resume(run_dir) == 0
+    assert server.resumed[0]["sandbox"] == "danger-full-access"
+    assert captured == {"cli": "claude", "sandbox": "danger-full-access", "read_only": False}
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+
+
+def test_direct_worker_resume_skips_chef_and_keeps_worker_result(tmp_path, monkeypatch):
+    from brigade import run_resume
+
+    run_dir = _interrupted_resume_run(tmp_path, worker="coder", direct_worker=True)
+    server = _SandboxRecordingServer()
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", lambda *a, **k: server)
+    chef_calls: list[dict[str, object]] = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        chef_calls.append({"cli": cli_ref, "sandbox": kwargs.get("sandbox"), "read_only": kwargs.get("read_only")})
+        raise AssertionError("direct-worker resume must not invoke chef")
+
+    monkeypatch.setattr(run_resume.agents, "run_agent", fake_run_agent)
+    assert run_resume.resume(run_dir) == 0
+    assert server.resumed[0]["sandbox"] == "danger-full-access"
+    assert chef_calls == []
+    results = json.loads((run_dir / "worker-results.json").read_text())
+    assert results["results"][0]["ok"] is True
+    assert results["results"][0]["text"] == "finished now"
+    assert results["ground_truth"]["verify_receipt"] == "20260831-000147-work-verify-4b2d5d"
+    synthesis = json.loads((run_dir / "synthesis.json").read_text())
+    assert synthesis["mode"] == "direct-worker"
+    assert synthesis["result"]["text"] == "finished now"
+    assert (run_dir / "final.txt").read_text().strip() == "finished now"
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+
+
+def test_resume_read_only_sandbox_never_becomes_a_write(tmp_path, monkeypatch):
+    from brigade import run_resume
+
+    run_dir = _interrupted_resume_run(tmp_path, worker="cook", direct_worker=False, sandbox="read-only")
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["read_only"] = True
+    (run_dir / "run.json").write_text(json.dumps(run_meta))
+    server = _SandboxRecordingServer()
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", lambda *a, **k: server)
+    captured: dict[str, object] = {}
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        captured["cli"] = cli_ref
+        captured["sandbox"] = kwargs.get("sandbox")
+        captured["read_only"] = kwargs.get("read_only")
+        return agents.AgentResult(text="read-only synthesis", ok=True)
+
+    monkeypatch.setattr(run_resume.agents, "run_agent", fake_run_agent)
+    assert run_resume.resume(run_dir) == 0
+    assert server.resumed[0]["sandbox"] == "read-only"
+    assert captured["sandbox"] == "read-only"
+    assert captured["read_only"] is True
+    write_invocation = captured["sandbox"] not in {"read-only", None} or (
+        captured["sandbox"] is None and captured["read_only"] is False
+    )
+    assert write_invocation is False

--- a/tests/test_work_cmd_services.py
+++ b/tests/test_work_cmd_services.py
@@ -1622,7 +1622,9 @@ role = "code"
 
     monkeypatch.setattr(run_resume.codex_appserver, "AppServer", ResumeServer)
     assert cli.main(["runs", "resume", str(run_dir)]) == 0
-    assert (run_dir / "final.txt").read_text().strip() == "resumed synthesis"
+    # This fixture is a `--worker coder` run. Direct-worker resume now uses the
+    # worker turn as the user-visible result and does not re-speak it through chef.
+    assert (run_dir / "final.txt").read_text().strip() == "approval continuation complete"
     resumed = json.loads((run_dir / "run.json").read_text())
     assert resumed["status"] == "ok"
     assert len(resume_tokens) == 1


### PR DESCRIPTION
Fixes #1341

Propagate the explicit run sandbox into resume synthesis and skip an unnecessary write-capable chef after a finished `--worker` result. A later chef/handoff stage must not drop `--sandbox danger-full-access` and reclassify a completed worker.

Review follow-up on this draft: a not-ok direct-worker resume now has its own failure typing (`failure_phase` from the worker or `dispatch`, `failure.seat` = the worker, `final.txt` written, worker-phrased stderr) instead of chef synthesis labels.

Branch: `cursor/issue-1341-propagate-sandbox-0ad9`
HEAD: `5b41a86c07db1438f251fd2f210b9f1e500e1e3a`
Base: `main`

## New tests

Failing-first (require this branch; fail on main):

- `test_resume_synthesis_receives_explicit_sandbox`
- `test_direct_worker_resume_skips_chef_and_keeps_worker_result`
- `test_resume_read_only_sandbox_never_becomes_a_write`
- `test_direct_worker_resume_failed_worker_keeps_worker_failure_typing`

Characterization (pass on main; document existing contracts):

- `test_dispatch_passes_explicit_sandbox_to_direct_worker`
- `test_direct_worker_handoff_propagates_explicit_sandbox`
- `test_direct_worker_read_only_sandbox_never_becomes_a_write`
- `test_handoff_failure_preserves_direct_worker_result_and_verification`

`test_tools_child_process_requests_owner_process_pause_and_releases_parent_lock` is a `--worker coder` approval-resume. After skip-chef, `final.txt` is the worker turn (`approval continuation complete`), not the chef stub (`resumed synthesis`). The assertion was updated for that reason.

## `roster_sandbox` fallback

Kept. Resume and `_run_orchestrator` are also called without a CLI-resolved sandbox (`dogfood_cmd`, `model_trials`, and a roster snapshot on resume). Dropping the roster fallback would let those callers silently inherit `None` (write-capable) when the roster declared a sandbox. That is the same drop #1341 is fixing. `health.effective_sandbox` still wins when present.

## Brigade proof receipt

- Receipt id: `20260901-142435-work-verify-ac0b54`
- Status: `completed`
- Command exit: `0`
- Recorded command: `./scripts/verify-focused tests/test_run_transport.py tests/test_run_transport_recovery.py tests/test_work_cmd_services.py`

Proof command used:

    brigade work verify run --target . --argv-json '[./scripts/verify-focused, tests/test_run_transport.py, tests/test_run_transport_recovery.py, tests/test_work_cmd_services.py]' --capture brigade-work

Receipt stdout: All checks passed; 984 files already formatted; mypy Success no issues found in 549 source files; version=0.27.0; managed snapshot ok; template profile snapshot ok; 116 passed in 22.02s.

## Envelope verification

- pytest: exit 0, 116 passed in 23.76s
- ruff check src/brigade: exit 0
- ruff format --check src/brigade: exit 0, 549 files already formatted
- mypy: exit 0, Success: no issues found in 549 source files
- git diff --check: exit 0