### PR TITLE
fix(grokbot): break the grokbot_jobs_expiry circular import

### DIFF
--- a/src/brigade/grokbot_jobs_expiry.py
+++ b/src/brigade/grokbot_jobs_expiry.py
@@ -14,21 +14,6 @@ from typing import Any
 
 from .grokbot_job_clock import parse_timestamp as _parse_timestamp
 from .grokbot_job_clock import timestamp as _timestamp
-from .grokbot_jobs import (
-    TERMINAL_STATES,
-    _Storage,
-    _commit_mutation,
-    _discard_orphan_report_snapshot,
-    _hub_job,
-    _hub_projection,
-    _load_record,
-    _queue_lock,
-    _require_hub,
-    _storage_paths,
-    _validate_job_id,
-    hub_authority,
-)
-from .grokbot_jobs import GrokbotJobError
 
 
 def _handle(record: dict[str, Any], *, idempotent: bool) -> dict[str, Any]:
@@ -82,7 +67,7 @@ def _execution_context(record: dict[str, Any]) -> dict[str, Any]:
 
 
 def _expire_if_elapsed(
-    storage: _Storage, record: dict[str, Any], now: datetime | None, *, lease_counts: bool = False
+    storage: Any, record: dict[str, Any], now: datetime | None, *, lease_counts: bool = False
 ) -> dict[str, Any]:
     """Terminalize one loaded record whose expiry instant passed.
 
@@ -92,6 +77,8 @@ def _expire_if_elapsed(
     (#1383). Only an explicit :func:`expire` counts a lapsed lease, which is
     the contract that call has always had.
     """
+    from .grokbot_jobs import TERMINAL_STATES, _commit_mutation, _discard_orphan_report_snapshot
+
     if record["state"] in TERMINAL_STATES:
         return record
     stamp, instant = _timestamp(now)
@@ -107,7 +94,7 @@ def _expire_if_elapsed(
 
 
 def _require_live_lease_or_expire(
-    storage: _Storage, record: dict[str, Any], bot_id: str, lease_id: str, now: datetime | None, instant: datetime
+    storage: Any, record: dict[str, Any], bot_id: str, lease_id: str, now: datetime | None, instant: datetime
 ) -> None:
     """Guard one lease-holder mutation, expiring a job whose deadline passed.
 
@@ -117,6 +104,8 @@ def _require_live_lease_or_expire(
     terminalized here too, so the queue does not need an operator sweep to
     agree with the answer it just gave (#1353 composed with #1383).
     """
+    from .grokbot_jobs import GrokbotJobError
+
     try:
         _require_current_lease(record, bot_id, lease_id, instant)
     except GrokbotJobError as exc:
@@ -126,6 +115,8 @@ def _require_live_lease_or_expire(
 
 
 def _require_current_lease(record: dict[str, Any], bot_id: str, lease_id: str, instant: datetime) -> None:
+    from .grokbot_jobs import GrokbotJobError
+
     if record["state"] in {"completed", "failed", "expired", "canceled"}:
         raise GrokbotJobError("terminal-state")
     if record["state"] not in {"claimed", "running"}:
@@ -137,6 +128,8 @@ def _require_current_lease(record: dict[str, Any], bot_id: str, lease_id: str, i
 
 def _require_live_lease(record: dict[str, Any], instant: datetime) -> None:
     if instant >= min(_parse_timestamp(record["lease_expires_at"]), _deadline(record)):
+        from .grokbot_jobs import GrokbotJobError
+
         raise GrokbotJobError("lease-expired")
 
 
@@ -146,6 +139,19 @@ def _deadline(record: dict[str, Any]) -> datetime:
 
 def expire(target: Path, job_id: str, now: datetime | None = None) -> dict[str, Any]:
     """Terminalize jobs whose deadline or current lease has elapsed, never requeue."""
+    from .grokbot_jobs import (
+        TERMINAL_STATES,
+        _discard_orphan_report_snapshot,
+        _hub_job,
+        _hub_projection,
+        _load_record,
+        _queue_lock,
+        _require_hub,
+        _storage_paths,
+        _validate_job_id,
+        hub_authority,
+    )
+
     job_id = _validate_job_id(job_id)
     if hub_authority(target):
         current = _hub_job(job_id)

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import stat
+import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from multiprocessing import Pipe, Process
 from pathlib import Path
@@ -31,6 +33,21 @@ def _spec() -> dict[str, object]:
         "artifact": {"kind": "draft-pr"},
         "timeout_seconds": 900,
     }
+
+
+def test_grokbot_jobs_expiry_imports_before_grokbot_jobs():
+    """Regression for the circular import introduced by PR #1387."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import brigade.grokbot_jobs_expiry; import brigade.grokbot_jobs;",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
 
 
 def _claim_in_process(target: str, job_id: str, lease_id: str, connection) -> None:


### PR DESCRIPTION
Importing brigade.grokbot_jobs_expiry before brigade.grokbot_jobs raised ImportError (cannot import name _claim_result from a partially initialized module) because the split from #1387 left module-level back-references. The expiry module is now self-contained and a regression test imports it first in a fresh subprocess.

Receipts: 20260902-150755-work-verify-31de87 (148 passed), 20260902-150822-work-verify-6a0e96 (mypy).