### PR TITLE
feat(grokbot): make the listener lease configurable and name an expired lease

### DIFF
--- a/docs/grokbot-mcp.md
+++ b/docs/grokbot-mcp.md
@@ -71,13 +71,25 @@ An optional argument sent as `null` means the same as omitting it, in the advert
 
 The role stays pinned server-side. A worker listener still lists only its own role's jobs, an operator listener still lists every role, and no argument widens either. A refused list call returns a bounded reason that names the accepted keys, states, or role instead of the generic validation message, so a Bot can correct the call itself. The reason never repeats the value that was sent.
 
-`grokbot_queue_claim` takes a required `job_id` and an optional `lease_id`. When `lease_id` is omitted or sent as `null` the listener mints a uuid4 hex lease and returns it in the claim result as `lease_id`. Carry that value on `grokbot_queue_start`, `grokbot_queue_renew`, `grokbot_queue_complete`, `grokbot_queue_fail`, and `grokbot_queue_ack_cancel` for that job. A supplied `lease_id` is echoed back unchanged, and a malformed one is still refused with the generic validation error before any queue mutation. Lease duration, worker identity, and role remain deployment-fixed.
+`grokbot_queue_claim` takes a required `job_id` and the optional `lease_id` and `lease_seconds`. When `lease_id` is omitted or sent as `null` the listener mints a uuid4 hex lease and returns it in the claim result as `lease_id`. Carry that value on `grokbot_queue_start`, `grokbot_queue_renew`, `grokbot_queue_complete`, `grokbot_queue_fail`, and `grokbot_queue_ack_cancel` for that job. A supplied `lease_id` is echoed back unchanged, and a malformed one is still refused with the generic validation error before any queue mutation. Worker identity and role remain deployment-fixed.
+
+The lease is a per-listener setting. `lease_seconds` defaults to 900, an interval chosen so one cloud-agent step fits inside a single lease: the previous fixed 300 lapsed mid-step, and the refusal that followed read as a broken adapter rather than an expired lease. Set it per instance with `BRIGADE_GROKBOT_<INSTANCE>_LEASE_SECONDS` (for example `BRIGADE_GROKBOT_IMPLEMENTATION_WORKER_LEASE_SECONDS`), or for every role on the host with `BRIGADE_GROKBOT_LEASE_SECONDS`. `build_listener_config` also accepts `lease_seconds` directly. The bound is the queue's own, 30 to 3600 seconds, and it is the same bound the Fleet Hub enforces server-side; a value outside it fails listener configuration rather than being silently clamped.
+
+A claim may request its own `lease_seconds` inside that bound. An out-of-bound or non-integer request is refused with the bounded reason `lease_seconds must be an integer between 30 and 3600`, before any queue mutation. Every claim answers with the granted `lease_seconds` and the `lease_expires_at` deadline. The job's own deadline still wins: a lease is clamped to it, so read `lease_expires_at` rather than adding the granted seconds to the current time. `grokbot_queue_renew` extends the lease by the listener's configured length and returns the same two fields.
+
+A `grokbot_queue_renew` or `grokbot_queue_fail` that arrives after `lease_expires_at` is refused with the bounded reason `lease-expired` instead of the generic validation message. That reason means the lease lapsed and the call was well formed. Under hub authority the hub answers a holder refusal with `lease-conflict`; the listener confirms an elapsed deadline against the job itself before naming it `lease-expired`, so a job another worker has re-claimed stays a conflict.
 
 The listener writes one INFO line per tool call to its journal:
 
 ```text
 grokbot tool=grokbot_queue_list args=limit,state unknown=0 decision=ok reason=-
 grokbot tool=grokbot_queue_list args=- unknown=1 decision=refused reason=grokbot_queue_list accepts only these arguments: include_all, limit, role, state
+```
+
+A claim or renew that granted a lease adds a second line for the window it opened, so a lapsed lease can be read out of the journal instead of inferred from a later refusal:
+
+```text
+grokbot tool=grokbot_queue_claim lease_seconds=900 deadline=2026-09-02T02:32:15.812112Z
 ```
 
 The line carries the tool name, the accepted argument keys that were present, a count of unrecognized keys, the decision, and the bounded reason. It never carries argument values, job payloads, lease values, or bearer material. Unrecognized key names are counted rather than printed. Raw requests refused at the HTTP edge are journaled the same way, so a reported "input validation" failure can be read from `journalctl` instead of reproduced by hand.

