### PR TITLE
fix(agents): pass --print-timeout to agy from the seat timeout

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -210,12 +210,22 @@ def _opencode_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path 
     return ["opencode", "run", prompt]
 
 
-def _antigravity_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
+def _antigravity_argv(
+    prompt: str,
+    read_only: bool,
+    sandbox: str | None,
+    cwd: Path | None,
+    timeout_seconds: int | float | None = None,
+) -> List[str]:
+    timeout_flags: List[str] = []
+    if timeout_seconds is not None and _antigravity_supports_print_timeout():
+        seconds = max(60, int(timeout_seconds) - 30)
+        timeout_flags = ["--print-timeout", f"{seconds}s"]
     if read_only or sandbox == "read-only":
-        return ["agy", "--sandbox", "--print", prompt]
+        return ["agy", "--sandbox", *timeout_flags, "--print", prompt]
     effective_cwd = cwd if cwd is not None else Path.cwd().resolve()
     argv = ["agy", "--add-dir", str(effective_cwd)]
-    argv.extend(["--dangerously-skip-permissions", "--print", prompt])
+    argv.extend(["--dangerously-skip-permissions", *timeout_flags, "--print", prompt])
     return argv
 
 
@@ -313,7 +323,7 @@ def _oracle_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | 
     return ["oracle", "-p", prompt]
 
 
