### PR TITLE
fix(run): resume writes the handoff and matches orchestrator failure statuses

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -522,7 +522,13 @@ greater than 1 cannot be salvaged this way when earlier-stage worker results
 were never persisted. Resume fails closed before provider construction instead
 of synthesizing from partial stage output. A successful resume refreshes
 `finished_at` and `duration_seconds` to the post-resume completion time rather
-than retaining the pre-resume owner-exit timestamp.
+than retaining the pre-resume owner-exit timestamp. When the original run
+requested `--handoff`, resume writes the Memory Handoff through the same
+`write_run_handoff` path the orchestrator uses and records the path on
+`run.json`. A timed-out direct worker finishes as `status: timeout` and an
+interrupted one as `status: canceled`, matching the orchestrator finish path.
+Resume clears each worker's prior `failure_phase` before the retry so a new
+failure is not labeled with the earlier phase.
 
 If the approved action completed but the process exited before recording
 `approval.consumed` and `run.resumed`, run `brigade runs resume <run>` again.

--- a/src/brigade/aboyeur/artifacts.py
+++ b/src/brigade/aboyeur/artifacts.py
@@ -648,6 +648,7 @@ def _run_payload(
     finished_at: datetime | None = None,
     output_dir: Path | None = None,
     handoff_path: Path | None = None,
+    handoff_inbox: Path | str | None = None,
     error: str | None = None,
     failure_phase: str | None = None,
     failure_kind: str | None = None,
@@ -751,6 +752,8 @@ def _run_payload(
         payload["artifacts"] = str(output_dir)
     if handoff_path is not None:
         payload["handoff"] = str(handoff_path)
+    if handoff_inbox is not None:
+        payload["handoff_inbox"] = str(handoff_inbox)
     if error is not None:
         payload["error"] = error
         if failure_phase is not None or failure_kind is not None:
@@ -822,6 +825,7 @@ def record_run_start(
     verification_contract_payload: Mapping[str, Any] | None = None,
     run_budget_payload: Mapping[str, Any] | None = None,
     kind: str = "work",
+    handoff_inbox: Path | None = None,
 ) -> bool:
     """Write the minimal typed receipt needed before optional or blocking work.
 
@@ -930,6 +934,7 @@ def record_run_start(
                     else (causal_receipt.recorded_run(run_id=output_dir.name) if new_run else None)
                 ),
                 retry_decisions=existing_retry_decisions,
+                handoff_inbox=handoff_inbox,
             ),
         )
     except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:

--- a/src/brigade/aboyeur/direct_worker_finish.py
+++ b/src/brigade/aboyeur/direct_worker_finish.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Mapping
 
 from .. import agents
 from .. import receipt_schema
@@ -80,17 +80,18 @@ def synthesis_document_payload(
     final: agents.AgentResult,
     ground_truth: Mapping[str, Any],
     run_id: str,
-    worker_results: Sequence[WorkerResult],
+    worker_results: list[WorkerResult],
     synth_captured: Any | None,
 ) -> dict[str, object]:
     result = _agent_result_payload(final)
     workers = _worker_payload(worker_results)
+    truth = dict(ground_truth)
     if direct_worker:
         payload = receipt_schema.synthesis_document(
             mode="direct-worker",
             worker=worker,
             result=result,
-            ground_truth=ground_truth,
+            ground_truth=truth,
             run_id=run_id,
             worker_results=workers,
         )
@@ -98,7 +99,7 @@ def synthesis_document_payload(
         payload = receipt_schema.synthesis_document(
             orchestrator=roster.orchestrator,
             result=result,
-            ground_truth=ground_truth,
+            ground_truth=truth,
             run_id=run_id,
             worker_results=workers,
         )
@@ -141,16 +142,17 @@ def write_completed_run_receipt(
     write_json: JsonWriter,
     payload: PayloadBuilder,
     final: agents.AgentResult,
-    worker_results: Sequence[WorkerResult],
+    worker_results: list[WorkerResult],
     direct_worker: bool,
     workers_ok: bool,
     defer_artifact_collection: bool,
     pending_handoff: bool,
-    transport_warning: str | None,
+    transport_warning: dict[str, object] | None,
     base: Mapping[str, Any],
     extra: Mapping[str, Any],
 ) -> None:
     failed_seats = [result.worker for result in worker_results if not result.ok]
+    finished_at: datetime | None
     if not workers_ok:
         run_status = "incomplete"
         finished_at = datetime.now(timezone.utc)

--- a/src/brigade/aboyeur/direct_worker_finish.py
+++ b/src/brigade/aboyeur/direct_worker_finish.py
@@ -1,0 +1,230 @@
+"""Direct-worker finish and terminal failure-status mapping for `brigade run`.
+
+The orchestrator finish path and resume salvage path must agree on how a timed-out,
+interrupted, or failed worker/orchestrator result is typed onto run.json. Helpers
+here are the single mapping; they must not import ``orchestrator`` at module level.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .. import agents
+from .. import receipt_schema
+from .. import seat_health_policy
+from ..roster import Roster
+from ..run_receipts import (
+    agent_result_payload as _agent_result_payload,
+    worker_payload as _worker_payload,
+)
+from ..run_transport import WorkerResult
+
+JsonWriter = Callable[[Path, object], None]
+PayloadBuilder = Callable[..., dict[str, object]]
+
+
+def terminal_run_status(final: agents.AgentResult) -> str:
+    """Map a failed worker/orchestrator result the way the orchestrator finish path does."""
+    if final.timed_out:
+        return "timeout"
+    if final.status == "interrupted":
+        return "canceled"
+    return "failed"
+
+
+def terminal_failure_kind(final: agents.AgentResult) -> str:
+    if final.timed_out:
+        return "timeout"
+    if final.failure_kind:
+        return final.failure_kind
+    if final.status == "interrupted":
+        return "interrupted"
+    return "agent-error"
+
+
+def terminal_failure_phase(final: agents.AgentResult, *, direct_worker: bool) -> str:
+    if final.failure_phase:
+        return final.failure_phase
+    if final.timed_out:
+        return "inference"
+    return "dispatch" if direct_worker else "synthesis"
+
+
+def missing_direct_worker_result(*, worker: str, task: str) -> WorkerResult:
+    return WorkerResult(
+        worker=worker or "",
+        task=task,
+        text="",
+        ok=False,
+        detail="direct worker produced no result",
+    )
+
+
+def report_terminal_failure(final: agents.AgentResult, *, direct_worker: bool) -> None:
+    if direct_worker:
+        print(f"error: worker failed: {final.detail}", file=sys.stderr)
+        if final.text:
+            print(final.text)
+        return
+    print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
+
+
+def synthesis_document_payload(
+    *,
+    direct_worker: bool,
+    worker: str | None,
+    roster: Roster,
+    final: agents.AgentResult,
+    ground_truth: Mapping[str, Any],
+    run_id: str,
+    worker_results: Sequence[WorkerResult],
+    synth_captured: Any | None,
+) -> dict[str, object]:
+    result = _agent_result_payload(final)
+    workers = _worker_payload(worker_results)
+    if direct_worker:
+        payload = receipt_schema.synthesis_document(
+            mode="direct-worker",
+            worker=worker,
+            result=result,
+            ground_truth=ground_truth,
+            run_id=run_id,
+            worker_results=workers,
+        )
+    else:
+        payload = receipt_schema.synthesis_document(
+            orchestrator=roster.orchestrator,
+            result=result,
+            ground_truth=ground_truth,
+            run_id=run_id,
+            worker_results=workers,
+        )
+    if synth_captured is not None:
+        payload["provenance"] = synth_captured.envelope
+    return payload
+
+
+def write_failed_run_receipt(
+    output_dir: Path,
+    *,
+    write_json: JsonWriter,
+    payload: PayloadBuilder,
+    final: agents.AgentResult,
+    direct_worker: bool,
+    worker: str | None,
+    roster: Roster,
+    base: Mapping[str, Any],
+) -> None:
+    if direct_worker:
+        (output_dir / "final.txt").write_text(final.text + "\n")
+    write_json(
+        output_dir / "run.json",
+        payload(
+            **base,
+            status=terminal_run_status(final),
+            finished_at=datetime.now(timezone.utc),
+            error=final.detail,
+            failure_phase=terminal_failure_phase(final, direct_worker=direct_worker),
+            failure_kind=terminal_failure_kind(final),
+            failure_seat=worker if direct_worker else roster.orchestrator,
+            transport_warning=final.transport_warning,
+        ),
+    )
+
+
+def write_completed_run_receipt(
+    output_dir: Path,
+    *,
+    write_json: JsonWriter,
+    payload: PayloadBuilder,
+    final: agents.AgentResult,
+    worker_results: Sequence[WorkerResult],
+    direct_worker: bool,
+    workers_ok: bool,
+    defer_artifact_collection: bool,
+    pending_handoff: bool,
+    transport_warning: str | None,
+    base: Mapping[str, Any],
+    extra: Mapping[str, Any],
+) -> None:
+    failed_seats = [result.worker for result in worker_results if not result.ok]
+    if not workers_ok:
+        run_status = "incomplete"
+        finished_at = datetime.now(timezone.utc)
+    else:
+        final_status = "artifact-collection" if defer_artifact_collection else "ok"
+        finished_at = None if defer_artifact_collection or pending_handoff else datetime.now(timezone.utc)
+        run_status = "handoff" if pending_handoff else final_status
+    (output_dir / "final.txt").write_text(final.text + "\n")
+    write_json(
+        output_dir / "run.json",
+        payload(
+            **base,
+            **extra,
+            status=run_status,
+            finished_at=finished_at,
+            error=(
+                f"{len(failed_seats)} worker(s) failed or were skipped: {', '.join(failed_seats)}"
+                if not workers_ok
+                else None
+            ),
+            failure_phase="workers" if not workers_ok else None,
+            failure_kind="worker-failure" if not workers_ok else None,
+            failure_seat=",".join(failed_seats) if not workers_ok else None,
+            transport_warning=transport_warning,
+            worker_failure_summary=(
+                seat_health_policy.worker_failure_summary(worker_results) if not workers_ok else None
+            ),
+        ),
+    )
+
+
+def write_handoff_failure_receipt(
+    output_dir: Path,
+    *,
+    write_json: JsonWriter,
+    payload: PayloadBuilder,
+    detail: str,
+    roster: Roster,
+    base: Mapping[str, Any],
+    extra: Mapping[str, Any],
+) -> None:
+    write_json(
+        output_dir / "run.json",
+        payload(
+            **base,
+            **extra,
+            status="failed",
+            finished_at=datetime.now(timezone.utc),
+            error=detail,
+            failure_phase="handoff",
+            failure_kind="handoff-write-error",
+            failure_seat=roster.orchestrator,
+        ),
+    )
+
+
+def write_ok_after_handoff_receipt(
+    output_dir: Path,
+    *,
+    write_json: JsonWriter,
+    payload: PayloadBuilder,
+    handoff: Path,
+    defer_artifact_collection: bool,
+    base: Mapping[str, Any],
+    extra: Mapping[str, Any],
+) -> None:
+    finished_at = None if defer_artifact_collection else datetime.now(timezone.utc)
+    write_json(
+        output_dir / "run.json",
+        payload(
+            **base,
+            **extra,
+            status="artifact-collection" if defer_artifact_collection else "ok",
+            finished_at=finished_at,
+            handoff_path=handoff,
+        ),
+    )

--- a/src/brigade/aboyeur/orchestrator.py
+++ b/src/brigade/aboyeur/orchestrator.py
@@ -61,6 +61,7 @@ from ..route_policy import (
 )
 
 from . import briefs, run_io, planning, prompts, artifacts, model_admission
+from . import direct_worker_finish
 
 
 @dataclass(frozen=True)
@@ -1669,13 +1670,7 @@ def run(
         direct_result = (
             worker_results[0]
             if worker_results
-            else WorkerResult(
-                worker=worker or "",
-                task=task,
-                text="",
-                ok=False,
-                detail="direct worker produced no result",
-            )
+            else direct_worker_finish.missing_direct_worker_result(worker=worker or "", task=task)
         )
         final = _agent_result_from_worker(direct_result)
     else:
@@ -1775,29 +1770,42 @@ def run(
     drift_rc = _drift_failure_rc()
     if drift_rc is not None:
         return drift_rc
+    finish_base: dict[str, Any] = {
+        "task": task,
+        "cwd": cwd,
+        "roster": roster,
+        "dry_run": dry_run,
+        "read_only": read_only,
+        "started_at": started_at,
+        "output_dir": output_dir,
+        "code_graph": code_graph,
+        "drift_impact": drift_impact,
+        "evidence": evidence,
+        "brief_set": brief_set,
+        "codex_transport": transport_for_payload,
+        "route": route,
+        "code_graph_delta": code_graph_delta,
+        "context_eval_payload": context_eval_payload,
+        "suspected_noop": suspected_noop,
+        "worker": worker,
+    }
+    finish_extra: dict[str, Any] = {
+        "control_socket": control_socket,
+        "control_transport": control_transport,
+    }
     if output_dir is not None:
         if not direct_worker:
             final = _write_agent_logs(output_dir, "synthesis", final)
-        synthesis_payload = (
-            receipt_schema.synthesis_document(
-                mode="direct-worker",
-                worker=worker,
-                result=_agent_result_payload(final),
-                ground_truth=ground_truth,
-                run_id=output_dir.name,
-                worker_results=_worker_payload(worker_results),
-            )
-            if direct_worker
-            else receipt_schema.synthesis_document(
-                orchestrator=roster.orchestrator,
-                result=_agent_result_payload(final),
-                ground_truth=ground_truth,
-                run_id=output_dir.name,
-                worker_results=_worker_payload(worker_results),
-            )
+        synthesis_payload = direct_worker_finish.synthesis_document_payload(
+            direct_worker=direct_worker,
+            worker=worker,
+            roster=roster,
+            final=final,
+            ground_truth=ground_truth,
+            run_id=output_dir.name,
+            worker_results=worker_results,
+            synth_captured=synth_captured,
         )
-        if synth_captured is not None:
-            synthesis_payload["provenance"] = synth_captured.envelope
         causal_receipt.write_synthesis_lineage_artifacts(
             output_dir,
             synthesis_payload,
@@ -1806,52 +1814,17 @@ def run(
         )
     if not final.ok:
         if output_dir is not None:
-            finished_at = datetime.now(timezone.utc)
-            interrupted = final.status == "interrupted"
-            if direct_worker:
-                (output_dir / "final.txt").write_text(final.text + "\n")
-            run_io._write_json(
-                output_dir / "run.json",
-                _payload(
-                    task=task,
-                    cwd=cwd,
-                    roster=roster,
-                    dry_run=dry_run,
-                    read_only=read_only,
-                    status="timeout" if final.timed_out else "canceled" if interrupted else "failed",
-                    started_at=started_at,
-                    finished_at=finished_at,
-                    output_dir=output_dir,
-                    error=final.detail,
-                    failure_phase=(
-                        final.failure_phase
-                        or ("inference" if final.timed_out else "dispatch" if direct_worker else "synthesis")
-                    ),
-                    failure_kind=(
-                        "timeout"
-                        if final.timed_out
-                        else final.failure_kind or ("interrupted" if interrupted else "agent-error")
-                    ),
-                    failure_seat=worker if direct_worker else roster.orchestrator,
-                    code_graph=code_graph,
-                    drift_impact=drift_impact,
-                    evidence=evidence,
-                    brief_set=brief_set,
-                    codex_transport=transport_for_payload,
-                    route=route,
-                    code_graph_delta=code_graph_delta,
-                    context_eval_payload=context_eval_payload,
-                    suspected_noop=suspected_noop,
-                    worker=worker,
-                    transport_warning=final.transport_warning,
-                ),
+            direct_worker_finish.write_failed_run_receipt(
+                output_dir,
+                write_json=run_io._write_json,
+                payload=_payload,
+                final=final,
+                direct_worker=direct_worker,
+                worker=worker,
+                roster=roster,
+                base=finish_base,
             )
-        if direct_worker:
-            print(f"error: worker failed: {final.detail}", file=sys.stderr)
-            if final.text:
-                print(final.text)
-        else:
-            print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
+        direct_worker_finish.report_terminal_failure(final, direct_worker=direct_worker)
         return 2
     # Drift checkpoint: immediately before finalization. The final ok receipt
     # must not be written on top of state a concurrent commit moved out from
@@ -1860,55 +1833,20 @@ def run(
     if drift_rc is not None:
         return drift_rc
     workers_ok = direct_worker or all(result.ok for result in worker_results)
-    failed_seats = [result.worker for result in worker_results if not result.ok]
     if output_dir is not None:
-        pending_handoff = handoff_inbox is not None
-        if not workers_ok:
-            final_status = "incomplete"
-            finished_at = datetime.now(timezone.utc)
-            run_status = "incomplete"
-        else:
-            final_status = "artifact-collection" if defer_artifact_collection else "ok"
-            finished_at = None if defer_artifact_collection or pending_handoff else datetime.now(timezone.utc)
-            run_status = "handoff" if pending_handoff else final_status
-        (output_dir / "final.txt").write_text(final.text + "\n")
-        run_io._write_json(
-            output_dir / "run.json",
-            _payload(
-                task=task,
-                cwd=cwd,
-                roster=roster,
-                dry_run=dry_run,
-                read_only=read_only,
-                status=run_status,
-                started_at=started_at,
-                finished_at=finished_at,
-                output_dir=output_dir,
-                error=(
-                    f"{len(failed_seats)} worker(s) failed or were skipped: {', '.join(failed_seats)}"
-                    if not workers_ok
-                    else None
-                ),
-                failure_phase="workers" if not workers_ok else None,
-                failure_kind="worker-failure" if not workers_ok else None,
-                failure_seat=",".join(failed_seats) if not workers_ok else None,
-                code_graph=code_graph,
-                drift_impact=drift_impact,
-                evidence=evidence,
-                brief_set=brief_set,
-                codex_transport=transport_for_payload,
-                route=route,
-                control_socket=control_socket,
-                control_transport=control_transport,
-                code_graph_delta=code_graph_delta,
-                context_eval_payload=context_eval_payload,
-                suspected_noop=suspected_noop,
-                worker=worker,
-                transport_warning=direct_result.transport_warning if direct_worker else None,
-                worker_failure_summary=(
-                    seat_health_policy.worker_failure_summary(worker_results) if not workers_ok else None
-                ),
-            ),
+        direct_worker_finish.write_completed_run_receipt(
+            output_dir,
+            write_json=run_io._write_json,
+            payload=_payload,
+            final=final,
+            worker_results=worker_results,
+            direct_worker=direct_worker,
+            workers_ok=workers_ok,
+            defer_artifact_collection=defer_artifact_collection,
+            pending_handoff=handoff_inbox is not None,
+            transport_warning=direct_result.transport_warning if direct_worker else None,
+            base=finish_base,
+            extra=finish_extra,
         )
     if handoff_inbox is not None and workers_ok:
         try:
@@ -1925,69 +1863,28 @@ def run(
         except OSError as exc:
             detail = f"handoff failed: {exc}"
             if output_dir is not None:
-                finished_at = datetime.now(timezone.utc)
-                run_io._write_json(
-                    output_dir / "run.json",
-                    _payload(
-                        task=task,
-                        cwd=cwd,
-                        roster=roster,
-                        dry_run=dry_run,
-                        read_only=read_only,
-                        status="failed",
-                        started_at=started_at,
-                        finished_at=finished_at,
-                        output_dir=output_dir,
-                        error=detail,
-                        failure_phase="handoff",
-                        failure_kind="handoff-write-error",
-                        failure_seat=roster.orchestrator,
-                        code_graph=code_graph,
-                        drift_impact=drift_impact,
-                        evidence=evidence,
-                        brief_set=brief_set,
-                        codex_transport=transport_for_payload,
-                        route=route,
-                        control_socket=control_socket,
-                        control_transport=control_transport,
-                        code_graph_delta=code_graph_delta,
-                        context_eval_payload=context_eval_payload,
-                        suspected_noop=suspected_noop,
-                        worker=worker,
-                    ),
+                direct_worker_finish.write_handoff_failure_receipt(
+                    output_dir,
+                    write_json=run_io._write_json,
+                    payload=_payload,
+                    detail=detail,
+                    roster=roster,
+                    base=finish_base,
+                    extra=finish_extra,
                 )
             print(f"error: {detail}", file=sys.stderr)
             print(final.text)
             return 2
         print(f"handoff: {handoff}", file=sys.stderr)
         if output_dir is not None:
-            finished_at = None if defer_artifact_collection else datetime.now(timezone.utc)
-            run_io._write_json(
-                output_dir / "run.json",
-                _payload(
-                    task=task,
-                    cwd=cwd,
-                    roster=roster,
-                    dry_run=dry_run,
-                    read_only=read_only,
-                    status="artifact-collection" if defer_artifact_collection else "ok",
-                    started_at=started_at,
-                    finished_at=finished_at,
-                    output_dir=output_dir,
-                    handoff_path=handoff,
-                    code_graph=code_graph,
-                    drift_impact=drift_impact,
-                    evidence=evidence,
-                    brief_set=brief_set,
-                    codex_transport=transport_for_payload,
-                    route=route,
-                    control_socket=control_socket,
-                    control_transport=control_transport,
-                    code_graph_delta=code_graph_delta,
-                    context_eval_payload=context_eval_payload,
-                    suspected_noop=suspected_noop,
-                    worker=worker,
-                ),
+            direct_worker_finish.write_ok_after_handoff_receipt(
+                output_dir,
+                write_json=run_io._write_json,
+                payload=_payload,
+                handoff=handoff,
+                defer_artifact_collection=defer_artifact_collection,
+                base=finish_base,
+                extra=finish_extra,
             )
     reroute_summary = seat_health_policy.format_reroute_summary(roster.seat_routing)
     if reroute_summary is not None:

--- a/src/brigade/aboyeur/orchestrator.py
+++ b/src/brigade/aboyeur/orchestrator.py
@@ -535,6 +535,7 @@ def run(
                 scheduler=scheduler,
                 verification_contract_payload=verification_contract_payload,
                 run_budget_payload=run_budget_payload,
+                handoff_inbox=handoff_inbox,
             )
         if output_dir is not None and (output_dir / "run.json").is_file():
             artifacts.record_run_termination(
@@ -581,6 +582,8 @@ def run(
         scheduler_resolution["fallback_reason"] = fallback_reason
 
     def _payload(**kwargs: Any) -> dict[str, object]:
+        if "handoff_inbox" not in kwargs and handoff_inbox is not None:
+            kwargs["handoff_inbox"] = handoff_inbox
         if "skill_route_policy" not in kwargs and skill_policy is not None:
             kwargs["skill_route_policy"] = skill_policy
         if "retry_decisions" not in kwargs and quarantine_state.retry_decisions:
@@ -640,6 +643,8 @@ def run(
                         kwargs["run_budget_payload"] = dict(existing["run_budget"])
                     if "kind" not in kwargs and isinstance(existing.get("kind"), str) and existing["kind"].strip():
                         kwargs["kind"] = existing["kind"].strip()
+                    if "handoff_inbox" not in kwargs and isinstance(existing.get("handoff_inbox"), str):
+                        kwargs["handoff_inbox"] = existing["handoff_inbox"]
                     if "causal_receipt_payload" not in kwargs and isinstance(existing.get("causal_receipt"), dict):
                         kwargs["causal_receipt_payload"] = dict(existing["causal_receipt"])
                     existing_retry = existing.get("retry_decisions")
@@ -754,6 +759,7 @@ def run(
             scheduler=scheduler,
             verification_contract_payload=verification_contract_payload,
             run_budget_payload=run_budget_payload,
+            handoff_inbox=handoff_inbox,
         )
         run_io._write_json(output_dir / "roster.json", _roster_with_admission(roster, model_policy.receipt))
     if code_graph is None:

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -32,6 +32,7 @@ from . import (
 from .aboyeur.planning import resolve_run_sandbox
 from .roster import Agent, Roster, _as_bool, _as_capabilities, _as_command, _as_env
 from .run_receipts import agent_result_from_worker
+from .run_transport import Assignment
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
 _NONTERMINAL_RUN_STATUSES = frozenset(
@@ -467,7 +468,7 @@ def _assignments_from_plan(run_dir: Path) -> list:
             continue
         stage = item.get("stage", 1)
         assignments.append(
-            aboyeur.Assignment(
+            Assignment(
                 worker=worker,
                 task=task,
                 stage=stage if isinstance(stage, int) and not isinstance(stage, bool) else 1,

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -425,24 +425,116 @@ def _continuation_prompt(task: str) -> str:
     )
 
 
+def _resume_terminal_status(final: agents.AgentResult) -> str:
+    """Map a failed worker/orchestrator result the way the orchestrator finish path does."""
+    if final.timed_out:
+        return "timeout"
+    if final.status == "interrupted":
+        return "canceled"
+    return "failed"
+
+
+def _resume_terminal_failure_kind(final: agents.AgentResult) -> str:
+    if final.timed_out:
+        return "timeout"
+    if final.failure_kind:
+        return final.failure_kind
+    if final.status == "interrupted":
+        return "interrupted"
+    return "agent-error"
+
+
+def _resume_terminal_failure_phase(final: agents.AgentResult, *, direct_worker: bool) -> str:
+    if final.failure_phase:
+        return final.failure_phase
+    if final.timed_out:
+        return "inference"
+    return "dispatch" if direct_worker else "synthesis"
+
+
+def _assignments_from_plan(run_dir: Path) -> list:
+    plan = _load_json(run_dir, "plan.json")
+    raw = plan.get("assignments") if plan is not None else None
+    if not isinstance(raw, list):
+        return []
+    assignments = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        worker = item.get("worker")
+        task = item.get("task")
+        if not isinstance(worker, str) or not isinstance(task, str):
+            continue
+        stage = item.get("stage", 1)
+        assignments.append(
+            aboyeur.Assignment(
+                worker=worker,
+                task=task,
+                stage=stage if isinstance(stage, int) and not isinstance(stage, bool) else 1,
+            )
+        )
+    return assignments
+
+
+def _write_requested_run_handoff(
+    run_dir: Path,
+    run_meta: dict,
+    *,
+    worker_results: list,
+    final_text: str,
+) -> str | None:
+    """Write the same run handoff the orchestrator writes when --handoff was requested.
+
+    Returns a bounded error detail when the write fails, otherwise None.
+    """
+    raw_inbox = run_meta.get("handoff_inbox")
+    if not isinstance(raw_inbox, str) or not raw_inbox.strip():
+        return None
+    if not all(result.ok for result in worker_results):
+        return None
+    raw_cwd = run_meta.get("cwd")
+    cwd = Path(raw_cwd).expanduser() if isinstance(raw_cwd, str) and raw_cwd else None
+    task = run_meta.get("task", "")
+    if not isinstance(task, str):
+        task = ""
+    try:
+        handoff = aboyeur.write_run_handoff(
+            Path(raw_inbox),
+            task=task,
+            cwd=cwd,
+            output_dir=run_dir,
+            assignments=_assignments_from_plan(run_dir),
+            worker_results=worker_results,
+            final_text=final_text,
+            read_only=bool(run_meta.get("read_only")),
+        )
+    except OSError as exc:
+        return f"handoff failed: {exc}"
+    run_meta["handoff"] = str(handoff)
+    print(f"handoff: {handoff}", file=sys.stderr)
+    return None
+
+
 def _finish_resume_receipt(
     run_dir: Path,
     run_meta: dict,
     final: agents.AgentResult,
     *,
     seat: str,
+    worker_results: list,
 ) -> int:
     now = datetime.now(timezone.utc).isoformat()
     run_meta.setdefault("resumed_at", []).append(now)
     if not final.ok:
         bounded_detail = (final.detail or "orchestrator failed during synthesis")[:2000]
+        failure_phase = _resume_terminal_failure_phase(final, direct_worker=False)
         _archive_failure(run_meta)
-        run_meta["status"] = "failed"
+        run_meta["status"] = _resume_terminal_status(final)
         run_meta["error"] = bounded_detail
-        run_meta["failure_phase"] = "synthesis"
+        run_meta["failure_phase"] = failure_phase
         run_meta["failure"] = {
-            "phase": "synthesis",
-            "kind": "agent-error",
+            "phase": failure_phase,
+            "kind": _resume_terminal_failure_kind(final),
             "detail": bounded_detail,
             "seat": seat,
         }
@@ -457,6 +549,31 @@ def _finish_resume_receipt(
     run_meta["status"] = "ok"
     run_meta.pop("error", None)
     _archive_failure(run_meta)
+    handoff_error = _write_requested_run_handoff(
+        run_dir,
+        run_meta,
+        worker_results=worker_results,
+        final_text=final.text,
+    )
+    if handoff_error is not None:
+        _archive_failure(run_meta)
+        run_meta["status"] = "failed"
+        run_meta["error"] = handoff_error
+        run_meta["failure_phase"] = "handoff"
+        run_meta["failure"] = {
+            "phase": "handoff",
+            "kind": "handoff-write-error",
+            "detail": handoff_error,
+            "seat": seat,
+        }
+        _refresh_run_timing(run_meta)
+        try:
+            aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
+        except run_lifecycle.LifecycleJournalError as exc:
+            raise runguard.RetainRunLockError(f"failed to write failed-handoff run receipt: {exc}") from exc
+        print(f"error: {handoff_error}", file=sys.stderr)
+        print(final.text)
+        return 2
     _refresh_run_timing(run_meta)
     try:
         aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
@@ -472,27 +589,29 @@ def _finish_direct_worker_resume_receipt(
     final: agents.AgentResult,
     *,
     worker: str,
+    worker_results: list,
 ) -> int:
     """Terminalize a resumed ``--worker`` result without chef synthesis labels.
 
     A failed direct worker is still the user-visible result: write ``final.txt``,
-    type ``failure_phase`` from the worker (or ``dispatch``), and attribute the
-    seat to the worker. Reusing ``_finish_resume_receipt`` would mislabel this
-    as a chef synthesis failure.
+    type ``failure_phase`` from the worker (or ``dispatch``/``inference``), and
+    attribute the seat to the worker. Reusing ``_finish_resume_receipt`` would
+    mislabel this as a chef synthesis failure. Timeout and interrupt map to
+    ``timeout`` / ``canceled`` the same way the orchestrator finish path does.
     """
     now = datetime.now(timezone.utc).isoformat()
     run_meta.setdefault("resumed_at", []).append(now)
     (run_dir / "final.txt").write_text(final.text + "\n")
     if not final.ok:
         bounded_detail = (final.detail or "worker failed")[:2000]
-        failure_phase = final.failure_phase or "dispatch"
+        failure_phase = _resume_terminal_failure_phase(final, direct_worker=True)
         _archive_failure(run_meta)
-        run_meta["status"] = "failed"
+        run_meta["status"] = _resume_terminal_status(final)
         run_meta["error"] = bounded_detail
         run_meta["failure_phase"] = failure_phase
         run_meta["failure"] = {
             "phase": failure_phase,
-            "kind": final.failure_kind or "agent-error",
+            "kind": _resume_terminal_failure_kind(final),
             "detail": bounded_detail,
             "seat": worker,
         }
@@ -508,6 +627,31 @@ def _finish_direct_worker_resume_receipt(
     run_meta["status"] = "ok"
     run_meta.pop("error", None)
     _archive_failure(run_meta)
+    handoff_error = _write_requested_run_handoff(
+        run_dir,
+        run_meta,
+        worker_results=worker_results,
+        final_text=final.text,
+    )
+    if handoff_error is not None:
+        _archive_failure(run_meta)
+        run_meta["status"] = "failed"
+        run_meta["error"] = handoff_error
+        run_meta["failure_phase"] = "handoff"
+        run_meta["failure"] = {
+            "phase": "handoff",
+            "kind": "handoff-write-error",
+            "detail": handoff_error,
+            "seat": worker,
+        }
+        _refresh_run_timing(run_meta)
+        try:
+            aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
+        except run_lifecycle.LifecycleJournalError as exc:
+            raise runguard.RetainRunLockError(f"failed to write failed-handoff run receipt: {exc}") from exc
+        print(f"error: {handoff_error}", file=sys.stderr)
+        print(final.text)
+        return 2
     _refresh_run_timing(run_meta)
     try:
         aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
@@ -694,6 +838,7 @@ def _resume_locked(
     probe = seat_health.SeatHealthProbe(collect_executable_version=False)
     try:
         for entry in resumable:
+            entry.pop("failure_phase", None)
             worker = entry.get("worker", "")
             agent = roster.agents.get(worker)
             if agent is not None:
@@ -752,6 +897,9 @@ def _resume_locked(
             entry["ok"] = turn.ok and bool(entry["text"])
             entry["detail"] = "" if entry["ok"] else redact_approval_token(turn.detail or f"turn {turn.status}")[:200]
             entry["status"] = turn.status
+            entry["timed_out"] = bool(getattr(turn, "timed_out", False))
+            if entry["timed_out"] and not entry["ok"]:
+                entry["failure_kind"] = "timeout"
             if getattr(turn, "output_limit_exceeded", False):
                 entry["failure_kind"] = "output-limit"
                 entry["output_truncated"] = True
@@ -804,6 +952,7 @@ def _resume_locked(
             failure_phase=(
                 r.get("failure_phase") if not r.get("ok") and isinstance(r.get("failure_phase"), str) else None
             ),
+            timed_out=bool(r.get("timed_out")),
             output_truncated=bool(r.get("output_truncated")),
             output_bytes=int(r.get("output_bytes") or 0),
             output_cap_bytes=int(r.get("output_cap_bytes") or 0),
@@ -856,6 +1005,7 @@ def _resume_locked(
             run_meta,
             final,
             worker=str(run_meta.get("worker") or direct_result.worker),
+            worker_results=worker_results,
         )
     synth_prompt = aboyeur.build_synth_prompt(
         task,
@@ -930,4 +1080,10 @@ def _resume_locked(
         "synthesis.json",
         synthesis_payload,
     )
-    return _finish_resume_receipt(run_dir, run_meta, final, seat=roster.orchestrator)
+    return _finish_resume_receipt(
+        run_dir,
+        run_meta,
+        final,
+        seat=roster.orchestrator,
+        worker_results=worker_results,
+    )

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -29,6 +29,11 @@ from . import (
     verification_contract,
     worker_events,
 )
+from .aboyeur.direct_worker_finish import (
+    terminal_failure_kind as _resume_terminal_failure_kind,
+    terminal_failure_phase as _resume_terminal_failure_phase,
+    terminal_run_status as _resume_terminal_status,
+)
 from .aboyeur.planning import resolve_run_sandbox
 from .roster import Agent, Roster, _as_bool, _as_capabilities, _as_command, _as_env
 from .run_receipts import agent_result_from_worker
@@ -424,33 +429,6 @@ def _continuation_prompt(task: str) -> str:
         f"{task}\n\n"
         "Finish the sub-task and return a concise, complete final result."
     )
-
-
-def _resume_terminal_status(final: agents.AgentResult) -> str:
-    """Map a failed worker/orchestrator result the way the orchestrator finish path does."""
-    if final.timed_out:
-        return "timeout"
-    if final.status == "interrupted":
-        return "canceled"
-    return "failed"
-
-
-def _resume_terminal_failure_kind(final: agents.AgentResult) -> str:
-    if final.timed_out:
-        return "timeout"
-    if final.failure_kind:
-        return final.failure_kind
-    if final.status == "interrupted":
-        return "interrupted"
-    return "agent-error"
-
-
-def _resume_terminal_failure_phase(final: agents.AgentResult, *, direct_worker: bool) -> str:
-    if final.failure_phase:
-        return final.failure_phase
-    if final.timed_out:
-        return "inference"
-    return "dispatch" if direct_worker else "synthesis"
 
 
 def _assignments_from_plan(run_dir: Path) -> list:

--- a/tests/test_aboyeur_facade.py
+++ b/tests/test_aboyeur_facade.py
@@ -98,3 +98,26 @@ def test_facade_shared_import_assignment_reads_back(monkeypatch: pytest.MonkeyPa
     import sys as real_sys
 
     assert aboyeur.sys is real_sys
+
+
+def test_direct_worker_finish_imports_first_without_orchestrator_cycle() -> None:
+    import ast
+    import subprocess
+    import sys
+
+    module_path = Path(aboyeur.__file__).resolve().parent / "direct_worker_finish.py"
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.append("." * node.level + (node.module or ""))
+    assert not any("orchestrator" in name for name in imported)
+    probe = (
+        "import brigade.aboyeur.direct_worker_finish as finish; "
+        "from brigade.agents import AgentResult; "
+        "assert finish.terminal_run_status(AgentResult(text='', ok=False, timed_out=True)) == 'timeout'"
+    )
+    completed = subprocess.run([sys.executable, "-c", probe], check=False, capture_output=True, text=True)
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -1527,3 +1527,222 @@ def test_resume_allows_undeclared_budget_for_backward_compatibility(tmp_path, mo
 
     assert run_resume.resume(run_dir) == 0
     assert json.loads((run_dir / "run.json").read_text())["status"] == "ok"
+
+
+def test_resume_writes_run_handoff_via_write_run_handoff(tmp_path, monkeypatch, capsys):
+    inbox = tmp_path / "memory-handoffs"
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["handoff_inbox"] = str(inbox)
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    seen: dict[str, object] = {}
+    real_write = run_resume.aboyeur.write_run_handoff
+
+    def spy_write(target, **kwargs):
+        seen["inbox"] = target
+        seen["kwargs"] = kwargs
+        return real_write(target, **kwargs)
+
+    monkeypatch.setattr(run_resume.aboyeur, "write_run_handoff", spy_write)
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(text="final synthesis", ok=True),
+    )
+
+    assert run_resume.resume(run_dir) == 0
+    assert seen["inbox"] == inbox
+    assert seen["kwargs"]["task"] == "big task"
+    assert seen["kwargs"]["final_text"] == "final synthesis"
+    handoffs = list(inbox.glob("*.md"))
+    assert len(handoffs) == 1
+    run_json = json.loads((run_dir / "run.json").read_text())
+    assert run_json["status"] == "ok"
+    assert run_json["handoff"] == str(handoffs[0])
+    assert "handoff:" in capsys.readouterr().err
+
+
+def test_resume_skips_handoff_when_inbox_was_not_requested(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    calls: list[object] = []
+    monkeypatch.setattr(
+        run_resume.aboyeur,
+        "write_run_handoff",
+        lambda *a, **k: calls.append((a, k)) or (_ for _ in ()).throw(AssertionError("handoff not requested")),
+    )
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(text="final synthesis", ok=True),
+    )
+
+    assert run_resume.resume(run_dir) == 0
+    assert calls == []
+    run_json = json.loads((run_dir / "run.json").read_text())
+    assert run_json["status"] == "ok"
+    assert "handoff" not in run_json
+
+
+class _StatusThread:
+    def __init__(self, thread_id, *, text, ok, status, detail="", timed_out=False):
+        self.thread_id = thread_id
+        self._text = text
+        self._ok = ok
+        self._status = status
+        self._detail = detail
+        self._timed_out = timed_out
+
+    def run_turn(self, prompt, *, timeout, on_event=None):  # noqa: ARG002
+        return codex_appserver.TurnResult(
+            text=self._text,
+            ok=self._ok,
+            status=self._status,
+            detail=self._detail,
+            thread_id=self.thread_id,
+            timed_out=self._timed_out,
+        )
+
+
+class _StatusServer(_StubServer):
+    def __init__(
+        self,
+        *a,
+        turn_text="partial",
+        turn_ok=False,
+        turn_status="failed",
+        turn_detail="",
+        turn_timed_out=False,
+        **k,
+    ):
+        super().__init__(*a, **k)
+        self.turn_text = turn_text
+        self.turn_ok = turn_ok
+        self.turn_status = turn_status
+        self.turn_detail = turn_detail
+        self.turn_timed_out = turn_timed_out
+
+    def resume_thread(self, thread_id, *, cwd, model=None, sandbox=None):
+        self.resumed.append(thread_id)
+        return _StatusThread(
+            thread_id,
+            text=self.turn_text,
+            ok=self.turn_ok,
+            status=self.turn_status,
+            detail=self.turn_detail,
+            timed_out=self.turn_timed_out,
+        )
+
+
+def test_resume_maps_timed_out_direct_worker_to_timeout(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["worker"] = "cook"
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda *a, **k: _StatusServer(
+            turn_text="partial worker output",
+            turn_ok=False,
+            turn_status="interrupted",
+            turn_detail="turn timed out",
+            turn_timed_out=True,
+        ),
+    )
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("direct-worker resume must not invoke chef")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    run_json = json.loads((run_dir / "run.json").read_text())
+    assert run_json["status"] == "timeout"
+    assert run_json["failure"]["kind"] == "timeout"
+    assert run_json["failure"]["seat"] == "cook"
+
+
+def test_resume_maps_interrupted_direct_worker_to_canceled(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["worker"] = "cook"
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda *a, **k: _StatusServer(
+            turn_text="partial worker output",
+            turn_ok=False,
+            turn_status="interrupted",
+            turn_detail="operator interrupted",
+            turn_timed_out=False,
+        ),
+    )
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("direct-worker resume must not invoke chef")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    run_json = json.loads((run_dir / "run.json").read_text())
+    assert run_json["status"] == "canceled"
+    assert run_json["failure"]["kind"] == "interrupted"
+    assert run_json["failure"]["seat"] == "cook"
+
+
+def test_resume_maps_timed_out_synthesis_to_timeout(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(tmp_path, results=[dict(_RESUMABLE_COOK)])
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(
+            text="",
+            ok=False,
+            detail="orchestrator timed out",
+            timed_out=True,
+            status="failed",
+        ),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    run_json = json.loads((run_dir / "run.json").read_text())
+    assert run_json["status"] == "timeout"
+    assert run_json["failure"]["kind"] == "timeout"
+    assert run_json["failure_phase"] == "inference"
+
+
+def test_resume_resets_stale_failure_phase_before_retry(tmp_path, monkeypatch):
+    stale = dict(_RESUMABLE_COOK)
+    stale["failure_phase"] = "dispatch"
+    stale["detail"] = "run owner exited"
+    run_dir = _write_run_dir(tmp_path, results=[stale])
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["worker"] = "cook"
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda *a, **k: _StatusServer(
+            turn_text="",
+            turn_ok=False,
+            turn_status="failed",
+            turn_detail="provider hung up",
+            turn_timed_out=False,
+        ),
+    )
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(text="unused", ok=True),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    results = json.loads((run_dir / "worker-results.json").read_text())["results"]
+    assert results[0]["ok"] is False
+    assert results[0]["detail"] == "provider hung up"
+    assert results[0].get("failure_phase") != "dispatch"
+    assert "failure_phase" not in results[0]

--- a/tests/test_run_transport.py
+++ b/tests/test_run_transport.py
@@ -1349,3 +1349,34 @@ def test_resume_read_only_sandbox_never_becomes_a_write(tmp_path, monkeypatch):
         captured["sandbox"] is None and captured["read_only"] is False
     )
     assert write_invocation is False
+
+
+def test_handoff_run_persists_inbox_so_resume_can_write_it(monkeypatch, tmp_path):
+    from brigade import aboyeur
+    from tests.run_test_helpers import run_aboyeur_guarded
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):  # noqa: ARG001
+        return agents.AgentResult(text="worker final output", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    output_dir = tmp_path / "run"
+    inbox = tmp_path / "handoffs"
+
+    rc = run_aboyeur_guarded(
+        "implement the bounded fix",
+        _direct_worker_roster(),
+        worker="coder",
+        sandbox="danger-full-access",
+        handoff_inbox=inbox,
+        output_dir=output_dir,
+        cwd=tmp_path,
+        route_enabled=False,
+        code_graph_enabled=False,
+        evidence_enabled=False,
+    )
+
+    assert rc == 0
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "ok"
+    assert run_meta["handoff_inbox"] == str(inbox)
+    assert list(inbox.glob("*.md"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1375

Resume now writes the Memory Handoff through the same `write_run_handoff` path the orchestrator uses when the original run requested `--handoff`, maps a timed-out direct worker to `timeout` and an interrupted one to `canceled`, and resets `entry["failure_phase"]` before a resumed retry.

Item 4 (the unreachable `resolve_run_sandbox` `read_only` arm) was left alone.

A follow-up commit on this same branch splits the orchestrator finish-path helpers into `src/brigade/aboyeur/direct_worker_finish.py` so `orchestrator.py` stays under the 2000-line ratchet (1903 lines). The ratchet test and `LEGACY_OVERSIZED` were not edited.

## What and why

`brigade run resume` could finish `status="ok"` with no handoff file, stamped every failed direct worker as `failed`, and kept a stale `failure_phase` across a retry. Those three gaps are closed; the orchestrator start receipt now persists `handoff_inbox` so resume can see the original `--handoff` request after an owner-exit.

CI then failed the module-size ratchet because `orchestrator.py` was 2006 lines. Finish-path failure-status mapping and receipt writes now live in a sibling module with no module-level import back to `orchestrator.py`. Public `brigade.aboyeur` names are unchanged.

## Type of change

- [x] Bug fix
- [x] Docs
- [x] Refactor with no command-surface change

## Owned paths

- `src/brigade/run_resume.py`
- `src/brigade/aboyeur`
- `tests`
- `docs`

No edits outside those paths. `scripts/verify*`, `.github/workflows`, `pyproject.toml`, and `src/brigade/fleet_hub_http.py` were not touched. `CHANGELOG.md` is outside the owned-path set and was left alone.

## Proof receipt

- Skill `verify-brigade` / `work-verify` (temp target, `--capture verify-brigade`): `20260902-183501-work-verify-126d90` — **status completed**
- Evidence dir: `.brigade/verification-evidence/20260902-183501-orchestrator-size-split`
- Checkout builder receipt (`brigade work verify run --target . --capture brigade-work`): `20260902-183509-work-verify-0fc4a4` — **status completed** (focused gate, 97 passed)

## Verification (all exit 0)

1. `python -m pytest -q tests/test_module_size_ratchet.py tests/test_run_resume.py tests/test_run_transport.py tests/test_aboyeur_facade.py` — exit 0 — `97 passed in 4.20s`
2. `ruff check src/brigade` — exit 0 — `All checks passed!`
3. `ruff format --check src/brigade` — exit 0 — `563 files already formatted`
4. `mypy` — exit 0 — `Success: no issues found in 563 source files`
5. `git diff --check` — exit 0 — no whitespace errors

`wc -l`: `orchestrator.py` 1903, `direct_worker_finish.py` 232.

`./scripts/verify-fast` and the full test suite were not run.

## Checklist

- [x] Focused pytest selectors above pass
- [x] Added or updated tests covering the three scoped items (failing-first)
- [ ] `CHANGELOG.md` Unreleased — omitted; file is outside owned paths
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

This PR stays draft. Do not mark ready. Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c281327e-7e29-4ba6-b510-ae3fe9563b5d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c281327e-7e29-4ba6-b510-ae3fe9563b5d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