--- a/src/brigade/grokbot_job_validation.py
+++ b/src/brigade/grokbot_job_validation.py
@@ -17,6 +17,10 @@ GITHUB_PULL_URL_RE = re.compile(
 LOWER_HEX_40_RE = re.compile(r"^[0-9a-f]{40}$")
 LOWER_HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
 ARTIFACT_KINDS = frozenset({"draft-pr", "branch", "report"})
+# The one queue-side bound on a lease. Callers that offer a configurable or
+# caller-requested lease read these instead of restating the numbers.
+LEASE_SECONDS_MIN = 30
+LEASE_SECONDS_MAX = 3600
 
 
 class GrokbotJobError(ValueError):
@@ -104,7 +108,7 @@ def validate_opaque_id(value: object, reason: str) -> str:
 
 
 def validate_lease_seconds(value: object) -> int:
-    if type(value) is not int or not 30 <= value <= 3600:
+    if type(value) is not int or not LEASE_SECONDS_MIN <= value <= LEASE_SECONDS_MAX:
         raise GrokbotJobError("invalid-lease-seconds")
     return value
 

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -2,7 +2,8 @@
 
 The adapter deliberately delegates all queue authority to :mod:`grokbot_jobs`.
 It contains no queue persistence and never accepts a caller-selected worker
-identity, target, role, or lease duration.
+identity, target, or role. A claim may request a lease length, but only inside
+the queue's own bound, and the listener's configured lease is the default.
 """
 
 from __future__ import annotations
@@ -17,15 +18,23 @@ import re
 import stat
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from . import cloud_tracker, fleet_client, grokbot_jobs
+from . import cloud_tracker, fleet_client, grokbot_job_validation, grokbot_jobs
 
 
 DEFAULT_BIND = "127.0.0.1:8766"
 MAX_REQUEST_BYTES = 80_000
-LEASE_SECONDS = 300
+# A Grok Bot routine that spawns a cloud agent routinely goes minutes between
+# tool calls, so the default lease has to outlast one agent step (issue #1383).
+# The bound is the queue's own, so a listener can never hand out a lease the
+# queue or the hub would refuse.
+DEFAULT_LEASE_SECONDS = 900
+MIN_LEASE_SECONDS = grokbot_job_validation.LEASE_SECONDS_MIN
+MAX_LEASE_SECONDS = grokbot_job_validation.LEASE_SECONDS_MAX
+LEASE_SECONDS_ENV = "BRIGADE_GROKBOT_LEASE_SECONDS"
 MAX_LISTED_JOBS = 100
 MAX_LIST_LIMIT = 100
 LIST_ARGUMENT_KEYS = ("include_all", "limit", "role", "state")
@@ -101,9 +110,12 @@ class ListenerConfig:
     allowed_origins: tuple[str, ...]
     bearer: str
     hub_token: str | None = None
+    lease_seconds: int = DEFAULT_LEASE_SECONDS
 
     def validate(self) -> None:
         if self.instance not in INSTANCES or not self.target.is_dir():
+            raise ConfigurationError("invalid")
+        if not _within_lease_bound(self.lease_seconds):
             raise ConfigurationError("invalid")
         if not isinstance(self.bearer, str):
             raise ConfigurationError("invalid")
@@ -175,6 +187,29 @@ def load_hub_token(*, instance: str) -> str | None:
     if path_text is None:
         return None
     return _read_mode600_secret(Path(path_text))
+
+
+def load_lease_seconds(*, instance: str) -> int:
+    """Resolve one listener's lease length, per instance and then fleet-wide.
+
+    ``BRIGADE_GROKBOT_<INSTANCE>_LEASE_SECONDS`` sets the length for a single
+    packaged role; ``BRIGADE_GROKBOT_LEASE_SECONDS`` sets it for every role on
+    the host. An unset pair means the 15-minute default, and anything outside
+    the queue's own bound is a configuration failure rather than a clamp.
+    """
+    names = (f"BRIGADE_GROKBOT_{instance.replace('-', '_').upper()}_LEASE_SECONDS", LEASE_SECONDS_ENV)
+    text = next((os.environ[name] for name in names if os.environ.get(name)), None)
+    if text is None:
+        return DEFAULT_LEASE_SECONDS
+    seconds = int(text) if text.strip().isdecimal() else None
+    if seconds is None or not _within_lease_bound(seconds):
+        raise ConfigurationError("invalid")
+    return seconds
+
+
+def _within_lease_bound(value: object) -> bool:
+    """The listener never widens the queue's own lease bound."""
+    return type(value) is int and MIN_LEASE_SECONDS <= value <= MAX_LEASE_SECONDS
 
 
 def load_direct_queue_listener_token() -> str | None:
@@ -291,7 +326,7 @@ class GrokbotAdapter:
 
     def tool_inventory(self) -> list[dict[str, str]]:
         return [
-            {"name": name, "description": tool_description(name, self.config.instance)}
+            {"name": name, "description": tool_description(name, self.config.instance, self.config.lease_seconds)}
             for name in sorted(self._tools())
         ]
 
@@ -357,31 +392,34 @@ class GrokbotAdapter:
             job_id = _job_id(arguments)
             return grokbot_jobs.read_report(self.config.target, job_id)
         if name == "grokbot_queue_claim":
-            job = self._eligible_job(arguments, allowed={"job_id"}, optional={"lease_id"})
+            job = self._eligible_job(arguments, allowed={"job_id"}, optional={"lease_id", "lease_seconds"})
             lease_id = _lease_id(arguments, mint=True)
+            lease_seconds = self._requested_lease_seconds(arguments)
             if grokbot_jobs.hub_authority(self.config.target):
-                return _with_lease_id(
+                return self._granted_lease(
+                    name,
                     self._hub_lifecycle(
                         grokbot_jobs.claim_execution_context,
                         job["job_id"],
                         self.config.bot_id,
                         lease_id,
-                        LEASE_SECONDS,
+                        lease_seconds,
                     ),
                     lease_id,
+                    lease_seconds,
                 )
             holder, session = fleet_holder(job["job_id"], lease_id), fleet_session(job["job_id"], lease_id)
-            cloud_decision = self._admit_hub_lease_decision(job, lease_id)
+            cloud_decision = self._admit_hub_lease_decision(job, lease_id, lease_seconds)
             if _cloud_refused(cloud_decision):
                 raise AdapterError()
-            decision = self._fleet_acquire(job["job_id"], holder, session)
+            decision = self._fleet_acquire(job["job_id"], holder, session, lease_seconds)
             if _fleet_refused(decision):
                 if cloud_decision is not None and cloud_decision.granted:
                     self._release_hub_lease(job["job_id"], lease_id, "released")
                 raise AdapterError()
             try:
                 result = grokbot_jobs.claim_execution_context(
-                    self.config.target, job["job_id"], self.config.bot_id, lease_id, LEASE_SECONDS
+                    self.config.target, job["job_id"], self.config.bot_id, lease_id, lease_seconds
                 )
             except Exception:
                 self._release_hub_lease(job["job_id"], lease_id, "released")
@@ -390,35 +428,59 @@ class GrokbotAdapter:
                 raise
             self._bind_hub_lease(job["job_id"], lease_id)
             self._fleet_event(job["job_id"], session, "external.claimed")
-            return _with_lease_id(result, lease_id)
+            return self._granted_lease(name, result, lease_id, lease_seconds)
         if name == "grokbot_queue_renew":
             job = self._eligible_job(arguments, allowed={"job_id", "lease_id"})
             lease_id = _lease_id(arguments)
             job_id = job["job_id"]
+            lease_seconds = self.config.lease_seconds
             if grokbot_jobs.hub_authority(self.config.target):
-                return self._hub_lifecycle(grokbot_jobs.renew, job_id, self.config.bot_id, lease_id, LEASE_SECONDS)
+                return self._granted_lease(
+                    name,
+                    self._lease_call(
+                        job_id,
+                        self._hub_lifecycle,
+                        grokbot_jobs.renew,
+                        job_id,
+                        self.config.bot_id,
+                        lease_id,
+                        lease_seconds,
+                    ),
+                    None,
+                    lease_seconds,
+                )
             holder, session = fleet_holder(job_id, lease_id), fleet_session(job_id, lease_id)
-            decision = self._fleet_renew(holder)
+            decision = self._fleet_renew(holder, lease_seconds)
             if not decision.granted and decision.reason == "missing":
-                decision = self._fleet_acquire(job_id, holder, session)
+                decision = self._fleet_acquire(job_id, holder, session, lease_seconds)
             if _fleet_refused(decision):
                 raise AdapterError()
             try:
-                result = grokbot_jobs.renew(self.config.target, job_id, self.config.bot_id, lease_id, LEASE_SECONDS)
+                result = self._lease_call(
+                    job_id, grokbot_jobs.renew, self.config.target, job_id, self.config.bot_id, lease_id, lease_seconds
+                )
             except Exception:
                 if decision.granted:
                     self._fleet_release(holder)
                 raise
             self._renew_or_reconcile_hub_lease(result, lease_id)
             self._fleet_event(job_id, session, "external.heartbeat")
-            return result
+            return self._granted_lease(name, result, None, lease_seconds)
         if name in {"grokbot_queue_start", "grokbot_queue_fail", "grokbot_queue_ack_cancel"}:
             job_id, lease_id = _job_id(arguments, {"job_id", "lease_id"}), _lease_id(arguments)
             if grokbot_jobs.hub_authority(self.config.target):
                 if name.endswith("start"):
                     return self._hub_lifecycle(grokbot_jobs.transition, job_id, self.config.bot_id, lease_id, "running")
                 if name.endswith("fail"):
-                    return self._hub_lifecycle(grokbot_jobs.transition, job_id, self.config.bot_id, lease_id, "failed")
+                    return self._lease_call(
+                        job_id,
+                        self._hub_lifecycle,
+                        grokbot_jobs.transition,
+                        job_id,
+                        self.config.bot_id,
+                        lease_id,
+                        "failed",
+                    )
                 return self._hub_lifecycle(grokbot_jobs.acknowledge_cancel, job_id, self.config.bot_id, lease_id)
             holder, session = fleet_holder(job_id, lease_id), fleet_session(job_id, lease_id)
             if name.endswith("start"):
@@ -427,7 +489,15 @@ class GrokbotAdapter:
                 self._fleet_event(job_id, session, "external.running")
                 return result
             if name.endswith("fail"):
-                result = grokbot_jobs.transition(self.config.target, job_id, self.config.bot_id, lease_id, "failed")
+                result = self._lease_call(
+                    job_id,
+                    grokbot_jobs.transition,
+                    self.config.target,
+                    job_id,
+                    self.config.bot_id,
+                    lease_id,
+                    "failed",
+                )
                 self._fleet_release(holder)
                 self._fleet_event(job_id, session, "external.failed")
                 self._release_hub_lease(job_id, lease_id, result["state"])
@@ -500,7 +570,61 @@ class GrokbotAdapter:
         """Run one hub-authoritative queue mutation with this listener's node token."""
         return operation(self.config.target, *args, **kwargs)
 
-    def _admit_hub_lease_decision(self, job: Mapping[str, Any], holder: str) -> fleet_client.CloudDecision | None:
+    def _requested_lease_seconds(self, arguments: Mapping[str, Any]) -> int:
+        """Grant the caller's requested lease, or this listener's configured one."""
+        requested = arguments.get("lease_seconds")
+        if requested is None:
+            return self.config.lease_seconds
+        if not _within_lease_bound(requested):
+            raise AdapterError(f"lease_seconds must be an integer between {MIN_LEASE_SECONDS} and {MAX_LEASE_SECONDS}")
+        assert isinstance(requested, int)
+        return requested
+
+    def _granted_lease(
+        self, tool: str, result: dict[str, Any], lease_id: str | None, lease_seconds: int
+    ) -> dict[str, Any]:
+        """Answer with the granted lease and journal the window it opened."""
+        granted = {**result, "lease_seconds": lease_seconds}
+        if lease_id is not None:
+            granted["lease_id"] = lease_id
+        journal_lease(tool, lease_seconds, granted.get("lease_expires_at"))
+        return granted
+
+    def _lease_call(self, job_id: str, operation: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Run one lease-holder mutation, naming an expired lease as such.
+
+        A lapsed lease is an ordinary, recoverable state, not a malformed
+        request. Folding it into the generic validation error is what makes a
+        Bot read the listener as a broken adapter (issue #1383).
+        """
+        try:
+            return operation(*args, **kwargs)
+        except grokbot_jobs.GrokbotJobError as exc:
+            if self._lease_lapsed(job_id, exc.reason):
+                raise AdapterError("lease-expired") from None
+            raise
+
+    def _lease_lapsed(self, job_id: str, reason: str | None) -> bool:
+        """True when the queue refused because this job's lease deadline passed.
+
+        Hub authority answers every holder refusal with ``lease-conflict``, so
+        an expiry is confirmed against the job's own deadline rather than by
+        widening the hub's error contract. A job another worker has since
+        re-claimed carries a live deadline and stays a conflict.
+        """
+        if reason == "lease-expired":
+            return True
+        if reason != "lease-conflict":
+            return False
+        try:
+            deadline = grokbot_jobs.get_job(self.config.target, job_id).get("lease_expires_at")
+            return isinstance(deadline, str) and _parse_deadline(deadline) <= datetime.now(timezone.utc)
+        except Exception:
+            return False
+
+    def _admit_hub_lease_decision(
+        self, job: Mapping[str, Any], holder: str, lease_seconds: int | None = None
+    ) -> fleet_client.CloudDecision | None:
         """Ask the hub for one deterministic GrokBot cloud lease."""
         task_hash = job.get("task_hash")
         repository = job.get("repository")
@@ -515,14 +639,14 @@ class GrokbotAdapter:
             label=cloud_tracker.lease_label("grokbot-cloud", repository, prompt_hash),
             prompt_hash=prompt_hash,
             conductor=self.config.instance,
-            ttl_seconds=LEASE_SECONDS,
+            ttl_seconds=lease_seconds if lease_seconds is not None else self.config.lease_seconds,
             lease_id=job_id,
             holder=holder,
         )
 
     def _admit_hub_lease(self, job: Mapping[str, Any], holder: str) -> bool:
         """True only when the hub granted the separate GrokBot cloud lease."""
-        decision = self._admit_hub_lease_decision(job, holder)
+        decision = self._admit_hub_lease_decision(job, holder, self.config.lease_seconds)
         return bool(decision is not None and decision.granted)
 
     def _bind_hub_lease(self, job_id: str, holder: str) -> None:
@@ -534,7 +658,9 @@ class GrokbotAdapter:
         job_id = job.get("job_id")
         if not isinstance(job_id, str):
             return
-        decision = self._hub_call(fleet_client.renew_cloud, job_id, ttl_seconds=LEASE_SECONDS, holder=holder)
+        decision = self._hub_call(
+            fleet_client.renew_cloud, job_id, ttl_seconds=self.config.lease_seconds, holder=holder
+        )
         if decision is None or decision.granted or decision.reason != "refused":
             return
         if self._admit_hub_lease(job, holder):
@@ -556,12 +682,14 @@ class GrokbotAdapter:
     def _fleet_target(self) -> str:
         return fleet_client.resolve_claim_target(self.config.target)
 
-    def _fleet_acquire(self, job_id: str, holder: str, session: str) -> fleet_client.ClaimDecision:
+    def _fleet_acquire(
+        self, job_id: str, holder: str, session: str, lease_seconds: int | None = None
+    ) -> fleet_client.ClaimDecision:
         try:
             return fleet_client.acquire_claim(
                 self._fleet_target(),
                 holder=holder,
-                ttl_seconds=LEASE_SECONDS,
+                ttl_seconds=lease_seconds if lease_seconds is not None else self.config.lease_seconds,
                 harness="grokbot",
                 role=self.config.instance,
                 job=job_id,
@@ -570,9 +698,10 @@ class GrokbotAdapter:
         except Exception:
             return fleet_client.ClaimDecision(granted=False, reason="hub-unavailable", holder=holder)
 
-    def _fleet_renew(self, holder: str) -> fleet_client.ClaimDecision:
+    def _fleet_renew(self, holder: str, lease_seconds: int | None = None) -> fleet_client.ClaimDecision:
         try:
-            return fleet_client.renew_claim(self._fleet_target(), holder=holder, ttl_seconds=LEASE_SECONDS)
+            ttl = lease_seconds if lease_seconds is not None else self.config.lease_seconds
+            return fleet_client.renew_claim(self._fleet_target(), holder=holder, ttl_seconds=ttl)
         except Exception:
             return fleet_client.ClaimDecision(granted=False, reason="hub-unavailable", holder=holder)
 
@@ -646,6 +775,7 @@ def build_listener_config(
     allowed_origins: list[str],
     bearer_file: Path | None,
     bearer_env: str | None,
+    lease_seconds: int | None = None,
 ) -> ListenerConfig:
     host, port = parse_bind(bind)
     config = ListenerConfig(
@@ -657,6 +787,7 @@ def build_listener_config(
         allowed_origins=tuple(allowed_origins),
         bearer=load_bearer(bearer_file=bearer_file, bearer_env=bearer_env),
         hub_token=load_hub_token(instance=instance),
+        lease_seconds=lease_seconds if lease_seconds is not None else load_lease_seconds(instance=instance),
     )
     config.validate()
     return config
@@ -707,7 +838,7 @@ def _register_tool(server: Any, adapter: GrokbotAdapter, name: str) -> None:
 
 def _tool_handler(adapter: GrokbotAdapter, name: str) -> Callable[..., Any]:
     """Build the typed wrapper whose signature becomes the advertised inputSchema."""
-    description = tool_description(name, adapter.config.instance)
+    description = tool_description(name, adapter.config.instance, adapter.config.lease_seconds)
 
     if name == "grokbot_queue_list":
 
@@ -723,10 +854,12 @@ def _tool_handler(adapter: GrokbotAdapter, name: str) -> Callable[..., Any]:
         handler: Callable[..., Any] = invoke_list
     elif name == "grokbot_queue_claim":
 
-        def invoke_claim(job_id: str, lease_id: str | None = None) -> dict[str, Any]:
+        def invoke_claim(job_id: str, lease_id: str | None = None, lease_seconds: int | None = None) -> dict[str, Any]:
             payload: dict[str, Any] = {"job_id": job_id}
             if lease_id is not None:
                 payload["lease_id"] = lease_id
+            if lease_seconds is not None:
+                payload["lease_seconds"] = lease_seconds
             return _invoke_adapter(adapter, name, payload)
 
         handler = invoke_claim
@@ -916,11 +1049,6 @@ def _lease_id(arguments: dict[str, Any], *, mint: bool = False) -> str:
     return lease_id
 
 
-def _with_lease_id(result: dict[str, Any], lease_id: str) -> dict[str, Any]:
-    """Echo the claim's own lease so a minted lease can carry the next call."""
-    return {**result, "lease_id": lease_id}
-
-
 @dataclass(frozen=True)
 class ListOptions:
     """The validated, role-pinned projection filters for one list call."""
@@ -971,6 +1099,20 @@ def journal_tool_call(name: object, arguments: object, decision: str, reason: st
         sum(1 for key in keys if key not in accepted),
         decision,
         reason or ("-" if decision == "ok" else "invalid-request"),
+    )
+
+
+def journal_lease(tool: str, lease_seconds: int, deadline: object) -> None:
+    """Journal the lease window a claim or renew opened, never the job or lease.
+
+    The deadline is the queue's own answer, so a lapsed lease can be read out
+    of the journal instead of inferred from a later refusal.
+    """
+    _JOURNAL.info(
+        "grokbot tool=%s lease_seconds=%d deadline=%s",
+        tool if tool in _TOOL_ARGUMENT_TYPES else "unknown",
+        lease_seconds,
+        deadline if isinstance(deadline, str) else "-",
     )
 
 
@@ -1035,7 +1177,7 @@ _TOOL_ARGUMENT_TYPES: dict[str, tuple[dict[str, type[object]], dict[str, type[ob
     "grokbot_queue_cancel": ({"job_id": str}, {}),
     "grokbot_queue_expire": ({"job_id": str}, {}),
     "grokbot_queue_report": ({"job_id": str}, {}),
-    "grokbot_queue_claim": ({"job_id": str}, {"lease_id": str}),
+    "grokbot_queue_claim": ({"job_id": str}, {"lease_id": str, "lease_seconds": int}),
     "grokbot_queue_renew": ({"job_id": str, "lease_id": str}, {}),
     "grokbot_queue_start": ({"job_id": str, "lease_id": str}, {}),
     "grokbot_queue_complete": ({"job_id": str, "lease_id": str, "artifact": dict}, {"report_text": str}),
@@ -1085,6 +1227,11 @@ def _transport_allowed_hosts(config: ListenerConfig) -> list[str]:
     return list(config.allowed_hosts)
 
 
+def _parse_deadline(value: str) -> datetime:
+    """Read one queue timestamp as an aware instant."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
 def _valid_host(value: str) -> bool:
     return isinstance(value, str) and bool(value) and len(value) <= 253 and all(part for part in value.split("."))
 
@@ -1111,13 +1258,17 @@ _LIST_DESCRIPTION = (
     "widen it. Any other argument is refused."
 )
 _CLAIM_DESCRIPTION = (
-    "Claim one queued job for this listener's fixed worker identity. Arguments: job_id (required) "
-    "and lease_id (optional, and null means omitted). When lease_id is omitted the listener mints "
-    "one and returns it as lease_id; carry that value on every later call for this job. The routine "
-    "sequence is grokbot_queue_list, grokbot_queue_claim, grokbot_queue_start, grokbot_queue_renew "
-    "before the lease expires, then grokbot_queue_complete or grokbot_queue_fail, and "
-    "grokbot_queue_ack_cancel when the operator requests cancellation. The role, worker identity, "
-    "and lease duration are fixed server-side and cannot be selected by arguments."
+    "Claim one queued job for this listener's fixed worker identity. Arguments: job_id (required), "
+    "lease_id (optional), and lease_seconds (optional, integer {lease_min}..{lease_max}); null means "
+    "omitted for either optional. When lease_id is omitted the listener mints one and returns it as "
+    "lease_id; carry that value on every later call for this job. When lease_seconds is omitted the "
+    "listener grants its configured lease ({lease_default} seconds here). The result carries the "
+    "granted lease_seconds and the lease_expires_at deadline; the job's own deadline can shorten it. "
+    "The routine sequence is grokbot_queue_list, grokbot_queue_claim, grokbot_queue_start, "
+    "grokbot_queue_renew before lease_expires_at, then grokbot_queue_complete or grokbot_queue_fail, "
+    "and grokbot_queue_ack_cancel when the operator requests cancellation. A renew or fail sent after "
+    "the deadline is refused with lease-expired, which means the lease lapsed, not that the call was "
+    "malformed. The role and worker identity are fixed server-side."
 )
 
 
@@ -1136,11 +1287,14 @@ _TOOL_DESCRIPTIONS = {
 }
 
 
-def tool_description(name: str, instance: str) -> str:
-    """Describe one tool for a listener whose role is already fixed."""
+def tool_description(name: str, instance: str, lease_seconds: int | None = None) -> str:
+    """Describe one tool for a listener whose role and lease are already fixed."""
     return _TOOL_DESCRIPTIONS[name].format(
         states=", ".join(sorted(grokbot_jobs.JOB_STATES)),
         limit=MAX_LIST_LIMIT,
         default=MAX_LISTED_JOBS,
         role=instance,
+        lease_min=MIN_LEASE_SECONDS,
+        lease_max=MAX_LEASE_SECONDS,
+        lease_default=lease_seconds if lease_seconds is not None else DEFAULT_LEASE_SECONDS,
     )

--- a/tests/test_grokbot_mcp.py
+++ b/tests/test_grokbot_mcp.py
@@ -56,7 +56,7 @@ def _report_artifact(text: str = REPORT_TEXT, path: str = "artifacts/report.md")
 
 def _running_scout_job(tmp_path: Path) -> str:
     job_id = grokbot_jobs.enqueue(tmp_path, _spec("repository-scout"), "scout-job")["job_id"]
-    grokbot_jobs.claim(tmp_path, job_id, "grokbot-repository-scout", "lease-a", grokbot_mcp.LEASE_SECONDS)
+    grokbot_jobs.claim(tmp_path, job_id, "grokbot-repository-scout", "lease-a", grokbot_mcp.DEFAULT_LEASE_SECONDS)
     grokbot_jobs.transition(tmp_path, job_id, "grokbot-repository-scout", "lease-a", "running")
     return job_id
 
@@ -630,7 +630,7 @@ def test_workers_cannot_retrieve_reports_and_operator_can(tmp_path: Path):
     job_id = grokbot_jobs.enqueue(tmp_path, spec, "scout-report")["job_id"]
     worker = _adapter(tmp_path, "repository-scout")
     operator = _adapter(tmp_path, "operator")
-    grokbot_jobs.claim(tmp_path, job_id, worker.config.bot_id, "lease-a", grokbot_mcp.LEASE_SECONDS)
+    grokbot_jobs.claim(tmp_path, job_id, worker.config.bot_id, "lease-a", grokbot_mcp.DEFAULT_LEASE_SECONDS)
     grokbot_jobs.transition(tmp_path, job_id, worker.config.bot_id, "lease-a", "running")
     report = "Scout findings stay private."
     digest = __import__("hashlib").sha256(report.encode()).hexdigest()
@@ -751,7 +751,7 @@ def test_claim_is_admitted_before_queue_mutation_and_binds_the_deterministic_hub
         "label": f"grokbot-cloud:example/brigade@{claimed['task_hash'].removeprefix('sha256:')[:12]}",
         "prompt_hash": claimed["task_hash"].removeprefix("sha256:"),
         "conductor": "implementation-worker",
-        "ttl_seconds": grokbot_mcp.LEASE_SECONDS,
+        "ttl_seconds": grokbot_mcp.DEFAULT_LEASE_SECONDS,
         "lease_id": job_id,
         "holder": "lease-a",
     }
@@ -804,7 +804,7 @@ def test_claim_releases_an_admitted_hub_lease_when_the_local_claim_fails(tmp_pat
 def test_renew_reconciles_a_legacy_running_job_and_normal_renewals_refresh_the_hub(tmp_path: Path, monkeypatch):
     job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
     adapter = _adapter(tmp_path)
-    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.LEASE_SECONDS)
+    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.DEFAULT_LEASE_SECONDS)
     grokbot_jobs.transition(tmp_path, job_id, adapter.config.bot_id, "lease-a", "running")
     calls: list[tuple[str, dict[str, object]]] = []
 
@@ -828,7 +828,7 @@ def test_renew_reconciles_a_legacy_running_job_and_normal_renewals_refresh_the_h
 
     assert renewed["state"] == "running"
     assert [name for name, _ in calls] == ["renew", "admit", "bind"]
-    assert calls[0][1] == {"lease_id": job_id, "ttl_seconds": grokbot_mcp.LEASE_SECONDS, "holder": "lease-a"}
+    assert calls[0][1] == {"lease_id": job_id, "ttl_seconds": grokbot_mcp.DEFAULT_LEASE_SECONDS, "holder": "lease-a"}
     assert calls[-1][1] == {"lease_id": job_id, "provider_task_id": job_id, "holder": "lease-a"}
 
     calls.clear()
@@ -846,7 +846,7 @@ def test_renew_reconciles_a_legacy_running_job_and_normal_renewals_refresh_the_h
 def test_start_reconciles_a_missing_hub_lease_without_rolling_back_the_local_transition(tmp_path: Path, monkeypatch):
     job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
     adapter = _adapter(tmp_path)
-    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.LEASE_SECONDS)
+    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.DEFAULT_LEASE_SECONDS)
     calls: list[str] = []
     monkeypatch.setattr(
         fleet_client,
@@ -896,7 +896,7 @@ def test_terminal_worker_transitions_release_hub_leases(
 ):
     job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
     adapter = _adapter(tmp_path)
-    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.LEASE_SECONDS)
+    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.DEFAULT_LEASE_SECONDS)
     if prepare == "running":
         grokbot_jobs.transition(tmp_path, job_id, adapter.config.bot_id, "lease-a", "running")
     elif prepare == "cancel":
@@ -921,7 +921,7 @@ def test_hub_mirror_failures_do_not_undo_a_local_terminal_transition_or_leak_pri
 ):
     job_id = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "implementation-job")["job_id"]
     adapter = _adapter(tmp_path)
-    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.LEASE_SECONDS)
+    grokbot_jobs.claim(tmp_path, job_id, adapter.config.bot_id, "lease-a", grokbot_mcp.DEFAULT_LEASE_SECONDS)
     monkeypatch.setattr(
         fleet_client,
         "release_cloud",
@@ -1713,7 +1713,7 @@ def test_mismatched_hub_actor_credential_refuses_listener_service(tmp_path: Path
 def _queued_and_failed_worker_jobs(tmp_path: Path) -> tuple[str, str]:
     queued = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "queued-job")["job_id"]
     failed = grokbot_jobs.enqueue(tmp_path, _spec("implementation-worker"), "failed-job")["job_id"]
-    grokbot_jobs.claim(tmp_path, failed, "grokbot-implementation-worker", "lease-a", grokbot_mcp.LEASE_SECONDS)
+    grokbot_jobs.claim(tmp_path, failed, "grokbot-implementation-worker", "lease-a", grokbot_mcp.DEFAULT_LEASE_SECONDS)
     grokbot_jobs.transition(tmp_path, failed, "grokbot-implementation-worker", "lease-a", "failed")
     return queued, failed
 
@@ -1856,9 +1856,10 @@ def test_registered_tool_signatures_advertise_exactly_the_accepted_arguments(tmp
     assert all(parameter.default is None for parameter in listing.parameters.values())
 
     claim = inspect.signature(grokbot_mcp._tool_handler(worker, "grokbot_queue_claim"))
-    assert list(claim.parameters) == ["job_id", "lease_id"]
+    assert list(claim.parameters) == ["job_id", "lease_id", "lease_seconds"]
     assert claim.parameters["job_id"].default is inspect.Parameter.empty
     assert claim.parameters["lease_id"].default is None
+    assert claim.parameters["lease_seconds"].default is None
 
 
 def test_one_bounded_journal_line_per_tool_call_never_holds_an_argument_value(tmp_path: Path, caplog):
@@ -1952,7 +1953,7 @@ def test_advertised_input_schema_and_served_gate_accept_the_documented_list_filt
     tools = {tool["name"]: tool for tool in listing.json()["result"]["tools"]}
     assert set(tools["grokbot_queue_list"]["inputSchema"]["properties"]) == {"state", "include_all", "limit", "role"}
     assert set(tools["grokbot_queue_claim"]["inputSchema"].get("required", [])) == {"job_id"}
-    assert set(tools["grokbot_queue_claim"]["inputSchema"]["properties"]) == {"job_id", "lease_id"}
+    assert set(tools["grokbot_queue_claim"]["inputSchema"]["properties"]) == {"job_id", "lease_id", "lease_seconds"}
 
 
 def _raw_tool_call(name: str, arguments: object) -> bytes:
@@ -2077,3 +2078,150 @@ def test_journal_lines_do_not_propagate_to_ancestor_handlers(capsys):
     assert previous_propagate is not None
     assert sink.getvalue() == ""
     assert captured.count("tool=grokbot_queue_list") == 1
+
+
+def _long_spec(role: str = "implementation-worker") -> dict[str, object]:
+    """A job whose own deadline is wide enough not to clamp the lease under test."""
+    return {**_spec(role), "timeout_seconds": 3600}
+
+
+def _expire_lease(target: Path, job_id: str) -> None:
+    """Rewind one claimed job's lease deadline to the instant it was claimed."""
+    path = target / ".brigade" / "cloud" / "grokbot" / "jobs" / f"{job_id}.json"
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record["lease_expires_at"] = record["claimed_at"]
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+
+def test_listener_lease_defaults_to_fifteen_minutes_and_is_a_per_instance_setting(tmp_path: Path, monkeypatch):
+    assert grokbot_mcp.DEFAULT_LEASE_SECONDS == 900
+    assert grokbot_mcp.MIN_LEASE_SECONDS <= 900 <= grokbot_mcp.MAX_LEASE_SECONDS
+    assert _adapter(tmp_path).config.lease_seconds == 900
+
+    monkeypatch.delenv("BRIGADE_GROKBOT_LEASE_SECONDS", raising=False)
+    monkeypatch.setenv("BRIGADE_GROKBOT_IMPLEMENTATION_WORKER_LEASE_SECONDS", "1200")
+    monkeypatch.setenv("BRIGADE_GROKBOT_REPOSITORY_SCOUT_LEASE_SECONDS", "600")
+    assert grokbot_mcp.load_lease_seconds(instance="implementation-worker") == 1200
+    assert grokbot_mcp.load_lease_seconds(instance="repository-scout") == 600
+    assert grokbot_mcp.load_lease_seconds(instance="operator") == 900
+
+    monkeypatch.setenv("BRIGADE_GROKBOT_LEASE_SECONDS", "1500")
+    assert grokbot_mcp.load_lease_seconds(instance="operator") == 1500
+    monkeypatch.setenv("BRIGADE_GROKBOT_LEASE_SECONDS", "5")
+    with pytest.raises(grokbot_mcp.ConfigurationError):
+        grokbot_mcp.load_lease_seconds(instance="operator")
+    monkeypatch.setenv("BRIGADE_GROKBOT_LEASE_SECONDS", "not-a-number")
+    with pytest.raises(grokbot_mcp.ConfigurationError):
+        grokbot_mcp.load_lease_seconds(instance="operator")
+
+
+def test_out_of_bound_listener_lease_is_refused_by_configuration(tmp_path: Path):
+    for seconds in (grokbot_mcp.MIN_LEASE_SECONDS - 1, grokbot_mcp.MAX_LEASE_SECONDS + 1, True, 900.0):
+        config = grokbot_mcp.ListenerConfig(
+            target=tmp_path,
+            instance="implementation-worker",
+            bind_host="127.0.0.1",
+            bind_port=8766,
+            allowed_hosts=(),
+            allowed_origins=(),
+            bearer="not-a-real-token",
+            lease_seconds=seconds,  # type: ignore[arg-type]
+        )
+        with pytest.raises(grokbot_mcp.ConfigurationError):
+            config.validate()
+
+
+def test_claim_grants_the_configured_lease_and_returns_its_deadline(tmp_path: Path):
+    job_id = grokbot_jobs.enqueue(tmp_path, _long_spec(), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+
+    claimed = adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-default"})
+
+    assert claimed["lease_seconds"] == grokbot_mcp.DEFAULT_LEASE_SECONDS
+    granted = datetime.fromisoformat(claimed["lease_expires_at"].replace("Z", "+00:00"))
+    assert timedelta(seconds=870) <= granted - datetime.now(timezone.utc) <= timedelta(seconds=900)
+
+
+def test_claim_accepts_a_requested_lease_within_the_bound(tmp_path: Path):
+    job_id = grokbot_jobs.enqueue(tmp_path, _long_spec(), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+
+    claimed = adapter.call_tool(
+        "grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-long", "lease_seconds": 1800}
+    )
+
+    assert claimed["lease_seconds"] == 1800
+    granted = datetime.fromisoformat(claimed["lease_expires_at"].replace("Z", "+00:00"))
+    assert timedelta(seconds=1770) <= granted - datetime.now(timezone.utc) <= timedelta(seconds=1800)
+
+
+@pytest.mark.parametrize("requested", [10, 7200, True, "900", 900.0])
+def test_claim_refuses_a_requested_lease_outside_the_bound(tmp_path: Path, requested: object):
+    job_id = grokbot_jobs.enqueue(tmp_path, _long_spec(), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+
+    with pytest.raises(grokbot_mcp.AdapterError) as refusal:
+        adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_seconds": requested})
+
+    assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "queued"
+    if isinstance(requested, int) and not isinstance(requested, bool):
+        assert refusal.value.reason == (
+            f"lease_seconds must be an integer between {grokbot_mcp.MIN_LEASE_SECONDS} "
+            f"and {grokbot_mcp.MAX_LEASE_SECONDS}"
+        )
+
+
+def test_claim_advertises_the_optional_lease_seconds_argument(tmp_path: Path):
+    required, optional = grokbot_mcp._TOOL_ARGUMENT_TYPES["grokbot_queue_claim"]
+
+    assert "lease_seconds" not in required
+    assert optional["lease_seconds"] is int
+    assert grokbot_mcp._valid_tool_arguments("grokbot_queue_claim", {"job_id": "grokbot-a", "lease_seconds": 900})
+    assert grokbot_mcp._valid_tool_arguments("grokbot_queue_claim", {"job_id": "grokbot-a", "lease_seconds": None})
+    assert not grokbot_mcp._valid_tool_arguments("grokbot_queue_claim", {"job_id": "grokbot-a", "lease_seconds": "900"})
+
+
+def test_renew_and_fail_after_expiry_answer_lease_expired(tmp_path: Path):
+    for tool in ("grokbot_queue_renew", "grokbot_queue_fail"):
+        job_id = grokbot_jobs.enqueue(tmp_path, _long_spec(), f"implementation-job-{tool}")["job_id"]
+        adapter = _adapter(tmp_path)
+        adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-lapsed"})
+        _expire_lease(tmp_path, job_id)
+
+        with pytest.raises(grokbot_mcp.AdapterError) as refusal:
+            adapter.call_tool(tool, {"job_id": job_id, "lease_id": "lease-lapsed"})
+
+        assert refusal.value.reason == "lease-expired"
+        assert refusal.value.public_error()["error"]["message"] == "lease-expired"
+        assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "claimed"
+
+
+def test_a_live_lease_conflict_is_still_not_reported_as_expiry(tmp_path: Path):
+    job_id = grokbot_jobs.enqueue(tmp_path, _long_spec(), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+    adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-held"})
+
+    with pytest.raises(grokbot_mcp.AdapterError) as refusal:
+        adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": "lease-other"})
+
+    assert refusal.value.reason is None
+
+
+def test_claim_and_renew_journal_the_lease_deadline(tmp_path: Path, caplog):
+    import logging
+
+    job_id = grokbot_jobs.enqueue(tmp_path, _long_spec(), "implementation-job")["job_id"]
+    adapter = _adapter(tmp_path)
+
+    with caplog.at_level(logging.INFO, logger="brigade.grokbot_mcp"):
+        claimed = adapter.call_tool("grokbot_queue_claim", {"job_id": job_id, "lease_id": "lease-journal"})
+        renewed = adapter.call_tool("grokbot_queue_renew", {"job_id": job_id, "lease_id": "lease-journal"})
+
+    lines = [record.getMessage() for record in caplog.records if record.name == "brigade.grokbot_mcp"]
+    lease_lines = [line for line in lines if " lease_seconds=" in line]
+    assert lease_lines == [
+        f"grokbot tool=grokbot_queue_claim lease_seconds=900 deadline={claimed['lease_expires_at']}",
+        f"grokbot tool=grokbot_queue_renew lease_seconds=900 deadline={renewed['lease_expires_at']}",
+    ]
+    assert job_id not in "\n".join(lease_lines)
+    assert "lease-journal" not in "\n".join(lease_lines)


### PR DESCRIPTION
Fixes #1383

The listener granted a fixed 300s lease on claim, renew, and the fleet claim,
shorter than one cloud-agent step, and a renew or fail after expiry came back
as invalid-request, which the Bot read as a broken adapter. The lease length is
now a per-instance listener setting (default 900s, bounded by the validator),
claim accepts an optional requested lease within the bound and returns the
granted value and deadline, a renew or fail after expiry returns the bounded
reason lease-expired, and every claim and renew logs its deadline.

Receipts: 20260902-033204-work-verify-ca52f8 (grokbot mcp and jobs tests),
20260902-033220-work-verify-034fdb (mypy).