-_ADAPTERS: dict[str, Callable[[str, bool, str | None, Path | None], List[str]]] = {
+_ADAPTERS: dict[str, Callable[..., List[str]]] = {
     "claude": _claude_argv,
     "codex": _codex_argv,
     "opencode": _opencode_argv,
@@ -637,6 +647,43 @@ def _oracle_supports_browser_engine(
     return bool(_ORACLE_BROWSER_ENGINE_HELP_RE.search("\n".join((result.stdout, result.stderr))))
 
 
+_ANTIGRAVITY_PRINT_TIMEOUT_HELP = "--print-timeout"
+_ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED: bool | None = None
+
+
+def _antigravity_supports_print_timeout(
+    executable: str = "agy",
+    *,
+    env: dict[str, str] | None = None,
+    process_registry: proc.ProcessRegistry | None = None,
+) -> bool:
+    """Whether this Antigravity executable advertises --print-timeout in agy --help."""
+    global _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED
+    if _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED is not None:
+        return _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED
+    result = proc.run(
+        [executable, "--help"],
+        timeout=5.0,
+        env=env,
+        process_registry=process_registry,
+    )
+    if result.code != 0:
+        supported = False
+    else:
+        combined = "\n".join((result.stdout, result.stderr))
+        supported = _ANTIGRAVITY_PRINT_TIMEOUT_HELP in combined
+    _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED = supported
+    return supported
+
+
+def _clear_antigravity_print_timeout_cache() -> None:
+    global _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED
+    _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED = None
+
+
+_antigravity_supports_print_timeout.cache_clear = _clear_antigravity_print_timeout_cache  # type: ignore[attr-defined]
+
+
 def _oracle_auth_detail(cli_ref: str, stdout: str, stderr: str) -> str | None:
     """Turn an oracle browser-session auth failure into a pantry next step.
 
@@ -790,6 +837,7 @@ def build_argv(
     resume_session_id: str | None = None,
     session_binding_id: str | None = None,
     oracle_browser_engine: bool = False,
+    timeout_seconds: int | float | None = None,
 ) -> List[str]:
     if resume_session_id is not None:
         if cli_ref != "grok":
@@ -828,7 +876,10 @@ def build_argv(
             "copilot, qwen, kimi, adal, openhands, grok, amp, crush, ollama:<model>, "
             "codex-cloud:<env-id>)"
         )
-    argv = builder(prompt, read_only, sandbox, cwd)
+    if _accepts_keyword(builder, "timeout_seconds"):
+        argv = builder(prompt, read_only, sandbox, cwd, timeout_seconds=timeout_seconds)
+    else:
+        argv = builder(prompt, read_only, sandbox, cwd)
     if cli_ref == "oracle" and oracle_browser_engine:
         argv = [argv[0], "--engine", "browser", *argv[1:]]
     if resume_session_id is not None:

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -216,9 +216,12 @@ def _antigravity_argv(
     sandbox: str | None,
     cwd: Path | None,
     timeout_seconds: int | float | None = None,
+    print_timeout_supported: bool | None = None,
 ) -> List[str]:
     timeout_flags: List[str] = []
-    if timeout_seconds is not None and _antigravity_supports_print_timeout():
+    if timeout_seconds is not None and (
+        _antigravity_supports_print_timeout() if print_timeout_supported is None else print_timeout_supported
+    ):
         seconds = max(60, int(timeout_seconds) - 30)
         timeout_flags = ["--print-timeout", f"{seconds}s"]
     if read_only or sandbox == "read-only":
@@ -648,7 +651,7 @@ def _oracle_supports_browser_engine(
 
 
 _ANTIGRAVITY_PRINT_TIMEOUT_HELP = "--print-timeout"
-_ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED: bool | None = None
+_ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED: dict[tuple[str, tuple[tuple[str, str], ...]], bool] = {}
 
 
 def _antigravity_supports_print_timeout(
@@ -658,9 +661,9 @@ def _antigravity_supports_print_timeout(
     process_registry: proc.ProcessRegistry | None = None,
 ) -> bool:
     """Whether this Antigravity executable advertises --print-timeout in agy --help."""
-    global _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED
-    if _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED is not None:
-        return _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED
+    cache_key = (executable, tuple(sorted(env.items())) if env is not None else ())
+    if cache_key in _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED:
+        return _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED[cache_key]
     result = proc.run(
         [executable, "--help"],
         timeout=5.0,
@@ -672,13 +675,12 @@ def _antigravity_supports_print_timeout(
     else:
         combined = "\n".join((result.stdout, result.stderr))
         supported = _ANTIGRAVITY_PRINT_TIMEOUT_HELP in combined
-    _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED = supported
+    _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED[cache_key] = supported
     return supported
 
 
 def _clear_antigravity_print_timeout_cache() -> None:
-    global _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED
-    _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED = None
+    _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED.clear()
 
 
 _antigravity_supports_print_timeout.cache_clear = _clear_antigravity_print_timeout_cache  # type: ignore[attr-defined]
@@ -838,6 +840,7 @@ def build_argv(
     session_binding_id: str | None = None,
     oracle_browser_engine: bool = False,
     timeout_seconds: int | float | None = None,
+    antigravity_print_timeout_supported: bool | None = None,
 ) -> List[str]:
     if resume_session_id is not None:
         if cli_ref != "grok":
@@ -876,10 +879,12 @@ def build_argv(
             "copilot, qwen, kimi, adal, openhands, grok, amp, crush, ollama:<model>, "
             "codex-cloud:<env-id>)"
         )
+    builder_kwargs: dict[str, object] = {}
     if _accepts_keyword(builder, "timeout_seconds"):
-        argv = builder(prompt, read_only, sandbox, cwd, timeout_seconds=timeout_seconds)
-    else:
-        argv = builder(prompt, read_only, sandbox, cwd)
+        builder_kwargs["timeout_seconds"] = timeout_seconds
+    if _accepts_keyword(builder, "print_timeout_supported"):
+        builder_kwargs["print_timeout_supported"] = antigravity_print_timeout_supported
+    argv = builder(prompt, read_only, sandbox, cwd, **builder_kwargs)
     if cli_ref == "oracle" and oracle_browser_engine:
         argv = [argv[0], "--engine", "browser", *argv[1:]]
     if resume_session_id is not None:
@@ -1310,9 +1315,17 @@ def run_agent(
 
     try:
         oracle_browser_engine = False
+        antigravity_print_timeout_supported = None
         if cli_ref == "oracle":
             assert executable.path is not None
             oracle_browser_engine = _oracle_supports_browser_engine(
+                executable.path,
+                env=child_env,
+                process_registry=process_registry,
+            )
+        if cli_ref == "antigravity" and timeout is not None:
+            assert executable.path is not None
+            antigravity_print_timeout_supported = _antigravity_supports_print_timeout(
                 executable.path,
                 env=child_env,
                 process_registry=process_registry,
@@ -1328,6 +1341,8 @@ def run_agent(
             resume_session_id=resume_session_id,
             session_binding_id=session_binding_id,
             oracle_browser_engine=oracle_browser_engine,
+            timeout_seconds=timeout,
+            antigravity_print_timeout_supported=antigravity_print_timeout_supported,
         )
     except UnsupportedSandboxError as exc:
         # A builder rejected the launch before spawning because the requested

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -7,11 +7,13 @@ does not store provider keys or import provider SDKs.
 from __future__ import annotations
 
 import functools
+import hashlib
 import inspect
 import json
 import os
 import re
 import unicodedata
+from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -651,7 +653,19 @@ def _oracle_supports_browser_engine(
 
 
 _ANTIGRAVITY_PRINT_TIMEOUT_HELP = "--print-timeout"
-_ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED: dict[tuple[str, tuple[tuple[str, str], ...]], bool] = {}
+_ANTIGRAVITY_PRINT_TIMEOUT_CACHE_LIMIT = 16
+_ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED: OrderedDict[tuple[str, str], bool] = OrderedDict()
+
+
+def _antigravity_env_fingerprint(env: dict[str, str] | None) -> str:
+    """Return a non-reversible fingerprint for an environment dict.
+
+    The fingerprint is a SHA-256 hex digest of a deterministic JSON encoding of
+    the sorted env items.  No env keys or values are retained in the returned
+    value, and ``env=None`` is treated as an empty environment.
+    """
+    items = sorted(env.items()) if env is not None else []
+    return hashlib.sha256(json.dumps(items, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
 def _antigravity_supports_print_timeout(
@@ -660,8 +674,14 @@ def _antigravity_supports_print_timeout(
     env: dict[str, str] | None = None,
     process_registry: proc.ProcessRegistry | None = None,
 ) -> bool:
-    """Whether this Antigravity executable advertises --print-timeout in agy --help."""
-    cache_key = (executable, tuple(sorted(env.items())) if env is not None else ())
+    """Whether this Antigravity executable advertises --print-timeout in agy --help.
+
+    Probes are cached per (executable, environment fingerprint) and bounded to
+    ``_ANTIGRAVITY_PRINT_TIMEOUT_CACHE_LIMIT`` entries.  The cache stores only
+    the executable string and a SHA-256 hex digest of the environment; it never
+    retains env keys or values.
+    """
+    cache_key = (executable, _antigravity_env_fingerprint(env))
     if cache_key in _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED:
         return _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED[cache_key]
     result = proc.run(
@@ -675,6 +695,8 @@ def _antigravity_supports_print_timeout(
     else:
         combined = "\n".join((result.stdout, result.stderr))
         supported = _ANTIGRAVITY_PRINT_TIMEOUT_HELP in combined
+    if len(_ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED) >= _ANTIGRAVITY_PRINT_TIMEOUT_CACHE_LIMIT:
+        _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED.popitem(last=False)
     _ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED[cache_key] = supported
     return supported
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -428,6 +428,114 @@ def test_build_argv_antigravity_read_only_keeps_sandbox_without_write_flags(tmp_
     assert "--dangerously-skip-permissions" not in argv
 
 
+def test_build_argv_antigravity_with_timeout_seconds_and_help_probe_adds_print_timeout(tmp_path, monkeypatch):
+    monkeypatch.setattr(agents, "_antigravity_supports_print_timeout", lambda *args, **kwargs: True)
+
+    writable_argv = agents.build_argv("antigravity", "hi", cwd=tmp_path, timeout_seconds=900)
+    assert writable_argv == [
+        "agy",
+        "--add-dir",
+        str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print-timeout",
+        "870s",
+        "--print",
+        "hi",
+    ]
+
+    read_only_argv = agents.build_argv("antigravity", "hi", read_only=True, timeout_seconds=900)
+    assert read_only_argv == [
+        "agy",
+        "--sandbox",
+        "--print-timeout",
+        "870s",
+        "--print",
+        "hi",
+    ]
+
+
+def test_build_argv_antigravity_without_flag_in_help_probe_leaves_argv_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setattr(agents, "_antigravity_supports_print_timeout", lambda *args, **kwargs: False)
+
+    writable_argv = agents.build_argv("antigravity", "hi", cwd=tmp_path, timeout_seconds=900)
+    assert writable_argv == [
+        "agy",
+        "--add-dir",
+        str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
+    assert "--print-timeout" not in writable_argv
+
+
+def test_build_argv_antigravity_without_timeout_seconds_leaves_argv_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setattr(agents, "_antigravity_supports_print_timeout", lambda *args, **kwargs: True)
+
+    argv = agents.build_argv("antigravity", "hi", cwd=tmp_path)
+    assert argv == [
+        "agy",
+        "--add-dir",
+        str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
+    assert "--print-timeout" not in argv
+
+    argv_none = agents.build_argv("antigravity", "hi", cwd=tmp_path, timeout_seconds=None)
+    assert argv_none == argv
+
+
+def test_build_argv_antigravity_timeout_floor(monkeypatch):
+    monkeypatch.setattr(agents, "_antigravity_supports_print_timeout", lambda *args, **kwargs: True)
+
+    argv_60 = agents.build_argv("antigravity", "hi", read_only=True, timeout_seconds=60)
+    assert argv_60 == ["agy", "--sandbox", "--print-timeout", "60s", "--print", "hi"]
+
+    argv_30 = agents.build_argv("antigravity", "hi", read_only=True, timeout_seconds=30)
+    assert argv_30 == ["agy", "--sandbox", "--print-timeout", "60s", "--print", "hi"]
+
+
+def test_antigravity_supports_print_timeout_probe(monkeypatch):
+    if hasattr(agents, "_clear_antigravity_print_timeout_cache"):
+        agents._clear_antigravity_print_timeout_cache()
+    elif hasattr(agents._antigravity_supports_print_timeout, "cache_clear"):
+        agents._antigravity_supports_print_timeout.cache_clear()
+
+    calls = []
+
+    def stub_run(argv, **kwargs):
+        calls.append(argv)
+        return agents.proc.Result(0, "Usage: agy [options]\n  --print-timeout <duration>  timeout for print mode\n", "")
+
+    monkeypatch.setattr(agents.proc, "run", stub_run)
+    assert agents._antigravity_supports_print_timeout() is True
+    assert calls == [["agy", "--help"]]
+
+    # Cached on subsequent call
+    assert agents._antigravity_supports_print_timeout() is True
+    assert len(calls) == 1
+
+    # Returns False when flag is absent
+    if hasattr(agents, "_clear_antigravity_print_timeout_cache"):
+        agents._clear_antigravity_print_timeout_cache()
+    elif hasattr(agents._antigravity_supports_print_timeout, "cache_clear"):
+        agents._antigravity_supports_print_timeout.cache_clear()
+
+    monkeypatch.setattr(agents.proc, "run", lambda *a, **kw: agents.proc.Result(0, "Usage: agy\n", ""))
+    assert agents._antigravity_supports_print_timeout() is False
+
+    # Returns False when command fails
+    if hasattr(agents, "_clear_antigravity_print_timeout_cache"):
+        agents._clear_antigravity_print_timeout_cache()
+    elif hasattr(agents._antigravity_supports_print_timeout, "cache_clear"):
+        agents._antigravity_supports_print_timeout.cache_clear()
+
+    monkeypatch.setattr(agents.proc, "run", lambda *a, **kw: agents.proc.Result(1, "", "unknown command"))
+    assert agents._antigravity_supports_print_timeout() is False
+
+
 def test_build_argv_cursor_sandbox_read_only_uses_plan_mode():
     assert agents.build_argv("cursor", "hi", sandbox="read-only") == [
         "cursor-agent",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -504,29 +504,36 @@ def test_antigravity_supports_print_timeout_probe(monkeypatch):
         agents._antigravity_supports_print_timeout.cache_clear()
 
     calls = []
+    current_env = {"PATH": "/seat/bin", "AGY_PROFILE": "current"}
+    legacy_env = {"PATH": "/legacy/bin", "AGY_PROFILE": "legacy"}
 
     def stub_run(argv, **kwargs):
-        calls.append(argv)
-        return agents.proc.Result(0, "Usage: agy [options]\n  --print-timeout <duration>  timeout for print mode\n", "")
+        calls.append((argv, kwargs))
+        if argv[0] == "/seat/bin/agy":
+            return agents.proc.Result(
+                0, "Usage: agy [options]\n  --print-timeout <duration>  timeout for print mode\n", ""
+            )
+        return agents.proc.Result(0, "Usage: agy\n", "")
 
     monkeypatch.setattr(agents.proc, "run", stub_run)
-    assert agents._antigravity_supports_print_timeout() is True
-    assert calls == [["agy", "--help"]]
+    assert agents._antigravity_supports_print_timeout("/seat/bin/agy", env=current_env) is True
+    assert calls == [(["/seat/bin/agy", "--help"], {"timeout": 5.0, "env": current_env, "process_registry": None})]
 
-    # Cached on subsequent call
-    assert agents._antigravity_supports_print_timeout() is True
+    # Cache only identical executable/environment capability probes.
+    assert agents._antigravity_supports_print_timeout("/seat/bin/agy", env=current_env) is True
     assert len(calls) == 1
 
-    # Returns False when flag is absent
+    assert agents._antigravity_supports_print_timeout("/legacy/bin/agy", env=legacy_env) is False
+    assert calls[-1] == (["/legacy/bin/agy", "--help"], {"timeout": 5.0, "env": legacy_env, "process_registry": None})
+
+    # Returns False when command fails.
     if hasattr(agents, "_clear_antigravity_print_timeout_cache"):
         agents._clear_antigravity_print_timeout_cache()
     elif hasattr(agents._antigravity_supports_print_timeout, "cache_clear"):
         agents._antigravity_supports_print_timeout.cache_clear()
-
     monkeypatch.setattr(agents.proc, "run", lambda *a, **kw: agents.proc.Result(0, "Usage: agy\n", ""))
     assert agents._antigravity_supports_print_timeout() is False
 
-    # Returns False when command fails
     if hasattr(agents, "_clear_antigravity_print_timeout_cache"):
         agents._clear_antigravity_print_timeout_cache()
     elif hasattr(agents._antigravity_supports_print_timeout, "cache_clear"):
@@ -1212,6 +1219,48 @@ def test_run_agent_threads_cwd_into_argv_builder(monkeypatch, tmp_path):
     ]
 
 
+def test_run_agent_antigravity_forwards_timeout_and_probes_resolved_seat(monkeypatch, tmp_path):
+    agents._clear_antigravity_print_timeout_cache()
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        if argv == ["/seat/bin/agy", "--help"]:
+            return agents.proc.Result(0, "--print-timeout <duration>", "")
+        return agents.proc.Result(0, "answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda command, path=None: "/seat/bin/agy")
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    result = agents.run_agent(
+        "antigravity",
+        "hi",
+        timeout=900,
+        cwd=tmp_path,
+        env={"PATH": "/seat/bin", "AGY_PROFILE": "seat-specific"},
+    )
+
+    assert result.ok is True
+    assert calls[0] == (
+        ["/seat/bin/agy", "--help"],
+        {
+            "timeout": 5.0,
+            "env": {**agents.os.environ, "PATH": "/seat/bin", "AGY_PROFILE": "seat-specific"},
+            "process_registry": None,
+        },
+    )
+    assert calls[1][0] == [
+        "/seat/bin/agy",
+        "--add-dir",
+        str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print-timeout",
+        "870s",
+        "--print",
+        "hi",
+    ]
+
+
 def test_ollama_model_present_threads_process_registry(monkeypatch):
     registry = agents.proc.ProcessRegistry()
     seen = {}
@@ -1282,7 +1331,7 @@ def test_run_agent_antigravity_with_no_cwd_allows_current_cwd(monkeypatch, tmp_p
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setattr(agents.proc, "run", fake_run)
-    res = agents.run_agent("antigravity", "hi")
+    res = agents.run_agent("antigravity", "hi", timeout=None)
 
     assert res.ok is True
     assert captured["cwd"] is None

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -543,6 +543,54 @@ def test_antigravity_supports_print_timeout_probe(monkeypatch):
     assert agents._antigravity_supports_print_timeout() is False
 
 
+def test_antigravity_supports_print_timeout_cache_does_not_retain_environment_values(monkeypatch):
+    if hasattr(agents, "_clear_antigravity_print_timeout_cache"):
+        agents._clear_antigravity_print_timeout_cache()
+    elif hasattr(agents._antigravity_supports_print_timeout, "cache_clear"):
+        agents._antigravity_supports_print_timeout.cache_clear()
+
+    sentinel = "SECRET-VALUE-123"
+    env = {"PATH": "/seat/bin", "AGY_SECRET": sentinel}
+
+    def stub_run(argv, **kwargs):
+        return agents.proc.Result(
+            0,
+            "Usage: agy [options]\n  --print-timeout <duration>  timeout for print mode\n",
+            "",
+        )
+
+    monkeypatch.setattr(agents.proc, "run", stub_run)
+    agents._antigravity_supports_print_timeout("/seat/bin/agy", env=env)
+
+    cache_repr = repr(agents._ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED)
+    assert sentinel not in cache_repr
+
+
+def test_antigravity_supports_print_timeout_cache_bounds_to_sixteen_entries(monkeypatch):
+    if hasattr(agents, "_clear_antigravity_print_timeout_cache"):
+        agents._clear_antigravity_print_timeout_cache()
+    elif hasattr(agents._antigravity_supports_print_timeout, "cache_clear"):
+        agents._antigravity_supports_print_timeout.cache_clear()
+
+    calls = []
+
+    def stub_run(argv, **kwargs):
+        calls.append(argv[0])
+        return agents.proc.Result(0, "Usage: agy [options]\n  --print-timeout <duration>\n", "")
+
+    monkeypatch.setattr(agents.proc, "run", stub_run)
+
+    for i in range(17):
+        assert agents._antigravity_supports_print_timeout(f"/agy/{i}", env={"PATH": "/bin"}) is True
+
+    assert len(calls) == 17
+    assert len(agents._ANTIGRAVITY_PRINT_TIMEOUT_SUPPORTED) == 16
+
+    # The first executable should have been evicted, so probing it again re-runs.
+    assert agents._antigravity_supports_print_timeout("/agy/0", env={"PATH": "/bin"}) is True
+    assert len(calls) == 18
+
+
 def test_build_argv_cursor_sandbox_read_only_uses_plan_mode():
     assert agents.build_argv("cursor", "hi", sandbox="read-only") == [
         "cursor-agent",


### PR DESCRIPTION
## What

The Antigravity adapter built `agy --add-dir <cwd> --dangerously-skip-permissions --print <prompt>` and never passed `--print-timeout`, so agy's own five-minute print default killed any worker turn longer than that with `Error: timeout waiting for response`, no matter what `timeout_seconds` the roster declared.

`_antigravity_argv` now takes the seat timeout and emits `--print-timeout <max(60, timeout_seconds - 30)>s` ahead of `--print`, so agy gives up before Brigade's own kill. The flag is only emitted when `agy --help` advertises it (probed once per process and cached), and a seat with no declared timeout keeps the old argv unchanged.

Closes #1416.

## Verification

```
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_agents.py","tests/test_agents_model_pin.py","tests/test_agents_oracle.py"]' --capture brigade-work
exit 0
```

Built by the `agy_flash` seat (Gemini 3.8 Flash High) under `brigade run`, with one formatting pass afterwards because the seat hit its own timeout before running `ruff format`.
