### PR TITLE
feat(grokbot): wake a webhook routine after enqueue

### DIFF
--- a/docs/grokbot-mcp.md
+++ b/docs/grokbot-mcp.md
@@ -168,7 +168,7 @@ brigade run cloud grokbot feed --target . --manifest /path/to/approved-feed.json
 brigade run cloud grokbot feed --target . --manifest /path/to/approved-feed.json --apply --limit 1
 ```
 
-The first command validates only and writes no queue state. `--apply` is required to enqueue. `--limit` bounds newly created jobs from 1 through 10 and defaults to 1. Known idempotency records do not consume the limit. The feed stops on the first invalid entry and performs no enqueue when validation fails. Output is counts and safe job projections only.
+The first command validates only and writes no queue state. `--apply` is required to enqueue. `--limit` bounds newly created jobs from 1 through 10 and defaults to 1. Known idempotency records do not consume the limit. The feed stops on the first invalid entry and performs no enqueue when validation fails. Output is counts and safe job projections only. After each newly created job, `--apply` optionally POSTs `{job_id, role, label, repository}` to the webhook named in `.brigade/cloud/grokbot/wake.json`. See [Builder wake](grokbot-operating-guide.md#builder-wake).
 
 The command does not schedule itself. systemd, cron, OpenClaw, or another operator may run an approved manifest later. Repeated runs are safe through the existing idempotency store.
 
@@ -198,16 +198,18 @@ brigade run cloud grokbot scout-feed --target . --policy /etc/brigade/grokbot-sc
 brigade run cloud grokbot scout-feed --target . --policy /etc/brigade/grokbot-scout-feed.json --apply
 ```
 
