### PR TITLE
fix(fleet): bound dashboard board queries with window and LIMIT

### DIFF
--- a/docs/fleet-sync.md
+++ b/docs/fleet-sync.md
@@ -280,8 +280,14 @@ phone over Tailscale:
 - Query params: `sort=attention|age|node|repo|state|seat`, substring filters
   `node=`, `repo=`, `seat=` (matches seat or harness), `state=` (bucket or raw
   event type), `attention=1` (needs-attention only), `all=1` (include
-  finished runs). Same params on both boards; the board links carry them
-  across.
+  finished runs, still paginated), `offset=` (next LIMIT page). Same params
+  on both boards; the board links carry them across.
+- Board queries reuse latest-state-per-run. The default fetch windows
+  terminal history to the deck horizon (`stale_history_after_seconds`,
+  default 24h) so the 10s refresh does not scan the whole journal; `all=1`
+  drops the window and still applies LIMIT plus a `more` link. Start times
+  and node cards are derived from those rendered rows. GET never prunes
+  events; operators compact the journal from the Proxmox runbook.
 - Server-rendered, stdlib only, no framework or CDN asset. Tables, sorting,
   and filtering are plain HTML + query params and work with JavaScript off;
   refresh is a `<meta http-equiv="refresh" content="10">`. The inline

--- a/docs/runbooks/fleet-hub-proxmox.md
+++ b/docs/runbooks/fleet-hub-proxmox.md
@@ -436,6 +436,23 @@ ls -lh /var/backups/brigade/
 
 Copy backups off the CT through the operator's existing backup system. The local timer is not a replacement for an off-host copy.
 
+## 9. Compact the event journal (optional)
+
+The classic boards (`/view/machines`, `/view/repos`) refresh about every 10s and now read a latest-state-per-run page: terminal history is windowed to 24h unless `all=1`, and each page is LIMITed. That keeps render cost flat as the journal grows. The events table itself is still an append-only log. Dashboard GET handlers never delete rows.
+
+If the SQLite file is still larger than you want, prune events older than N days as a planned maintenance step after a backup (section 8). Stop or briefly idle writers if you can; WAL mode allows a live delete, but take the backup first.
+
+```bash
+systemctl start brigade-fleet-backup.service
+cutoff=$(date -u -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ)
+sqlite3 /var/lib/brigade/fleet-hub.db \
+  "DELETE FROM events WHERE received_at < '$cutoff';"
+sqlite3 /var/lib/brigade/fleet-hub.db "PRAGMA wal_checkpoint(TRUNCATE);"
+sqlite3 /var/lib/brigade/fleet-hub.db "VACUUM;"
+```
+
+Fourteen days is a starting horizon, not a required policy. Keep at least the deck history window (default 24h, configurable as `stale_history_after_seconds`). Do not run this from a read-only dashboard request. Confirm `/health` and a board refresh afterward.
+
 ## Upgrade and rollback
 
 Before changing the Brigade ref, run a backup and save the current ref:

--- a/src/brigade/fleet_dashboard.py
+++ b/src/brigade/fleet_dashboard.py
@@ -689,8 +689,13 @@ def render_page(
     started_at: dict[tuple[str, str], str],
     nonce: str,
     now: datetime | None = None,
+    more_href: str | None = None,
 ) -> str:
-    """Render the full dashboard document for one board."""
+    """Render the full dashboard document for one board.
+
+    ``more_href`` is supplied by the hub when the bounded latest-state page
+    has another LIMIT page. The renderer does not query the journal.
+    """
     current = now or datetime.now(timezone.utc)
     query = parse_query(query_string, view=view)
     all_rows = build_rows(runs, started_at, now=current)
@@ -709,12 +714,13 @@ def render_page(
         f'<p class="center-freshness">{esc(f"data as of {stamp}, refreshes every {REFRESH_SECONDS}s")}, '
         f'<a href="{esc(_href(query))}">{esc("refresh")}</a></p>'
     )
+    more = f'<p class="fleet-more"><a href="{esc(more_href)}">{esc("more")}</a></p>' if more_href else ""
     body = (
         f'<h1 class="page-title">{esc(title)}</h1>'
         f"{freshness}{_summary(all_rows, node_ids, claim_rows)}{_legend()}{_controls(query)}"
         f'<label class="fleet-quick-filter">{esc("filter rows")} '
         f'<input type="search" data-filter-all="1" placeholder="{esc("type to narrow (needs JS)")}"></label>'
-        f"{board}"
+        f"{board}{more}"
     )
     return _document(f"{title} - Brigade Fleet", nonce, _nav(query), body)
 
