### PR TITLE
fix(fleet): skip the current-schema write lock in init_db and wrap run-dir workspace resolve

### DIFF
--- a/docs/fleet-sync.md
+++ b/docs/fleet-sync.md
@@ -512,11 +512,13 @@ Hub-arbitrated repo claims (`POST /claims`, `GET /claims`,
   inside a workspace is refused, never resolved upward). Without `--force`,
   both modes run the same proof that the run which took the claim is dead:
   `POST /claims` `inspect` returns the recorded run directory to the owner
-  node only, the CLI maps it to a workspace on this machine (`run.json`
-  `lock_workspace` / `cwd`, or the `.brigade/runs/<id>` layout; with
-  `--path` it must be the workspace given) and refuses while that
-  `run.lock` has a live owner or is malformed, or when it cannot resolve
-  the run at all, or when the probe finds no claim owned by this node.
+  node only, the CLI maps it to a workspace on this machine through
+  `runguard.resolve_run_lock_workspace` (`run.json` `lock_workspace`, the
+  `.brigade/runs/<id>` layout, then `cwd`; a resolved path that is not a
+  directory here is refused; with `--path` it must be the workspace given)
+  and refuses while that `run.lock` has a live owner or is malformed, or
+  when it cannot resolve the run at all, or when the probe finds no claim
+  owned by this node.
   When the row records no run directory (`--no-artifacts`, or a claim
   predating the lease columns), `--path` proves deadness via the
   pointed-at workspace's own `run.lock` instead of requiring `--force`;

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -802,11 +802,17 @@ def _dispatch_preference_pull(args: argparse.Namespace) -> int:
 
 
 def _workspace_from_run_dir(raw_run_dir: str | None) -> tuple[Path | None, str]:
-    """(workspace, reason) for a claim's recorded run directory: the workspace
-    it belongs to when that directory is on this machine — ``run.json``'s
-    ``lock_workspace`` / ``cwd``, else the ``<workspace>/.brigade/runs/<id>``
-    layout — or ``None`` and why not."""
+    """(workspace, reason) for a claim's recorded run directory.
+
+    Resolution is ``runguard.resolve_run_lock_workspace`` so this CLI path
+    cannot drift from every other run-lock caller (#1159). Existence on
+    this machine is CLI-only: a missing run directory or a resolved path
+    that is not a directory is ``None`` and a refusal reason, never a
+    guessed ancestor.
+    """
     import json as _json
+
+    from .. import runguard
 
     if not raw_run_dir:
         return None, "the claim records no run directory"
@@ -817,13 +823,11 @@ def _workspace_from_run_dir(raw_run_dir: str | None) -> tuple[Path | None, str]:
         meta = _json.loads((run_dir / "run.json").read_text())
     except (OSError, ValueError):
         meta = None
-    if isinstance(meta, dict):
-        for key in ("lock_workspace", "cwd"):
-            value = meta.get(key)
-            if isinstance(value, str) and value and Path(value).expanduser().is_dir():
-                return Path(value).expanduser().resolve(), "ok"
-    if run_dir.parent.name == "runs" and run_dir.parent.parent.name == ".brigade":
-        return run_dir.parent.parent.parent.resolve(), "ok"
+    resolved = runguard.resolve_run_lock_workspace(meta if isinstance(meta, dict) else {}, run_dir)
+    if resolved is not None and resolved.is_dir():
+        return resolved, "ok"
+    if resolved is not None:
+        return None, f"its recorded workspace {resolved} does not exist on this machine"
     return None, (
         f"its run directory {raw_run_dir} has no readable run.json naming its workspace and is not under a "
         "<workspace>/.brigade/runs layout"

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -564,11 +564,19 @@ def _init_schema(conn: sqlite3.Connection, db_path: Path) -> None:
     ALTER) so a later CREATE or ``ensure_schema`` cannot escape as
     ``database is locked``. A caller that loses the write lock treats
     "someone else already set user_version" as success.
