### PR TITLE
ci: install the grokbot extra so the mcp.server tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,9 +290,15 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install
+        if: matrix.python != '3.12'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
+      - name: Install with grokbot extra
+        if: matrix.python == '3.12'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,grokbot]"
       - name: Pytest shard
         if: matrix.python != '3.12'
         run: python scripts/ci_pytest_shard.py --shard-index "${{ matrix.shard }}" --shard-count 4 -- -q
@@ -301,6 +307,15 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.${{ matrix.python }}.${{ matrix.shard }}
         run: python scripts/ci_pytest_shard.py --shard-index "${{ matrix.shard }}" --shard-count 4 -- -q --cov=brigade --cov-report=
+      - name: Assert grokbot MCP tests run without skips
+        if: matrix.python == '3.12'
+        run: |
+          output=$(python -m pytest tests/test_grokbot_mcp.py -q --no-header -p no:cacheprovider 2>&1)
+          echo "$output"
+          if grep -q 'skipped' <<< "$output"; then
+            echo "ERROR: grokbot MCP tests were skipped; install the grokbot extra"
+            exit 1
+          fi
       - name: Upload coverage data
         if: matrix.python == '3.12'
         uses: actions/upload-artifact@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,12 @@ Then install dev dependencies:
 pip install -e ".[dev]"
 ```
 
+`tests/test_grokbot_mcp.py` contains MCP-server tests that require the optional `grokbot` extra (`mcp` and `starlette`). To run the full test suite locally, install with the extra included:
+
+```bash
+pip install -e ".[dev,grokbot]"
+```
+
 On PEP 668-managed Python (many Linux distributions), installing into the system interpreter fails; a virtual environment avoids that.
 
 **Docs-only changes:** CI runs the `content-guard` job on the repo. Locally, scan each edited markdown file before you push (one path per invocation):

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -14,6 +14,15 @@ def _workflow_job_section(text: str, job_name: str) -> str:
     return text[start:end]
 
 
+def _workflow_step_section(text: str, job_name: str, step_name: str) -> str:
+    job = _workflow_job_section(text, job_name)
+    marker = f"      - name: {step_name}"
+    start = job.index(marker)
+    next_step = job.find("\n      - name:", start + len(marker))
+    end = next_step if next_step != -1 else len(job)
+    return job[start:end]
+
+
 def test_ci_workflow_path_filter_has_valid_structure_and_engine_paths():
     text = (ROOT / ".github/workflows/ci.yml").read_text()
     changes = _workflow_job_section(text, "changes")
@@ -347,6 +356,32 @@ def test_ci_workflow_caches_pip_for_jobs_that_install_dev_extras():
         section = _workflow_job_section(text, job_name)
         assert "cache: pip" in section
         assert "cache-dependency-path: pyproject.toml" in section
+
+
+def test_ci_workflow_test_shards_installs_grokbot_extra_on_python312():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+    section = _workflow_job_section(text, "test-shards")
+
+    grokbot_step = _workflow_step_section(text, "test-shards", "Install with grokbot extra")
+    assert "if: matrix.python == '3.12'" in grokbot_step
+    assert 'python -m pip install -e ".[dev,grokbot]"' in grokbot_step
+
+    default_step = _workflow_step_section(text, "test-shards", "Install")
+    assert "if: matrix.python != '3.12'" in default_step
+    assert 'python -m pip install -e ".[dev]"' in default_step
+
+    assert section.index("      - name: Install\n") < section.index("      - name: Install with grokbot extra\n")
+
+
+def test_ci_workflow_test_shards_asserts_grokbot_mcp_tests_run_without_skips():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+    step = _workflow_step_section(text, "test-shards", "Assert grokbot MCP tests run without skips")
+
+    assert "if: matrix.python == '3.12'" in step
+    assert "tests/test_grokbot_mcp.py" in step
+    assert "grep -q 'skipped'" in step
+    assert "grokbot MCP tests were skipped" in step
+    assert "exit 1" in step
 
 
 def test_agents_doc_names_ci_only_jobs_outside_local_verify():


### PR DESCRIPTION
Fixes #1368

CI never installed the `grokbot` extra, so every `importorskip("mcp.server")` test was silently skipped. This installs `.[dev,grokbot]` in the CI test job and adds a zero-skip assertion to `tests/test_ci_workflow.py`.

Verification receipts: `20260902-025320-work-verify-5dfa4f` (workflow test) and `20260902-025510-work-verify-b63fd5` (85 passed, 0 skipped after installing the extra).