### PR TITLE
feat(work): report verify receipt scoreability and document the manifest path

### DIFF
--- a/docs/outcome-scoring.md
+++ b/docs/outcome-scoring.md
@@ -7,7 +7,12 @@ This is outcome-based skill scoring, promotion, and rollback from verification e
 ## Workflow
 
 ```bash
+# audit-only evidence: a receipt a human can read, never a scoreable trial
 brigade work verify run --target . --command "pytest -q" --capture brigade-work
+
+# scoreable evidence: verifier-owned checks bound to one artifact
+brigade work verify run --target . --manifest <manifest-id> --capture <artifact-id>
+
 # or, after a verify without --capture:
 brigade outcome capture brigade-work --run-id latest --kind skill
 
@@ -27,6 +32,28 @@ brigade outcome explain <skill-or-card-id> --target .
 | `outcome explain` | Print the signal trail behind a score or reconcile decision |
 
 Capture against an id that actually guided the work. Invented skill names pollute the ranking. Capture failures too: a `-1` is how a bad skill gets rolled back. Ledger files live under `memory/outcome/` as plain JSON and markdown.
+
+## Which receipts are scoreable
+
+`--capture` does not make a receipt scoreable. Scorecard eligibility is projected only from a verifier-authored `subject_binding`, and only a tracked manifest under `verify/manifests/` can author one. Ad-hoc `--command` and `--argv-json` runs are audit-only: real evidence for a human reader, never a trial for `outcome rank` or the promotion ratchet. The artifact id passed to `--capture` is caller-supplied and is deliberately not trusted as the scored subject (`docs/proposals/skill-scorecards.md`, core contract 2 and 3).
+
+Every `--capture` run now prints its verdict, so an ineligible receipt is visible on the run that produced it rather than only in `brigade work brief`:
+
+```
+scoreable: yes
+```
+
+```
+warning: scoreable: no (reason=unattributed); this receipt cannot score the captured artifact
+  ad-hoc --command/--argv-json receipts are audit-only evidence and never score an artifact; run
+  `brigade work verify run --manifest <id>` against a manifest tracked under verify/manifests/ to
+  produce a scoreable receipt
+  registered manifests: none tracked under verify/manifests/ in this target
+```
+
+`--json` carries the same verdict as `outcome_scoreability` on the printed payload. `brigade work brief` lists the ids this target has as `outcome_verify_manifests`, and the `outcome_loop_half_fed` warning names them inline.
+
+A repo with no tracked manifest cannot produce an eligible receipt at all. That is the expected state until someone declares one; `ineligibility_rate=1.0` there means "nothing has been declared scoreable yet", not "the checks were untrustworthy".
 
 ## Read-time recomputation
 

--- a/registry/skills/verify-brigade/SKILL.md
+++ b/registry/skills/verify-brigade/SKILL.md
@@ -248,3 +248,8 @@ brigade work verify run --target . \
 ```
 
 Then paste the `run_id`, the status, and the `evidence_dir` from this skill.
+
+That receipt is proof for a human reader, not a scored trial. `--command` and
+`--argv-json` receipts are audit-only; only `--manifest <id>` produces a receipt
+the outcome ratchet can score. Each `--capture` run prints which one it was.
+See `docs/outcome-scoring.md`.

--- a/registry/skills/verify-brigade/features/work-verify-receipts.md
+++ b/registry/skills/verify-brigade/features/work-verify-receipts.md
@@ -81,6 +81,14 @@ Observed: helper exit 3, `"status": "failed"`, and a receipt written anyway at
 - `--capture` is mandatory in this repo's hook policy. A raw
   `brigade work verify run` without `--capture brigade-work` is refused before
   it runs, and no receipt exists to point at.
