### PR TITLE
fix(run): fail fast on a retained stale run-lock claim and name the recover command

### DIFF
--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -1057,6 +1057,58 @@ def _wait_retry_after_acquire_error(path: Path) -> bool:
     return _lock_is_stale(path)
 
 
+def _retained_claim_wait_error(path: Path) -> RunLockError | None:
+    """Return the explicit-recovery error when one retained claim blocks a waiter."""
+    try:
+        lock_is_directory = _lock_path_is_directory(path)
+    except RunLockError:
+        return None
+    if lock_is_directory is not None and not _lock_is_stale(path):
+        return None
+    retained_prefix = f".{path.name}.retained-"
+    claims = _stale_claims(path)
+    retained = [claim for claim in claims if claim.name.startswith(retained_prefix)]
+    if len(claims) != 1 or len(retained) != 1:
+        return None
+    claim = retained[0]
+    try:
+        if _lock_path_is_directory(claim) is None:
+            return None
+    except RunLockError:
+        return None
+    owner = _read_lock_owner(claim)
+    if owner is None:
+        return None
+    pid = owner.get("pid")
+    run_dir = owner.get("run_dir")
+    if not isinstance(pid, int) or _pid_is_active(pid) or not isinstance(run_dir, str) or not run_dir:
+        return None
+    run_id = Path(run_dir).name
+    if not run_id:
+        return None
+    workspace = path.parent.parent.resolve()
+    return RunLockError(
+        "retained stale run lock claim requires explicit recovery: "
+        f"{claim}; owner run_dir {run_dir}; owner pid {pid} is dead; "
+        f"recover with: brigade runs recover --cwd {workspace} {run_id}"
+    )
+
+
+def _run_lock_wait_timeout_error(path: Path, wait_seconds: float) -> RunLockError:
+    """Describe the final owner observation for a timed-out run-lock wait."""
+    owner = _read_lock_owner(path) if _lock_path_is_directory(path) is not None else None
+    pid = owner.get("pid") if owner is not None else None
+    run_dir = owner.get("run_dir") if owner is not None else None
+    pid_alive = _pid_is_active(pid) if isinstance(pid, int) else None
+    shown_pid = str(pid) if isinstance(pid, int) else "unknown"
+    shown_run_dir = run_dir if isinstance(run_dir, str) and run_dir else "unknown"
+    shown_alive = "yes" if pid_alive else "no" if pid_alive is False else "unknown"
+    return RunLockError(
+        f"timed out after {wait_seconds:g}s waiting for run lock: {path}; "
+        f"owner pid {shown_pid}; owner run_dir {shown_run_dir}; pid alive at last check: {shown_alive}"
+    )
+
+
 def _wait_to_acquire_lock(
     path: Path,
     *,
@@ -1092,6 +1144,9 @@ def _wait_to_acquire_lock(
                 try:
                     return _acquire()
                 except RunLockError as exc:
+                    retained_error = _retained_claim_wait_error(path)
+                    if retained_error is not None:
+                        raise retained_error from exc
                     if _wait_retry_after_acquire_error(path):
                         immediately_retryable = True
                     else:
@@ -1100,7 +1155,7 @@ def _wait_to_acquire_lock(
                 if not unbounded:
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
-                        raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}")
+                        raise _run_lock_wait_timeout_error(path, wait_seconds)
                 else:
                     time.sleep(poll_interval)
                 continue
@@ -1108,10 +1163,8 @@ def _wait_to_acquire_lock(
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     if timed_out_acquire_exc is not None:
-                        raise RunLockError(
-                            f"timed out after {wait_seconds:g}s waiting for run lock: {path}"
-                        ) from timed_out_acquire_exc
-                    raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}")
+                        raise _run_lock_wait_timeout_error(path, wait_seconds) from timed_out_acquire_exc
+                    raise _run_lock_wait_timeout_error(path, wait_seconds)
                 time.sleep(min(poll_interval, remaining))
             else:
                 time.sleep(poll_interval)

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import math
 import os
+import shlex
 import shutil
 import stat
 import tempfile
@@ -1090,7 +1091,7 @@ def _retained_claim_wait_error(path: Path) -> RunLockError | None:
     return RunLockError(
         "retained stale run lock claim requires explicit recovery: "
         f"{claim}; owner run_dir {run_dir}; owner pid {pid} is dead; "
-        f"recover with: brigade runs recover --cwd {workspace} {run_id}"
+        f"recover with: brigade runs recover --cwd {shlex.quote(str(workspace))} {shlex.quote(run_id)}"
     )
 
 

--- a/tests/test_runguard_wait.py
+++ b/tests/test_runguard_wait.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 
 import pytest
 
@@ -8,7 +9,7 @@ from brigade import runguard
 
 
 def _repo(tmp_path):
-    repo = tmp_path / "repo"
+    repo = tmp_path / "repo with spaces"
     repo.mkdir()
     for args in (
         ("init",),
@@ -68,7 +69,9 @@ def test_run_lock_wait_fails_immediately_for_retained_claim_with_recovery_comman
     assert str(retained_claims[0]) in message
     assert str(run_dir.resolve()) in message
     assert "43210" in message
-    assert f"brigade runs recover --cwd {repo.resolve()} abandoned-run" in message
+    expected = ["brigade", "runs", "recover", "--cwd", str(repo.resolve()), "abandoned-run"]
+    command = message.split("recover with: ", 1)[1]
+    assert shlex.split(command) == expected
     assert sleeps == []
 
 

--- a/tests/test_runguard_wait.py
+++ b/tests/test_runguard_wait.py
@@ -1,0 +1,95 @@
+import json
+import os
+
+import pytest
+
+from brigade import proc
+from brigade import runguard
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (
+        ("init",),
+        ("config", "user.email", "test@example.invalid"),
+        ("config", "user.name", "Test User"),
+    ):
+        result = proc.run(["git", *args], cwd=repo)
+        assert result.code == 0, result.stderr
+    (repo / "tracked.txt").write_text("base\n")
+    result = proc.run(["git", "add", "tracked.txt"], cwd=repo)
+    assert result.code == 0, result.stderr
+    result = proc.run(["git", "commit", "-m", "initial"], cwd=repo)
+    assert result.code == 0, result.stderr
+    return repo
+
+
+def _write_owner(lock, *, pid, run_dir):
+    lock.mkdir(parents=True)
+    (lock / "pid").write_text(f"{pid}\n")
+    (lock / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "test-owner",
+                "pid": pid,
+                "run_dir": str(run_dir.resolve()),
+                "acquired_at": "2026-09-02T00:00:00+00:00",
+            }
+        )
+    )
+
+
+def test_run_lock_wait_fails_immediately_for_retained_claim_with_recovery_command(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = repo / ".brigade" / "runs" / "abandoned-run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text(json.dumps({"status": "dispatching"}))
+    lifecycle = run_dir / "events" / "lifecycle.jsonl"
+    lifecycle.parent.mkdir()
+    lifecycle.write_text("{}\n")
+    lock_path = runguard.lock_path(repo)
+    retained = lock_path.with_name(f".{lock_path.name}.retained-dead.stale")
+    _write_owner(retained, pid=43210, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: pid == os.getpid())
+    monotonic = iter((0.0, 0.0, 60.1))
+    monkeypatch.setattr(runguard.time, "monotonic", lambda: next(monotonic))
+    sleeps = []
+    monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
+
+    with pytest.raises(runguard.RunLockError) as exc:
+        with runguard.run_lock(repo, wait_seconds=60.0, poll_interval=0.1):
+            pass
+
+    message = str(exc.value)
+    retained_claims = list(lock_path.parent.glob(f".{lock_path.name}.retained-*.stale"))
+    assert len(retained_claims) == 1
+    assert str(retained_claims[0]) in message
+    assert str(run_dir.resolve()) in message
+    assert "43210" in message
+    assert f"brigade runs recover --cwd {repo.resolve()} abandoned-run" in message
+    assert sleeps == []
+
+
+def test_run_lock_wait_timeout_reports_live_owner_details(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = repo / ".brigade" / "runs" / "live-run"
+    run_dir.mkdir(parents=True)
+    _write_owner(runguard.lock_path(repo), pid=43210, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: True)
+    monotonic = iter((10.0, 10.0, 10.25))
+    sleeps = []
+    monkeypatch.setattr(runguard.time, "monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
+
+    with pytest.raises(runguard.RunLockError) as exc:
+        with runguard.run_lock(repo, wait_seconds=0.2, poll_interval=0.05):
+            pass
+
+    message = str(exc.value)
+    assert "timed out after 0.2s waiting for run lock" in message
+    assert "owner pid 43210" in message
+    assert str(run_dir.resolve()) in message
+    assert "pid alive at last check: yes" in message
+    assert sleeps == [0.05]


### PR DESCRIPTION
## What

`brigade run --wait` used to sit for the whole timeout when the only blocker was a retained stale claim left by a run whose process died with an activated journal, then fail with a message naming only the lock path.

Now the waiter fails within one poll interval in that case and prints the retained claim path, the dead pid, the owner run directory, and the exact `brigade runs recover --cwd <workspace> <run-id>` command. A genuinely live lock still waits and times out as before, and that timeout message now names the owner pid, run directory, and whether the pid was alive at the last check. The safety decision is unchanged: an activated-journal lock is never auto-reclaimed.

Closes #1422.

## Verification

```
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_runguard_wait.py","tests/test_runguard.py","tests/test_run_control.py"]' --capture brigade-work
160 passed
```

Built by the `coder` seat (GPT-5.6 Terra) under `brigade run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved run-lock errors when a retained stale claim blocks execution.
  - Error messages now identify the claim, owner details, and provide the exact recovery command.
  - Lock-wait timeouts now report the last observed owner, including process ID, working directory, and process status.
  - Wait behavior now distinguishes retained stale claims from ordinary lock timeouts, providing more actionable guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->