### PR TITLE
feat(verify): ship tracked manifests so brigade receipts can score

### DIFF
--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -117,10 +117,12 @@ From then on, every repo the agent opens gets the work brief injected at session
 Once doctor is healthy, **you** (the coding agent) should prefer:
 
 ```bash
-brigade work verify run --target . --command "<real check>" --capture brigade-work
+brigade work verify run --manifest <path> --capture <id>
 brigade code impact <symbol>    # when a change has blast radius
 brigade evidence search "<query>"  # when you need prior runs or claims
 ```
+
+`--command` and `--argv-json` receipts are audit-only. When dirty paths match a tracked manifest under `verify/manifests/`, `suggested_command` should name that manifest. See [outcome scoring](outcome-scoring.md).
 
 Do not claim tests passed without a real exit code. Prefer Brigade-wrapped verify over raw test commands when the project wires the work loop.
 

--- a/docs/outcome-scoring.md
+++ b/docs/outcome-scoring.md
@@ -7,11 +7,11 @@ This is outcome-based skill scoring, promotion, and rollback from verification e
 ## Workflow
 
 ```bash
+# scoreable evidence: a git-tracked manifest under verify/manifests/ authors subject_binding
+brigade work verify run --manifest verify/manifests/work-cmd-verification.json --capture brigade-work
+
 # audit-only evidence: a receipt a human can read, never a scoreable trial
 brigade work verify run --target . --command "pytest -q" --capture brigade-work
-
-# scoreable evidence: verifier-owned checks bound to one artifact
-brigade work verify run --target . --manifest <manifest-id> --capture <artifact-id>
 
 # or, after a verify without --capture:
 brigade outcome capture brigade-work --run-id latest --kind skill
@@ -54,6 +54,40 @@ warning: scoreable: no (reason=unattributed); this receipt cannot score the capt
 `--json` carries the same verdict as `outcome_scoreability` on the printed payload. `brigade work brief` lists the ids this target has as `outcome_verify_manifests`, and the `outcome_loop_half_fed` warning names them inline.
 
 A repo with no tracked manifest cannot produce an eligible receipt at all. That is the expected state until someone declares one; `ineligibility_rate=1.0` there means "nothing has been declared scoreable yet", not "the checks were untrustworthy".
+
+## Tracked manifests in this checkout
+
+The work loop should call:
+
+```bash
+brigade work verify run --manifest <path> --capture <id>
+```
+
+`--manifest` accepts a registered `manifest_id` or the workspace source path (`verify/manifests/<id>.json`). Both resolve through `verify_manifest.resolve_manifest`. Untracked files under that directory are refused.
+
+This checkout ships patch-backed manifests for the focused suites agents actually run here. Each binds the file `subject_hash` can read (a concrete module, not a directory) and uses `scope_globs` for the package or sibling files the suite covers:
+
+| Manifest | Tests | `subject_path` |
+| --- | --- | --- |
+| `verify/manifests/work-cmd-verification.json` | `tests/test_work_cmd_verification.py` | `src/brigade/work_cmd/verification.py` |
+| `verify/manifests/guard.json` | `tests/guard` | `src/brigade/guard/engine.py` |
+| `verify/manifests/grokbot-feed.json` | `tests/test_grokbot_feed.py` | `src/brigade/grokbot_feed.py` |
+| `verify/manifests/grokbot-reconcile.json` | `tests/test_grokbot_reconcile.py` | `src/brigade/grokbot_reconcile.py` |
+| `verify/manifests/fleet-claims.json` | `tests/test_fleet_claims.py`, `tests/test_fleet_claim_release.py` | `src/brigade/fleet_hub.py` |
+| `verify/manifests/run-resume.json` | `tests/test_run_resume.py` | `src/brigade/run_resume.py` |
+| `verify/manifests/verify-manifest.json` | `tests/test_verify_manifest_tracked.py` | `src/brigade/verify_manifest.py` |
+
+Every `*.json` under `verify/manifests/` must resolve through `verify_manifest.resolve_manifest` by id and by source path. `tests/test_verify_manifest_tracked.py` walks that directory and asserts both lookups.
+
+Write check commands as the argv the receipt will record. Do not prefix `PYTHONPATH=src`: receipts store env assignments separately, and a plan mismatch makes the trial `verifier_manifest_mismatch`.
+
+When dirty paths match a tracked manifest's `subject_path` or `scope_globs`, `suggested_command` should name that manifest instead of an ad-hoc `--command`:
+
+```text
+brigade work verify run --manifest "verify/manifests/<id>.json" --capture <artifact-id>
+```
+
+`verify_manifest.suggested_manifest_command` returns that string from dirty paths so `brigade work verify plan` and `brigade work brief` can surface it.
 
 ## Read-time recomputation
 

--- a/src/brigade/verify_manifest.py
+++ b/src/brigade/verify_manifest.py
@@ -546,7 +546,10 @@ def suggested_manifest_command(
     *,
     capture: str | None = None,
 ) -> str | None:
-    """Return a scoreable verify command when a tracked manifest matches dirty paths."""
+    """Return a scoreable ``--manifest`` command when a tracked manifest matches dirty paths.
+
+    ``suggested_command`` should name this string instead of an ad-hoc ``--command``.
+    """
     matches = manifests_matching_paths(target, paths)
     if not matches:
         return None

--- a/src/brigade/verify_manifest.py
+++ b/src/brigade/verify_manifest.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -414,15 +416,57 @@ def registered_manifest_ids(target: Path) -> list[str]:
     return sorted(set(ids))
 
 
+def _normalize_repo_path(path: str) -> str:
+    return path.replace("\\", "/").lstrip("./")
+
+
+def _workspace_manifest_file_from_selector(target: Path, selector: str) -> Path | None:
+    raw = selector.strip()
+    if not raw:
+        return None
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = target / candidate
+    try:
+        resolved = candidate.resolve()
+        workspace_root = _workspace_manifests_root(target).resolve()
+        resolved.relative_to(workspace_root)
+    except (OSError, ValueError):
+        return None
+    if resolved.suffix != ".json" or not resolved.is_file():
+        return None
+    return resolved
+
+
+def _load_tracked_workspace_manifest(
+    target: Path, path: Path, *, selector: str
+) -> tuple[VerifyManifest | None, str | None]:
+    payload = _load_manifest_file(path)
+    manifest_label = selector
+    if isinstance(payload, dict):
+        named = payload.get("manifest_id")
+        if isinstance(named, str) and named.strip():
+            manifest_label = named
+    if not _is_git_tracked(target, path):
+        return None, f"verify manifest not tracked: {manifest_label}"
+    if not isinstance(payload, dict):
+        return None, f"verify manifest not found: {selector}"
+    try:
+        return manifest_from_payload(payload, path=path), None
+    except ValueError as exc:
+        return None, str(exc)
+
+
 def resolve_manifest(target: Path, manifest_id: str) -> tuple[VerifyManifest | None, str | None]:
     target = target.expanduser().resolve()
+    selector = str(manifest_id).strip()
     matches: list[VerifyManifest] = []
     untracked_workspace_match = False
     for path in _discover_manifest_files(target):
         payload = _load_manifest_file(path)
         if not isinstance(payload, dict):
             continue
-        if str(payload.get("manifest_id") or "") != manifest_id:
+        if str(payload.get("manifest_id") or "") != selector:
             continue
         if not _is_builtin_manifest(path) and not _is_git_tracked(target, path):
             untracked_workspace_match = True
@@ -431,13 +475,85 @@ def resolve_manifest(target: Path, manifest_id: str) -> tuple[VerifyManifest | N
             matches.append(manifest_from_payload(payload, path=path))
         except ValueError as exc:
             return None, str(exc)
+    if matches:
+        if len(matches) > 1:
+            return None, f"verify manifest id is ambiguous: {selector}"
+        return matches[0], None
+    path = _workspace_manifest_file_from_selector(target, selector)
+    if path is not None:
+        return _load_tracked_workspace_manifest(target, path, selector=selector)
+    if untracked_workspace_match:
+        return None, f"verify manifest not tracked: {selector}"
+    return None, f"verify manifest not found: {selector}"
+
+
+def _path_matches_subject(subject_path: str | None, candidate: str) -> bool:
+    if not subject_path:
+        return False
+    subject = _normalize_repo_path(subject_path)
+    path = _normalize_repo_path(candidate)
+    if not subject or not path:
+        return False
+    if path == subject:
+        return True
+    return path.startswith(f"{subject.rstrip('/')}/")
+
+
+def _path_matches_scope_glob(pattern: str, candidate: str) -> bool:
+    path = _normalize_repo_path(candidate)
+    glob = pattern.replace("\\", "/")
+    if not path or not glob:
+        return False
+    if fnmatch(path, glob):
+        return True
+    if glob.endswith("/**"):
+        prefix = glob[:-3].rstrip("/")
+        return bool(prefix) and (path == prefix or path.startswith(f"{prefix}/"))
+    return False
+
+
+def manifests_matching_paths(target: Path, paths: Sequence[str]) -> list[VerifyManifest]:
+    """Return tracked workspace manifests whose subject_path or scope_globs cover any path."""
+    target = target.expanduser().resolve()
+    candidates = [str(item).strip() for item in paths if str(item).strip()]
+    if not candidates:
+        return []
+    matches: list[VerifyManifest] = []
+    seen: set[str] = set()
+    for path in _discover_workspace_manifest_files(target, tracked_only=True):
+        payload = _load_manifest_file(path)
+        if not isinstance(payload, dict):
+            continue
+        try:
+            manifest = manifest_from_payload(payload, path=path)
+        except ValueError:
+            continue
+        if manifest.manifest_id in seen:
+            continue
+        if any(
+            _path_matches_subject(manifest.subject_path, item)
+            or any(_path_matches_scope_glob(glob, item) for glob in manifest.scope_globs)
+            for item in candidates
+        ):
+            seen.add(manifest.manifest_id)
+            matches.append(manifest)
+    return matches
+
+
+def suggested_manifest_command(
+    target: Path,
+    paths: Sequence[str],
+    *,
+    capture: str | None = None,
+) -> str | None:
+    """Return a scoreable verify command when a tracked manifest matches dirty paths."""
+    matches = manifests_matching_paths(target, paths)
     if not matches:
-        if untracked_workspace_match:
-            return None, f"verify manifest not tracked: {manifest_id}"
-        return None, f"verify manifest not found: {manifest_id}"
-    if len(matches) > 1:
-        return None, f"verify manifest id is ambiguous: {manifest_id}"
-    return matches[0], None
+        return None
+    manifest = matches[0]
+    source = manifest_source_path(target, manifest) or manifest.manifest_id
+    artifact = capture or manifest.artifact_id
+    return f'brigade work verify run --manifest "{source}" --capture {artifact}'
 
 
 def resolve_subject_fingerprint(target: Path, manifest: VerifyManifest) -> str | None:

--- a/src/brigade/verify_manifest.py
+++ b/src/brigade/verify_manifest.py
@@ -479,9 +479,9 @@ def resolve_manifest(target: Path, manifest_id: str) -> tuple[VerifyManifest | N
         if len(matches) > 1:
             return None, f"verify manifest id is ambiguous: {selector}"
         return matches[0], None
-    path = _workspace_manifest_file_from_selector(target, selector)
-    if path is not None:
-        return _load_tracked_workspace_manifest(target, path, selector=selector)
+    source_path = _workspace_manifest_file_from_selector(target, selector)
+    if source_path is not None:
+        return _load_tracked_workspace_manifest(target, source_path, selector=selector)
     if untracked_workspace_match:
         return None, f"verify manifest not tracked: {selector}"
     return None, f"verify manifest not found: {selector}"

--- a/tests/test_verify_manifest_tracked.py
+++ b/tests/test_verify_manifest_tracked.py
@@ -97,9 +97,7 @@ def test_suggested_manifest_command_names_matching_tracked_manifest(scoreable_ta
         scoreable_target,
         ["skills/brigade-work/SKILL.md"],
     )
-    assert command == (
-        'brigade work verify run --manifest "verify/manifests/local-patch.json" --capture brigade-work'
-    )
+    assert command == ('brigade work verify run --manifest "verify/manifests/local-patch.json" --capture brigade-work')
 
 
 def test_suggested_manifest_command_matches_scope_glob_prefix(scoreable_target):
@@ -130,7 +128,5 @@ def test_suggested_manifest_command_matches_scope_glob_prefix(scoreable_target):
         ["src/brigade/work_cmd/helpers.py"],
         capture="brigade-work",
     )
-    assert command == (
-        'brigade work verify run --manifest "verify/manifests/scoped-patch.json" --capture brigade-work'
-    )
+    assert command == ('brigade work verify run --manifest "verify/manifests/scoped-patch.json" --capture brigade-work')
     assert verify_manifest.suggested_manifest_command(scoreable_target, ["docs/readme.md"]) is None

--- a/tests/test_verify_manifest_tracked.py
+++ b/tests/test_verify_manifest_tracked.py
@@ -1,0 +1,136 @@
+"""Tracked workspace verify manifests must resolve and match dirty paths (#1384)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import verify_manifest
+from brigade.verify_manifest import _WORKSPACE_MANIFESTS_REL
+
+from tests.test_verify_trial import _track_workspace_manifest, _write_patch_manifest
+
+pytest_plugins = ["tests.test_verify_trial"]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _workspace_manifest_paths() -> list[Path]:
+    root = _REPO_ROOT / _WORKSPACE_MANIFESTS_REL
+    if not root.is_dir():
+        return []
+    return sorted(path for path in root.glob("*.json") if path.is_file())
+
+
+def test_every_workspace_verify_manifest_resolves_by_id_and_path():
+    paths = _workspace_manifest_paths()
+    assert paths, "expected tracked manifests under verify/manifests/"
+    seen_ids: set[str] = set()
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert isinstance(payload, dict)
+        manifest_id = payload.get("manifest_id")
+        assert isinstance(manifest_id, str) and manifest_id.strip()
+        assert manifest_id not in seen_ids, f"duplicate manifest_id: {manifest_id}"
+        seen_ids.add(manifest_id)
+        assert payload.get("binding_mode") == "patch_backed"
+        subject = payload.get("subject")
+        assert isinstance(subject, dict)
+        subject_path = subject.get("subject_path")
+        assert isinstance(subject_path, str) and subject_path.strip()
+
+        by_id, id_error = verify_manifest.resolve_manifest(_REPO_ROOT, manifest_id)
+        assert id_error is None, (manifest_id, id_error)
+        assert by_id is not None
+        assert by_id.manifest_id == manifest_id
+        assert by_id.subject_path == subject_path
+
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        by_path, path_error = verify_manifest.resolve_manifest(_REPO_ROOT, rel)
+        assert path_error is None, (rel, path_error)
+        assert by_path is not None
+        assert by_path.manifest_id == manifest_id
+        assert by_path.path is not None
+        assert by_path.path.resolve() == path.resolve()
+
+
+def test_resolve_manifest_accepts_tracked_workspace_source_path(scoreable_target):
+    _write_patch_manifest(scoreable_target, manifest_id="local-patch")
+    rel = f"{_WORKSPACE_MANIFESTS_REL.as_posix()}/local-patch.json"
+    manifest, error = verify_manifest.resolve_manifest(scoreable_target, rel)
+    assert error is None
+    assert manifest is not None
+    assert manifest.manifest_id == "local-patch"
+    assert manifest.subject_path == "skills/brigade-work/SKILL.md"
+
+
+def test_resolve_manifest_rejects_untracked_workspace_source_path(scoreable_target):
+    payload = {
+        "schema": "brigade.verify_manifest.v1",
+        "schema_version": 1,
+        "manifest_id": "untracked-path",
+        "binding_mode": "patch_backed",
+        "verifier_id": "brigade.verify.test",
+        "subject": {
+            "artifact_kind": "skill",
+            "artifact_id": "brigade-work",
+            "subject_path": "skills/brigade-work/SKILL.md",
+        },
+        "checks": [
+            {
+                "check_id": "verify.echo-ok",
+                "check_role": "effectiveness",
+                "command": "true",
+            }
+        ],
+    }
+    written = verify_manifest.write_workspace_manifest(scoreable_target, payload)
+    rel = written.resolve().relative_to(scoreable_target.resolve()).as_posix()
+    manifest, error = verify_manifest.resolve_manifest(scoreable_target, rel)
+    assert manifest is None
+    assert error == "verify manifest not tracked: untracked-path"
+
+
+def test_suggested_manifest_command_names_matching_tracked_manifest(scoreable_target):
+    _write_patch_manifest(scoreable_target, manifest_id="local-patch")
+    command = verify_manifest.suggested_manifest_command(
+        scoreable_target,
+        ["skills/brigade-work/SKILL.md"],
+    )
+    assert command == (
+        'brigade work verify run --manifest "verify/manifests/local-patch.json" --capture brigade-work'
+    )
+
+
+def test_suggested_manifest_command_matches_scope_glob_prefix(scoreable_target):
+    payload = {
+        "schema": "brigade.verify_manifest.v1",
+        "schema_version": 1,
+        "manifest_id": "scoped-patch",
+        "binding_mode": "patch_backed",
+        "verifier_id": "brigade.verify.test",
+        "subject": {
+            "artifact_kind": "skill",
+            "artifact_id": "brigade-work",
+            "subject_path": "src/brigade/work_cmd/verification.py",
+        },
+        "scope_globs": ["src/brigade/work_cmd/**", "tests/test_work_cmd_verification.py"],
+        "checks": [
+            {
+                "check_id": "verify.echo-ok",
+                "check_role": "effectiveness",
+                "command": "true",
+            }
+        ],
+    }
+    verify_manifest.write_workspace_manifest(scoreable_target, payload)
+    _track_workspace_manifest(scoreable_target, "scoped-patch")
+    command = verify_manifest.suggested_manifest_command(
+        scoreable_target,
+        ["src/brigade/work_cmd/helpers.py"],
+        capture="brigade-work",
+    )
+    assert command == (
+        'brigade work verify run --manifest "verify/manifests/scoped-patch.json" --capture brigade-work'
+    )
+    assert verify_manifest.suggested_manifest_command(scoreable_target, ["docs/readme.md"]) is None

--- a/verify/manifests/fleet-claims.json
+++ b/verify/manifests/fleet-claims.json
@@ -1,0 +1,25 @@
+{
+  "schema": "brigade.verify_manifest.v1",
+  "schema_version": 1,
+  "manifest_id": "fleet-claims",
+  "binding_mode": "patch_backed",
+  "verifier_id": "brigade.verify.pytest",
+  "patch_source": "worktree",
+  "subject": {
+    "artifact_kind": "skill",
+    "artifact_id": "brigade-work",
+    "subject_path": "src/brigade/fleet_hub.py"
+  },
+  "scope_globs": [
+    "src/brigade/fleet_hub.py",
+    "tests/test_fleet_claims.py",
+    "tests/test_fleet_claim_release.py"
+  ],
+  "checks": [
+    {
+      "check_id": "pytest.fleet-claims",
+      "check_role": "effectiveness",
+      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_fleet_claims.py tests/test_fleet_claim_release.py"
+    }
+  ]
+}

--- a/verify/manifests/fleet-claims.json
+++ b/verify/manifests/fleet-claims.json
@@ -19,7 +19,7 @@
     {
       "check_id": "pytest.fleet-claims",
       "check_role": "effectiveness",
-      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_fleet_claims.py tests/test_fleet_claim_release.py"
+      "command": "python3 -m pytest -q tests/test_fleet_claims.py tests/test_fleet_claim_release.py"
     }
   ]
 }

--- a/verify/manifests/grokbot-feed.json
+++ b/verify/manifests/grokbot-feed.json
@@ -1,0 +1,24 @@
+{
+  "schema": "brigade.verify_manifest.v1",
+  "schema_version": 1,
+  "manifest_id": "grokbot-feed",
+  "binding_mode": "patch_backed",
+  "verifier_id": "brigade.verify.pytest",
+  "patch_source": "worktree",
+  "subject": {
+    "artifact_kind": "skill",
+    "artifact_id": "brigade-work",
+    "subject_path": "src/brigade/grokbot_feed.py"
+  },
+  "scope_globs": [
+    "src/brigade/grokbot_feed.py",
+    "tests/test_grokbot_feed.py"
+  ],
+  "checks": [
+    {
+      "check_id": "pytest.grokbot-feed",
+      "check_role": "effectiveness",
+      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_grokbot_feed.py"
+    }
+  ]
+}

--- a/verify/manifests/grokbot-feed.json
+++ b/verify/manifests/grokbot-feed.json
@@ -18,7 +18,7 @@
     {
       "check_id": "pytest.grokbot-feed",
       "check_role": "effectiveness",
-      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_grokbot_feed.py"
+      "command": "python3 -m pytest -q tests/test_grokbot_feed.py"
     }
   ]
 }

--- a/verify/manifests/grokbot-reconcile.json
+++ b/verify/manifests/grokbot-reconcile.json
@@ -1,0 +1,24 @@
+{
+  "schema": "brigade.verify_manifest.v1",
+  "schema_version": 1,
+  "manifest_id": "grokbot-reconcile",
+  "binding_mode": "patch_backed",
+  "verifier_id": "brigade.verify.pytest",
+  "patch_source": "worktree",
+  "subject": {
+    "artifact_kind": "skill",
+    "artifact_id": "brigade-work",
+    "subject_path": "src/brigade/grokbot_reconcile.py"
+  },
+  "scope_globs": [
+    "src/brigade/grokbot_reconcile.py",
+    "tests/test_grokbot_reconcile.py"
+  ],
+  "checks": [
+    {
+      "check_id": "pytest.grokbot-reconcile",
+      "check_role": "effectiveness",
+      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_grokbot_reconcile.py"
+    }
+  ]
+}

--- a/verify/manifests/grokbot-reconcile.json
+++ b/verify/manifests/grokbot-reconcile.json
@@ -18,7 +18,7 @@
     {
       "check_id": "pytest.grokbot-reconcile",
       "check_role": "effectiveness",
-      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_grokbot_reconcile.py"
+      "command": "python3 -m pytest -q tests/test_grokbot_reconcile.py"
     }
   ]
 }

--- a/verify/manifests/guard.json
+++ b/verify/manifests/guard.json
@@ -18,7 +18,7 @@
     {
       "check_id": "pytest.guard",
       "check_role": "effectiveness",
-      "command": "PYTHONPATH=src python3 -m pytest -q tests/guard"
+      "command": "python3 -m pytest -q tests/guard"
     }
   ]
 }

--- a/verify/manifests/guard.json
+++ b/verify/manifests/guard.json
@@ -1,0 +1,24 @@
+{
+  "schema": "brigade.verify_manifest.v1",
+  "schema_version": 1,
+  "manifest_id": "guard",
+  "binding_mode": "patch_backed",
+  "verifier_id": "brigade.verify.pytest",
+  "patch_source": "worktree",
+  "subject": {
+    "artifact_kind": "skill",
+    "artifact_id": "brigade-work",
+    "subject_path": "src/brigade/guard/engine.py"
+  },
+  "scope_globs": [
+    "src/brigade/guard/**",
+    "tests/guard/**"
+  ],
+  "checks": [
+    {
+      "check_id": "pytest.guard",
+      "check_role": "effectiveness",
+      "command": "PYTHONPATH=src python3 -m pytest -q tests/guard"
+    }
+  ]
+}

--- a/verify/manifests/run-resume.json
+++ b/verify/manifests/run-resume.json
@@ -18,7 +18,7 @@
     {
       "check_id": "pytest.run-resume",
       "check_role": "effectiveness",
-      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_run_resume.py"
+      "command": "python3 -m pytest -q tests/test_run_resume.py"
     }
   ]
 }

--- a/verify/manifests/run-resume.json
+++ b/verify/manifests/run-resume.json
@@ -1,0 +1,24 @@
+{
+  "schema": "brigade.verify_manifest.v1",
+  "schema_version": 1,
+  "manifest_id": "run-resume",
+  "binding_mode": "patch_backed",
+  "verifier_id": "brigade.verify.pytest",
+  "patch_source": "worktree",
+  "subject": {
+    "artifact_kind": "skill",
+    "artifact_id": "brigade-work",
+    "subject_path": "src/brigade/run_resume.py"
+  },
+  "scope_globs": [
+    "src/brigade/run_resume.py",
+    "tests/test_run_resume.py"
+  ],
+  "checks": [
+    {
+      "check_id": "pytest.run-resume",
+      "check_role": "effectiveness",
+      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_run_resume.py"
+    }
+  ]
+}

--- a/verify/manifests/verify-manifest.json
+++ b/verify/manifests/verify-manifest.json
@@ -19,7 +19,7 @@
     {
       "check_id": "pytest.verify-manifest-tracked",
       "check_role": "effectiveness",
-      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_verify_manifest_tracked.py"
+      "command": "python3 -m pytest -q tests/test_verify_manifest_tracked.py"
     }
   ]
 }

--- a/verify/manifests/verify-manifest.json
+++ b/verify/manifests/verify-manifest.json
@@ -1,0 +1,25 @@
+{
+  "schema": "brigade.verify_manifest.v1",
+  "schema_version": 1,
+  "manifest_id": "verify-manifest",
+  "binding_mode": "patch_backed",
+  "verifier_id": "brigade.verify.pytest",
+  "patch_source": "worktree",
+  "subject": {
+    "artifact_kind": "skill",
+    "artifact_id": "brigade-work",
+    "subject_path": "src/brigade/verify_manifest.py"
+  },
+  "scope_globs": [
+    "src/brigade/verify_manifest.py",
+    "verify/manifests/**",
+    "tests/test_verify_manifest_tracked.py"
+  ],
+  "checks": [
+    {
+      "check_id": "pytest.verify-manifest-tracked",
+      "check_role": "effectiveness",
+      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_verify_manifest_tracked.py"
+    }
+  ]
+}

--- a/verify/manifests/work-cmd-verification.json
+++ b/verify/manifests/work-cmd-verification.json
@@ -18,7 +18,7 @@
     {
       "check_id": "pytest.work-cmd-verification",
       "check_role": "effectiveness",
-      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_work_cmd_verification.py"
+      "command": "python3 -m pytest -q tests/test_work_cmd_verification.py"
     }
   ]
 }

--- a/verify/manifests/work-cmd-verification.json
+++ b/verify/manifests/work-cmd-verification.json
@@ -1,0 +1,24 @@
+{
+  "schema": "brigade.verify_manifest.v1",
+  "schema_version": 1,
+  "manifest_id": "work-cmd-verification",
+  "binding_mode": "patch_backed",
+  "verifier_id": "brigade.verify.pytest",
+  "patch_source": "worktree",
+  "subject": {
+    "artifact_kind": "skill",
+    "artifact_id": "brigade-work",
+    "subject_path": "src/brigade/work_cmd/verification.py"
+  },
+  "scope_globs": [
+    "src/brigade/work_cmd/**",
+    "tests/test_work_cmd_verification.py"
+  ],
+  "checks": [
+    {
+      "check_id": "pytest.work-cmd-verification",
+      "check_role": "effectiveness",
+      "command": "PYTHONPATH=src python3 -m pytest -q tests/test_work_cmd_verification.py"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1384

Ship git-tracked patch-backed manifests under `verify/manifests/` so this checkout's own `brigade work verify run --manifest` receipts can author `subject_binding` and become eligible. `--command` and `--argv-json` stay audit-only.

`resolve_manifest` now accepts a registered id or a workspace source path. `suggested_manifest_command` returns a `--manifest` command when dirty paths match `subject_path` or `scope_globs`. Docs in `docs/outcome-scoring.md` and `docs/agents-guide.md` tell the work loop to call `--manifest <path> --capture <id>` and let `suggested_command` name a matching manifest. Work-cmd / verify-brigade skill edits were out of ownership.

Manifest check commands are plain `python3 -m pytest` argv (no `PYTHONPATH=src` prefix) so receipt command plans match. `subject_path` is a readable file because `subject_hash_for_path` cannot hash a directory; `scope_globs` cover the package or sibling files.

CHANGELOG.md was not updated: it is outside this slice's ownership paths.

## Lint fix on rebased head (`a50136d4`)

CI lint failed `ruff format --check .` on two parenthesized `assert command == (...)` strings in `tests/test_verify_manifest_tracked.py`. `ruff check` was clean. Formatted those asserts and pushed a normal fast-forward commit to this same branch.

## Verification receipt

- id: `20260902-220728-work-verify-beec4c`
- status: `completed`
- command: `./scripts/verify-focused tests/test_verify_manifest_tracked.py` exit 0
- also: `20260902-220751-work-verify-819d2f` (`--manifest verify/manifests/verify-manifest.json`, completed; scoreable=no because empty_patch after commit)

## Envelope verification (in order, all exit 0)

```
python -m pytest -q tests/test_scorecard.py tests/test_work_cmd_verification.py
165 passed in 19.85s
EXIT:0

ruff check src/brigade
All checks passed!
EXIT:0

ruff format --check src/brigade
562 files already formatted
EXIT:0

mypy
Success: no issues found in 562 source files
EXIT:0

git diff --check
EXIT:0
```

## Type of change

- [x] Docs
- [x] Added or updated tests covering the change

## Checklist

- [x] Envelope pytest selectors pass
- [x] Added tests covering tracked-manifest resolve
- [ ] CHANGELOG.md Unreleased — omitted (ownership bound)
- [x] No personal details or live auth profiles
- [x] No new runtime dependencies
- [x] Conventional commits

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efa0d102-9695-4002-81d9-d19eff4d4a96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efa0d102-9695-4002-81d9-d19eff4d4a96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