+- `--capture` does not make a receipt *scoreable*. `--command` and `--argv-json`
+  receipts are audit-only: they carry no verifier-authored `subject_binding`, so
+  `outcome rank` and the promotion ratchet never count them. Only
+  `--manifest <id>`, against a manifest tracked under `verify/manifests/`, yields
+  an eligible receipt. Each `--capture` run prints its verdict
+  (`scoreable: yes` / `warning: scoreable: no (reason=...)`) and `--json` carries
+  it as `outcome_scoreability`. Read `docs/outcome-scoring.md` before treating a
+  green receipt as a fed loop.
 - Passing receipts are reused when the tree fingerprint is unchanged, so a
   second identical run can return the earlier `run_id`. That is correct
   behavior, not a stale result. `--no-reuse` forces execution - but never pass

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -2668,17 +2668,28 @@ def health(target: Path) -> dict:
     promoted_count = sum(1 for entry in load_status(target).values() if entry.get("status") == "promoted")
     receipt_audit = scorecard_mod.receipt_scorecard_audit(target)
 
+    from . import verify_manifest
+
+    registered_manifest_ids = verify_manifest.registered_manifest_ids(target)
+
     issues: list[dict] = []
     if verify_run_count > 0 and receipt_audit["eligible"] == 0:
+        # Name the manifests this target actually has (#1378): "use --manifest <id>"
+        # is not actionable when the reader has no way to learn the available ids.
+        if registered_manifest_ids:
+            available = "registered manifest ids: " + ", ".join(registered_manifest_ids)
+        else:
+            available = "no verify manifests are tracked under verify/manifests/ in this target yet"
         issues.append(
             {
                 "status": "warn",
                 "name": "outcome_loop_half_fed",
                 "detail": (
                     f"{verify_run_count} verify run(s) but 0 eligible receipt(s); "
-                    "run `brigade work verify run --target . --manifest <id>` "
+                    "ad-hoc --command/--argv-json receipts are audit-only and never score. "
+                    "Run `brigade work verify run --target . --manifest <id>` "
                     "with a tracked manifest under verify/manifests/ so receipts "
-                    "carry verifier-authored subject_binding and check_role"
+                    f"carry verifier-authored subject_binding and check_role ({available})"
                 ),
             }
         )
@@ -2707,6 +2718,7 @@ def health(target: Path) -> dict:
         "attributed_ineligible_receipt_count": receipt_audit["attributed_ineligible"],
         "ineligibility_rate": receipt_audit["ineligibility_rate"],
         "leading_ineligibility_reason": receipt_audit["leading_ineligibility_reason"],
+        "registered_verify_manifest_ids": registered_manifest_ids,
         "exploration_bands": receipt_audit["exploration_bands"],
         "latest_receipt_window": receipt_audit["latest_receipt_window"],
         "issue_count": len(issues),

--- a/src/brigade/work_cmd/session/briefing.py
+++ b/src/brigade/work_cmd/session/briefing.py
@@ -535,6 +535,7 @@ def _brief_payload(target: Path, *, limit: int = 3, include_code_graph: bool = F
             "attributed_ineligible_receipt_count": outcome_health["attributed_ineligible_receipt_count"],
             "ineligibility_rate": outcome_health["ineligibility_rate"],
             "leading_ineligibility_reason": outcome_health["leading_ineligibility_reason"],
+            "registered_verify_manifest_ids": outcome_health["registered_verify_manifest_ids"],
             "exploration_bands": outcome_health["exploration_bands"],
             "latest_receipt_window": outcome_health["latest_receipt_window"],
             "issue_count": outcome_health["issue_count"],
@@ -712,6 +713,10 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
             f"ineligibility_rate={outcome_loop.get('ineligibility_rate')} "
             f"promoted={outcome_loop.get('promoted_count')}"
         )
