### PR TITLE
docs(skills): extend verify-brigade with a pstack-style verification map

### DIFF
--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -2,7 +2,7 @@
 
 You are a coding agent. **You** install, set up, verify, and leave handoffs. The human usually does not type these commands. They point you at this repo (or paste a short prompt) and expect files and a doctor result on disk.
 
-Developing Brigade itself? Start from root `AGENTS.md`, then `CONTRIBUTING.md`. That file is for contributors, not for wiring a user workspace.
+Developing Brigade itself? Start from root `AGENTS.md`, then `CONTRIBUTING.md`. That file is for contributors, not for wiring a user workspace. To prove a change by driving the CLI, follow [`registry/skills/verify-brigade/SKILL.md`](../registry/skills/verify-brigade/SKILL.md) (Launch / Doctor / Drive / Evidence / Cleanup / Feature map).
 
 ## What Brigade is for
 

--- a/registry/skills/verify-brigade/SKILL.md
+++ b/registry/skills/verify-brigade/SKILL.md
@@ -49,9 +49,17 @@ There is no long-running process. "Launch" means: have a Brigade CLI, and have
 a fresh target to drive it against.
 
 ```bash
-# once per checkout, if .venv/ is missing
-python -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
+# fresh checkout (this repo). Quote the extras so the shell does not glob them.
+python3 -m venv .venv
+.venv/bin/pip install -e ".[dev,grokbot]"
 ```
+
+Observed on this checkout: that install printed
+`Successfully installed ... brigade-cli-0.27.0 ... mcp-2.1.1 ...`, and
+`.venv/bin/brigade --version` then printed `brigade 0.27.0`. The `grokbot`
+extra pulls the optional `mcp` package (`pyproject.toml`:
+`grokbot = ["mcp>=2,<3"]`). The `[dev]` extra alone is enough for pytest /
+ruff / mypy; add `grokbot` when the change touches the listener.
 
 Create the target:
 
@@ -110,6 +118,21 @@ registry/skills/verify-brigade/control-brigade.py doctor-target --target "$TARGE
 are normal on a fresh target - memory-care, security, and backups are not
 initialized yet.
 
+Against this checkout itself (the development tree, not a temp target):
+
+```bash
+.venv/bin/brigade doctor --target .
+.venv/bin/brigade status --target .
+```
+
+Observed here, both exit 0. Doctor printed
+`summary: 43 checks, 0 failed, 0 manual` and a list of `warn` rows
+(missing operator bootstrap files, unwired memory-care / security). Status
+printed group rows (`core`, `skills`, `memory`, `guard`, ...) with `0 fail`
+on every group; several groups were `[degraded]` or `[not-installed]` because
+this tree is not an initialized operator workspace. Healthy for a Brigade
+source checkout is **exit 0 and 0 failed**, not zero warnings.
+
 ## Drive
 
 Real commands from this repo, one per mapped feature. The full map is in