+
+    A current ``user_version`` is accepted after a plain read so an
+    already-migrated database never takes the write lock (#1159). Request
+    handlers still use ``open_db`` (#1161); this path is for startup and
+    other ``init_db`` callers (tools, tests, a first-touch storm).
     """
     for delay in _MIGRATION_LOCK_DELAYS:
         try:
-            conn.execute("PRAGMA journal_mode=WAL")
             _refuse_newer_schema(conn, db_path)
+            current = conn.execute("PRAGMA user_version").fetchone()[0]
+            if current == SCHEMA_VERSION:
+                return
+            conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("BEGIN IMMEDIATE")
         except sqlite3.OperationalError as exc:
             if not _locked_operational_error(exc):

--- a/tests/test_fleet_claim_release.py
+++ b/tests/test_fleet_claim_release.py
@@ -11,6 +11,7 @@ claim row that run took under its ``run.lock`` lease — and ``brigade run
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import os
 import sqlite3
@@ -358,9 +359,11 @@ class TestHubScopes:
             conn.close()
 
     def test_lease_column_upgrade_is_safe_under_concurrent_init(self, tmp_path):
-        """init_db runs per request on a threading server: many first-touch
-        connections against a v2 database (one lease column already present,
-        as a half-finished upgrade would leave it) must all succeed.
+        """Many first-touch ``init_db`` callers against a v2 database (one
+        lease column already present, as a half-finished upgrade would
+        leave it) must all succeed. Request handlers no longer call
+        ``init_db`` (#1161); this still covers tools, tests, and a
+        cross-process first-touch storm (#1159).
 
         Bounded ``database is locked`` is retried with the same delays as
         ``_init_schema``; any other error still fails the test.
@@ -1178,3 +1181,99 @@ def test_run_lock_reports_reconciled_dead_owner_and_its_own_lease(tmp_path):
         with runguard.run_lock(repo, on_reconcile=seen.append):
             pass  # pragma: no cover - never entered
     assert seen == []
+
+
+class TestWorkspaceFromRunDir:
+    """#1159: ``_workspace_from_run_dir`` wraps ``resolve_run_lock_workspace``
+    and keeps CLI-only refusal reasons when a workspace is missing here."""
+
+    def test_source_calls_runguard_helper_instead_of_a_local_parser(self):
+        from brigade.cli import fleet as fleet_cli
+
+        source = inspect.getsource(fleet_cli._workspace_from_run_dir)
+        assert "resolve_run_lock_workspace" in source
+        assert 'for key in ("lock_workspace", "cwd")' not in source
+
+    def test_delegates_resolution_to_runguard(self, tmp_path, monkeypatch):
+        from brigade import runguard
+        from brigade.cli import fleet as fleet_cli
+
+        workspace = tmp_path / "ws"
+        run_dir = workspace / ".brigade" / "runs" / "r1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "run.json").write_text(json.dumps({"lock_workspace": str(workspace), "status": "completed"}))
+        seen: list[tuple[dict[str, object], Path]] = []
+        real = runguard.resolve_run_lock_workspace
+
+        def spy(meta: dict[str, object], path: Path, **kwargs: object) -> Path | None:
+            seen.append((dict(meta), Path(path)))
+            assert kwargs == {}
+            return real(meta, path)
+
+        monkeypatch.setattr(runguard, "resolve_run_lock_workspace", spy)
+        resolved, why = fleet_cli._workspace_from_run_dir(str(run_dir))
+        assert resolved == workspace.resolve() and why == "ok"
+        assert len(seen) == 1
+        assert seen[0][0]["lock_workspace"] == str(workspace)
+        assert seen[0][1] == run_dir
+
+    def test_follows_runguard_precedence_over_cwd(self, tmp_path):
+        from brigade.cli import fleet as fleet_cli
+
+        canonical = tmp_path / "canonical"
+        worktree = tmp_path / "worktree"
+        canonical.mkdir()
+        worktree.mkdir()
+        run_dir = worktree / ".brigade" / "runs" / "r1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "run.json").write_text(json.dumps({"lock_workspace": str(canonical), "cwd": str(worktree)}))
+        resolved, why = fleet_cli._workspace_from_run_dir(str(run_dir))
+        assert resolved == canonical.resolve() and why == "ok"
+
+    def test_layout_without_run_json_still_resolves(self, tmp_path):
+        from brigade.cli import fleet as fleet_cli
+
+        workspace = tmp_path / "ws"
+        run_dir = workspace / ".brigade" / "runs" / "r1"
+        run_dir.mkdir(parents=True)
+        resolved, why = fleet_cli._workspace_from_run_dir(str(run_dir))
+        assert resolved == workspace.resolve() and why == "ok"
+
+    def test_missing_run_dir_keeps_cli_refusal_and_does_not_call_runguard(self, monkeypatch):
+        from brigade import runguard
+        from brigade.cli import fleet as fleet_cli
+
+        def boom(*_args: object, **_kwargs: object) -> Path | None:
+            raise AssertionError("resolve_run_lock_workspace must not run before the run dir exists")
+
+        monkeypatch.setattr(runguard, "resolve_run_lock_workspace", boom)
+        resolved, why = fleet_cli._workspace_from_run_dir(None)
+        assert resolved is None and why == "the claim records no run directory"
+        resolved, why = fleet_cli._workspace_from_run_dir("/nonexistent/.brigade/runs/x")
+        assert resolved is None
+        assert why == "its run directory /nonexistent/.brigade/runs/x does not exist on this machine"
+
+    def test_refuses_when_recorded_workspace_is_missing_on_this_machine(self, tmp_path):
+        from brigade.cli import fleet as fleet_cli
+
+        missing = tmp_path / "gone"
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        run_dir = worktree / ".brigade" / "runs" / "r1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "run.json").write_text(json.dumps({"lock_workspace": str(missing), "cwd": str(worktree)}))
+        resolved, why = fleet_cli._workspace_from_run_dir(str(run_dir))
+        assert resolved is None
+        assert str(missing.resolve()) in why
+        assert "does not exist on this machine" in why
+
+    def test_unreadable_run_json_off_layout_keeps_cli_refusal(self, tmp_path):
+        from brigade.cli import fleet as fleet_cli
+
+        run_dir = tmp_path / "orphan" / "r1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "run.json").write_text("{not-json")
+        resolved, why = fleet_cli._workspace_from_run_dir(str(run_dir))
+        assert resolved is None
+        assert "has no readable run.json naming its workspace" in why
+        assert "<workspace>/.brigade/runs layout" in why

--- a/tests/test_fleet_nodes.py
+++ b/tests/test_fleet_nodes.py
@@ -852,8 +852,12 @@ class TestOpenDbSideEffectFree:
 
     def test_init_schema_reads_user_version_before_taking_the_write_lock(self):
         source = inspect.getsource(fleet_hub._init_schema)
-        assert source.index("PRAGMA user_version") < source.index("BEGIN IMMEDIATE")
-        assert source.index("if current == SCHEMA_VERSION:") < source.index("BEGIN IMMEDIATE")
+        assert source.index('conn.execute("PRAGMA user_version")') < source.index(
+            'conn.execute("BEGIN IMMEDIATE")'
+        )
+        assert source.index("if current == SCHEMA_VERSION:") < source.index(
+            'conn.execute("BEGIN IMMEDIATE")'
+        )
 
     def test_init_db_skips_write_lock_when_user_version_is_current(self, tmp_path):
         """#1159: a current schema is accepted after a plain ``user_version``

--- a/tests/test_fleet_nodes.py
+++ b/tests/test_fleet_nodes.py
@@ -849,3 +849,26 @@ class TestOpenDbSideEffectFree:
         assert mode == "wal"
         assert version == fleet_hub.SCHEMA_VERSION
         assert {"events", "claims", "nodes"} <= tables
+
+    def test_init_schema_reads_user_version_before_taking_the_write_lock(self):
+        source = inspect.getsource(fleet_hub._init_schema)
+        assert source.index("PRAGMA user_version") < source.index("BEGIN IMMEDIATE")
+        assert source.index("if current == SCHEMA_VERSION:") < source.index("BEGIN IMMEDIATE")
+
+    def test_init_db_skips_write_lock_when_user_version_is_current(self, tmp_path):
+        """#1159: a current schema is accepted after a plain ``user_version``
+        read. Another connection can hold ``BEGIN IMMEDIATE`` and ``init_db``
+        must still return without waiting on that write lock."""
+        db = tmp_path / "hub" / "fleet.db"
+        fleet_hub.init_db(db).close()
+        blocker = sqlite3.connect(str(db))
+        try:
+            blocker.execute("BEGIN IMMEDIATE")
+            reopened = fleet_hub.init_db(db)
+            try:
+                assert reopened.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION
+            finally:
+                reopened.close()
+        finally:
+            blocker.rollback()
+            blocker.close()

--- a/tests/test_fleet_nodes.py
+++ b/tests/test_fleet_nodes.py
@@ -852,12 +852,8 @@ class TestOpenDbSideEffectFree:
 
     def test_init_schema_reads_user_version_before_taking_the_write_lock(self):
         source = inspect.getsource(fleet_hub._init_schema)
-        assert source.index('conn.execute("PRAGMA user_version")') < source.index(
-            'conn.execute("BEGIN IMMEDIATE")'
-        )
-        assert source.index("if current == SCHEMA_VERSION:") < source.index(
-            'conn.execute("BEGIN IMMEDIATE")'
-        )
+        assert source.index('conn.execute("PRAGMA user_version")') < source.index('conn.execute("BEGIN IMMEDIATE")')
+        assert source.index("if current == SCHEMA_VERSION:") < source.index('conn.execute("BEGIN IMMEDIATE")')
 
     def test_init_db_skips_write_lock_when_user_version_is_current(self, tmp_path):
         """#1159: a current schema is accepted after a plain ``user_version``


### PR DESCRIPTION
Fixes #1159

Opened by the conductor from the Grok Bot Builder branch `cursor/issue-1159-init-db-lock-and-workspace-b999` (job grokbot-6827f633). The Builder finished the change but its `./scripts/verify-fast` run tripped on unrelated timing flakes (receipt `20260901-190602-work-verify-902edf`), so it never opened this PR. CI here is the verification; a human review is still required before merge (touches `src/brigade/fleet_hub*`).