+        manifest_ids = outcome_loop.get("registered_verify_manifest_ids")
+        if isinstance(manifest_ids, list):
+            listed = ", ".join(str(item) for item in manifest_ids) if manifest_ids else "none"
+            print(f"outcome_verify_manifests: {listed}")
         bands = outcome_loop.get("exploration_bands") if isinstance(outcome_loop.get("exploration_bands"), dict) else {}
         if bands:
             print(

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -31,6 +31,7 @@ from . import constants, helpers, ledger as ledger_mod
 from . import reviews as reviews_mod
 from . import scanners as scanners_mod
 from . import verify_ranking
+from .verify_scoreability import _print_graph_impact, _print_scoreability_notice, _scoreability_notice
 
 
 def _verification_is_windows() -> bool:
@@ -1971,77 +1972,6 @@ def verify_plan(
             print(f"  - {blocker}")
     print(f"run: {payload['suggested_command']}")
     return 0 if not blockers else 1
-
-
-def _print_graph_impact(ranking: object) -> None:
-    if not isinstance(ranking, dict):
-        return
-    if ranking.get("degraded") is True:
-        reason = ranking.get("degraded_reason") or "graphtrail unavailable"
-        print(f"graph_impact: degraded ({reason})")
-        return
-    candidates = ranking.get("candidates") if isinstance(ranking.get("candidates"), list) else []
-    changed = ranking.get("changed_files") if isinstance(ranking.get("changed_files"), list) else []
-    print(f"graph_impact: {len(candidates)} candidate(s) from {len(changed)} changed file(s)")
-    for item in candidates:
-        if not isinstance(item, dict):
-            continue
-        confidence = item.get("confidence") if isinstance(item.get("confidence"), dict) else {}
-        band = confidence.get("band") or "unknown"
-        score = confidence.get("score")
-        hops = confidence.get("min_hops")
-        evidence = item.get("evidence") if isinstance(item.get("evidence"), dict) else {}
-        via = evidence.get("via") if isinstance(evidence.get("via"), list) else []
-        via_text = ",".join(str(symbol) for symbol in via[:3]) if via else "-"
-        print(f"- [{band} score={score} hops={hops} via={via_text}] {item.get('command')}")
-    note = ranking.get("attribution")
-    if isinstance(note, str) and note.strip() and candidates:
-        print(f"graph_impact_note: {note.strip()}")
-
-
-_ADHOC_SCOREABILITY_REMEDIATION = (
-    "ad-hoc --command/--argv-json receipts are audit-only evidence and never score an artifact; "
-    "run `brigade work verify run --manifest <id>` against a manifest tracked under "
-    "verify/manifests/ to produce a scoreable receipt"
-)
-
-
-def _scoreability_notice(target: Path, receipt: dict[str, Any]) -> dict[str, Any]:
-    """Project whether this receipt can score its ``--capture`` artifact (#1378).
-
-    Eligibility used to be visible only in an aggregate ``work brief`` field, so a
-    session could run dozens of green ``--command --capture`` checks and feed the
-    ratchet nothing while every immediate indicator said otherwise. Project the
-    verdict on the run that produced the receipt instead.
-    """
-    run_dir_value = receipt.get("path")
-    patch_path = (
-        Path(str(run_dir_value)) / "changes.patch" if isinstance(run_dir_value, str) and run_dir_value else None
-    )
-    projection = verify_trial.project_trial(receipt, target=target, patch_path=patch_path)
-    notice: dict[str, Any] = {
-        "eligible": projection.eligible,
-        "reason": projection.reason,
-        "attributed": projection.attributed,
-    }
-    if projection.eligible:
-        return notice
-    notice["registered_manifest_ids"] = verify_manifest.registered_manifest_ids(target)
-    notice["remediation"] = _ADHOC_SCOREABILITY_REMEDIATION
-    return notice
-
-
-def _print_scoreability_notice(notice: dict[str, Any]) -> None:
-    if notice.get("eligible"):
-        print("scoreable: yes")
-        return
-    print(f"warning: scoreable: no (reason={notice.get('reason')}); this receipt cannot score the captured artifact")
-    print(f"  {notice.get('remediation')}")
-    manifest_ids = notice.get("registered_manifest_ids")
-    if isinstance(manifest_ids, list) and manifest_ids:
-        print(f"  registered manifests: {', '.join(manifest_ids)}")
-    else:
-        print("  registered manifests: none tracked under verify/manifests/ in this target")
 
 
 def _attach_miseledger_indexing(

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -1999,6 +1999,51 @@ def _print_graph_impact(ranking: object) -> None:
         print(f"graph_impact_note: {note.strip()}")
 
 
+_ADHOC_SCOREABILITY_REMEDIATION = (
+    "ad-hoc --command/--argv-json receipts are audit-only evidence and never score an artifact; "
+    "run `brigade work verify run --manifest <id>` against a manifest tracked under "
+    "verify/manifests/ to produce a scoreable receipt"
+)
+
+
+def _scoreability_notice(target: Path, receipt: dict[str, Any]) -> dict[str, Any]:
+    """Project whether this receipt can score its ``--capture`` artifact (#1378).
+
+    Eligibility used to be visible only in an aggregate ``work brief`` field, so a
+    session could run dozens of green ``--command --capture`` checks and feed the
+    ratchet nothing while every immediate indicator said otherwise. Project the
+    verdict on the run that produced the receipt instead.
+    """
+    run_dir_value = receipt.get("path")
+    patch_path = (
+        Path(str(run_dir_value)) / "changes.patch" if isinstance(run_dir_value, str) and run_dir_value else None
+    )
+    projection = verify_trial.project_trial(receipt, target=target, patch_path=patch_path)
+    notice: dict[str, Any] = {
+        "eligible": projection.eligible,
+        "reason": projection.reason,
+        "attributed": projection.attributed,
+    }
+    if projection.eligible:
+        return notice
+    notice["registered_manifest_ids"] = verify_manifest.registered_manifest_ids(target)
+    notice["remediation"] = _ADHOC_SCOREABILITY_REMEDIATION
+    return notice
+
+
+def _print_scoreability_notice(notice: dict[str, Any]) -> None:
+    if notice.get("eligible"):
+        print("scoreable: yes")
+        return
+    print(f"warning: scoreable: no (reason={notice.get('reason')}); this receipt cannot score the captured artifact")
+    print(f"  {notice.get('remediation')}")
+    manifest_ids = notice.get("registered_manifest_ids")
+    if isinstance(manifest_ids, list) and manifest_ids:
+        print(f"  registered manifests: {', '.join(manifest_ids)}")
+    else:
+        print("  registered manifests: none tracked under verify/manifests/ in this target")
+
+
 def _attach_miseledger_indexing(
     receipt: dict[str, object],
     *,
@@ -2113,6 +2158,7 @@ def verify_run(
 
             from .. import outcome_cmd
 
+            scoreability = _scoreability_notice(target, receipt)
             sink = io.StringIO()
             with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
                 outcome_cmd.capture(
@@ -2122,6 +2168,7 @@ def verify_run(
                     run_id=receipt["run_id"],
                     json_output=False,
                 )
+            receipt["outcome_scoreability"] = scoreability
             _attach_miseledger_indexing(receipt, target=target, json_output=True)
         print(json.dumps(receipt, indent=2, sort_keys=True))
         return rc
@@ -2136,6 +2183,7 @@ def verify_run(
     if capture:
         from .. import outcome_cmd
 
+        scoreability = _scoreability_notice(target, receipt)
         outcome_cmd.capture(
             target=target,
             artifact_id=capture,
@@ -2143,7 +2191,9 @@ def verify_run(
             run_id=receipt["run_id"],
             json_output=False,
         )
+        receipt["outcome_scoreability"] = scoreability
         _attach_miseledger_indexing(receipt, target=target, json_output=False)
+        _print_scoreability_notice(scoreability)
     return rc
 
 

--- a/src/brigade/work_cmd/verify_scoreability.py
+++ b/src/brigade/work_cmd/verify_scoreability.py
@@ -1,0 +1,84 @@
+"""Scoreability projection and graph-impact printing for work verification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .. import verify_manifest, verify_trial
+
+
+def _print_graph_impact(ranking: object) -> None:
+    if not isinstance(ranking, dict):
+        return
+    if ranking.get("degraded") is True:
+        reason = ranking.get("degraded_reason") or "graphtrail unavailable"
+        print(f"graph_impact: degraded ({reason})")
+        return
+    candidates_raw = ranking.get("candidates")
+    candidates = candidates_raw if isinstance(candidates_raw, list) else []
+    changed_raw = ranking.get("changed_files")
+    changed = changed_raw if isinstance(changed_raw, list) else []
+    print(f"graph_impact: {len(candidates)} candidate(s) from {len(changed)} changed file(s)")
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        confidence_raw = item.get("confidence")
+        confidence = confidence_raw if isinstance(confidence_raw, dict) else {}
+        band = confidence.get("band") or "unknown"
+        score = confidence.get("score")
+        hops = confidence.get("min_hops")
+        evidence_raw = item.get("evidence")
+        evidence = evidence_raw if isinstance(evidence_raw, dict) else {}
+        via_raw = evidence.get("via")
+        via = via_raw if isinstance(via_raw, list) else []
+        via_text = ",".join(str(symbol) for symbol in via[:3]) if via else "-"
+        print(f"- [{band} score={score} hops={hops} via={via_text}] {item.get('command')}")
+    note = ranking.get("attribution")
+    if isinstance(note, str) and note.strip() and candidates:
+        print(f"graph_impact_note: {note.strip()}")
+
+
+_ADHOC_SCOREABILITY_REMEDIATION = (
+    "ad-hoc --command/--argv-json receipts are audit-only evidence and never score an artifact; "
+    "run `brigade work verify run --manifest <id>` against a manifest tracked under "
+    "verify/manifests/ to produce a scoreable receipt"
+)
+
+
+def _scoreability_notice(target: Path, receipt: dict[str, Any]) -> dict[str, Any]:
+    """Project whether this receipt can score its ``--capture`` artifact (#1378).
+
+    Eligibility used to be visible only in an aggregate ``work brief`` field, so a
+    session could run dozens of green ``--command --capture`` checks and feed the
+    ratchet nothing while every immediate indicator said otherwise. Project the
+    verdict on the run that produced the receipt instead.
+    """
+    run_dir_value = receipt.get("path")
+    patch_path = (
+        Path(str(run_dir_value)) / "changes.patch" if isinstance(run_dir_value, str) and run_dir_value else None
+    )
+    projection = verify_trial.project_trial(receipt, target=target, patch_path=patch_path)
+    notice: dict[str, Any] = {
+        "eligible": projection.eligible,
+        "reason": projection.reason,
+        "attributed": projection.attributed,
+    }
+    if projection.eligible:
+        return notice
+    notice["registered_manifest_ids"] = verify_manifest.registered_manifest_ids(target)
+    notice["remediation"] = _ADHOC_SCOREABILITY_REMEDIATION
+    return notice
+
+
+def _print_scoreability_notice(notice: dict[str, Any]) -> None:
+    if notice.get("eligible"):
+        print("scoreable: yes")
+        return
+    print(f"warning: scoreable: no (reason={notice.get('reason')}); this receipt cannot score the captured artifact")
+    print(f"  {notice.get('remediation')}")
+    manifest_ids = notice.get("registered_manifest_ids")
+    if isinstance(manifest_ids, list) and manifest_ids:
+        print(f"  registered manifests: {', '.join(manifest_ids)}")
+    else:
+        print("  registered manifests: none tracked under verify/manifests/ in this target")

--- a/src/brigade/work_cmd/verify_scoreability.py
+++ b/src/brigade/work_cmd/verify_scoreability.py
@@ -55,19 +55,22 @@ def _scoreability_notice(target: Path, receipt: dict[str, Any]) -> dict[str, Any
     verdict on the run that produced the receipt instead.
     """
     run_dir_value = receipt.get("path")
-    patch_path = (
-        Path(str(run_dir_value)) / "changes.patch" if isinstance(run_dir_value, str) and run_dir_value else None
-    )
+    patch_path = None
+    if isinstance(run_dir_value, str) and run_dir_value:
+        candidate = Path(run_dir_value) / "changes.patch"
+        if candidate.is_file():
+            patch_path = candidate
     projection = verify_trial.project_trial(receipt, target=target, patch_path=patch_path)
     notice: dict[str, Any] = {
         "eligible": projection.eligible,
         "reason": projection.reason,
         "attributed": projection.attributed,
+        "registered_manifest_ids": [],
+        "remediation": None,
     }
-    if projection.eligible:
-        return notice
-    notice["registered_manifest_ids"] = verify_manifest.registered_manifest_ids(target)
-    notice["remediation"] = _ADHOC_SCOREABILITY_REMEDIATION
+    if not projection.eligible:
+        notice["registered_manifest_ids"] = verify_manifest.registered_manifest_ids(target)
+        notice["remediation"] = _ADHOC_SCOREABILITY_REMEDIATION
     return notice
 
 
@@ -76,7 +79,9 @@ def _print_scoreability_notice(notice: dict[str, Any]) -> None:
         print("scoreable: yes")
         return
     print(f"warning: scoreable: no (reason={notice.get('reason')}); this receipt cannot score the captured artifact")
-    print(f"  {notice.get('remediation')}")
+    remediation = notice.get("remediation")
+    if remediation:
+        print(f"  {remediation}")
     manifest_ids = notice.get("registered_manifest_ids")
     if isinstance(manifest_ids, list) and manifest_ids:
         print(f"  registered manifests: {', '.join(manifest_ids)}")

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -3676,6 +3676,29 @@ def test_manifest_capture_run_reports_an_eligible_attributed_receipt(tmp_target,
     assert [audit.eligible for audit in audits] == [True]
 
 
+def test_manifest_capture_run_prints_scoreable_yes_on_stdout(tmp_target, monkeypatch, capsys):
+    """#1378: the non-JSON eligible path must print the scoreability verdict too."""
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+    manifest_id = _register_tracked_verify_manifest(tmp_target)
+    assert work_cmd.start(target=tmp_target, title="demo") == 0
+    (tmp_target / "skills" / "demo" / "SKILL.md").write_text("# demo skill\nchanged\n")
+    capsys.readouterr()
+
+    rc = verification.verify_run(
+        target=tmp_target,
+        manifest_id=manifest_id,
+        timeout=60,
+        capture="demo",
+        json_output=False,
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "scoreable: yes" in captured.out
+
+
 def test_outcome_health_names_registered_manifest_ids_for_remediation(tmp_target, monkeypatch, capsys):
     """#1378: `work brief` remediation must be actionable without reading the source."""
     from brigade import outcome_cmd

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -3575,3 +3575,119 @@ def test_distinct_skill_captures_accumulate_separate_rank_signals(tmp_target, mo
     assert by_id["taste"]["helped"] == 1
     assert by_id["refire"]["helped"] == 1
     assert "brigade-work" not in by_id or by_id.get("brigade-work", {}).get("helped", 0) == 0
+
+
+def _register_tracked_verify_manifest(target, *, manifest_id="demo-verify"):
+    """Track a patch-backed manifest so a --manifest run can be scoreable (#1378)."""
+    skill_dir = target / "skills" / "demo"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text("# demo skill\n")
+    manifest_dir = target / "verify" / "manifests"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        manifest_dir / f"{manifest_id}.json",
+        {
+            "schema": "brigade.verify_manifest.v1",
+            "schema_version": 1,
+            "manifest_id": manifest_id,
+            "binding_mode": "patch_backed",
+            "verifier_id": "demo-verifier",
+            "subject": {
+                "artifact_kind": "skill",
+                "artifact_id": "demo",
+                "subject_path": "skills/demo/SKILL.md",
+                "content_fingerprint": "sha256:demo",
+            },
+            "checks": [{"check_id": "eff-1", "check_role": "effectiveness", "command": "true"}],
+        },
+    )
+    subprocess.run(["git", "add", "-A"], cwd=target, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "-c", "user.name=Test User", "-c", "user.email=test@example.invalid", "commit", "-m", "manifest"],
+        cwd=target,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    return manifest_id
+
+
+def test_command_capture_run_warns_that_receipt_is_not_scoreable(tmp_target, monkeypatch, capsys):
+    """#1378: the documented --command --capture loop must say the receipt cannot score."""
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    assert verification.verify_run(target=tmp_target, commands=["true"], timeout=60, capture="brigade-work") == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "scoreable: no" in combined
+    assert "unattributed" in combined
+    assert "--manifest" in combined
+    assert "verify/manifests" in combined
+
+
+def test_argv_json_capture_run_warns_and_still_writes_a_receipt(tmp_target, monkeypatch, capsys):
+    """#1378: --argv-json keeps working and carries the same scoreability verdict."""
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    rc = verification.verify_run(
+        target=tmp_target,
+        commands=[[sys.executable, "-c", "print(1)"]],
+        timeout=60,
+        capture="brigade-work",
+        json_output=True,
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome_scoreability"]["eligible"] is False
+    assert payload["outcome_scoreability"]["reason"] == "unattributed"
+    assert payload["outcome_scoreability"]["registered_manifest_ids"] == []
+    assert payload["commands"][0]["exit_code"] == 0
+
+
+def test_manifest_capture_run_reports_an_eligible_attributed_receipt(tmp_target, monkeypatch, capsys):
+    """#1378: the scoreable path stays scoreable and now says so on the run."""
+    from brigade import scorecard
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+    manifest_id = _register_tracked_verify_manifest(tmp_target)
+    assert work_cmd.start(target=tmp_target, title="demo") == 0
+    (tmp_target / "skills" / "demo" / "SKILL.md").write_text("# demo skill\nchanged\n")
+    capsys.readouterr()
+
+    rc = verification.verify_run(
+        target=tmp_target,
+        manifest_id=manifest_id,
+        timeout=60,
+        capture="demo",
+        json_output=True,
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["outcome_scoreability"]["eligible"] is True
+    assert payload["outcome_scoreability"]["attributed"] is True
+    audits = scorecard.audit_all_verify_receipts(tmp_target)
+    assert [audit.eligible for audit in audits] == [True]
+
+
+def test_outcome_health_names_registered_manifest_ids_for_remediation(tmp_target, monkeypatch, capsys):
+    """#1378: `work brief` remediation must be actionable without reading the source."""
+    from brigade import outcome_cmd
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+    manifest_id = _register_tracked_verify_manifest(tmp_target)
+    assert verification.verify_run(target=tmp_target, commands=["true"], timeout=60, capture="brigade-work") == 0
+    capsys.readouterr()
+
+    health = outcome_cmd.health(tmp_target)
+    assert health["registered_verify_manifest_ids"] == [manifest_id]
+    assert health["top_issue"]["name"] == "outcome_loop_half_fed"
+    assert manifest_id in health["top_issue"]["detail"]


### PR DESCRIPTION
Fixes #1378

Ad-hoc --command and --argv-json receipts are audit-only by contract: only a
git-tracked manifest under verify/manifests/ can author the subject_binding that
outcome eligibility requires. Every --capture run now prints scoreable: yes or a
warning naming the reason and the registered manifest ids, --json carries
outcome_scoreability, and brigade work brief lists outcome_verify_manifests, so
a repo with no manifests reads ineligibility_rate=1.0 as 'nothing declared
scoreable yet' instead of a silent failure.

Receipts: 20260902-025956-work-verify-22d81f (focused suite), failing-first
20260902-025824-work-verify-5d6596, adjacent suites 20260902-030040-work-verify-5b797b.