@@ -855,6 +861,7 @@ table.data-table th {{ background: #f0f0f0; }}
 .fleet-state-stale {{ border-style: dashed; border-color: #8b0000; }}
 .fleet-state-queued, .fleet-state-interrupted {{ border-style: dashed; }}
 .machine-empty {{ margin: 0; color: #333; font-size: 0.9rem; }}
+.fleet-more {{ margin: 1rem 0 0; font-size: 0.9rem; }}
 </style>
 </head>
 <body>

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -76,7 +76,10 @@ Endpoints:
 - ``GET /claims`` — admin or node token; active claims (``?all=1`` includes
   expired).
 - ``GET /`` and ``GET /deck`` — the server-rendered Command Deck, with the
-  legacy Fleet dashboard retained at ``/view/{machines,repos}``. Same bearer auth,
+  legacy Fleet dashboard retained at ``/view/{machines,repos}``. The classic
+  boards reuse latest-state-per-run, window terminal history to the deck
+  horizon (default 24h) unless ``all=1``, and cap each page with LIMIT plus
+  a ``more`` link. Same bearer auth,
   or the ``brigade_fleet_view`` cookie: opening the page once with
   ``?token=<fleet token>`` from a phone sets an HttpOnly, SameSite=Strict
   cookie and 303-redirects to the same URL without the token. The cookie
@@ -109,12 +112,14 @@ import time
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping, Sequence
 
 from . import fleet_command_deck, fleet_hub_preference, worklore_store
 from .fleet_hub_status import (
     ACTIVE_EVENT_TTL_SECONDS as ACTIVE_EVENT_TTL_SECONDS,
+    BOARD_LIMIT as BOARD_LIMIT,
     STALE_HISTORY_AFTER_SECONDS as STALE_HISTORY_AFTER_SECONDS,
+    board_status as board_status,
     latest_status as latest_status,
 )
 
@@ -501,6 +506,7 @@ def _apply_schema(conn: sqlite3.Connection) -> None:
     if _claims_table_needs_migration(_claims_columns(conn)):
         _migrate_claims_table(conn)
     conn.execute("CREATE INDEX IF NOT EXISTS events_run_seq ON events (node_id, run_id, sequence)")
+    conn.execute("CREATE INDEX IF NOT EXISTS events_received_at ON events (received_at)")
     # v3 -> v4 is one additive table; v5-v8 add cloud lease and policy
     # tables only, and v9 canonicalizes provider aliases. Existing event,
     # claim, node, and active lease rows survive.
@@ -757,41 +763,38 @@ def set_run_preference(conn: sqlite3.Connection, raw: Any, *, updated_by: str | 
     return fleet_hub_preference.set_run_preference(conn, raw, updated_by=updated_by)
 
 
-def run_started_at(conn: sqlite3.Connection) -> dict[tuple[str, str], str]:
-    """Timestamp of the first observed event per dashboard run key, for elapsed."""
-    rows = conn.execute(
-        "WITH starts AS ("
-        "  SELECT node_id, run_id, harness, ts, ROW_NUMBER() OVER ("
-        "    PARTITION BY node_id, run_id ORDER BY sequence ASC, received_at ASC, digest ASC"
-        "  ) AS rn FROM events"
-        "), latest_grokbot AS ("
-        "  SELECT node_id, run_id FROM ("
-        "    SELECT node_id, run_id, ROW_NUMBER() OVER ("
-        "      PARTITION BY run_id ORDER BY sequence DESC, received_at DESC, digest DESC"
-        "    ) AS rn FROM events WHERE harness = 'grokbot'"
-        "  ) WHERE rn = 1"
-        "), first_grokbot AS ("
-        "  SELECT run_id, ts FROM ("
-        "    SELECT run_id, ts, ROW_NUMBER() OVER ("
-        "      PARTITION BY run_id ORDER BY sequence ASC, received_at ASC, digest ASC"
-        "    ) AS rn FROM events WHERE harness = 'grokbot'"
-        "  ) WHERE rn = 1"
-        ") SELECT starts.node_id, starts.run_id, COALESCE(first_grokbot.ts, starts.ts)"
-        " FROM starts"
-        " LEFT JOIN latest_grokbot ON starts.harness = 'grokbot'"
-        "  AND starts.node_id = latest_grokbot.node_id AND starts.run_id = latest_grokbot.run_id"
-        " LEFT JOIN first_grokbot ON latest_grokbot.run_id = first_grokbot.run_id"
-        " WHERE starts.rn = 1"
-    ).fetchall()
-    return {(row[0], row[1]): row[2] for row in rows}
+def run_started_at(
+    conn: sqlite3.Connection,
+    runs: Sequence[tuple[str, str, str | None]] = (),
+) -> dict[tuple[str, str], str]:
+    """Timestamp of the first observed event for the rendered run keys.
+
+    The boards pass the bounded latest-state rows. This looks up those keys
+    only; it does not scan the events journal.
+    """
+    return fleet_command_deck.fetch_started_at(conn, runs)
 
 
-def node_summary(conn: sqlite3.Connection) -> list[dict[str, Any]]:
-    """Every observed node with when the hub last heard from it and its event count."""
-    rows = conn.execute(
-        "SELECT node_id, MAX(received_at), COUNT(*) FROM events GROUP BY node_id ORDER BY node_id"
-    ).fetchall()
-    return [{"node_id": row[0], "last_received_at": row[1], "events": row[2]} for row in rows]
+def node_summary(runs: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Nodes present on the bounded board, derived from those latest-state rows.
+
+    Last receipt and the per-node count come from the rendered runs. This
+    does not ``COUNT(*)`` the events table.
+    """
+    latest: dict[str, str] = {}
+    counts: dict[str, int] = {}
+    for run in runs:
+        node_id = str(run.get("node_id") or "")
+        if not node_id:
+            continue
+        received = str(run.get("received_at") or "")
+        counts[node_id] = counts.get(node_id, 0) + 1
+        if received > latest.get(node_id, ""):
+            latest[node_id] = received
+    return [
+        {"node_id": node_id, "last_received_at": latest[node_id], "events": counts[node_id]}
+        for node_id in sorted(latest)
+    ]
 
 
 def dashboard_cookie_value(token: str) -> str:

--- a/src/brigade/fleet_hub_http.py
+++ b/src/brigade/fleet_hub_http.py
@@ -20,6 +20,7 @@ from urllib.parse import parse_qs, urlencode
 from . import fleet_command_deck, fleet_dashboard, fleet_hub_grokbot, fleet_hub_sessions, worklore_http
 from . import fleet_hub as _hub
 from . import fleet_hub_model_roster
+from . import fleet_hub_status
 from .fleet_hub import (
     DASHBOARD_COOKIE,
     DASHBOARD_COOKIE_MAX_AGE,
@@ -54,12 +55,27 @@ def latest_status(*args: Any, **kwargs: Any) -> Any:
     return _hub.latest_status(*args, **kwargs)
 
 
+def board_status(*args: Any, **kwargs: Any) -> Any:
+    return _hub.board_status(*args, **kwargs)
+
+
 def run_started_at(*args: Any, **kwargs: Any) -> Any:
     return _hub.run_started_at(*args, **kwargs)
 
 
 def node_summary(*args: Any, **kwargs: Any) -> Any:
     return _hub.node_summary(*args, **kwargs)
+
+
+def _board_include_all(params: dict[str, list[str]]) -> bool:
+    return params.get("all", [""])[0].lower() in ("1", "true", "yes", "on")
+
+
+def _board_more_href(path: str, params: dict[str, list[str]], *, next_offset: int) -> str:
+    next_params = {key: list(values) for key, values in params.items()}
+    next_params["offset"] = [str(next_offset)]
+    rest = urlencode(next_params, doseq=True)
+    return f"{path}?{rest}" if rest else path
 
 
 def handle_claim(*args: Any, **kwargs: Any) -> Any:
@@ -398,28 +414,44 @@ def make_handler(
                 self._send_html(500, f"hub database error: {exc}\n", content_type=plain)
                 return
             try:
-                runs = latest_status(
+                include_all = _board_include_all(params)
+                offset = fleet_hub_status.clamp_board_offset(params.get("offset", ["0"])[0])
+                board = board_status(
                     conn,
-                    include_all=True,
+                    include_all=include_all,
+                    offset=offset,
+                    history_window_seconds=frozen_deck.stale_history_after_seconds,
                     stale_history_after_seconds=frozen_deck.stale_history_after_seconds,
                 )
                 claims = list_claims(conn)
-                started_at = run_started_at(conn)
-                nodes = node_summary(conn)
+                started_at = run_started_at(
+                    conn,
+                    [
+                        (
+                            str(row["node_id"]),
+                            str(row["run_id"]),
+                            row["harness"] if isinstance(row.get("harness"), str) else None,
+                        )
+                        for row in board.runs
+                    ],
+                )
+                nodes = node_summary(board.runs)
             except sqlite3.Error as exc:
                 self._send_html(500, f"hub database error: {exc}\n", content_type=plain)
                 return
             finally:
                 conn.close()
+            more_href = _board_more_href(path, params, next_offset=board.offset + board.limit) if board.more else None
             nonce = secrets.token_urlsafe(16)
             page = fleet_dashboard.render_page(
                 view=view,
                 query_string=urlencode(params, doseq=True),
-                runs=runs,
+                runs=board.runs,
                 claims=claims,
                 nodes=nodes,
                 started_at=started_at,
                 nonce=nonce,
+                more_href=more_href,
             )
             # The legacy board used ``/`` as its machines route. Root now
             # belongs to the Command Deck, so keep every legacy navigation

--- a/src/brigade/fleet_hub_status.py
+++ b/src/brigade/fleet_hub_status.py
@@ -8,6 +8,7 @@ authority for active TTL and stale-history aging.
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -15,6 +16,31 @@ from . import fleet_command_deck
 
 ACTIVE_EVENT_TTL_SECONDS = 30 * 60
 STALE_HISTORY_AFTER_SECONDS = 24 * 60 * 60
+BOARD_LIMIT = 200
+BOARD_OFFSET_MAX = 1_000_000
+
+_LATEST_COLUMNS = (
+    "node_id, run_id, repo, seat, harness, state, ts, sequence, digest, "
+    "exit_status, capability_fingerprint, repo_identity, received_at"
+)
+_LATEST_PARTITION = (
+    "SELECT e.node_id, e.run_id, e.repo, e.seat, e.harness, e.state, e.ts, e.sequence, "
+    "e.digest, e.exit_status, e.capability_fingerprint, e.repo_identity, e.received_at, "
+    "ROW_NUMBER() OVER ("
+    "  PARTITION BY CASE WHEN e.harness = 'grokbot' THEN 'grokbot' ELSE 'node:' || e.node_id END, e.run_id "
+    "  ORDER BY e.sequence DESC, e.received_at DESC, e.digest DESC"
+    ") AS rn FROM events e"
+)
+
+
+@dataclass(frozen=True)
+class BoardStatus:
+    """Bounded latest-state page for the machine and repo boards."""
+
+    runs: list[dict[str, Any]]
+    more: bool
+    offset: int
+    limit: int
 
 
 def _received_at_is_active(value: object, *, now: datetime, ttl_seconds: int) -> bool:
@@ -41,6 +67,44 @@ def _received_at_age_seconds(value: object, *, now: datetime) -> float | None:
     return (now - received.astimezone(timezone.utc)).total_seconds()
 
 
+def _latest_sql(*, received_after: bool = False) -> str:
+    inner = _LATEST_PARTITION
+    if received_after:
+        inner += " WHERE e.received_at >= ?"
+    return f"SELECT {_LATEST_COLUMNS} FROM ({inner}) WHERE rn = 1"
+
+
+def board_latest_sql(*, windowed: bool) -> str:
+    """Latest-state-per-run page used by the HTML boards.
+
+    Default boards window the inner scan by ``received_at`` so cost follows
+    the horizon, not the journal. ``all=1`` skips the window and still
+    applies LIMIT/OFFSET. Tests pin this shape; do not drop either bound.
+    """
+    return f"{_latest_sql(received_after=windowed)} ORDER BY received_at DESC, node_id, run_id LIMIT ? OFFSET ?"
+
+
+def clamp_board_offset(raw: object) -> int:
+    """Non-negative board page offset; hostile or blank values become 0."""
+    try:
+        value = int(str(raw).strip() or 0)
+    except (TypeError, ValueError):
+        return 0
+    if value < 0:
+        return 0
+    return min(value, BOARD_OFFSET_MAX)
+
+
+def clamp_board_limit(raw: object, *, default: int = BOARD_LIMIT) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value < 1:
+        return default
+    return min(value, BOARD_LIMIT)
+
+
 def latest_status(
     conn: sqlite3.Connection,
     *,
@@ -61,15 +125,7 @@ def latest_status(
     ``run.stale`` from Hub ``received_at``, keeping the recorded state in
     ``original_state``. Event history itself is not rewritten.
     """
-    rows = conn.execute(
-        "SELECT node_id, run_id, repo, seat, harness, state, ts, sequence, digest, exit_status, "
-        "capability_fingerprint, repo_identity, received_at FROM ("
-        "  SELECT e.*, ROW_NUMBER() OVER ("
-        "    PARTITION BY CASE WHEN harness = 'grokbot' THEN 'grokbot' ELSE 'node:' || node_id END, run_id "
-        "    ORDER BY sequence DESC, received_at DESC, digest DESC"
-        "  ) AS rn FROM events e"
-        ") WHERE rn = 1 ORDER BY node_id, run_id"
-    ).fetchall()
+    rows = conn.execute(f"{_latest_sql()} ORDER BY node_id, run_id").fetchall()
     current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     result = []
     for row in rows:
@@ -79,28 +135,95 @@ def latest_status(
             or not _received_at_is_active(row[12], now=current, ttl_seconds=active_ttl_seconds)
         ):
             continue
-        entry = {
-            "node_id": row[0],
-            "run_id": row[1],
-            "repo": row[2],
-            "seat": _last_known_seat(conn, row[0], row[1], row[3]),
-            "harness": row[4],
-            "state": state,
-            "ts": row[6],
-            "sequence": row[7],
-            "digest": row[8],
-            "exit_status": row[9],
-            "capability_fingerprint": row[10],
-            "repo_identity": row[11],
-            "received_at": row[12],
-        }
-        if include_all and not fleet_command_deck.is_terminal_state(state):
-            age = _received_at_age_seconds(row[12], now=current)
-            if age is not None and age > stale_history_after_seconds:
-                entry["original_state"] = state
-                entry["state"] = "run.stale"
-        result.append(entry)
+        result.append(
+            _status_entry(
+                conn,
+                row,
+                now=current,
+                age_stale=include_all,
+                stale_history_after_seconds=stale_history_after_seconds,
+            )
+        )
     return result
+
+
+def board_status(
+    conn: sqlite3.Connection,
+    *,
+    include_all: bool = False,
+    offset: int = 0,
+    limit: int = BOARD_LIMIT,
+    now: datetime | None = None,
+    history_window_seconds: int = STALE_HISTORY_AFTER_SECONDS,
+    stale_history_after_seconds: int = STALE_HISTORY_AFTER_SECONDS,
+) -> BoardStatus:
+    """Latest-state-per-run for the HTML boards, windowed and LIMITed.
+
+    Default (``include_all=False``) keeps live runs and terminal history
+    inside ``history_window_seconds`` (deck ``stale_history_after_seconds``,
+    default 24h) by filtering ``events.received_at`` before the window
+    function. ``include_all=True`` (``?all=1``) drops the time window so
+    older terminals remain visible, still paginated. Neither path rewrites
+    or deletes events.
+    """
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    page_limit = clamp_board_limit(limit)
+    page_offset = clamp_board_offset(offset)
+    windowed = not include_all
+    sql = board_latest_sql(windowed=windowed)
+    params: list[Any] = []
+    if windowed:
+        cutoff = datetime.fromtimestamp(
+            current.timestamp() - max(1, int(history_window_seconds)),
+            tz=timezone.utc,
+        ).isoformat()
+        params.append(cutoff)
+    params.extend((page_limit + 1, page_offset))
+    rows = conn.execute(sql, params).fetchall()
+    more = len(rows) > page_limit
+    mapped = [
+        _status_entry(
+            conn,
+            row,
+            now=current,
+            age_stale=include_all,
+            stale_history_after_seconds=stale_history_after_seconds,
+        )
+        for row in rows[:page_limit]
+    ]
+    return BoardStatus(runs=mapped, more=more, offset=page_offset, limit=page_limit)
+
+
+def _status_entry(
+    conn: sqlite3.Connection,
+    row: tuple[Any, ...],
+    *,
+    now: datetime,
+    age_stale: bool,
+    stale_history_after_seconds: int,
+) -> dict[str, Any]:
+    state = row[5]
+    entry = {
+        "node_id": row[0],
+        "run_id": row[1],
+        "repo": row[2],
+        "seat": _last_known_seat(conn, row[0], row[1], row[3]),
+        "harness": row[4],
+        "state": state,
+        "ts": row[6],
+        "sequence": row[7],
+        "digest": row[8],
+        "exit_status": row[9],
+        "capability_fingerprint": row[10],
+        "repo_identity": row[11],
+        "received_at": row[12],
+    }
+    if age_stale and not fleet_command_deck.is_terminal_state(state):
+        age = _received_at_age_seconds(row[12], now=now)
+        if age is not None and age > stale_history_after_seconds:
+            entry["original_state"] = state
+            entry["state"] = "run.stale"
+    return entry
 
 
 def _last_known_seat(conn: sqlite3.Connection, node_id: str, run_id: str, latest: Any) -> Any:

--- a/src/brigade/fleet_hub_status.py
+++ b/src/brigade/fleet_hub_status.py
@@ -95,14 +95,10 @@ def clamp_board_offset(raw: object) -> int:
     return min(value, BOARD_OFFSET_MAX)
 
 
-def clamp_board_limit(raw: object, *, default: int = BOARD_LIMIT) -> int:
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
+def clamp_board_limit(raw: int, *, default: int = BOARD_LIMIT) -> int:
+    if raw < 1:
         return default
-    if value < 1:
-        return default
-    return min(value, BOARD_LIMIT)
+    return min(raw, BOARD_LIMIT)
 
 
 def latest_status(

--- a/tests/test_fleet_cloud.py
+++ b/tests/test_fleet_cloud.py
@@ -379,7 +379,13 @@ def test_legacy_dashboard_start_map_uses_global_grokbot_start_for_latest_claiman
         (NODE_B, "grok-run"),
         (NODE_B, "shared-generic"),
     ]
-    started = fleet_hub.run_started_at(conn)
+    started = fleet_hub.run_started_at(
+        conn,
+        [
+            (str(row["node_id"]), str(row["run_id"]), row["harness"] if isinstance(row.get("harness"), str) else None)
+            for row in latest
+        ],
+    )
     assert started[(NODE_B, "grok-run")] == "2026-08-30T00:00:00+00:00"
     assert started[(NODE_A, "shared-generic")] == "2026-08-30T00:20:00+00:00"
     assert started[(NODE_B, "shared-generic")] == "2026-08-30T00:30:00+00:00"

--- a/tests/test_fleet_dashboard.py
+++ b/tests/test_fleet_dashboard.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from brigade import fleet_dashboard, fleet_hub, fleet_hub_sessions
+from brigade import fleet_dashboard, fleet_hub, fleet_hub_sessions, fleet_hub_status
 
 NODE_A = "11111111-1111-4111-8111-111111111111"
 NODE_B = "22222222-2222-4222-8222-222222222222"
@@ -25,14 +25,14 @@ def hub(tmp_path):
     server = fleet_hub.make_server("127.0.0.1", 0, db, TOKEN, allow_admin_writes=True)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    yield ("127.0.0.1", server.server_address[1])
+    yield ("127.0.0.1", server.server_address[1], db)
     server.shutdown()
     server.server_close()
 
 
 def _request(hub, method: str, path: str, *, headers: dict | None = None, body=None):
     """Raw request so redirects are not followed and Set-Cookie is visible."""
-    host, port = hub
+    host, port = hub[0], hub[1]
     conn = http.client.HTTPConnection(host, port, timeout=5)
     data = json.dumps(body).encode() if body is not None else None
     conn.request(method, path, body=data, headers=headers or {})
@@ -352,7 +352,7 @@ class TestNoSecretsInHtml:
 
 def _asset_request(hub, path: str):
     """Raw bytes request for binary assets; does not decode as text."""
-    host, port = hub
+    host, port = hub[0], hub[1]
     conn = http.client.HTTPConnection(host, port, timeout=5)
     conn.request("GET", path, headers={})
     response = conn.getresponse()
@@ -734,3 +734,191 @@ def test_cli_serve_trust_tailscale_identity_defaults_off():
     args = cli._build_parser().parse_args(["fleet", "serve", "--host", "127.0.0.1"])
 
     assert args.trust_tailscale_identity is False
+
+
+def _insert_event(
+    conn,
+    node: str,
+    run_id: str,
+    seq: int,
+    state: str,
+    received_at: str,
+    *,
+    repo: str = "repo",
+    harness: str = "claude",
+) -> None:
+    conn.execute(
+        "INSERT INTO events (node_id, run_id, sequence, digest, repo, seat, harness, state, ts, received_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (node, run_id, seq, f"{run_id}-{seq}", repo, "worker", harness, state, received_at, received_at),
+    )
+
+
+class TestBoardBounds:
+    def test_board_sql_shape_is_windowed_or_paginated(self):
+        windowed = fleet_hub_status.board_latest_sql(windowed=True)
+        assert "received_at >=" in windowed
+        assert "LIMIT ? OFFSET ?" in windowed
+        assert "ROW_NUMBER()" in windowed
+        history = fleet_hub_status.board_latest_sql(windowed=False)
+        assert "received_at >=" not in history
+        assert "LIMIT ? OFFSET ?" in history
+        assert "ROW_NUMBER()" in history
+
+    def test_events_received_at_index_exists(self, tmp_path):
+        conn = fleet_hub.init_db(tmp_path / "fleet.db")
+        try:
+            names = {row[1] for row in conn.execute("PRAGMA index_list(events)")}
+        finally:
+            conn.close()
+        assert "events_received_at" in names
+        assert "events_run_seq" in names
+
+    def test_node_summary_uses_rendered_runs_not_the_journal(self):
+        runs = [
+            {"node_id": NODE_A, "received_at": "2026-08-01T00:00:00+00:00"},
+            {"node_id": NODE_A, "received_at": "2026-08-02T00:00:00+00:00"},
+            {"node_id": NODE_B, "received_at": "2026-08-01T12:00:00+00:00"},
+        ]
+        assert fleet_hub.node_summary(runs) == [
+            {"node_id": NODE_A, "last_received_at": "2026-08-02T00:00:00+00:00", "events": 2},
+            {"node_id": NODE_B, "last_received_at": "2026-08-01T12:00:00+00:00", "events": 1},
+        ]
+
+    def test_run_started_at_looks_up_only_rendered_keys(self, tmp_path):
+        conn = fleet_hub.init_db(tmp_path / "fleet.db")
+        try:
+            now = datetime(2026, 8, 23, 12, tzinfo=timezone.utc)
+            old = (now - timedelta(hours=48)).isoformat()
+            recent = now.isoformat()
+            _insert_event(conn, NODE_A, "kept", 1, "run.created", old)
+            _insert_event(conn, NODE_A, "kept", 2, "run.dispatch.observed", recent)
+            _insert_event(conn, NODE_A, "ignored", 1, "run.created", old)
+            conn.commit()
+            started = fleet_hub.run_started_at(conn, [(NODE_A, "kept", "claude")])
+            assert started == {(NODE_A, "kept"): old}
+        finally:
+            conn.close()
+
+    def test_board_status_windows_terminals_and_keeps_latest_per_run(self, tmp_path):
+        conn = fleet_hub.init_db(tmp_path / "fleet.db")
+        try:
+            now = datetime(2026, 8, 23, 12, tzinfo=timezone.utc)
+            old = (now - timedelta(hours=48)).isoformat()
+            recent = (now - timedelta(hours=2)).isoformat()
+            live = now.isoformat()
+            _insert_event(conn, NODE_A, "ancient", 1, "run.created", old, repo="repo-old")
+            _insert_event(conn, NODE_A, "ancient", 2, "run.completed", old, repo="repo-old")
+            _insert_event(conn, NODE_A, "recent-done", 1, "run.created", recent, repo="repo-new")
+            _insert_event(conn, NODE_A, "recent-done", 2, "run.completed", recent, repo="repo-new")
+            _insert_event(conn, NODE_A, "live", 1, "run.created", live, repo="repo-live")
+            _insert_event(conn, NODE_A, "live", 2, "run.dispatch.observed", live, repo="repo-live")
+            conn.commit()
+            default = fleet_hub.board_status(conn, now=now)
+            default_ids = {row["run_id"] for row in default.runs}
+            assert default_ids == {"recent-done", "live"}
+            assert default.more is False
+            history = fleet_hub.board_status(conn, include_all=True, now=now)
+            assert {row["run_id"] for row in history.runs} == {"ancient", "recent-done", "live"}
+            live_row = next(row for row in default.runs if row["run_id"] == "live")
+            assert live_row["state"] == "run.dispatch.observed"
+            assert live_row["sequence"] == 2
+        finally:
+            conn.close()
+
+    def test_board_status_all_is_paginated(self, tmp_path):
+        conn = fleet_hub.init_db(tmp_path / "fleet.db")
+        try:
+            now = datetime(2026, 8, 23, 12, tzinfo=timezone.utc)
+            for index in range(5):
+                stamp = (now - timedelta(minutes=5 - index)).isoformat()
+                _insert_event(conn, NODE_A, f"done-{index}", 1, "run.completed", stamp, repo=f"repo-{index}")
+            conn.commit()
+            first = fleet_hub.board_status(conn, include_all=True, now=now, limit=3, offset=0)
+            assert [row["run_id"] for row in first.runs] == ["done-4", "done-3", "done-2"]
+            assert first.more is True
+            assert first.limit == 3
+            second = fleet_hub.board_status(conn, include_all=True, now=now, limit=3, offset=3)
+            assert [row["run_id"] for row in second.runs] == ["done-1", "done-0"]
+            assert second.more is False
+        finally:
+            conn.close()
+
+    def test_board_status_does_not_delete_events(self, tmp_path):
+        conn = fleet_hub.init_db(tmp_path / "fleet.db")
+        try:
+            now = datetime(2026, 8, 23, 12, tzinfo=timezone.utc)
+            _insert_event(conn, NODE_A, "r", 1, "run.completed", now.isoformat())
+            conn.commit()
+            fleet_hub.board_status(conn, include_all=True, now=now)
+            assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    def test_render_page_emits_more_link_from_owned_http_flag(self):
+        page = fleet_dashboard.render_page(
+            view="machines",
+            query_string="all=1",
+            runs=[],
+            claims=[],
+            nodes=[],
+            started_at={},
+            nonce="abc",
+            more_href="/view/machines?all=1&offset=200",
+        )
+        assert 'class="fleet-more"' in page
+        assert 'href="/view/machines?all=1&amp;offset=200"' in page
+        assert ">more<" in page
+
+    def test_default_board_omits_old_terminal_outcome_all_keeps_it(self, hub):
+        now = datetime.now(timezone.utc)
+        old = (now - timedelta(hours=48)).isoformat()
+        recent = now.isoformat()
+        events = [
+            _event(NODE_A, "old-done", 1, "run.completed", repo="repo-old", harness="claude", ts=old),
+            _event(NODE_A, "new-done", 1, "run.completed", repo="repo-new", harness="claude", ts=recent),
+            _event(NODE_A, "live-run", 1, "run.dispatch.observed", repo="repo-live", harness="claude", ts=recent),
+        ]
+        status, _headers, text = _request(hub, "POST", "/events", headers=_bearer(), body=events)
+        assert status == 200, text
+        conn = fleet_hub.open_db(hub[2])
+        try:
+            conn.execute("UPDATE events SET received_at = ? WHERE run_id = ?", (old, "old-done"))
+            conn.commit()
+        finally:
+            conn.close()
+        _status, _headers, machines = _request(hub, "GET", "/view/machines", headers=_bearer())
+        assert "live-run" in machines
+        assert "old-done" not in machines
+        assert "new-done" not in machines
+        _status, _headers, repos = _request(hub, "GET", "/view/repos", headers=_bearer())
+        assert "repo-live" in repos
+        assert "repo-new" in repos
+        assert "repo-old" not in repos
+        _status, _headers, all_machines = _request(hub, "GET", "/view/machines?all=1", headers=_bearer())
+        assert "old-done" in all_machines
+        assert "new-done" in all_machines
+        _status, _headers, all_repos = _request(hub, "GET", "/view/repos?all=1", headers=_bearer())
+        assert "repo-old" in all_repos
+
+    def test_all_board_paginates_with_more_link(self, hub):
+        now = datetime.now(timezone.utc).isoformat()
+        events = [
+            _event(NODE_A, f"page-{index}", 1, "run.completed", repo=f"repo-{index}", harness="claude", ts=now)
+            for index in range(fleet_hub.BOARD_LIMIT + 1)
+        ]
+        status, _headers, text = _request(hub, "POST", "/events", headers=_bearer(), body=events)
+        assert status == 200, text
+        _status, _headers, first = _request(hub, "GET", "/view/machines?all=1", headers=_bearer())
+        assert 'class="fleet-more"' in first
+        assert "offset=200" in first
+        first_ids = {f"page-{index}" for index in range(fleet_hub.BOARD_LIMIT + 1) if f'title="page-{index}"' in first}
+        assert len(first_ids) == fleet_hub.BOARD_LIMIT
+        _status, _headers, second = _request(hub, "GET", "/view/machines?all=1&offset=200", headers=_bearer())
+        assert 'class="fleet-more"' not in second
+        second_ids = {
+            f"page-{index}" for index in range(fleet_hub.BOARD_LIMIT + 1) if f'title="page-{index}"' in second
+        }
+        assert len(second_ids) == 1
+        assert first_ids.isdisjoint(second_ids)
+        assert len(first_ids | second_ids) == fleet_hub.BOARD_LIMIT + 1


### PR DESCRIPTION
Fixes #1146

Opened by the conductor from the Grok Bot Builder branch `cursor/fleet-board-query-bounds-27a1` (job grokbot-3dbf3c90). The Builder finished the change but its `./scripts/verify-fast` run tripped on unrelated timing flakes (receipt `20260901-180939-work-verify-1f2b2c`), so it never opened this PR. CI here is the verification; a human review is still required before merge (touches `src/brigade/fleet_hub*`).