@@ -155,6 +178,32 @@ normalizes (`run_id`, `status`, `summary.failed`, `checks[].status`, `valid`,
 `$TARGET/.brigade/work/verify-runs/<run-id>/`. Do not grep the human prose;
 it changes.
 
+Checkout-level focused gates for a change in this repo (no full suite).
+`./scripts/verify-focused` itself runs ruff, ruff format `--check`, mypy,
+version-sync, the managed and template-profile snapshots, then the named
+pytest selectors. The three lint/type pieces can also be run alone:
+
+```bash
+./scripts/verify-focused tests/test_skills_cmd.py tests/test_ci_workflow.py
+.venv/bin/ruff check src/brigade
+.venv/bin/ruff format --check src/brigade
+.venv/bin/mypy
+```
+
+Receipted form — same focused command, recorded as a work-verify receipt
+(`brigade work verify run --help` lists `--argv-json`, `--capture`, and
+`--json`; `--help` itself exits 0):
+
+```bash
+.venv/bin/brigade work verify run --target . \
+  --argv-json '["./scripts/verify-focused","tests/test_skills_cmd.py","tests/test_ci_workflow.py"]' \
+  --capture brigade-work
+```
+
+`--command` and `--argv-json` receipts are audit-only. Do not pass
+`--no-reuse` to the full `./scripts/verify` gate. Do not run
+`./scripts/verify-fast` or the full suite from this skill.
+
 ## Evidence
 
 ```bash
@@ -185,6 +234,13 @@ Proof standards for this repo:
   genuinely absent is a running Grok Bot listener, and the skill reads its
   absence as data rather than faking it.
 
+Checkout `work verify` receipts live at
+`.brigade/work/verify-runs/<run-id>/receipt.json`. Cite the `run_id` in the
+PR body (`work-verify receipt: <run-id>`). A passing receipt has
+`"status": "completed"` and `commands[].exit_code` of `0`. See
+`docs/receipt-schemas.md` and the citation paragraph at the end of this
+skill.
+
 ## Cleanup
 
 ```bash
@@ -203,6 +259,32 @@ After cleanup, confirm the proof survived:
 ```bash
 ls .brigade/verification-evidence/<stamp>-<label>/manifest.json
 ```
+
+`.venv/` is gitignored (`.gitignore` line `.venv/`). Never commit `.brigade/`
+— the root `.gitignore` lists `.brigade/` and `.brigade/work/` among the
+ignored paths. Evidence under `.brigade/verification-evidence/` is also
+gitignored; copy a receipt id into the PR body instead of adding the
+directory. After a checkout-level verify, leave `.venv/` in place for the
+next drive; remove it only when you are done with the tree
+(`rm -rf .venv`). Do not `git add` either tree.
+
+## Feature map
+
+CLI surfaces in this repo and the tests that cover them. Drive the helper
+feature your change actually touched (`features/README.md`); use the
+pytest selectors here when the proof is a focused gate. Names confirmed
+present under `tests/` on this checkout.
+
+| Surface | Command | Tests |
+|---|---|---|
+| run | `brigade run` | `tests/test_run_cli.py`, `tests/test_run_lifecycle.py`, `tests/test_run_events.py`, `tests/test_run_control.py`, `tests/test_run_resume.py`, `tests/test_run_receipts.py` (32 `tests/test_run_*.py` / `tests/test_runs_*.py` files) |
+| work verify | `brigade work verify` | `tests/test_work_cmd_verification.py`, `tests/test_work_cmd_verify_ranking.py`, `tests/test_verify_trial.py`, `tests/test_verification_contract.py`, `tests/test_verify_brigade_skill.py` |
+| fleet | `brigade fleet` | `tests/test_fleet_claims.py`, `tests/test_fleet_claim_release.py`, `tests/test_fleet_nodes.py`, `tests/test_fleet_sync.py`, `tests/test_fleet_cloud.py`, `tests/test_fleet_command_deck.py` (14 `tests/test_fleet_*.py` files) |
+| grokbot listener | `brigade run cloud grokbot` (`serve`, `setup`, `doctor`, `canary`, queue verbs) | `tests/test_grokbot_ops.py`, `tests/test_grokbot_jobs.py`, `tests/test_grokbot_mcp.py`, `tests/test_grokbot_feed.py`, `tests/test_grokbot_packs.py` |
+| guard | `brigade guard` / `brigade scrub` | `tests/guard/test_cli.py`, `tests/guard/test_engine.py`, `tests/guard/test_rules.py`, `tests/test_scrub.py`, `tests/test_runguard.py` |
+
+Doctor and status for the checkout itself: `tests/test_doctor.py`,
+`tests/test_status.py`.
 
 ## Helpers
 
@@ -253,3 +335,19 @@ That receipt is proof for a human reader, not a scored trial. `--command` and
 `--argv-json` receipts are audit-only; only `--manifest <id>` produces a receipt
 the outcome ratchet can score. Each `--capture` run prints which one it was.
 See `docs/outcome-scoring.md`.
+
+Checkout receipts from `brigade work verify run --target .` land at:
+
+```
+.brigade/work/verify-runs/<run-id>/receipt.json
+```
+
+Cite the `run_id` in the PR body as a single line, for example
+`work-verify receipt: <run-id>`. Read it back with
+`brigade work verify show <run-id> --json`. A passing receipt
+(`docs/receipt-schemas.md`, `brigade.work_verify_receipt` schema_version 2)
+has `"status": "completed"`, a `run_id` shaped
+`<YYYYMMDD>-<HHMMSS>-work-verify-<hex>`, `commands[].exit_code` of `0`,
+and the identity tuple `baseline_commit` / `tree_fingerprint` /
+`changes_patch_sha256`. Failures still write a receipt (`"status": "failed"`);
+that is the ledger signal, not a missing file.

--- a/registry/skills/verify-brigade/features/README.md
+++ b/registry/skills/verify-brigade/features/README.md
@@ -17,11 +17,24 @@ exact helper calls (`Driving it with control-brigade`), and what bites
 | Grok Bot job queue and feed | [run-cloud-grokbot-queue.md](run-cloud-grokbot-queue.md) | `grokbot-feed`, `grokbot-status` |
 | Handoff inbox lint | [handoff-lint.md](handoff-lint.md) | `handoff-lint` |
 
-Not yet mapped, and worth adding when a change lands there: `brigade memory`,
-`brigade security`, `brigade scrub` / `guard`, `brigade outcome`,
-`brigade evidence`, `brigade code`, `brigade skills`, `brigade daily`,
-`brigade fleet`. Add a file with the same four H2s rather than stretching an
-existing one.
+Checkout-level CLI surfaces (pytest selectors, not helper drives). Names
+confirmed under `tests/` on this checkout; the skill body table is the
+copy agents should cite.
+
+| Surface | Command | Tests |
+|---|---|---|
+| run | `brigade run` | `tests/test_run_cli.py`, `tests/test_run_lifecycle.py`, `tests/test_run_events.py`, `tests/test_run_control.py`, `tests/test_run_resume.py`, `tests/test_run_receipts.py` |
+| work verify | `brigade work verify` | `tests/test_work_cmd_verification.py`, `tests/test_work_cmd_verify_ranking.py`, `tests/test_verify_trial.py`, `tests/test_verification_contract.py`, `tests/test_verify_brigade_skill.py` |
+| fleet | `brigade fleet` | `tests/test_fleet_*.py` (14 files; start with `tests/test_fleet_claims.py`, `tests/test_fleet_nodes.py`, `tests/test_fleet_sync.py`) |
+| grokbot listener | `brigade run cloud grokbot` | `tests/test_grokbot_ops.py`, `tests/test_grokbot_jobs.py`, `tests/test_grokbot_mcp.py`, `tests/test_grokbot_feed.py`, `tests/test_grokbot_packs.py` |
+| guard | `brigade guard` / `brigade scrub` | `tests/guard/test_cli.py`, `tests/guard/test_engine.py`, `tests/guard/test_rules.py`, `tests/test_scrub.py`, `tests/test_runguard.py` |
+
+Helper drives still missing a feature file, and worth adding when a change
+lands there: `brigade memory`, `brigade security`, `brigade outcome`,
+`brigade evidence`, `brigade code`, `brigade skills`, `brigade daily`.
+`brigade scrub` / `guard` and `brigade fleet` now have checkout test
+selectors above; add a helper feature file with the same four H2s rather
+than stretching an existing one.
 
 Setup shared by every file:
 

--- a/tests/test_verify_brigade_skill.py
+++ b/tests/test_verify_brigade_skill.py
@@ -328,7 +328,7 @@ def test_skill_doc_includes_checkout_verification_map():
     features = (SKILL_DIR / "features" / "README.md").read_text(encoding="utf-8")
     for heading in ("## Launch", "## Doctor", "## Drive", "## Evidence", "## Cleanup", "## Feature map"):
         assert heading in doc, heading
-    assert 'python3 -m venv .venv' in doc
+    assert "python3 -m venv .venv" in doc
     assert 'pip install -e ".[dev,grokbot]"' in doc
     assert "brigade doctor --target ." in doc
     assert "brigade status --target ." in doc
@@ -344,7 +344,13 @@ def test_skill_doc_includes_checkout_verification_map():
     assert '"status": "completed"' in doc
     assert "Never commit `.brigade/`" in doc or "Never commit `.brigade/" in doc
     assert ".venv/" in doc
-    for surface in ("brigade run", "brigade work verify", "brigade fleet", "brigade run cloud grokbot", "brigade guard"):
+    for surface in (
+        "brigade run",
+        "brigade work verify",
+        "brigade fleet",
+        "brigade run cloud grokbot",
+        "brigade guard",
+    ):
         assert surface in doc, surface
         assert surface in features, surface
     for path in (

--- a/tests/test_verify_brigade_skill.py
+++ b/tests/test_verify_brigade_skill.py
@@ -322,6 +322,43 @@ def test_skill_doc_states_what_the_helper_enforces():
     assert "--manifest" in doc, "the one flag outside the target contract must be documented"
 
 
+def test_skill_doc_includes_checkout_verification_map():
+    """SKILL.md keeps the helper contract and adds the checkout verification map."""
+    doc = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    features = (SKILL_DIR / "features" / "README.md").read_text(encoding="utf-8")
+    for heading in ("## Launch", "## Doctor", "## Drive", "## Evidence", "## Cleanup", "## Feature map"):
+        assert heading in doc, heading
+    assert 'python3 -m venv .venv' in doc
+    assert 'pip install -e ".[dev,grokbot]"' in doc
+    assert "brigade doctor --target ." in doc
+    assert "brigade status --target ." in doc
+    assert "./scripts/verify-focused" in doc
+    assert "ruff check src/brigade" in doc
+    assert "ruff format --check src/brigade" in doc
+    assert ".venv/bin/mypy" in doc
+    assert "brigade work verify run --target ." in doc
+    assert "--argv-json" in doc
+    assert "--capture brigade-work" in doc
+    assert ".brigade/work/verify-runs/<run-id>/receipt.json" in doc
+    assert "work-verify receipt:" in doc
+    assert '"status": "completed"' in doc
+    assert "Never commit `.brigade/`" in doc or "Never commit `.brigade/" in doc
+    assert ".venv/" in doc
+    for surface in ("brigade run", "brigade work verify", "brigade fleet", "brigade run cloud grokbot", "brigade guard"):
+        assert surface in doc, surface
+        assert surface in features, surface
+    for path in (
+        "tests/test_run_cli.py",
+        "tests/test_work_cmd_verification.py",
+        "tests/test_fleet_claims.py",
+        "tests/test_grokbot_ops.py",
+        "tests/guard/test_cli.py",
+        "tests/test_scrub.py",
+    ):
+        assert path in doc, path
+        assert path in features, path
+
+
 def test_failed_brigade_init_leaves_no_target(tmp_path):
     root = tmp_path / "state"
     failing = shlex.join([sys.executable, "-c", "raise SystemExit(1)"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Extend the existing `registry/skills/verify-brigade` skill (PR #1355) with a pstack-style checkout verification map. The helper contract (`control-brigade.py`, temp-target isolation, evidence/cleanup) is unchanged. Agents now also get concrete, observed commands for launching this checkout, reading doctor/status, running the focused gates, citing a work-verify receipt, cleaning up, and picking pytest selectors from a CLI-to-test Feature map.

- [x] Docs
- [x] Added or updated tests covering the change
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

## Done predicate

The project-local skill at `registry/skills/verify-brigade/SKILL.md` still includes the original helper-driven Launch / Doctor / Drive / Evidence / Cleanup / Helpers sections, and now also documents:

1. **Launch** — `python3 -m venv .venv` then `.venv/bin/pip install -e ".[dev,grokbot]"` (observed: `brigade-cli-0.27.0`, `mcp-2.1.1`).
2. **Doctor** — `brigade doctor --target .` and `brigade status --target .`; healthy is exit 0 and `0 failed` (warnings are expected on this source tree).
3. **Drive** — `./scripts/verify-focused <tests>`, `ruff check`, `ruff format --check`, `mypy`, plus the receipted `brigade work verify run --argv-json ... --capture`.
4. **Evidence** — receipts at `.brigade/work/verify-runs/<run-id>/receipt.json`; cite `work-verify receipt: <id>`; passing means `"status": "completed"` and command exit 0.
5. **Cleanup** — `.venv/` is gitignored; never commit `.brigade/`.
6. **Feature map** — table mapping `run`, `work verify`, `fleet`, grokbot listener, and `guard` to the `tests/` files that cover them.

## Verification

Required envelope (all observed on HEAD `bde2310371b481e64157fc3c3c2756f4cc6dfad0`):

| Command | Exit | Key output |
|---|---|---|
| `python -m pytest -q tests/test_skills_cmd.py tests/test_ci_workflow.py` | 0 | `201 passed in 4.80s` |
| `ruff check src/brigade` | 0 | `All checks passed!` |
| `ruff format --check src/brigade` | 0 | `563 files already formatted` |
| `mypy` | 0 | `Success: no issues found in 563 source files` |
| `git diff --check` | 0 | (no output) |

Receipted form:

```bash
brigade work verify run --target . \
  --argv-json '["./scripts/verify-focused","tests/test_skills_cmd.py","tests/test_ci_workflow.py"]' \
  --capture brigade-work
```

work-verify receipt: `20260902-210556-work-verify-905fa6`

Passing receipt: `"status": "completed"`, command exit 0, `baseline_commit` `bde2310371b481e64157fc3c3c2756f4cc6dfad0`. Audit-only (`--argv-json`, not `--manifest`).

Did not run `./scripts/verify-fast` or the full suite.

No `Fixes #` — no open issue is specifically about this skill extension.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee44decf-da80-4598-ba43-a0c448221f3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee44decf-da80-4598-ba43-a0c448221f3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

