### PR TITLE
fix(fleet): release NULL run_dir claims by path and make the 409 payload transactional

### DIFF
--- a/docs/fleet-sync.md
+++ b/docs/fleet-sync.md
@@ -317,6 +317,17 @@ rejects the configured token with HTTP 401 or 403, the client logs one WARNING
 (carrying the hub's message) and continues under the local lock alone, just as
 it does when the hub is unreachable.
 
+Fleet claims require **machine-local workspaces**. Node identity is a
+per-workspace (or per-home) uuid4 stored in `.brigade/node.toml`, and
+deadness is a local pid check against that workspace's `run.lock`. A
+workspace shared across machines over a network filesystem (NFS, SMB, or
+a bind-mount of the same tree) collapses two machines into one `node_id`
+*and* one `run.lock`: machine B's pid check calls machine A's live owner
+dead because that PID is not local, and a same-node supersede or
+`--release` then fires. Copied `node.toml` files with *separate* local
+workspaces stay distinct (different `lock_token`s); a shared mount does
+not. Keep each machine's checkout on its own disk.
+
 Lost ownership fails closed by default (#1152): when the mid-run heartbeat
 learns another owner holds the claim (a renew answered 409 held-by-another),
 the run is aborted — with no callback the main thread is interrupted through
@@ -500,6 +511,10 @@ Hub-arbitrated repo claims (`POST /claims`, `GET /claims`,
   `--path` it must be the workspace given) and refuses while that
   `run.lock` has a live owner or is malformed, or when it cannot resolve
   the run at all, or when the probe finds no claim owned by this node.
+  When the row records no run directory (`--no-artifacts`, or a claim
+  predating the lease columns), `--path` proves deadness via the
+  pointed-at workspace's own `run.lock` instead of requiring `--force`;
+  a bare key still cannot verify that row.
   The release then carries the inspected row's `acquired_at` — the hub
   refuses a token-less node-scoped delete without it — and deletes only
   that exact row (one write transaction), so a claim re-acquired in

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -278,8 +278,9 @@ def register(sub: argparse._SubParsersAction) -> None:
             "Release the hub claim on TARGET, a claim key as listed by this command (a claim left behind by a "
             "crashed run). Refused unless this node holds it and the run that took it is verifiably dead: the "
             "claim's recorded run directory resolves to a workspace on this machine whose run lock has no live "
-            "owner (with --path, that workspace must be the one given). See --force. With --holder, release "
-            "the exact session that acquired the row instead of the operator recovery path."
+            "owner (with --path, that workspace must be the one given). When the row records no run directory, "
+            "--path proves deadness via the pointed-at workspace's own run.lock. See --force. With --holder, "
+            "release the exact session that acquired the row instead of the operator recovery path."
         ),
     )
     p_claims.add_argument("--harness", default=None, help="Opaque harness label for --acquire or --outcome.")