-The first command is preview-only. `--apply` may create at most one job per invocation. `daily_limit` includes every Repository Scout job created that UTC day, including failed and expired attempts. The adapter cannot infer the remaining Grok Bot quota percentage.
+The first command is preview-only. `--apply` may create at most one job per invocation. `daily_limit` includes every Repository Scout job created that UTC day, including failed and expired attempts. The adapter cannot infer the remaining Grok Bot quota percentage. A newly created job optionally wakes the scout routine through the private wake webhook; see [Builder wake](grokbot-operating-guide.md#builder-wake).
 
 An issue counts as known only while the queue still holds a job for it. Apply is the check that counts: it re-lists at the hub under hub authority, and reads the local queue under local authority, then confirms the job named by the local idempotency record or task snapshot against that listing. A job the granted listing omits, and a job the queue reports as `expired`, `failed`, or `canceled`, are both weaker than the local record that named them, so the issue stays selectable. A `completed` job keeps its issue known until the approval label is removed. Each retry moves to a fresh idempotency key, so the queue's own idempotency cannot answer a retry with the dead job it replaced; the retry still counts against `daily_limit` for that UTC day. Retries stop after ten revisions for one issue; an issue that has burnt all ten is reported as `retry-exhausted`, not as known.
 
 Preview reads the local queue only, so under hub authority it holds no listing and cannot see live jobs. It reports evidence it cannot confirm as not yet known, so it never answers `all-known` for a job it cannot see. It may still report `ready` for an issue that already has a live or completed hub job, which apply then refuses; apply is what settles that. Both results carry `known`, `terminal_retry_candidates`, and `retry_exhausted` counts over the approved open issues, in the text output as well as `--json`. `all-known` means every one of them has a job the queue still stands behind. `retry-exhausted` means no issue is selectable and at least one has used all ten revisions without landing such a job.
 
-An operator may run the apply command hourly with systemd. Replace the executable and policy paths with the local approved locations:
+Wake the scout routine from the enqueue POST when `wake.json` is present. A
+60-minute drain remains useful as a fallback if a POST failed. Replace the
+executable and policy paths with the local approved locations:
 
 ```bash
-systemd-run --user --on-calendar=hourly --unit=brigade-grokbot-scout-feed --collect /usr/local/bin/brigade run cloud grokbot scout-feed --target /srv/brigade --policy /etc/brigade/grokbot-scout-feed.json --apply
+systemd-run --user --on-calendar='*:0/60' --unit=brigade-grokbot-scout-feed --collect /usr/local/bin/brigade run cloud grokbot scout-feed --target /srv/brigade --policy /etc/brigade/grokbot-scout-feed.json --apply
 ```
 
 ## Approved build selector
@@ -245,7 +247,9 @@ brigade run cloud grokbot build-feed --target . --policy /etc/brigade/grokbot-bu
 ```
 
 The first command is preview-only. `--apply` may create at most one job per
-invocation. `daily_limit` includes every implementation-worker job created that
+invocation. A newly created job optionally wakes the builder routine through
+the private wake webhook; see [Builder wake](grokbot-operating-guide.md#builder-wake).
+`daily_limit` includes every implementation-worker job created that
 UTC day, including failed and expired attempts. Apply is the check that counts:
 it recounts under the queue lock on a local-authority target and re-lists at the
 hub under hub authority, at enqueue time, and it also refuses while an earlier
@@ -266,11 +270,12 @@ job. Set `require_scout_report` to `true` to hold every issue that has no such
 report; the selector then reports `scout-report-missing` instead of queueing
 blind work.
 
-An operator may run the apply command hourly with systemd. Replace the
+Wake the builder routine from the enqueue POST when `wake.json` is present. A
+60-minute drain remains useful as a fallback if a POST failed. Replace the
 executable and policy paths with the local approved locations:
 
 ```bash
-systemd-run --user --on-calendar=hourly --unit=brigade-grokbot-build-feed --collect /usr/local/bin/brigade run cloud grokbot build-feed --target /srv/brigade --policy /etc/brigade/grokbot-build-feed.json --apply
+systemd-run --user --on-calendar='*:0/60' --unit=brigade-grokbot-build-feed --collect /usr/local/bin/brigade run cloud grokbot build-feed --target /srv/brigade --policy /etc/brigade/grokbot-build-feed.json --apply
 ```
 
 ## Report reconciliation

--- a/docs/grokbot-operating-guide.md
+++ b/docs/grokbot-operating-guide.md
@@ -121,6 +121,45 @@ the report instead of re-reading the repository from scratch. Setting
 `require_scout_report` to `true` in the build policy makes that ordering
 mandatory.
 
+### Builder wake
+
+A 15-minute poll is the fallback, not the primary path. After a successful
+`--apply` enqueue, `feed`, `scout-feed`, and `build-feed` optionally POST a
+bounded wake body so a webhook-triggered Grok Bot routine can claim the new
+job immediately.
+
+Store the webhook URL and a sender-key *file path* (never the key itself) in
+an owner-only file at `.brigade/cloud/grokbot/wake.json`:
+
+```json
+{
+  "schema": "brigade.grokbot.wake.v1",
+  "webhook_url": "https://api2.cursor.sh/automations/webhook/",
+  "sender_key_file": "/etc/brigade/grokbot-wake.key"
+}
+```
+
+```bash
+chmod 600 /etc/brigade/grokbot-wake.key
+chmod 600 /path/to/target/.brigade/cloud/grokbot/wake.json
+```
+
+The sender key is read from that 0600 file at POST time and sent as both
+`Authorization: Bearer <key>` and `X-Automation-Key: <key>`. It never enters
+queue state, receipts, the notify log, stdout, or stderr. The POST body is
+exactly `{job_id, role, label, repository}`: no instructions, no verification
+commands, and no paths. Treat those four fields as untrusted context, then
+run the claim skill for that role. The request uses the standard library,
+waits at most eight seconds, and is not retried. HTTP 200 means the routine
+woke. Any other status, a timeout, or a missing/invalid config leaves the
+enqueue result unchanged. The local notify log
+`.brigade/cloud/grokbot/wake-notify.jsonl` records the HTTP status code only
+(`0` when no status arrived).
+
+A 60-minute drain remains useful as a safety net: if a POST failed, the
+routine can still list the queue and claim anything that was missed. Do not
+rely on a short poll as the primary wake.
+
 ### Leases
 
 A lease runs from 30 seconds to 3600 seconds and defaults to 300 seconds. The

--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -170,14 +170,22 @@ def add_cloud_subcommands(parser: argparse.ArgumentParser) -> None:
     add_target(p_feed)
     p_feed.add_argument("--manifest", type=Path, required=True, help="Path to the approved private feed manifest.")
     p_feed.add_argument("--limit", type=int, default=1, help="Maximum newly created jobs (1-10). Defaults to 1.")
-    p_feed.add_argument("--apply", action="store_true", help="Enqueue after validation. Default is validate only.")
+    p_feed.add_argument(
+        "--apply",
+        action="store_true",
+        help="Enqueue after validation. Default is validate only. A private wake webhook is notified after each new job.",
+    )
 
     p_scout_feed = grokbot_sub.add_parser(
         "scout-feed", help="Select one approved GitHub issue for Grok Bot Repository Scout."
     )
     add_target(p_scout_feed)
     p_scout_feed.add_argument("--policy", type=Path, required=True, help="Path to the approved private scout policy.")
-    p_scout_feed.add_argument("--apply", action="store_true", help="Enqueue after selection. Default is preview only.")
+    p_scout_feed.add_argument(
+        "--apply",
+        action="store_true",
+        help="Enqueue after selection. Default is preview only. A private wake webhook is notified after a new job.",
+    )
 
     from . import run_cloud_build_feed
 

--- a/src/brigade/grokbot_build_feed.py
+++ b/src/brigade/grokbot_build_feed.py
@@ -102,9 +102,10 @@ def apply(target: Path, policy_path: Path, *, now: datetime | None = None) -> di
         assert isinstance(issue_number, int)
         assert isinstance(repository, str)
         assert isinstance(daily_limit, int)
+        spec = _worker_spec(policy, issue_number, selection["scout_report"])
         admission = grokbot_jobs.enqueue_implementation_worker(
             target,
-            _worker_spec(policy, issue_number, selection["scout_report"]),
+            spec,
             _build_key(repository, issue_number),
             daily_limit=daily_limit,
             now=instant,
@@ -121,7 +122,19 @@ def apply(target: Path, policy_path: Path, *, now: datetime | None = None) -> di
             "scout_report": None,
             "handle": admission["handle"],
         }
-    return {**selection, "created": 1, "reason": "created", "handle": admission["handle"]}
+    handle = admission["handle"]
+    assert isinstance(handle, dict)
+    role = spec["role"]
+    label = spec["label"]
+    repository = spec["repository"]
+    job_id = handle["job_id"]
+    assert isinstance(job_id, str)
+    assert isinstance(role, str) and isinstance(label, str) and isinstance(repository, str)
+    grokbot_feed.notify_enqueue(
+        target,
+        {"job_id": job_id, "role": role, "label": label, "repository": repository},
+    )
+    return {**selection, "created": 1, "reason": "created", "handle": handle}
 
 
 def load_policy(path: Path) -> dict[str, object]:

--- a/src/brigade/grokbot_feed.py
+++ b/src/brigade/grokbot_feed.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import stat
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from . import grokbot_jobs
 
@@ -22,6 +26,15 @@ MIN_LIMIT = 1
 MAX_LIMIT = 10
 DEFAULT_LIMIT = 1
 LABEL_MAXIMUM = 160
+WAKE_SCHEMA = "brigade.grokbot.wake.v1"
+WAKE_CONFIG_NAME = "wake.json"
+WAKE_LOG_NAME = "wake-notify.jsonl"
+WAKE_REQUIRED_KEYS = frozenset({"schema", "webhook_url", "sender_key_file"})
+WAKE_BODY_KEYS = ("job_id", "role", "label", "repository")
+WAKE_TIMEOUT_SECONDS = 8
+WAKE_URL_MAXIMUM = 2048
+WAKE_KEY_MAXIMUM = 4096
+WAKE_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
 
 class FeedError(ValueError):
@@ -70,6 +83,15 @@ def apply(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[str,
             skipped += 1
         else:
             created += 1
+            notify_enqueue(
+                target,
+                {
+                    "job_id": handle["job_id"],
+                    "role": spec["role"],
+                    "label": spec["label"],
+                    "repository": spec["repository"],
+                },
+            )
     return {
         "valid": preview["valid"],
         "known": preview["known"],
@@ -224,3 +246,197 @@ def _existing_idempotency(target: Path, key: str) -> dict[str, Any] | None:
                 os.close(descriptor)
             except OSError as exc:
                 raise FeedError("unsafe-storage") from exc
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects so the sender key cannot follow a Location header."""
+
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def wake_config_path(target: Path) -> Path:
+    return Path(target).expanduser() / ".brigade" / "cloud" / "grokbot" / WAKE_CONFIG_NAME
+
+
+def wake_notify_log_path(target: Path) -> Path:
+    return Path(target).expanduser() / ".brigade" / "cloud" / "grokbot" / WAKE_LOG_NAME
+
+
+def notify_enqueue(target: Path, job: dict[str, Any]) -> None:
+    """Best-effort wake POST after a newly created enqueue. Never raises."""
+    try:
+        config = _load_wake_config(target)
+        if config is None:
+            return
+        key = _read_wake_sender_key(Path(config["sender_key_file"]))
+        status = _post_wake(config["webhook_url"], key, _wake_body(job))
+        _append_wake_status(target, status)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except Exception:
+        return
+
+
+def _wake_body(job: dict[str, Any]) -> dict[str, str]:
+    body = {key: job[key] for key in WAKE_BODY_KEYS}
+    if any(not isinstance(value, str) or not value or "\x00" in value for value in body.values()):
+        raise FeedError("invalid-wake-body")
+    return body
+
+
+def _load_wake_config(target: Path) -> dict[str, str] | None:
+    path = wake_config_path(target)
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        return None
+    if stat.S_IMODE(info.st_mode) != 0o600:
+        return None
+    owner_uid = getattr(os, "getuid", None)
+    if owner_uid is not None and info.st_uid != owner_uid():
+        return None
+    try:
+        payload = json.loads(_read_owner_regular_file(path, maximum=4096))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, FeedError):
+        return None
+    if not isinstance(payload, dict) or set(payload) != WAKE_REQUIRED_KEYS:
+        return None
+    if payload.get("schema") != WAKE_SCHEMA:
+        return None
+    url = payload.get("webhook_url")
+    key_file = payload.get("sender_key_file")
+    if not isinstance(url, str) or not _valid_wake_url(url):
+        return None
+    if not isinstance(key_file, str) or not key_file:
+        return None
+    expanded = Path(key_file).expanduser()
+    if not expanded.is_absolute():
+        return None
+    return {"schema": WAKE_SCHEMA, "webhook_url": url, "sender_key_file": str(expanded)}
+
+
+def _valid_wake_url(value: object) -> bool:
+    if not isinstance(value, str) or not value or len(value) > WAKE_URL_MAXIMUM or "\x00" in value:
+        return False
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or parsed.username is not None or parsed.password is not None:
+        return False
+    host = (parsed.hostname or "").casefold()
+    if not host:
+        return False
+    if parsed.scheme == "http" and host not in WAKE_LOOPBACK_HOSTS:
+        return False
+    return True
+
+
+def _read_wake_sender_key(path: Path) -> str:
+    data = _read_owner_regular_file(path, maximum=WAKE_KEY_MAXIMUM, require_mode=0o600)
+    text = data.decode("utf-8").rstrip("\r\n")
+    if not text or len(text) > WAKE_KEY_MAXIMUM or "\x00" in text or not text.isascii():
+        raise FeedError("unsafe-wake-key")
+    return text
+
+
+def _read_owner_regular_file(path: Path, *, maximum: int, require_mode: int | None = 0o600) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    else:
+        info = Path(path).lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise FeedError("unsafe-wake-config")
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(os.fspath(path), flags)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise FeedError("unsafe-wake-config")
+        owner_uid = getattr(os, "getuid", None)
+        if owner_uid is not None and info.st_uid != owner_uid():
+            raise FeedError("unsafe-wake-config")
+        if require_mode is not None and stat.S_IMODE(info.st_mode) != require_mode:
+            raise FeedError("unsafe-wake-config")
+        if info.st_size > maximum:
+            raise FeedError("unsafe-wake-config")
+        chunks: list[bytes] = []
+        remaining = maximum + 1
+        while remaining:
+            chunk = os.read(descriptor, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > maximum:
+            raise FeedError("unsafe-wake-config")
+        return data
+    except FeedError:
+        raise
+    except OSError as exc:
+        raise FeedError("unsafe-wake-config") from exc
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                raise FeedError("unsafe-wake-config") from exc
+
+
+def _post_wake(url: str, key: str, body: dict[str, str]) -> int:
+    data = json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method="POST")
+    request.add_header("Content-Type", "application/json")
+    request.add_header("Authorization", f"Bearer {key}")
+    request.add_header("X-Automation-Key", key)
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect())
+    try:
+        with opener.open(request, timeout=WAKE_TIMEOUT_SECONDS) as response:
+            return int(response.status)
+    except urllib.error.HTTPError as exc:
+        return int(exc.code)
+    except TimeoutError:
+        return 0
+    except urllib.error.URLError as exc:
+        reason = exc.reason
+        if isinstance(reason, TimeoutError) or isinstance(reason, socket.timeout):
+            return 0
+        message = str(reason).casefold() if reason is not None else ""
+        if "timed out" in message or "timeout" in message:
+            return 0
+        return 0
+    except (socket.timeout, OSError, ValueError):
+        return 0
+
+
+def _append_wake_status(target: Path, status: int) -> None:
+    path = wake_notify_log_path(target)
+    line = (json.dumps({"status": status}, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    descriptor: int | None = None
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        descriptor = os.open(os.fspath(path), flags, grokbot_jobs.FILE_MODE)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            return
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, grokbot_jobs.FILE_MODE)
+        os.write(descriptor, line)
+        os.fsync(descriptor)
+    except OSError:
+        return
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                return

--- a/src/brigade/grokbot_scout_feed.py
+++ b/src/brigade/grokbot_scout_feed.py
@@ -91,9 +91,10 @@ def apply(target: Path, policy_path: Path, *, now: datetime | None = None) -> di
         assert isinstance(issue_number, int)
         assert isinstance(key, str)
         assert isinstance(daily_limit, int)
+        spec = _scout_spec(policy, issue_number)
         admission = grokbot_jobs.enqueue_repository_scout(
             target,
-            _scout_spec(policy, issue_number),
+            spec,
             key,
             daily_limit=daily_limit,
             now=instant,
@@ -109,7 +110,19 @@ def apply(target: Path, policy_path: Path, *, now: datetime | None = None) -> di
             "created_today": admission["created_today"],
             "handle": admission["handle"],
         }
-    return {**selection, "created": 1, "reason": "created", "handle": admission["handle"]}
+    handle = admission["handle"]
+    assert isinstance(handle, dict)
+    role = spec["role"]
+    label = spec["label"]
+    repository = spec["repository"]
+    job_id = handle["job_id"]
+    assert isinstance(job_id, str)
+    assert isinstance(role, str) and isinstance(label, str) and isinstance(repository, str)
+    grokbot_feed.notify_enqueue(
+        target,
+        {"job_id": job_id, "role": role, "label": label, "repository": repository},
+    )
+    return {**selection, "created": 1, "reason": "created", "handle": handle}
 
 
 def load_policy(path: Path) -> dict[str, object]:

--- a/tests/test_grokbot_build_feed.py
+++ b/tests/test_grokbot_build_feed.py
@@ -11,7 +11,16 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, fleet_client_grokbot, grokbot_build_feed, grokbot_jobs, grokbot_scout_feed
+from brigade import cli, fleet_client_grokbot, grokbot_build_feed, grokbot_feed, grokbot_jobs, grokbot_scout_feed
+from tests.test_grokbot_feed import (
+    SECRET_WAKE_KEY,
+    _WakeRecorder,
+    _assert_wake_secret_absent,
+    _notify_log_text,
+    _start_wake_server,
+    _write_wake_config,
+    _write_wake_key,
+)
 
 
 NOW = datetime(2026, 8, 31, 12, 0, tzinfo=timezone.utc)
@@ -1295,3 +1304,98 @@ def test_the_non_posix_queue_walk_reports_a_missing_component_as_absent(
     _force_non_posix(monkeypatch)
 
     assert grokbot_build_feed._snapshot_job_id(tmp_path, key) == derived
+
+
+def test_build_apply_wake_notify_posts_bounded_body_on_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_build_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        assert result["reason"] == "created"
+        assert len(recorder.requests) == 1
+        request = recorder.requests[0]
+        assert request["authorization"] == f"Bearer {SECRET_WAKE_KEY}"
+        assert request["automation_key"] == SECRET_WAKE_KEY
+        body = json.loads(request["body"])
+        handle = result["handle"]
+        assert isinstance(handle, dict)
+        assert body == {
+            "job_id": handle["job_id"],
+            "label": "Implementation Worker",
+            "repository": "example/brigade",
+            "role": "implementation-worker",
+        }
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 200}
+        _assert_wake_secret_absent(result, log)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_build_apply_wake_notify_non_200_does_not_fail_enqueue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    recorder.status = 404
+    server = _start_wake_server(recorder)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_build_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        handle = result["handle"]
+        assert isinstance(handle, dict)
+        assert handle["state"] == "queued"
+        assert json.loads(_notify_log_text(tmp_path).strip()) == {"status": 404}
+        _assert_wake_secret_absent(result, _notify_log_text(tmp_path))
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_build_apply_wake_notify_timeout_does_not_fail_enqueue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    recorder.delay = 1.0
+    server = _start_wake_server(recorder)
+    try:
+        monkeypatch.setattr(grokbot_feed, "WAKE_TIMEOUT_SECONDS", 0.2)
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_build_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        assert json.loads(_notify_log_text(tmp_path).strip()) == {"status": 0}
+        _assert_wake_secret_absent(result, _notify_log_text(tmp_path))
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_build_apply_wake_notify_missing_config_skips_post(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_build_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        assert recorder.requests == []
+        assert not grokbot_feed.wake_notify_log_path(tmp_path).exists()
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -14,6 +17,7 @@ from brigade import cli, fleet_client_grokbot, fleet_hub, fleet_hub_grokbot, gro
 SECRET_INSTRUCTIONS = "SECRET_INSTRUCTION_DO_NOT_PRINT"
 SECRET_VERIFY = "SECRET_VERIFY_CMD"
 SECRET_OWNERSHIP = "SECRET_OWNERSHIP_PATH/file.py"
+SECRET_WAKE_KEY = "SECRET_WAKE_SENDER_KEY_DO_NOT_PRINT"
 
 
 def _spec(*, label: str = "Approved worker task") -> dict[str, object]:
@@ -652,3 +656,190 @@ def test_cli_feed_rejects_invalid_limit(tmp_path: Path, capsys):
     assert captured.out == ""
     assert captured.err.strip() == "error: invalid-limit"
     assert not _queue_root(tmp_path).exists()
+
+
+class _WakeRecorder:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+        self.status = 200
+        self.delay = 0.0
+
+
+def _start_wake_server(recorder: _WakeRecorder) -> ThreadingHTTPServer:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            if recorder.delay:
+                time.sleep(recorder.delay)
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length)
+            recorder.requests.append(
+                {
+                    "path": self.path,
+                    "authorization": self.headers.get("Authorization"),
+                    "automation_key": self.headers.get("X-Automation-Key"),
+                    "content_type": self.headers.get("Content-Type"),
+                    "body": body,
+                }
+            )
+            self.send_response(recorder.status)
+            self.end_headers()
+
+        def log_message(self, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def _write_wake_key(path: Path, value: str = SECRET_WAKE_KEY) -> Path:
+    path.write_text(value, encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def _write_wake_config(target: Path, url: str, key_file: Path) -> Path:
+    root = _queue_root(target)
+    root.mkdir(parents=True, exist_ok=True)
+    path = grokbot_feed.wake_config_path(target)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": grokbot_feed.WAKE_SCHEMA,
+                "webhook_url": url,
+                "sender_key_file": str(key_file),
+            }
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return path
+
+
+def _notify_log_text(target: Path) -> str:
+    path = grokbot_feed.wake_notify_log_path(target)
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _assert_wake_secret_absent(*payloads: object) -> None:
+    for payload in payloads:
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        assert SECRET_WAKE_KEY not in text
+        assert "X-Automation-Key" not in text
+        assert "Authorization" not in text
+
+
+def test_apply_wake_notify_posts_bounded_body_on_success(tmp_path: Path):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(tmp_path, url, key_file)
+        manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a", _spec(label="First"))))
+
+        result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+        assert result["created"] == 1
+        assert len(recorder.requests) == 1
+        request = recorder.requests[0]
+        assert request["authorization"] == f"Bearer {SECRET_WAKE_KEY}"
+        assert request["automation_key"] == SECRET_WAKE_KEY
+        assert request["content_type"] == "application/json"
+        body = json.loads(request["body"])
+        assert body == {
+            "job_id": result["jobs"][0]["job_id"],
+            "label": "First",
+            "repository": "example/brigade",
+            "role": "implementation-worker",
+        }
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 200}
+        _assert_wake_secret_absent(result, log)
+        _assert_redacted(result)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_apply_wake_notify_non_200_does_not_fail_enqueue(tmp_path: Path):
+    recorder = _WakeRecorder()
+    recorder.status = 503
+    server = _start_wake_server(recorder)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+        result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+        assert result["created"] == 1
+        assert result["jobs"][0]["state"] == "queued"
+        assert len(_job_files(tmp_path)) == 1
+        assert len(recorder.requests) == 1
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 503}
+        _assert_wake_secret_absent(result, log)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_apply_wake_notify_timeout_does_not_fail_enqueue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    recorder.delay = 1.0
+    server = _start_wake_server(recorder)
+    try:
+        monkeypatch.setattr(grokbot_feed, "WAKE_TIMEOUT_SECONDS", 0.2)
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+        result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+        assert result["created"] == 1
+        assert result["jobs"][0]["state"] == "queued"
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 0}
+        _assert_wake_secret_absent(result, log)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_apply_wake_notify_missing_config_skips_post(tmp_path: Path):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+        result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+        assert result["created"] == 1
+        assert recorder.requests == []
+        assert _notify_log_text(tmp_path) == ""
+        assert not grokbot_feed.wake_notify_log_path(tmp_path).exists()
+        _assert_redacted(result)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_cli_feed_apply_omits_wake_key_from_output(tmp_path: Path, capsys):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+        assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply") == 0
+        captured = capsys.readouterr()
+        assert "created=1" in captured.out
+        _assert_wake_secret_absent(captured.out, captured.err, _notify_log_text(tmp_path))
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_grokbot_scout_feed.py
+++ b/tests/test_grokbot_scout_feed.py
@@ -1089,9 +1089,7 @@ def test_scout_apply_wake_notify_non_200_does_not_fail_enqueue(tmp_path: Path, m
         server.server_close()
 
 
-def test_scout_apply_wake_notify_timeout_does_not_fail_enqueue(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_scout_apply_wake_notify_timeout_does_not_fail_enqueue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     recorder = _WakeRecorder()
     recorder.delay = 1.0
     server = _start_wake_server(recorder)

--- a/tests/test_grokbot_scout_feed.py
+++ b/tests/test_grokbot_scout_feed.py
@@ -9,7 +9,16 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, fleet_client_grokbot, grokbot_jobs, grokbot_scout_feed
+from brigade import cli, fleet_client_grokbot, grokbot_feed, grokbot_jobs, grokbot_scout_feed
+from tests.test_grokbot_feed import (
+    SECRET_WAKE_KEY,
+    _WakeRecorder,
+    _assert_wake_secret_absent,
+    _notify_log_text,
+    _start_wake_server,
+    _write_wake_config,
+    _write_wake_key,
+)
 
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
@@ -1021,3 +1030,100 @@ def test_cli_scout_feed_redacts_queue_errors(tmp_path: Path, monkeypatch: pytest
     assert captured.out == ""
     assert captured.err == "error: queue-error\n"
     assert "PRIVATE" not in captured.err
+
+
+def test_scout_apply_wake_notify_posts_bounded_body_on_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_scout_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        assert result["reason"] == "created"
+        assert len(recorder.requests) == 1
+        request = recorder.requests[0]
+        assert request["authorization"] == f"Bearer {SECRET_WAKE_KEY}"
+        assert request["automation_key"] == SECRET_WAKE_KEY
+        body = json.loads(request["body"])
+        handle = result["handle"]
+        assert isinstance(handle, dict)
+        assert body == {
+            "job_id": handle["job_id"],
+            "label": "Repository Scout",
+            "repository": "example/brigade",
+            "role": "repository-scout",
+        }
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 200}
+        _assert_wake_secret_absent(result, log)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_scout_apply_wake_notify_non_200_does_not_fail_enqueue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    recorder.status = 500
+    server = _start_wake_server(recorder)
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_scout_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        handle = result["handle"]
+        assert isinstance(handle, dict)
+        assert handle["state"] == "queued"
+        assert json.loads(_notify_log_text(tmp_path).strip()) == {"status": 500}
+        _assert_wake_secret_absent(result, _notify_log_text(tmp_path))
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_scout_apply_wake_notify_timeout_does_not_fail_enqueue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    recorder = _WakeRecorder()
+    recorder.delay = 1.0
+    server = _start_wake_server(recorder)
+    try:
+        monkeypatch.setattr(grokbot_feed, "WAKE_TIMEOUT_SECONDS", 0.2)
+        url = f"http://127.0.0.1:{server.server_address[1]}/wake"
+        _write_wake_config(tmp_path, url, _write_wake_key(tmp_path / "wake.key"))
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_scout_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        assert json.loads(_notify_log_text(tmp_path).strip()) == {"status": 0}
+        _assert_wake_secret_absent(result, _notify_log_text(tmp_path))
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_scout_apply_wake_notify_missing_config_skips_post(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        policy = _write_policy(tmp_path / "policy.json", _policy())
+        _gh_numbers(monkeypatch, [7])
+
+        result = grokbot_scout_feed.apply(tmp_path, policy, now=NOW)
+
+        assert result["created"] == 1
+        assert recorder.requests == []
+        assert not grokbot_feed.wake_notify_log_path(tmp_path).exists()
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1357

After a successful `--apply` enqueue in `feed`, `scout-feed`, and `build-feed`, optionally POST a bounded JSON body `{job_id, role, label, repository}` to a webhook URL from private config. The sender key is read from a 0600 file path (never stored in config, receipts, logs, or output) and sent as both `Authorization: Bearer ` and `X-Automation-Key: `. The stdlib POST uses an 8-second timeout and a single attempt. The local notify log records the HTTP status code only (`0` when no status arrived). A failed POST never fails the enqueue.

This slice is the notify half only. Pack setup and doctor commands are out of scope.

## What and why

The Fleet Hub queue can accumulate jobs that expire unclaimed because nothing wakes a Bot session. A webhook routine can be triggered at the exact moment a job is created. This PR adds that optional post-enqueue notify.

## Type of change

- [x] Docs
- [ ] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change)

## CI lint fix

`ruff format --check` failed on `tests/test_grokbot_scout_feed.py` (one function signature split across three lines). Applied `ruff format` only. No behavior, test, or docs changes beyond formatting.

## Verification

Proof receipt: `20260902-140500-work-verify-6c2ee4` (status: completed / passed)

```bash
brigade work verify run --target . --argv-json '["python","-m","pytest","-q","tests/test_grokbot_feed.py","tests/test_grokbot_build_feed.py","tests/test_grokbot_scout_feed.py"]' --capture brigade-work
```

Envelope commands (all exit 0):

1. `python -m pytest -q tests/test_grokbot_feed.py tests/test_grokbot_build_feed.py tests/test_grokbot_scout_feed.py` — exit 0 — 192 passed in 142.49s
2. `ruff check src/brigade` — exit 0 — All checks passed
3. `ruff format --check src/brigade` — exit 0 — 558 files already formatted
4. `mypy` — exit 0 — Success: no issues found in 558 source files
5. `git diff --check` — exit 0 — no whitespace errors

Proof pytest: 192 passed in 15.53s, command exit 0.

## Checklist

- [x] Focused pytest selectors covering the change (not the full `pytest -q` suite; that is reserved for the full gate)
- [x] Added or updated tests covering success, non-200, timeout, and missing config
- [ ] `CHANGELOG.md` Unreleased section — not updated; `CHANGELOG.md` is outside this slice's ownership paths
- [x] No personal details, live auth profiles, or sender-key values in code, templates, tests, or this PR
- [x] No new runtime dependencies
- [x] Conventional commit messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fd539d0-d247-4095-822a-6551fc6e86c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fd539d0-d247-4095-822a-6551fc6e86c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

