### PR TITLE
fix(center): rotate old operator report directories automatically (#1415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `brigade center report build` rotates old operator report directories automatically under `.brigade/center/reports/` into `reports-archive/` according to retention (default keep newest 20, configurable via `operator_report_retention` in `.brigade/daily.toml` alongside `allow_operator_report_build`), never rotates unclosed reports, and supports dry-run mode that previews rotation without deleting or moving bundles. Fixes #1415.
 - Fixed timing flakes in tests `test_release_with_renew_in_flight_never_resurrects` and `test_concurrent_edge_writes_do_not_lose_dependency_edges`. (#1396)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `brigade center report build` rotates old operator report directories automatically under `.brigade/center/reports/` into `reports-archive/` according to retention (default keep newest 20, configurable via `operator_report_retention` in `.brigade/daily.toml` alongside `allow_operator_report_build`), never rotates unclosed reports, and supports dry-run mode that previews rotation without deleting or moving bundles. Fixes #1415.
+- `brigade center report build` rotates old operator report directories automatically under `.brigade/center/reports/` into `reports-archive/` according to retention (default keep newest 20, configurable via `operator_report_retention` in `.brigade/daily.toml` alongside `allow_operator_report_build` or CLI flag `--keep N`), caps `reports-archive/` to the same retention count by deleting the oldest archived directories, never rotates unclosed reports, and supports `--dry-run` to preview rotation without deleting or moving bundles. Fixes #1415.
 - Fixed timing flakes in tests `test_release_with_renew_in_flight_never_resurrects` and `test_concurrent_edge_writes_do_not_lose_dependency_edges`. (#1396)
 
 ### Added

--- a/docs/operator-center.md
+++ b/docs/operator-center.md
@@ -150,7 +150,7 @@ Every center row uses the same wrapper-facing fields: `subsystem`, `local_id`, `
 
 `brigade daily status` summarizes the current local operating state from work, imports, center reviews, action queues, readiness, handoffs, memory-care, security, tools, release receipts, and operator reports. It also returns the next recommended command.
 
-`brigade daily init` writes conservative local defaults to `.brigade/daily.toml`. The config can prefer task, inbox, or readiness modes and can disable context pack builds, operator report builds, readiness imports, import promotion, or work runs.
+`brigade daily init` writes conservative local defaults to `.brigade/daily.toml`. The config can prefer task, inbox, or readiness modes and can disable context pack builds, operator report builds (`allow_operator_report_build`), readiness imports, import promotion, or work runs. It also configures operator report retention via `operator_report_retention` (defaults to 20).
 
 `brigade daily plan` ranks local candidate actions by urgency, safety, acceptance coverage, provenance, and expected usefulness. It prefers pending accepted tasks, then reviewed imports with acceptance criteria, reviewed center actions, readiness blockers that can become imports, and stale handoff, memory, or security issues. It chooses one recommended action and writes no state unless `--record` is passed. The local preferred mode can move inbox or readiness items upward without bypassing risk, approval, or remote-mutation guards. JSON output includes selection reasons, rejection reasons, safety blockers, approval blockers, stale evidence blockers, and quality blockers for wrappers.
 
@@ -239,6 +239,8 @@ Each bundle contains:
 - `CENTER_EVIDENCE.json`, stable JSON evidence for wrappers.
 
 `brigade center report plan` previews the same evidence without writing. `list`, `show`, and `archive` inspect or move local bundles. Report health warns when the latest bundle is unclosed, stale, references missing receipts, was built from an older git HEAD, or newer center activity exists. `brigade work brief`, `brigade work doctor`, `brigade release doctor`, release candidate evidence, and release candidate compare surface those report health checks.
+
+`brigade center report build` automatically rotates older closed operator report directories under `.brigade/center/reports/` into `.brigade/center/reports-archive/` beyond a retention threshold (configurable via `--keep N` or `operator_report_retention` in `.brigade/daily.toml`, defaulting to 20). Unclosed reports are never rotated. The archive directory `.brigade/center/reports-archive/` is bounded to the same keep count, deleting the oldest archived directories beyond retention. Passing `--dry-run` previews what would be rotated without writing or moving bundles.
 
 `brigade center report review <report-id|latest>` groups actionable report items into:
 

--- a/src/brigade/center_cmd/reports.py
+++ b/src/brigade/center_cmd/reports.py
@@ -7,6 +7,7 @@ import html
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
 from datetime import datetime
@@ -45,6 +46,7 @@ from ..render import emit
 
 from . import core as _core_mod
 from .schema_ops import (
+    DEFAULT_REPORT_RETENTION,
     REPORT_STALE_HOURS,
     SCHEMA_VERSION,
     _parse_time,
@@ -598,11 +600,145 @@ def report_plan(*, target: Path, json_output: bool = False) -> int:
     return 0
 
 
-def report_build(*, target: Path, json_output: bool = False) -> int:
+def _report_retention(target: Path, override: int | None = None) -> int:
+    """Return the retention keep count for operator reports.
+
+    Reads operator_report_retention from .brigade/daily.toml if configured alongside
+    allow_operator_report_build; defaults to DEFAULT_REPORT_RETENTION (20).
+    """
+    if override is not None and override >= 1:
+        return override
+    daily_toml = target / ".brigade" / "daily.toml"
+    if daily_toml.is_file():
+        try:
+            import tomllib
+
+            data = tomllib.loads(daily_toml.read_text())
+            val = data.get("operator_report_retention")
+            if isinstance(val, int) and val >= 1:
+                return val
+        except Exception:
+            pass
+    return DEFAULT_REPORT_RETENTION
+
+
+def _is_report_closed(report_dir: Path, report_payload: dict[str, Any] | None = None) -> bool:
+    """Return True if a report bundle has a recorded closeout with a recognized status."""
+    if report_payload is not None:
+        closeout = report_payload.get("closeout")
+        if isinstance(closeout, dict):
+            status = str(closeout.get("status") or "")
+            if status in reportstore.CLOSEOUT_STATUSES:
+                return True
+    closeout_file = report_dir / "CLOSEOUT.json"
+    if closeout_file.is_file():
+        closeout_data = _read_json(closeout_file)
+        if isinstance(closeout_data, dict):
+            status = str(closeout_data.get("status") or "")
+            if status in reportstore.CLOSEOUT_STATUSES:
+                return True
+    if report_payload is None:
+        payload = _read_report(report_dir)
+        if payload is not None:
+            closeout = payload.get("closeout")
+            if isinstance(closeout, dict):
+                status = str(closeout.get("status") or "")
+                if status in reportstore.CLOSEOUT_STATUSES:
+                    return True
+    return False
+
+
+def _report_dir_sort_key(report_dir: Path) -> tuple[str, str]:
+    payload = _read_report(report_dir)
+    created = ""
+    if payload is not None:
+        created = str(payload.get("created_at") or payload.get("generated_at") or "")
+    return (created or report_dir.name, report_dir.name)
+
+
+def _operator_report_dirs(target: Path) -> list[Path]:
+    root = _reports_root(target)
+    if not root.is_dir():
+        return []
+    dirs = [
+        p
+        for p in root.iterdir()
+        if p.is_dir()
+        and not p.name.startswith(".")
+        and not p.name.endswith("archive")
+        and ("operator-report" in p.name or (p / "CENTER_EVIDENCE.json").is_file())
+    ]
+    dirs.sort(key=_report_dir_sort_key, reverse=True)
+    return dirs
+
+
+def _rotate_reports(
+    target: Path,
+    *,
+    retention: int = DEFAULT_REPORT_RETENTION,
+    dry_run: bool = False,
+) -> list[Path]:
+    """Rotate operator report directories beyond retention into reports-archive/.
+
+    Never rotates an unclosed report.
+    Returns the list of report directories rotated (or that would be rotated if dry_run=True).
+    """
+    if retention < 1:
+        retention = DEFAULT_REPORT_RETENTION
+    dirs = _operator_report_dirs(target)
+    if len(dirs) <= retention:
+        return []
+
+    candidates = dirs[retention:]
+    to_rotate: list[Path] = []
+    for d in candidates:
+        if _is_report_closed(d):
+            to_rotate.append(d)
+
+    if dry_run:
+        return to_rotate
+
+    archive_root = _reports_archive_root(target)
+    for source_dir in to_rotate:
+        archive_dest = archive_root / source_dir.name
+        if archive_dest.exists():
+            shutil.rmtree(archive_dest)
+        reportstore.move_bundle(source_dir, archive_root)
+    return to_rotate
+
+
+def report_build(
+    *,
+    target: Path,
+    json_output: bool = False,
+    dry_run: bool = False,
+    keep: int | None = None,
+) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
+    retention = _report_retention(target, override=keep)
+    if dry_run:
+        would_rotate = _rotate_reports(target, retention=retention, dry_run=True)
+        if json_output:
+            payload = {
+                "schema_version": SCHEMA_VERSION,
+                "target": str(target),
+                "dry_run": True,
+                "retention": retention,
+                "would_rotate": [d.name for d in would_rotate],
+                "would_rotate_count": len(would_rotate),
+            }
+            print(json.dumps(payload, indent=2, sort_keys=True))
+            return 0
+        print(f"operator report build (dry run): {target}")
+        print(f"retention: keep={retention}")
+        print(f"would rotate: {len(would_rotate)}")
+        for d in would_rotate:
+            print(f"- {d.name}")
+        return 0
+
     created = _now()
     report_id = f"{created.strftime('%Y%m%d-%H%M%S')}-operator-report-{uuid4().hex[:6]}"
     report_dir = _reports_root(target) / report_id
@@ -616,13 +752,22 @@ def report_build(*, target: Path, json_output: bool = False) -> int:
         }
     )
     _write_report_bundle(report_dir, payload)
+    rotated = _rotate_reports(target, retention=retention, dry_run=False)
+    if rotated:
+        payload["rotated_reports"] = [d.name for d in rotated]
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
+    reviews = payload.get("reviews")
+    reviews_count = len(reviews) if isinstance(reviews, list) else 0
+    activity = payload.get("activity")
+    activity_count = len(activity) if isinstance(activity, list) else 0
     print(f"operator report: {report_id}")
-    print(f"reviews: {len(payload['reviews'])}")
-    print(f"activity: {len(payload['activity'])}")
+    print(f"reviews: {reviews_count}")
+    print(f"activity: {activity_count}")
     print(f"path: {report_dir}")
+    if rotated:
+        print(f"rotated: {len(rotated)}")
     return 0
 
 

--- a/src/brigade/center_cmd/reports.py
+++ b/src/brigade/center_cmd/reports.py
@@ -32,6 +32,7 @@ from .. import (
     research_cmd,
     roadmap_cmd,
     security_cmd,
+    toml_compat,
     tools_cmd,
     work_cmd,
 )
@@ -611,14 +612,15 @@ def _report_retention(target: Path, override: int | None = None) -> int:
     daily_toml = target / ".brigade" / "daily.toml"
     if daily_toml.is_file():
         try:
-            import tomllib
-
-            data = tomllib.loads(daily_toml.read_text())
+            data = toml_compat.loads(daily_toml.read_text())
+        except toml_compat.TOMLDecodeError as exc:
+            raise toml_compat.TOMLDecodeError(f"malformed {daily_toml}: {exc}") from exc
+        except OSError:
+            return DEFAULT_REPORT_RETENTION
+        if isinstance(data, dict):
             val = data.get("operator_report_retention")
             if isinstance(val, int) and val >= 1:
                 return val
-        except Exception:
-            pass
     return DEFAULT_REPORT_RETENTION
 
 
@@ -672,6 +674,34 @@ def _operator_report_dirs(target: Path) -> list[Path]:
     return dirs
 
 
+def _archived_report_dirs(target: Path) -> list[Path]:
+    root = _reports_archive_root(target)
+    if not root.is_dir():
+        return []
+    dirs = [
+        p
+        for p in root.iterdir()
+        if p.is_dir()
+        and not p.name.startswith(".")
+        and ("operator-report" in p.name or (p / "CENTER_EVIDENCE.json").is_file())
+    ]
+    dirs.sort(key=_report_dir_sort_key, reverse=True)
+    return dirs
+
+
+def _prune_archive(target: Path, *, retention: int = DEFAULT_REPORT_RETENTION) -> list[Path]:
+    """Prune archived operator report directories beyond retention, deleting the oldest."""
+    if retention < 1:
+        retention = DEFAULT_REPORT_RETENTION
+    dirs = _archived_report_dirs(target)
+    if len(dirs) <= retention:
+        return []
+    to_delete = dirs[retention:]
+    for d in to_delete:
+        shutil.rmtree(d)
+    return to_delete
+
+
 def _rotate_reports(
     target: Path,
     *,
@@ -681,19 +711,20 @@ def _rotate_reports(
     """Rotate operator report directories beyond retention into reports-archive/.
 
     Never rotates an unclosed report.
+    Crops reports-archive/ to the same retention count by deleting the oldest archived directories.
     Returns the list of report directories rotated (or that would be rotated if dry_run=True).
     """
     if retention < 1:
         retention = DEFAULT_REPORT_RETENTION
     dirs = _operator_report_dirs(target)
     if len(dirs) <= retention:
-        return []
-
-    candidates = dirs[retention:]
-    to_rotate: list[Path] = []
-    for d in candidates:
-        if _is_report_closed(d):
-            to_rotate.append(d)
+        to_rotate: list[Path] = []
+    else:
+        candidates = dirs[retention:]
+        to_rotate = []
+        for d in candidates:
+            if _is_report_closed(d):
+                to_rotate.append(d)
 
     if dry_run:
         return to_rotate
@@ -704,6 +735,8 @@ def _rotate_reports(
         if archive_dest.exists():
             shutil.rmtree(archive_dest)
         reportstore.move_bundle(source_dir, archive_root)
+
+    _prune_archive(target, retention=retention)
     return to_rotate
 
 

--- a/src/brigade/center_cmd/schema_ops.py
+++ b/src/brigade/center_cmd/schema_ops.py
@@ -48,6 +48,7 @@ SCHEMA_VERSION = 1
 SCHEMA_MANIFEST_VERSION = 1
 
 REPORT_STALE_HOURS = 24
+DEFAULT_REPORT_RETENTION = 20
 
 ACTION_STATUSES = {"pending", "active", "done", "deferred", "archived"}
 

--- a/src/brigade/cli/center.py
+++ b/src/brigade/cli/center.py
@@ -84,6 +84,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_center_report_build.add_argument(
         "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
     )
+    p_center_report_build.add_argument(
+        "--dry-run", action="store_true", help="Preview report rotation without writing or rotating bundles."
+    )
+    p_center_report_build.add_argument(
+        "--keep", type=int, default=None, metavar="N", help="Override report retention count."
+    )
     p_center_report_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_center_report_list = center_report_sub.add_parser("list", help="List local operator report bundles.")
     p_center_report_list.add_argument(
@@ -273,7 +279,12 @@ def dispatch(args) -> int:
         if args.center_report_command == "plan":
             return center_cmd.report_plan(target=args.target, json_output=args.json)
         if args.center_report_command == "build":
-            return center_cmd.report_build(target=args.target, json_output=args.json)
+            return center_cmd.report_build(
+                target=args.target,
+                dry_run=args.dry_run,
+                keep=args.keep,
+                json_output=args.json,
+            )
         if args.center_report_command == "list":
             return center_cmd.report_list(target=args.target, limit=args.limit, json_output=args.json)
         if args.center_report_command == "show":

--- a/src/brigade/daily_cmd/config.py
+++ b/src/brigade/daily_cmd/config.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "max_risk_without_approval": "medium",
     "allow_context_pack_build": True,
     "allow_operator_report_build": True,
+    "operator_report_retention": 20,
     "allow_readiness_imports": True,
     "allow_import_promotion_with_approval": True,
     "allow_work_run": True,
@@ -438,7 +439,12 @@ def _validate_config(config: dict[str, Any]) -> list[dict[str, Any]]:
     ):
         if not isinstance(config.get(key), bool):
             checks.append({"status": "fail", "name": key, "detail": "expected boolean"})
-    for key in ("stale_plan_threshold_hours", "stale_run_threshold_hours", "verification_timeout"):
+    for key in (
+        "stale_plan_threshold_hours",
+        "stale_run_threshold_hours",
+        "verification_timeout",
+        "operator_report_retention",
+    ):
         value = config.get(key)
         if not isinstance(value, int) or value < 1:
             checks.append({"status": "fail", "name": key, "detail": "expected positive integer"})

--- a/tests/test_center_report_cmd.py
+++ b/tests/test_center_report_cmd.py
@@ -2,6 +2,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from brigade import center_cmd
 from brigade import cli
 from brigade import handoff_cmd
@@ -410,10 +412,11 @@ def test_center_report_build_rotates_old_reports_down_to_keep_count(tmp_path, ca
     assert len(active) == 2
     assert set(active) == {built_ids[-1], built_ids[-2]}
 
-    # The 3 older reports should have been archived under reports-archive/
+    # The archive is capped at the same keep count (2), deleting the oldest archived report
     archived = [p.name for p in archive_root.iterdir() if p.is_dir()]
-    assert len(archived) == 3
-    assert set(archived) == {built_ids[0], built_ids[1], built_ids[2]}
+    assert len(archived) == 2
+    assert set(archived) == {built_ids[1], built_ids[2]}
+    assert built_ids[0] not in archived
 
 
 def test_center_report_build_never_deletes_or_rotates_unclosed_report(tmp_path, capsys):
@@ -526,3 +529,68 @@ def test_center_report_build_reads_retention_from_daily_toml(tmp_path, capsys):
 
     archived = {p.name for p in archive_root.iterdir() if p.is_dir()}
     assert built_ids[0] in archived
+
+
+def test_center_report_build_malformed_daily_toml_raises_error(tmp_path):
+    _seed_task_and_import(tmp_path)
+    (tmp_path / ".brigade").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".brigade" / "daily.toml").write_text("operator_report_retention = [invalid toml\n")
+    with pytest.raises(ValueError, match="malformed .*daily.toml"):
+        center_cmd.report_build(target=tmp_path)
+
+
+def test_center_report_build_cli_flags_dry_run_and_keep(tmp_path, capsys):
+    _seed_task_and_import(tmp_path)
+    # Build report via CLI with --keep
+    assert cli.main(["center", "report", "build", "--target", str(tmp_path), "--keep", "5", "--json"]) == 0
+    r1 = json.loads(capsys.readouterr().out)["report_id"]
+    assert center_cmd.report_closeout(target=tmp_path, report_id=r1, status="reviewed") == 0
+    capsys.readouterr()
+
+    # Build second report via CLI
+    assert cli.main(["center", "report", "build", "--target", str(tmp_path), "--keep", "5", "--json"]) == 0
+    r2 = json.loads(capsys.readouterr().out)["report_id"]
+    assert center_cmd.report_closeout(target=tmp_path, report_id=r2, status="reviewed") == 0
+    capsys.readouterr()
+
+    # Dry-run via CLI with --keep 1 should preview rotating r1 without moving it
+    assert cli.main(["center", "report", "build", "--target", str(tmp_path), "--dry-run", "--keep", "1", "--json"]) == 0
+    dry_data = json.loads(capsys.readouterr().out)
+    assert dry_data["dry_run"] is True
+    assert dry_data["retention"] == 1
+    assert dry_data["would_rotate_count"] == 1
+    assert dry_data["would_rotate"] == [r1]
+
+    # Active reports still contains both r1 and r2; reports-archive is empty
+    reports_root = tmp_path / ".brigade" / "center" / "reports"
+    archive_root = tmp_path / ".brigade" / "center" / "reports-archive"
+    active = {p.name for p in reports_root.iterdir() if p.is_dir() and not p.name.endswith("archive")}
+    assert {r1, r2} <= active
+    assert not archive_root.exists() or len(list(archive_root.iterdir())) == 0
+
+
+def test_center_report_archive_cap_prunes_oldest_archived_dirs(tmp_path, capsys):
+    _seed_task_and_import(tmp_path)
+    reports_root = tmp_path / ".brigade" / "center" / "reports"
+    archive_root = tmp_path / ".brigade" / "center" / "reports-archive"
+
+    # Build and close 6 reports with keep=2
+    built_ids: list[str] = []
+    for _ in range(6):
+        assert center_cmd.report_build(target=tmp_path, json_output=True, keep=2) == 0
+        rep = json.loads(capsys.readouterr().out)
+        built_ids.append(rep["report_id"])
+        assert center_cmd.report_closeout(target=tmp_path, report_id=rep["report_id"], status="reviewed") == 0
+        capsys.readouterr()
+
+    # Active reports: newest 2
+    active = {p.name for p in reports_root.iterdir() if p.is_dir() and not p.name.endswith("archive")}
+    assert active == {built_ids[4], built_ids[5]}
+
+    # Archived reports: capped at 2 (newest archived are built_ids[2] and built_ids[3])
+    # Oldest archived (built_ids[0] and built_ids[1]) must have been pruned
+    archived = {p.name for p in archive_root.iterdir() if p.is_dir()}
+    assert len(archived) == 2
+    assert archived == {built_ids[2], built_ids[3]}
+    assert built_ids[0] not in archived
+    assert built_ids[1] not in archived

--- a/tests/test_center_report_cmd.py
+++ b/tests/test_center_report_cmd.py
@@ -376,3 +376,153 @@ def test_center_report_build_size_does_not_grow_with_history(tmp_path, capsys):
     assert "reviews" not in latest_ref
     assert "activity" not in latest_ref
     assert "status" not in latest_ref
+
+
+def test_center_report_build_rotates_old_reports_down_to_keep_count(tmp_path, capsys):
+    _seed_task_and_import(tmp_path)
+    reports_root = tmp_path / ".brigade" / "center" / "reports"
+    archive_root = tmp_path / ".brigade" / "center" / "reports-archive"
+
+    built_ids: list[str] = []
+    for _ in range(4):
+        assert center_cmd.report_build(target=tmp_path, json_output=True, keep=2) == 0
+        rep = json.loads(capsys.readouterr().out)
+        built_ids.append(rep["report_id"])
+        # Close each report so it is eligible for rotation
+        assert (
+            center_cmd.report_closeout(
+                target=tmp_path,
+                report_id=rep["report_id"],
+                status="reviewed",
+                json_output=True,
+            )
+            == 0
+        )
+        capsys.readouterr()
+
+    # Build a 5th report with keep=2
+    assert center_cmd.report_build(target=tmp_path, json_output=True, keep=2) == 0
+    fifth = json.loads(capsys.readouterr().out)
+    built_ids.append(fifth["report_id"])
+
+    # Exactly 2 reports should remain in reports/
+    active = [p.name for p in reports_root.iterdir() if p.is_dir() and not p.name.endswith("archive")]
+    assert len(active) == 2
+    assert set(active) == {built_ids[-1], built_ids[-2]}
+
+    # The 3 older reports should have been archived under reports-archive/
+    archived = [p.name for p in archive_root.iterdir() if p.is_dir()]
+    assert len(archived) == 3
+    assert set(archived) == {built_ids[0], built_ids[1], built_ids[2]}
+
+
+def test_center_report_build_never_deletes_or_rotates_unclosed_report(tmp_path, capsys):
+    _seed_task_and_import(tmp_path)
+    reports_root = tmp_path / ".brigade" / "center" / "reports"
+    archive_root = tmp_path / ".brigade" / "center" / "reports-archive"
+
+    built_ids: list[str] = []
+    # Build report 0 (closed)
+    assert center_cmd.report_build(target=tmp_path, json_output=True, keep=10) == 0
+    r0 = json.loads(capsys.readouterr().out)["report_id"]
+    built_ids.append(r0)
+    assert center_cmd.report_closeout(target=tmp_path, report_id=r0, status="reviewed") == 0
+    capsys.readouterr()
+
+    # Build report 1 (UNCLOSED - no closeout recorded)
+    assert center_cmd.report_build(target=tmp_path, json_output=True, keep=10) == 0
+    r1 = json.loads(capsys.readouterr().out)["report_id"]
+    built_ids.append(r1)
+    capsys.readouterr()
+
+    # Build report 2 (closed)
+    assert center_cmd.report_build(target=tmp_path, json_output=True, keep=10) == 0
+    r2 = json.loads(capsys.readouterr().out)["report_id"]
+    built_ids.append(r2)
+    assert center_cmd.report_closeout(target=tmp_path, report_id=r2, status="reviewed") == 0
+    capsys.readouterr()
+
+    # Build report 3 (closed) with keep=2
+    # Candidates beyond newest 2 are r1 and r0.
+    # r1 is UNCLOSED, so it MUST NOT be rotated.
+    # r0 is closed, so it SHOULD be rotated.
+    assert center_cmd.report_build(target=tmp_path, json_output=True, keep=2) == 0
+    r3 = json.loads(capsys.readouterr().out)["report_id"]
+    built_ids.append(r3)
+
+    active = {p.name for p in reports_root.iterdir() if p.is_dir() and not p.name.endswith("archive")}
+    # r1 (unclosed) MUST still be in active reports
+    assert r1 in active
+    # r2 and r3 (newest) must be in active reports
+    assert r2 in active
+    assert r3 in active
+    # r0 (closed and beyond keep=2) must have been rotated
+    assert r0 not in active
+
+    archived = {p.name for p in archive_root.iterdir() if p.is_dir()}
+    assert r0 in archived
+    assert r1 not in archived
+
+
+def test_center_report_build_dry_run_lists_candidates_and_deletes_nothing(tmp_path, capsys):
+    _seed_task_and_import(tmp_path)
+    reports_root = tmp_path / ".brigade" / "center" / "reports"
+    archive_root = tmp_path / ".brigade" / "center" / "reports-archive"
+
+    built_ids: list[str] = []
+    for _ in range(3):
+        assert center_cmd.report_build(target=tmp_path, json_output=True, keep=10) == 0
+        rep = json.loads(capsys.readouterr().out)
+        built_ids.append(rep["report_id"])
+        assert center_cmd.report_closeout(target=tmp_path, report_id=rep["report_id"], status="reviewed") == 0
+        capsys.readouterr()
+
+    # Dry run with keep=1: should report that 2 oldest reports would be rotated
+    assert center_cmd.report_build(target=tmp_path, dry_run=True, keep=1, json_output=True) == 0
+    dry_json = json.loads(capsys.readouterr().out)
+    assert dry_json["dry_run"] is True
+    assert dry_json["retention"] == 1
+    assert dry_json["would_rotate_count"] == 2
+    assert set(dry_json["would_rotate"]) == {built_ids[0], built_ids[1]}
+
+    # Assert NOTHING was moved or deleted
+    active = {p.name for p in reports_root.iterdir() if p.is_dir() and not p.name.endswith("archive")}
+    assert active == set(built_ids)
+    assert not archive_root.exists() or len(list(archive_root.iterdir())) == 0
+
+    # Test text output in dry run
+    assert center_cmd.report_build(target=tmp_path, dry_run=True, keep=1, json_output=False) == 0
+    out = capsys.readouterr().out
+    assert "operator report build (dry run):" in out
+    assert "would rotate: 2" in out
+    assert f"- {built_ids[0]}" in out
+    assert f"- {built_ids[1]}" in out
+
+
+def test_center_report_build_reads_retention_from_daily_toml(tmp_path, capsys):
+    _seed_task_and_import(tmp_path)
+    reports_root = tmp_path / ".brigade" / "center" / "reports"
+    archive_root = tmp_path / ".brigade" / "center" / "reports-archive"
+
+    # Set retention in .brigade/daily.toml alongside allow_operator_report_build
+    (tmp_path / ".brigade").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".brigade" / "daily.toml").write_text(
+        "allow_operator_report_build = true\noperator_report_retention = 2\n"
+    )
+
+    built_ids: list[str] = []
+    for _ in range(3):
+        assert center_cmd.report_build(target=tmp_path, json_output=True) == 0
+        rep = json.loads(capsys.readouterr().out)
+        built_ids.append(rep["report_id"])
+        assert center_cmd.report_closeout(target=tmp_path, report_id=rep["report_id"], status="reviewed") == 0
+        capsys.readouterr()
+
+    # Now exactly 2 reports should remain because retention=2 was read from daily.toml
+    active = {p.name for p in reports_root.iterdir() if p.is_dir() and not p.name.endswith("archive")}
+    assert len(active) == 2
+    assert built_ids[0] not in active
+    assert {built_ids[1], built_ids[2]} == active
+
+    archived = {p.name for p in archive_root.iterdir() if p.is_dir()}
+    assert built_ids[0] in archived

--- a/tests/test_daily_driver_cmd.py
+++ b/tests/test_daily_driver_cmd.py
@@ -280,6 +280,14 @@ def test_daily_config_validation_preferred_mode_and_unsafe_warning(tmp_path, cap
     invalid_payload = json.loads(capsys.readouterr().out)
     assert any(check["name"] == "daily_preferred_mode" for check in invalid_payload["checks"])
 
+    (tmp_path / ".brigade" / "daily.toml").write_text("operator_report_retention = 0\n")
+    assert daily_cmd.doctor(target=tmp_path, json_output=True) == 1
+    invalid_retention = json.loads(capsys.readouterr().out)
+    assert any(
+        check["name"] == "operator_report_retention" and check["status"] == "fail"
+        for check in invalid_retention["checks"]
+    )
+
 
 def test_daily_plan_ranks_tasks_imports_center_actions_and_readiness(tmp_path, capsys):
     _seed_ready_repo(tmp_path, capsys)


### PR DESCRIPTION
Fixes #1415

Verification receipt: `20260903-021544-work-verify-6d00e0`

### Summary & Rationale

`brigade center report build` previously wrote a new `.brigade/center/reports/<ts>-operator-report-<hex>/` bundle on every build without removing or archiving older bundles. Over time this led to unbounded directory growth.

This change implements automated retention for operator report directories:
- Rotates report directories under `.brigade/center/reports/` beyond a configurable retention (default keep the newest 20) by moving them into `.brigade/center/reports-archive/` via `reportstore.move_bundle()`.
- Reuses the existing `report archive` path (`_reports_archive_root`), preserving accessibility for `report diff` and `report show`.
- Bounds `.brigade/center/reports-archive/` to the same keep count, deleting the oldest archived directories beyond retention.
- Added `dry_run` mode that identifies and lists directories that would be rotated without deleting or moving any files.
- Configurable via `operator_report_retention` in `.brigade/daily.toml` alongside `allow_operator_report_build` or CLI flag `--keep N`, defaulting to `DEFAULT_REPORT_RETENTION = 20`.

### Definition of "Unclosed" Report

In `src/brigade/center_cmd/reports.py` (see `report_health` lines 474-476) and `src/brigade/reportstore.py`, closeout status is stored in `report["closeout"]["status"]` and/or on disk in `<bundle_dir>/CLOSEOUT.json` (`reportstore.write_closeout`). Valid closeout statuses are defined in `reportstore.CLOSEOUT_STATUSES`: `{"reviewed", "deferred", "superseded", "archived"}`.
A report is considered **unclosed** if neither `CENTER_EVIDENCE.json` nor `CLOSEOUT.json` contains a valid closeout status in `CLOSEOUT_STATUSES`. Unclosed reports are never rotated or deleted, ensuring open review items are not prematurely archived.

### Review follow-up

Addressed the four SENDBACK review blocking items:
1. **Python 3.10 compatibility**: Switched `_report_retention()` in `src/brigade/center_cmd/reports.py` to use `src/brigade/toml_compat.py` instead of `tomllib`, and narrowed exception handling to raise a clear `TOMLDecodeError` on malformed `.brigade/daily.toml`. Added test `test_center_report_build_malformed_daily_toml_raises_error`.
2. **Wire the CLI**: Added `--dry-run` and `--keep N` flags to `center report build` in `src/brigade/cli/center.py` and forwarded them to `report_build()`. Added CLI test `test_center_report_build_cli_flags_dry_run_and_keep`.
3. **Register `operator_report_retention` in `daily_cmd/config.py`**: Added key to `DEFAULT_CONFIG` (default 20) next to `allow_operator_report_build` and to `_validate_config` as a positive integer. Documented key alongside `allow_operator_report_build` in `docs/operator-center.md`. Added doctor check test in `test_daily_driver_cmd.py`.
4. **State and enforce the archive bound**: Capped `.brigade/center/reports-archive/` to the same retention keep count by deleting the oldest archived directories via `_prune_archive()`. Documented the archive bound in `docs/operator-center.md` and added test `test_center_report_archive_cap_prunes_oldest_archived_dirs`.

Follow-up verification receipts:
- `20260903-023158-work-verify-700899` (`python -m pytest tests/test_center_report_cmd.py -q`: 15 passed in 14.52s)
- `20260903-023222-work-verify-b4d461` (`python -m pytest tests/test_daily_driver_cmd.py -q`: 40 passed in 36.06s)
- `20260903-023305-work-verify-f64c78` (`ruff check .`: completed, exit 0)
- `20260903-023311-work-verify-673476` (`ruff format --check .`: completed, exit 0)