@@ -303,8 +304,9 @@ def register(sub: argparse._SubParsersAction) -> None:
         action="store_true",
         help=(
             "With --release: TARGET is a workspace directory, not a key; its name is the claim key, its node "
-            "identity is used, and the claim must have been taken by a run in that workspace. The directory "
-            "must be the workspace itself, not a directory inside one."
+            "identity is used, and the claim must have been taken by a run in that workspace when the row "
+            "records a run directory. When the row records none, deadness is proved via this workspace's own "
+            "run.lock. The directory must be the workspace itself, not a directory inside one."
         ),
     )
     p_claims.add_argument(
@@ -836,7 +838,7 @@ def _print_claim_failure(decision, *, what: str) -> bool:
     if decision.reason == "no-identity":
         print(
             f"error: no usable fleet node identity ({decision.detail}); initialize this machine's "
-            "identity with `brigade node --machine`, or pass --node",
+            "identity with `brigade node --machine`",
             file=sys.stderr,
         )
         return True
@@ -865,7 +867,9 @@ def _release_claim(raw_target: str, *, as_path: bool, node_override: str | None,
     same proof: this node must own the claim, its recorded run directory
     must resolve to a workspace on this machine (with ``--path``, the one
     given), and that workspace's run lock must have no live owner; the
-    release is then fenced to the inspected row."""
+    release is then fenced to the inspected row. When the row records no
+    run directory, ``--path`` proves deadness via the pointed-at
+    workspace's own run.lock (#1160)."""
     import json as _json
 
     from .. import fleet_client, runguard
@@ -904,6 +908,15 @@ def _release_claim(raw_target: str, *, as_path: bool, node_override: str | None,
         )
         return 1
     node_id = node_override or local_node
+    if not fleet_client._node_id_is_claimable(node_id):
+        # ``--node`` cannot repair a missing local identity: any other value
+        # differs from ``unknown`` and is refused without ``--force`` (#1160).
+        print(
+            f"error: no usable fleet node identity ({node_id}); initialize this machine's "
+            "identity with `brigade node --machine`",
+            file=sys.stderr,
+        )
+        return 1
     inspected_acquired_at: str | None = None
     if not force:
         probe = fleet_client.inspect_claim(target, node_id=node_id)
@@ -936,18 +949,31 @@ def _release_claim(raw_target: str, *, as_path: bool, node_override: str | None,
                     file=sys.stderr,
                 )
             return 1
-        run_workspace, why = _workspace_from_run_dir(probe.lock_run_dir)
-        if run_workspace is None:
+        if probe.lock_run_dir:
+            run_workspace, why = _workspace_from_run_dir(probe.lock_run_dir)
+            if run_workspace is None:
+                print(
+                    f"error: cannot verify that the run holding {target!r} is dead ({why}); "
+                    "pass --force to release it anyway",
+                    file=sys.stderr,
+                )
+                return 1
+            if workspace is not None and run_workspace != workspace:
+                print(
+                    f"error: the claim on {target!r} was taken by a run in {run_workspace}, not {workspace}; "
+                    f"release it from that workspace (--release {run_workspace} --path) or pass --force",
+                    file=sys.stderr,
+                )
+                return 1
+        elif workspace is not None:
+            # --path: the operator pointed at the workspace. When the row
+            # recorded no run_dir (--no-artifacts, or a pre-lease claim),
+            # prove deadness via that workspace's own run.lock (#1160).
+            run_workspace = workspace
+        else:
             print(
-                f"error: cannot verify that the run holding {target!r} is dead ({why}); "
-                "pass --force to release it anyway",
-                file=sys.stderr,
-            )
-            return 1
-        if workspace is not None and run_workspace != workspace:
-            print(
-                f"error: the claim on {target!r} was taken by a run in {run_workspace}, not {workspace}; "
-                f"release it from that workspace (--release {run_workspace} --path) or pass --force",
+                f"error: cannot verify that the run holding {target!r} is dead "
+                "(the claim records no run directory); pass --force to release it anyway",
                 file=sys.stderr,
             )
             return 1

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -984,7 +984,8 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
     must carry the ``acquired_at`` of the row the caller inspected (400
     without it): the delete is fenced to that exact row, so a claim
     re-acquired between the caller's inspect and its release is never
-    deleted (409 with the current row). Only ``force`` deletes unfenced.
+    deleted (409 with the row seen inside the write transaction). Only
+    ``force`` deletes unfenced.
     """
     request = _validate_claim_request(raw)
     if caller_node is not None and request["node_id"] != caller_node:
@@ -1152,13 +1153,14 @@ def handle_claim(conn: sqlite3.Connection, raw: Any, *, caller_node: str | None 
         if prior is not None:
             released["claim"] = _claim_payload(prior)
         return 200, released
-    row = _fetch_claim(conn, target)
-    if row is not None:
-        if scope != "force" and row[1] != node:
-            error = f"target {target!r} is held by {row[1]}, not {node}"
+    # Reuse the in-transaction ``prior`` for the 409 payload. A post-commit
+    # re-read can describe a row that landed after this refusal (#1160).
+    if prior is not None:
+        if scope != "force" and prior[1] != node:
+            error = f"target {target!r} is held by {prior[1]}, not {node}"
         else:
-            error = f"target {target!r} was re-acquired since it was inspected (now acquired {row[7]})"
-        return 409, {"released": False, "error": error, "owner": _claim_payload(row)}
+            error = f"target {target!r} was re-acquired since it was inspected (now acquired {prior[7]})"
+        return 409, {"released": False, "error": error, "owner": _claim_payload(prior)}
     return 200, {"released": False}
 
 

--- a/tests/test_fleet_claim_release.py
+++ b/tests/test_fleet_claim_release.py
@@ -292,6 +292,44 @@ class TestHubScopes:
         no_fence.pop("holder")
         assert _post(url, token, no_fence)[0] == 400
 
+    def test_token_less_release_409_uses_in_transaction_prior(self, tmp_path, monkeypatch):
+        """A fenced-out token-less release's 409 owner is the row seen
+        inside the write transaction, not a row that appears after commit.
+
+        #1160 item 2: the failure branch used to re-read after ``commit()``,
+        so a concurrent replace could make the payload describe a different
+        owner than the one that caused the refusal.
+        """
+        db = tmp_path / "hub.db"
+        conn = fleet_hub.init_db(db)
+        try:
+            status, granted = fleet_hub.handle_claim(conn, _claim(holder="h1", conductor="chef"))
+            assert status == 200 and granted["granted"] is True
+            stale = "1999-01-01T00:00:00+00:00"
+            real_fetch = fleet_hub._fetch_claim
+            fetches: list = []
+
+            def fetch_then_lie(c: sqlite3.Connection, target: str):
+                row = real_fetch(c, target)
+                fetches.append(row)
+                # A post-commit re-read that sees a replaced owner. The
+                # in-transaction ``prior`` (first fetch) stays NODE_A/chef.
+                if len(fetches) >= 2 and row is not None:
+                    return (target, NODE_B, "intruder", *row[3:])
+                return row
+
+            monkeypatch.setattr(fleet_hub, "_fetch_claim", fetch_then_lie)
+            body = _claim("release", scope="node", acquired_at=stale)
+            body.pop("holder")
+            status, payload = fleet_hub.handle_claim(conn, body)
+            assert status == 409 and payload["released"] is False
+            assert payload["owner"]["owner_node"] == NODE_A
+            assert payload["owner"]["owner_conductor"] == "chef"
+            assert "re-acquired" in payload["error"]
+            assert f"now acquired {payload['owner']['acquired_at']}" in payload["error"]
+        finally:
+            conn.close()
+
     def test_v2_claim_rows_survive_the_lease_column_upgrade(self, tmp_path):
         db = tmp_path / "hub.db"
         conn = sqlite3.connect(str(db))
@@ -678,6 +716,53 @@ class TestReleaseCli:
         assert json.loads(capsys.readouterr().out)["forced"] is True
         assert fleet_client.fetch_claims() == []
 
+    def test_release_path_proves_deadness_when_claim_has_no_run_dir(self, hub, tmp_path, monkeypatch, capsys):
+        """#1160 item 1: a claim with no recorded ``lock_run_dir``
+        (``--no-artifacts``, or a row predating the lease columns) can be
+        released without ``--force`` when ``--path`` points at the workspace
+        whose own ``run.lock`` is dead.
+        """
+        from brigade import cli, runguard
+
+        url, token, _db = hub
+        _env(monkeypatch, url, token)
+        _bound_find_workspace_to_tmp(monkeypatch, tmp_path)
+        ws = tmp_path / "api"
+        ws.mkdir()
+        _post(url, token, _claim(target="api", holder="bare"))
+        inspect = _claim("inspect", target="api")
+        inspect.pop("holder")
+        probed = _post(url, token, inspect)[1]
+        assert probed["owned"] is True
+        assert probed.get("lock_run_dir") in (None, "")
+        lock = runguard.lock_path(ws)
+        lock.mkdir(parents=True)
+        (lock / "pid").write_text(f"{os.getpid()}\n")
+        assert cli.main(["fleet", "claims", "--release", str(ws), "--path"]) == 1
+        err = capsys.readouterr().err
+        assert "run owner is still alive" in err and str(ws) in err and "--force" in err
+        assert [c["target"] for c in fleet_client.fetch_claims()] == ["api"]
+        (lock / "pid").write_text(f"{DEAD_PID}\n")
+        assert cli.main(["fleet", "claims", "--release", str(ws), "--path", "--json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["released"] is True and payload["forced"] is False
+        assert payload["target"] == "api"
+        assert fleet_client.fetch_claims() == []
+        # Absent lock is also dead enough: no --force required.
+        _post(url, token, _claim(target="api", holder="bare2"))
+        import shutil
+
+        shutil.rmtree(lock)
+        assert cli.main(["fleet", "claims", "--release", str(ws), "--path"]) == 0
+        assert "released claim on 'api'" in capsys.readouterr().out
+        assert fleet_client.fetch_claims() == []
+        # Bare-key mode still cannot prove a NULL run_dir row.
+        _post(url, token, _claim(target="api", holder="bare3"))
+        assert cli.main(["fleet", "claims", "--release", "api"]) == 1
+        err = capsys.readouterr().err
+        assert "cannot verify" in err and "records no run directory" in err and "--force" in err
+        assert [c["target"] for c in fleet_client.fetch_claims()] == ["api"]
+
     def test_release_path_uses_the_workspace_itself(self, hub, tmp_path, monkeypatch, capsys):
         from brigade import cli, node as node_mod
 
@@ -751,7 +836,10 @@ class TestReleaseCli:
             assert "require --release" in capsys.readouterr().err
         monkeypatch.setattr(fleet_client, "resolve_node_id", lambda base_path=None: "unknown")
         assert cli.main(["fleet", "claims", "--release", "repo-a"]) == 1
-        assert "no usable fleet node identity" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "no usable fleet node identity" in err
+        assert "brigade node --machine" in err
+        assert "or pass --node" not in err
         monkeypatch.setenv("BRIGADE_FLEET_HUB_URL", "http://127.0.0.1:9")
         monkeypatch.setattr(fleet_client, "resolve_node_id", lambda base_path=None: NODE_A)
         assert cli.main(["fleet", "claims", "--release", "repo-a"]) == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1160

Items 1–4 only (item 5 left untouched).

## What and why

A hub claim with no recorded `lock_run_dir` (`--no-artifacts`, or a row predating the lease columns) could only be released with `--force`, even when `--path` already pointed at the workspace. `--path` now proves deadness via that workspace's own `run.lock`. A bare key still refuses that row without `--force`.

`fleet_hub.handle_claim` reuses the in-transaction `prior` row for a fenced-out token-less release's 409 payload instead of re-reading after `commit()`.

The CLI no-identity hint no longer suggests `--node` (a dead-end when `local_node` is `unknown`). `docs/fleet-sync.md` records that fleet claims require machine-local workspaces: a network-shared checkout collapses two machines into one `node_id` and one `run.lock`.

## Type of change

- [x] Bug fix
- [x] Docs

## Verification

Proof receipt: `20260902-075815-work-verify-66c446`  
status: `completed`  
command: `brigade work verify run --target . --argv-json '["python","-m","pytest","-q","tests/test_fleet_claim_release.py","tests/test_fleet_claims.py","tests/test_fleet_client_hardening.py"]' --capture brigade-work`  
proof pytest: 143 passed, exit 0

Envelope commands (all exit 0):

1. `python -m pytest -q tests/test_fleet_claim_release.py tests/test_fleet_claims.py tests/test_fleet_client_hardening.py` — exit 0, 143 passed in 138.07s
2. `ruff check src/brigade` — exit 0, All checks passed!
3. `ruff format --check src/brigade` — exit 0, 558 files already formatted
4. `mypy` — exit 0, Success: no issues found in 558 source files
5. `git diff --check` — exit 0

New tests (failing-first, then green):

- `TestReleaseCli.test_release_path_proves_deadness_when_claim_has_no_run_dir`
- `TestHubScopes.test_token_less_release_409_uses_in_transaction_prior`

## Checklist

- [x] Added or updated tests covering the change
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` (outside ownership_paths for this job)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

[Verification log](https://cursor.com/agents/bc-7527c90c-77ef-4ec9-9727-4a69536f0d94/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_1160_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7527c90c-77ef-4ec9-9727-4a69536f0d94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7527c90c-77ef-4ec9-9727-4a69536f0d94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

