### PR TITLE
feat(fleet): brigade fleet models list and actionable model-policy denials

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -28,7 +28,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade dogfood` (extras): 1 command path(s)
 - `brigade evidence`: 11 command path(s)
 - `brigade extras`: 3 command path(s)
-- `brigade fleet`: 32 command path(s)
+- `brigade fleet`: 33 command path(s)
 - `brigade friction` (extras): 3 command path(s)
 - `brigade guard`: 1 command path(s)
 - `brigade handoff`: 17 command path(s)
@@ -197,6 +197,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade fleet models admit`
 - `brigade fleet models default set`
 - `brigade fleet models doctor`
+- `brigade fleet models list`
 - `brigade fleet models reconcile`
 - `brigade fleet models retire`
 - `brigade fleet models set`

--- a/src/brigade/aboyeur_model_policy.py
+++ b/src/brigade/aboyeur_model_policy.py
@@ -125,6 +125,24 @@ def _local_cli_matches_hub_binding(aboyeur: Any, agent: Agent, binding: Mapping[
     return aboyeur.agents.command_for(local) == instance_id
 
 
+def _set_remediation_detail(row: Mapping[str, Any], revision: object, *, fallback_seat: str | None = None) -> str:
+    """Return a remediation block for a versioned roster seat row."""
+    provider = row.get("provider")
+    model = row.get("model")
+    seat = row.get("seat") or fallback_seat
+    reasoning = row.get("reasoning")
+    if not isinstance(provider, str) or not isinstance(model, str) or not isinstance(seat, str):
+        return ""
+    return "\n" + fleet_model_admission._set_command_remediation(
+        provider=provider,
+        model=model,
+        seat=seat,
+        reasoning=reasoning if isinstance(reasoning, str) and reasoning else None,
+        brigade_cli=fleet_model_admission._brigade_cli_from_row(row),
+        revision=revision,
+    )
+
+
 def resolve_fleet_model_policy(
     roster: Roster,
     *,
@@ -420,12 +438,15 @@ def _resolve_versioned(
             elif cleaned_override is not None and seat == worker and cleaned_override != policy_model:
                 outcome = "mismatch"
                 detail = f"--model {cleaned_override!r} does not match Hub model {policy_model!r}"
+                detail += _set_remediation_detail(row, revision, fallback_seat=seat)
             elif not isinstance(policy_reasoning, str) or not policy_reasoning:
                 outcome = "binding-missing"
                 detail = "registry entry is missing exact reasoning"
+                detail += _set_remediation_detail(row, revision, fallback_seat=seat)
             elif binding is None or not isinstance(binding.get("instance_id"), str) or not binding["instance_id"]:
                 outcome = "binding-missing"
                 detail = "registry entry is missing consumer binding"
+                detail += _set_remediation_detail(row, revision, fallback_seat=seat)
             elif row.get("enabled") is not True:
                 outcome = "disabled"
                 detail = "registry entry is disabled"

--- a/src/brigade/aboyeur_model_policy.py
+++ b/src/brigade/aboyeur_model_policy.py
@@ -139,6 +139,8 @@ def _set_remediation_detail(row: Mapping[str, Any], revision: object, *, fallbac
         seat=seat,
         reasoning=reasoning if isinstance(reasoning, str) and reasoning else None,
         brigade_cli=fleet_model_admission._brigade_cli_from_row(row),
+        t3_instance_id=fleet_model_admission._t3_instance_id_from_row(row),
+        t3_service_tier=fleet_model_admission._t3_service_tier_from_row(row),
         revision=revision,
     )
 

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -1372,7 +1372,7 @@ def _dispatch_models_list(args: argparse.Namespace) -> int:
     if consumer not in fleet_model_roster.CONSUMERS:
         print(f"error: unsupported consumer {consumer!r}", file=sys.stderr)
         return 2
-    decision = fleet_model_admission.fetch_versioned_roster(allow_lkg=False, cache_write=False, inspect_only=True)
+    decision = fleet_model_admission.fetch_versioned_roster(allow_lkg=True, cache_write=False, inspect_only=True)
     if not decision.ok:
         print(f"error: {decision.reason}", file=sys.stderr)
         return decision.exit_code
@@ -1380,6 +1380,7 @@ def _dispatch_models_list(args: argparse.Namespace) -> int:
     revision = roster.get("revision")
     if not isinstance(revision, int):
         revision = roster.get("roster_revision")
+    cached = roster.get("source") == "lkg"
     raw_seats = roster.get("seats")
     seats = [dict(item) for item in raw_seats if isinstance(item, dict)] if isinstance(raw_seats, list) else []
     selected_seat = args.seat
@@ -1426,6 +1427,8 @@ def _dispatch_models_list(args: argparse.Namespace) -> int:
         )
     widths = [max(len(h), *(len(r[i]) for r in rows)) if rows else len(h) for i, h in enumerate(headers)]
     print(f"roster revision {revision} (consumer {consumer})")
+    if cached:
+        print("note: roster served from cache; hub is unavailable")
     print("  ".join(h.ljust(w) for h, w in zip(headers, widths, strict=True)))
     for row in rows:
         print("  ".join(cell.ljust(w) for cell, w in zip(row, widths, strict=True)))

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -193,6 +193,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_models.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
     p_models.set_defaults(func=_dispatch_models)
     models_sub = p_models.add_subparsers(dest="models_command", metavar="<models-command>")
+    p_models_list = models_sub.add_parser("list", help="List hub roster entries.")
+    p_models_list.add_argument("--consumer", default=None, help="brigade-run or t3-fleet (default brigade-run).")
+    p_models_list.add_argument("--seat", default=None, help="Filter to one seat.")
+    p_models_list.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
+    p_models_list.set_defaults(func=_dispatch_models_list)
     p_models_set = models_sub.add_parser("set", help="Set one provider/model/seat policy (admin token).")
     p_models_set.add_argument("provider", help="Lowercase provider identifier.")
     p_models_set.add_argument("model", help="Lowercase model identifier.")
@@ -1358,6 +1363,77 @@ def _dispatch_models(args: argparse.Namespace) -> int:
     return 0
 
 
+def _dispatch_models_list(args: argparse.Namespace) -> int:
+    import json as _json
+
+    from .. import fleet_model_admission, fleet_model_roster
+
+    consumer = args.consumer or "brigade-run"
+    if consumer not in fleet_model_roster.CONSUMERS:
+        print(f"error: unsupported consumer {consumer!r}", file=sys.stderr)
+        return 2
+    decision = fleet_model_admission.fetch_versioned_roster(allow_lkg=False, cache_write=False, inspect_only=True)
+    if not decision.ok:
+        print(f"error: {decision.reason}", file=sys.stderr)
+        return decision.exit_code
+    roster = decision.payload
+    revision = roster.get("revision")
+    if not isinstance(revision, int):
+        revision = roster.get("roster_revision")
+    raw_seats = roster.get("seats")
+    seats = [dict(item) for item in raw_seats if isinstance(item, dict)] if isinstance(raw_seats, list) else []
+    selected_seat = args.seat
+    filtered: list[dict[str, object]] = []
+    for seat in seats:
+        seat_name = seat.get("seat")
+        if not isinstance(seat_name, str) or not seat_name:
+            continue
+        if selected_seat is not None and seat_name != selected_seat:
+            continue
+        binding = fleet_model_admission._binding_for(consumer, seat)
+        binding_value = binding.get("instance_id") if isinstance(binding, dict) else None
+        filtered.append(
+            {
+                "provider": seat.get("provider"),
+                "model": seat.get("model"),
+                "seat": seat_name,
+                "enabled": seat.get("enabled") is True,
+                "reasoning": seat.get("reasoning"),
+                "limit": seat.get("limit"),
+                "binding": binding_value,
+            }
+        )
+    if args.json:
+        print(
+            _json.dumps(
+                {"roster_revision": revision, "consumer": consumer, "seats": filtered}, indent=2, sort_keys=True
+            )
+        )
+        return 0
+    headers = ("provider", "model", "seat", "enabled", "reasoning", "limit", "binding")
+    rows = []
+    for item in filtered:
+        rows.append(
+            [
+                _safe_table_cell(str(item["provider"] or "-")),
+                _safe_table_cell(str(item["model"] or "-")),
+                _safe_table_cell(str(item["seat"])),
+                _safe_table_cell("yes" if item["enabled"] else "no"),
+                _safe_table_cell(str(item["reasoning"] or "-")),
+                _safe_table_cell(str(item["limit"] if item["limit"] is not None else "-")),
+                _safe_table_cell(str(item["binding"] or "-")),
+            ]
+        )
+    widths = [max(len(h), *(len(r[i]) for r in rows)) if rows else len(h) for i, h in enumerate(headers)]
+    print(f"roster revision {revision} (consumer {consumer})")
+    print("  ".join(h.ljust(w) for h, w in zip(headers, widths, strict=True)))
+    for row in rows:
+        print("  ".join(cell.ljust(w) for cell, w in zip(row, widths, strict=True)))
+    if not rows:
+        print("(no matching roster entries)")
+    return 0
+
+
 def _dispatch_models_set(args: argparse.Namespace) -> int:
     import json as _json
 
@@ -1431,6 +1507,9 @@ def _dispatch_models_admit(args: argparse.Namespace) -> int:
             _print_admission_json(decision.payload, reason=decision.reason, include_error=True)
     elif not decision.ok:
         print(f"error: {decision.reason}", file=sys.stderr)
+        remediation = decision.payload.get("remediation")
+        if isinstance(remediation, str) and remediation:
+            print(remediation, file=sys.stderr)
     return decision.exit_code
 
 

--- a/src/brigade/fleet_model_admission.py
+++ b/src/brigade/fleet_model_admission.py
@@ -677,7 +677,10 @@ def _resolve_from_roster(
             seat=str(seat_name),
             reasoning=match.get("reasoning"),
             brigade_cli=_brigade_cli_from_row(match),
+            t3_instance_id=_t3_instance_id_from_row(match),
+            t3_service_tier=_t3_service_tier_from_row(match),
             revision=roster.get("revision"),
+            consumer=consumer,
         )
         payload["error"] = f"{reason}\n{remediation}"
         payload["remediation"] = remediation
@@ -1190,6 +1193,7 @@ def doctor_model_roster(*, consumer: str) -> ModelAdmissionDecision:
                 "model": resolved.payload.get("model") or payload.get("model"),
             },
             roster,
+            consumer=consumer,
         )
     try:
         record = _load_lkg_record()
@@ -1230,7 +1234,7 @@ def _reconcile_findings(
                 {
                     "code": "empty-binding",
                     "seat": seat_name,
-                    "remediation": _empty_binding_remediation(item, roster),
+                    "remediation": _empty_binding_remediation(item, roster, consumer=consumer),
                 }
             )
             continue
@@ -1253,6 +1257,30 @@ def _reconcile_findings(
     return findings
 
 
+def _t3_instance_id_from_row(row: Mapping[str, Any]) -> str | None:
+    """Return the T3 Fleet instance binding from a versioned roster seat row."""
+    bindings = row.get("bindings")
+    if not isinstance(bindings, dict):
+        return None
+    t3_fleet = bindings.get("t3_fleet")
+    if not isinstance(t3_fleet, dict):
+        return None
+    instance_id = t3_fleet.get("instance_id")
+    return instance_id if isinstance(instance_id, str) and instance_id else None
+
+
+def _t3_service_tier_from_row(row: Mapping[str, Any]) -> str | None:
+    """Return the T3 Fleet service tier from a versioned roster seat row."""
+    bindings = row.get("bindings")
+    if not isinstance(bindings, dict):
+        return None
+    t3_fleet = bindings.get("t3_fleet")
+    if not isinstance(t3_fleet, dict):
+        return None
+    service_tier = t3_fleet.get("service_tier")
+    return service_tier if isinstance(service_tier, str) and service_tier else None
+
+
 def _set_command_remediation(
     *,
     provider: str,
@@ -1260,17 +1288,32 @@ def _set_command_remediation(
     seat: str,
     reasoning: str | None,
     brigade_cli: str | None,
+    t3_instance_id: str | None,
+    t3_service_tier: str | None,
     revision: object,
+    consumer: str = "brigade-run",
 ) -> str:
     """Human-readable 'brigade fleet models set' command for a seat row."""
     rev = revision if isinstance(revision, int) else "N"
     reason = reasoning if isinstance(reasoning, str) and reasoning else "none"
-    cli = brigade_cli if isinstance(brigade_cli, str) and brigade_cli else ""
-    return (
-        f"bind it with: brigade fleet models set {provider} {model} {seat} --enable "
-        f"--reasoning {reason} --brigade-cli {cli} --expect-revision {rev}\n"
-        f"see current rows: brigade fleet models list --seat {seat}"
-    )
+    cmd_parts = [f"brigade fleet models set {provider} {model} {seat} --enable"]
+    cmd_parts.append(f"--reasoning {reason}")
+    if consumer == "t3-fleet":
+        instance_id = t3_instance_id if isinstance(t3_instance_id, str) and t3_instance_id else brigade_cli
+        if isinstance(instance_id, str) and instance_id:
+            cmd_parts.append(f"--t3-instance-id {instance_id}")
+            if isinstance(t3_service_tier, str) and t3_service_tier:
+                cmd_parts.append(f"--t3-service-tier {t3_service_tier}")
+        else:
+            cmd_parts.append("--t3-instance-id INSTANCE")
+    else:
+        cli = brigade_cli if isinstance(brigade_cli, str) and brigade_cli else t3_instance_id
+        if isinstance(cli, str) and cli:
+            cmd_parts.append(f"--brigade-cli {cli}")
+        else:
+            cmd_parts.append("--brigade-cli CLI")
+    cmd_parts.append(f"--expect-revision {rev}")
+    return f"bind it with: {' '.join(cmd_parts)}\nsee current rows: brigade fleet models list --seat {seat}"
 
 
 def _brigade_cli_from_row(row: Mapping[str, Any]) -> str | None:
@@ -1285,7 +1328,12 @@ def _brigade_cli_from_row(row: Mapping[str, Any]) -> str | None:
     return cli if isinstance(cli, str) and cli else None
 
 
-def _empty_binding_remediation(seat: Mapping[str, Any], roster: Mapping[str, Any]) -> str:
+def _empty_binding_remediation(
+    seat: Mapping[str, Any],
+    roster: Mapping[str, Any],
+    *,
+    consumer: str = "brigade-run",
+) -> str:
     revision = roster.get("revision") or roster.get("roster_revision") or "N"
     name = seat.get("seat") or "SEAT"
     provider = seat.get("provider") or "provider"
@@ -1303,7 +1351,10 @@ def _empty_binding_remediation(seat: Mapping[str, Any], roster: Mapping[str, Any
         seat=str(name),
         reasoning=reasoning if isinstance(reasoning, str) and reasoning else None,
         brigade_cli=brigade_cli if isinstance(brigade_cli, str) and brigade_cli else None,
+        t3_instance_id=_t3_instance_id_from_row(seat),
+        t3_service_tier=_t3_service_tier_from_row(seat),
         revision=revision,
+        consumer=consumer,
     )
 
 

--- a/src/brigade/fleet_model_admission.py
+++ b/src/brigade/fleet_model_admission.py
@@ -54,6 +54,7 @@ _SAFE_ADMISSION_KEYS = (
     "expires_at",
     "error",
     "reason",
+    "remediation",
 )
 _SUCCESS_ADMISSION_KEYS = (
     "schema",
@@ -669,6 +670,17 @@ def _resolve_from_roster(
         "reasoning": None if match is None else match.get("reasoning"),
         "expires_at": roster.get("expires_at"),
     }
+    if reason == "binding-missing" and isinstance(match, dict):
+        remediation = _set_command_remediation(
+            provider=str(match.get("provider") or ""),
+            model=str(match.get("model") or ""),
+            seat=str(seat_name),
+            reasoning=match.get("reasoning"),
+            brigade_cli=_brigade_cli_from_row(match),
+            revision=roster.get("revision"),
+        )
+        payload["error"] = f"{reason}\n{remediation}"
+        payload["remediation"] = remediation
     return _fail(reason, 3, payload)
 
 
@@ -1241,15 +1253,57 @@ def _reconcile_findings(
     return findings
 
 
+def _set_command_remediation(
+    *,
+    provider: str,
+    model: str,
+    seat: str,
+    reasoning: str | None,
+    brigade_cli: str | None,
+    revision: object,
+) -> str:
+    """Human-readable 'brigade fleet models set' command for a seat row."""
+    rev = revision if isinstance(revision, int) else "N"
+    reason = reasoning if isinstance(reasoning, str) and reasoning else "none"
+    cli = brigade_cli if isinstance(brigade_cli, str) and brigade_cli else ""
+    return (
+        f"bind it with: brigade fleet models set {provider} {model} {seat} --enable "
+        f"--reasoning {reason} --brigade-cli {cli} --expect-revision {rev}\n"
+        f"see current rows: brigade fleet models list --seat {seat}"
+    )
+
+
+def _brigade_cli_from_row(row: Mapping[str, Any]) -> str | None:
+    """Return the brigade-run CLI binding from a versioned roster seat row."""
+    bindings = row.get("bindings")
+    if not isinstance(bindings, dict):
+        return None
+    brigade = bindings.get("brigade")
+    if not isinstance(brigade, dict):
+        return None
+    cli = brigade.get("cli")
+    return cli if isinstance(cli, str) and cli else None
+
+
 def _empty_binding_remediation(seat: Mapping[str, Any], roster: Mapping[str, Any]) -> str:
     revision = roster.get("revision") or roster.get("roster_revision") or "N"
     name = seat.get("seat") or "SEAT"
     provider = seat.get("provider") or "provider"
     model = seat.get("model") or "model"
-    return (
-        f"brigade fleet models set {provider} {model} {name} --enable "
-        f"--reasoning <reasoning|none> --brigade-cli <cli> --t3-instance-id <id> "
-        f"--expect-revision {revision}"
+    reasoning = seat.get("reasoning")
+    brigade_cli = None
+    bindings = seat.get("bindings")
+    if isinstance(bindings, dict):
+        brigade = bindings.get("brigade")
+        if isinstance(brigade, dict):
+            brigade_cli = brigade.get("cli")
+    return _set_command_remediation(
+        provider=str(provider),
+        model=str(model),
+        seat=str(name),
+        reasoning=reasoning if isinstance(reasoning, str) and reasoning else None,
+        brigade_cli=brigade_cli if isinstance(brigade_cli, str) and brigade_cli else None,
+        revision=revision,
     )
 
 

--- a/tests/test_fleet_model_admission.py
+++ b/tests/test_fleet_model_admission.py
@@ -3283,7 +3283,7 @@ def test_versioned_binding_missing_denial_includes_set_command_and_list_hint():
     assert "brigade fleet models list --seat cursor_grok" in resolution.error
 
 
-def test_resolve_from_roster_t3_binding_missing_uses_brigade_cli_in_remediation():
+def test_resolve_from_roster_t3_binding_missing_suggests_t3_instance_id_in_remediation():
     from brigade import fleet_model_admission
 
     seat = _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast", instance_id="cursor-agent")
@@ -3302,9 +3302,61 @@ def test_resolve_from_roster_t3_binding_missing_uses_brigade_cli_in_remediation(
     remediation = decision.payload.get("remediation")
     assert isinstance(remediation, str)
     assert "brigade fleet models set cursor cursor-grok-4.6-high-fast cursor_grok --enable" in remediation
-    assert "--brigade-cli cursor-agent" in remediation
+    assert "--t3-instance-id cursor-agent" in remediation
+    assert "--brigade-cli" not in remediation
     assert "--expect-revision 11" in remediation
     assert "brigade fleet models list --seat cursor_grok" in remediation
+
+
+def test_resolve_from_roster_brigade_run_binding_missing_suggests_brigade_cli_in_remediation():
+    from brigade import fleet_model_admission
+
+    seat = _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast", instance_id="cursor-agent")
+    seat["bindings"] = {"t3_fleet": {"instance_id": "cursor-agent", "service_tier": "standard"}}
+    roster = {
+        "revision": 11,
+        "document_sha256": "sha256:" + ("ab" * 32),
+        "expires_at": "2026-08-30T14:15:00Z",
+        "seats": [seat],
+        "consumer_defaults": {"brigade-run": "cursor_grok"},
+        "retired_models": [],
+    }
+    decision = fleet_model_admission._resolve_from_roster(roster, consumer="brigade-run", seat=None, source="hub")
+    assert not decision.ok
+    assert decision.reason == "binding-missing"
+    remediation = decision.payload.get("remediation")
+    assert isinstance(remediation, str)
+    assert "brigade fleet models set cursor cursor-grok-4.6-high-fast cursor_grok --enable" in remediation
+    assert "--brigade-cli cursor-agent" in remediation
+    assert "--t3-instance-id" not in remediation
+    assert "--expect-revision 11" in remediation
+    assert "brigade fleet models list --seat cursor_grok" in remediation
+
+
+def test_resolve_from_roster_t3_binding_missing_includes_service_tier_when_present():
+    from brigade import fleet_model_admission
+
+    seat = _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast", instance_id="cursor-agent")
+    seat["bindings"] = {
+        "brigade": {"cli": "cursor-agent"},
+        "t3_fleet": {"instance_id": "", "service_tier": "premium"},
+    }
+    roster = {
+        "revision": 11,
+        "document_sha256": "sha256:" + ("ab" * 32),
+        "expires_at": "2026-08-30T14:15:00Z",
+        "seats": [seat],
+        "consumer_defaults": {"t3-fleet": "cursor_grok"},
+        "retired_models": [],
+    }
+    decision = fleet_model_admission._resolve_from_roster(roster, consumer="t3-fleet", seat=None, source="hub")
+    assert not decision.ok
+    assert decision.reason == "binding-missing"
+    remediation = decision.payload.get("remediation")
+    assert isinstance(remediation, str)
+    assert "--t3-instance-id cursor-agent" in remediation
+    assert "--t3-service-tier premium" in remediation
+    assert "--brigade-cli" not in remediation
 
 
 def test_validate_roster_rows_requires_nonempty_reasoning_and_hub_lkg_schema_match():

--- a/tests/test_fleet_model_admission.py
+++ b/tests/test_fleet_model_admission.py
@@ -3246,6 +3246,67 @@ def test_versioned_model_override_requires_exact_hub_match_and_never_discards():
     assert matched.receipt["model_override"] == "cursor-grok-4.6-high-fast"
 
 
+def test_versioned_model_override_denial_includes_set_command_and_list_hint():
+    snapshot = _versioned_snapshot(
+        _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast", instance_id="cursor-agent"),
+        revision=11,
+    )
+    mismatch = aboyeur.resolve_fleet_model_policy(
+        _roster(),
+        worker="cursor_grok",
+        model_override="composer-2.5",
+        snapshot=snapshot,
+    )
+    assert mismatch.error is not None
+    assert "--model 'composer-2.5' does not match Hub model 'cursor-grok-4.6-high-fast'" in mismatch.error
+    assert "brigade fleet models set cursor cursor-grok-4.6-high-fast cursor_grok --enable" in mismatch.error
+    assert "--reasoning high" in mismatch.error
+    assert "--brigade-cli cursor-agent" in mismatch.error
+    assert "--expect-revision 11" in mismatch.error
+    assert "brigade fleet models list --seat cursor_grok" in mismatch.error
+
+
+def test_versioned_binding_missing_denial_includes_set_command_and_list_hint():
+    seat = _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast", instance_id="cursor-agent")
+    del seat["bindings"]["brigade"]
+    snapshot = _versioned_snapshot(seat, revision=11)
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster(),
+        worker="cursor_grok",
+        snapshot=snapshot,
+    )
+    assert resolution.error is not None
+    assert "registry entry is missing consumer binding" in resolution.error
+    assert "brigade fleet models set cursor cursor-grok-4.6-high-fast cursor_grok --enable" in resolution.error
+    assert "--brigade-cli" in resolution.error
+    assert "--expect-revision 11" in resolution.error
+    assert "brigade fleet models list --seat cursor_grok" in resolution.error
+
+
+def test_resolve_from_roster_t3_binding_missing_uses_brigade_cli_in_remediation():
+    from brigade import fleet_model_admission
+
+    seat = _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast", instance_id="cursor-agent")
+    seat["bindings"] = {"brigade": {"cli": "cursor-agent"}}
+    roster = {
+        "revision": 11,
+        "document_sha256": "sha256:" + ("ab" * 32),
+        "expires_at": "2026-08-30T14:15:00Z",
+        "seats": [seat],
+        "consumer_defaults": {"t3-fleet": "cursor_grok"},
+        "retired_models": [],
+    }
+    decision = fleet_model_admission._resolve_from_roster(roster, consumer="t3-fleet", seat=None, source="hub")
+    assert not decision.ok
+    assert decision.reason == "binding-missing"
+    remediation = decision.payload.get("remediation")
+    assert isinstance(remediation, str)
+    assert "brigade fleet models set cursor cursor-grok-4.6-high-fast cursor_grok --enable" in remediation
+    assert "--brigade-cli cursor-agent" in remediation
+    assert "--expect-revision 11" in remediation
+    assert "brigade fleet models list --seat cursor_grok" in remediation
+
+
 def test_validate_roster_rows_requires_nonempty_reasoning_and_hub_lkg_schema_match():
     from brigade import fleet_model_admission
 

--- a/tests/test_fleet_models_list.py
+++ b/tests/test_fleet_models_list.py
@@ -144,3 +144,34 @@ def test_list_reports_fetch_failure(monkeypatch):
     rc = cli.main(["fleet", "models", "list"])
     assert rc == 1
     assert "auth-failed" in err.getvalue()
+
+
+def test_list_uses_cached_lkg_when_hub_unavailable(monkeypatch):
+    snapshot = _versioned_snapshot(
+        _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast"),
+    )
+    snapshot["source"] = "lkg"
+    decision = fleet_model_admission.ModelAdmissionDecision(
+        ok=True,
+        exit_code=0,
+        reason="lkg",
+        payload=snapshot,
+    )
+    calls: list[dict[str, Any]] = []
+
+    def fake_fetch(**kwargs):
+        calls.append(kwargs)
+        return decision
+
+    monkeypatch.setattr(fleet_model_admission, "fetch_versioned_roster", fake_fetch)
+    out = StringIO()
+    err = StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+    rc = cli.main(["fleet", "models", "list"])
+    assert rc == 0
+    assert err.getvalue() == ""
+    assert any(kwargs.get("allow_lkg") is True for kwargs in calls)
+    assert "roster served from cache" in out.getvalue()
+    assert "hub is unavailable" in out.getvalue()
+    assert "cursor_grok" in out.getvalue()

--- a/tests/test_fleet_models_list.py
+++ b/tests/test_fleet_models_list.py
@@ -1,0 +1,146 @@
+"""Tests for 'brigade fleet models list'."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import Any
+
+from brigade import cli, fleet_model_admission, fleet_model_roster
+
+
+def _versioned_seat(
+    seat: str,
+    provider: str,
+    model: str,
+    *,
+    reasoning: str = "high",
+    enabled: bool = True,
+    brigade_cli: str = "cursor-agent",
+    t3_instance_id: str = "cursor",
+) -> dict[str, Any]:
+    return {
+        "seat": seat,
+        "provider": provider,
+        "model": model,
+        "reasoning": reasoning,
+        "enabled": enabled,
+        "bindings": {
+            "brigade": {"cli": brigade_cli},
+            "t3_fleet": {"instance_id": t3_instance_id, "service_tier": "standard"},
+        },
+    }
+
+
+def _versioned_snapshot(
+    *seats: dict[str, Any],
+    revision: int = 7,
+    digest: str = "sha256:" + ("ab" * 32),
+) -> dict[str, Any]:
+    return {
+        "schema": fleet_model_roster.ROSTER_SCHEMA,
+        "revision": revision,
+        "roster_revision": revision,
+        "document_sha256": digest,
+        "expires_at": "2026-08-30T14:15:00Z",
+        "seats": list(seats),
+        "consumer_defaults": {"brigade-run": seats[0]["seat"] if seats else None},
+        "retired_models": [],
+    }
+
+
+def _run_list(monkeypatch, snapshot: dict[str, Any], *extra_args: str) -> tuple[int, str, str]:
+    decision = fleet_model_admission.ModelAdmissionDecision(
+        ok=True,
+        exit_code=0,
+        reason="authoritative",
+        payload=snapshot,
+    )
+    monkeypatch.setattr(fleet_model_admission, "fetch_versioned_roster", lambda **kwargs: decision)
+    out = StringIO()
+    err = StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+    rc = cli.main(["fleet", "models", "list", *extra_args])
+    return rc, out.getvalue(), err.getvalue()
+
+
+def test_list_text_table_includes_revision_and_bindings(monkeypatch):
+    snapshot = _versioned_snapshot(
+        _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast"),
+        _versioned_seat("cursor_composer", "cursor", "composer-2.5", enabled=False, brigade_cli="composer"),
+    )
+    rc, out, err = _run_list(monkeypatch, snapshot)
+    assert rc == 0
+    assert err == ""
+    assert "roster revision 7 (consumer brigade-run)" in out
+    assert "cursor_grok" in out
+    assert "cursor_composer" in out
+    assert "cursor-agent" in out
+    assert "composer" in out
+    assert "cursor-grok-4.6-high-fast" in out
+    assert "composer-2.5" in out
+
+
+def test_list_json_includes_revision_and_consumer(monkeypatch):
+    snapshot = _versioned_snapshot(
+        _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast"),
+    )
+    rc, out, err = _run_list(monkeypatch, snapshot, "--json")
+    assert rc == 0
+    assert err == ""
+    parsed = json.loads(out)
+    assert parsed["roster_revision"] == 7
+    assert parsed["consumer"] == "brigade-run"
+    assert len(parsed["seats"]) == 1
+    seat = parsed["seats"][0]
+    assert seat["seat"] == "cursor_grok"
+    assert seat["provider"] == "cursor"
+    assert seat["model"] == "cursor-grok-4.6-high-fast"
+    assert seat["reasoning"] == "high"
+    assert seat["enabled"] is True
+    assert seat["binding"] == "cursor-agent"
+
+
+def test_list_filters_by_seat(monkeypatch):
+    snapshot = _versioned_snapshot(
+        _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast"),
+        _versioned_seat("cursor_composer", "cursor", "composer-2.5"),
+    )
+    rc, out, err = _run_list(monkeypatch, snapshot, "--seat", "cursor_composer")
+    assert rc == 0
+    assert "cursor_grok" not in out
+    assert "cursor_composer" in out
+
+
+def test_list_uses_t3_consumer_binding_when_requested(monkeypatch):
+    snapshot = _versioned_snapshot(
+        _versioned_seat("cursor_grok", "cursor", "cursor-grok-4.6-high-fast", t3_instance_id="t3-cursor"),
+    )
+    rc, out, err = _run_list(monkeypatch, snapshot, "--consumer", "t3-fleet")
+    assert rc == 0
+    assert "t3-cursor" in out
+
+
+def test_list_rejects_unsupported_consumer(monkeypatch):
+    snapshot = _versioned_snapshot()
+    rc, out, err = _run_list(monkeypatch, snapshot, "--consumer", "unknown")
+    assert rc == 2
+    assert "unsupported consumer" in err
+
+
+def test_list_reports_fetch_failure(monkeypatch):
+    decision = fleet_model_admission.ModelAdmissionDecision(
+        ok=False,
+        exit_code=1,
+        reason="auth-failed",
+        payload={},
+    )
+    monkeypatch.setattr(fleet_model_admission, "fetch_versioned_roster", lambda **kwargs: decision)
+    out = StringIO()
+    err = StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+    rc = cli.main(["fleet", "models", "list"])
+    assert rc == 1
+    assert "auth-failed" in err.getvalue()


### PR DESCRIPTION
## What

- `brigade fleet models list [--consumer NAME] [--seat SEAT] [--json]` prints one row per hub roster entry (provider, model, seat, enabled, reasoning, limit, brigade CLI binding) plus the roster revision, reading the same cached or fetched roster `doctor` uses. Default consumer is `brigade-run`.
- The `--model` mismatch denial and the missing-consumer-binding denial now end with the exact `brigade fleet models set ... --expect-revision <current>` command filled from the seat row, and a pointer to `fleet models list --seat <seat>`.
- Command inventory regenerated.

Closes #1417.

## Verification

```
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_fleet_models_list.py","tests/test_fleet_model_admission.py","tests/test_cli_inventory_contract.py","tests/test_completions.py"]' --capture brigade-work
116 passed
```

Built by the `cursor_worker` seat (kimi-k2.7-code) under `brigade run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `brigade fleet models list` to view model roster details in table or JSON format, with seat and consumer filtering.
  * Model admission errors now include actionable remediation commands and roster-listing guidance.

* **Bug Fixes**
  * Improved remediation details for model mismatches, missing reasoning, and missing consumer bindings.
  * Remediation commands now include the applicable reasoning, CLI binding, and expected roster revision.

* **Tests**
  * Added coverage for model listing, filtering, output formats, failures, and remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->