### PR TITLE
feat(evidence-ledger): add migrate codex-arguments for rows stored before the argument cap

### DIFF
--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -8,6 +8,9 @@ Releases before this changelog was started are on the [releases page](https://gi
 
 ## [Unreleased]
 
+### Added
+- Added `miseledger migrate codex-arguments` command to migrate and truncate oversized or duplicated tool call arguments in the database for existing rows (#1414).
+
 ### Security
 - Round 6 (#1201): the GOOS=darwin build is repaired without weakening linux. The descriptor-relative `openat`/`unlinkat` implementations are now linux-only, while darwin and the other non-linux unix platforms get a functional pathname-based equivalent: opens carry `O_NOFOLLOW|O_CLOEXEC` relative to the already-validated data-directory path (`O_CREAT|O_EXCL` where creation is required), the validated directory descriptor is `fstat`ed before and after every open/removal and must keep an identical dev/ino pair, and the opened file must be regular, singly linked (nlink 1), and exactly 0600. The residual darwin mutation window between those parent identity checks is pathname-based and exploitable only by a same-uid data-directory writer — a writer outside this engine's model (#1093). Windows keeps failing closed.
 - Round 5 (#1201): execution of the verified stationtrail snapshot is now descriptor-based. Previously the snapshot was executed by its pathname after digest verification, so a same-uid process could rename another executable over the cached snapshot entry between verification and exec (the executed inode was no longer the verified one), and the cached `snapPath` let later commands skip every digest check. The verified snapshot is now kept open: its digest is re-read from that open descriptor immediately before each exec, and on linux every exec targets `/proc/self/fd/<fd>` so the kernel executes exactly the verified inode; platforms without descriptor exec fail closed with a typed error instead of degrading to pathname execution.

--- a/engines/evidence-ledger/README.md
+++ b/engines/evidence-ledger/README.md
@@ -222,6 +222,7 @@ miseledger export markdown --out /tmp/miseledger-md
 miseledger relations backfill --json
 miseledger stats --json
 miseledger compact --json
+miseledger migrate codex-arguments --dry-run --json
 miseledger prune imports --before 2026-01-01 --dry-run --json
 miseledger sql "select count(*) as items from items" --json
 miseledger doctor --json
@@ -423,6 +424,7 @@ Archive maintenance commands are local-only:
 miseledger stats --json
 miseledger relations backfill --json
 miseledger compact --json
+miseledger migrate codex-arguments --dry-run --json
 miseledger prune --policy default --dry-run --json
 miseledger prune imports --before 2026-01-01 --dry-run --json
 miseledger prune scans --missing --dry-run --json

--- a/engines/evidence-ledger/docs/RETENTION_POLICY.md
+++ b/engines/evidence-ledger/docs/RETENTION_POLICY.md
@@ -10,6 +10,8 @@ miseledger prune policy --policy retention.json --dry-run --json
 
 Dry run is the default. A destructive run must include both `--apply` and `--export <path>`. Matched records are written to compressed adapter JSONL before any rows are deleted, so the slice can be restored later with `miseledger import adapter <file>`.
 
+> **Note:** The operator sequence for fully reclaiming space is `prune policy --apply` for chatter, then `migrate codex-arguments --apply` to truncate old tool arguments, then `compact`.
+
 ## Default Policy
 
 The default policy targets old operational noise:

--- a/engines/evidence-ledger/docs/RETENTION_POLICY.md
+++ b/engines/evidence-ledger/docs/RETENTION_POLICY.md
@@ -10,7 +10,7 @@ miseledger prune policy --policy retention.json --dry-run --json
 
 Dry run is the default. A destructive run must include both `--apply` and `--export <path>`. Matched records are written to compressed adapter JSONL before any rows are deleted, so the slice can be restored later with `miseledger import adapter <file>`.
 
-> **Note:** The operator sequence for fully reclaiming space is `prune policy --apply` for chatter, then `migrate codex-arguments --apply` to truncate old tool arguments, then `compact`.
+> **Note:** The operator sequence for fully reclaiming space is `prune policy --apply --export <path>` for chatter, then `migrate codex-arguments --apply` to truncate old tool arguments, then `compact`.
 
 ## Default Policy
 

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -80,6 +80,7 @@ var commandTable = []commandSpec{
 	{name: "diff", usage: "diff", description: "Compare archive forks.", run: cmdDiff},
 	{name: "compact", usage: "compact", description: "Compact the SQLite archive.", run: cmdCompact},
 	{name: "prune", usage: "prune", description: "Prune archive data.", run: cmdPrune},
+	{name: "migrate", usage: "migrate", description: "Rewrite stored rows into the current shape.", run: cmdMigrate},
 	{name: "sql", usage: "sql", description: "Run read-only SQL.", run: cmdSQL},
 	{name: "doctor", usage: "doctor", description: "Run diagnostic checks.", run: cmdDoctor},
 	{name: "trust", usage: "trust review", description: "Review or verify an item trust label.", run: cmdTrust},

--- a/engines/evidence-ledger/internal/app/migrate.go
+++ b/engines/evidence-ledger/internal/app/migrate.go
@@ -11,8 +11,11 @@ import (
 	"strings"
 
 	"github.com/escoffier-labs/miseledger/internal/provenance"
+	"github.com/escoffier-labs/miseledger/internal/sources"
 	"github.com/escoffier-labs/miseledger/internal/textnorm"
 )
+
+var migrateBatchSize = 1000
 
 // cmdMigrate dispatches `miseledger migrate <target>`; mirrors cmdPrune.
 func cmdMigrate(args []string, out, errw io.Writer) int {
@@ -39,7 +42,7 @@ func writeMigrateHelp(w io.Writer) int {
 }
 
 // cmdMigrateCodexArguments scans for Codex tool-call items whose arguments exceed
-// 4000 characters and truncates them, keeping a SHA-256 digest in metadata.
+// sources.DefaultTextCap characters and truncates them, keeping a SHA-256 digest in metadata.
 // Note: Candidate selection performs a full-table LIKE scan across items for matching metadata.
 func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 	_, bools, rest, err := splitFlags(args, nil, map[string]bool{"dry-run": true, "apply": true, "json": true, "help": true})
@@ -64,6 +67,29 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 	}
 	defer db.Close()
 
+	// Prepass: load item_id -> fts rowid for all codex rows in one scan (bounded memory).
+	ftsRowIDs := make(map[string]int64)
+	ftsRows, err := db.Query(`SELECT rowid, item_id FROM item_fts WHERE source_kind = 'codex'`)
+	if err != nil {
+		return fatalf(errw, "migrate codex-arguments fts prepass query: %s", err)
+	}
+	for ftsRows.Next() {
+		var rID int64
+		var itmID string
+		if err := ftsRows.Scan(&rID, &itmID); err != nil {
+			ftsRows.Close()
+			return fatalf(errw, "migrate codex-arguments fts prepass scan: %s", err)
+		}
+		if itmID != "" {
+			ftsRowIDs[itmID] = rID
+		}
+	}
+	if err := ftsRows.Err(); err != nil {
+		ftsRows.Close()
+		return fatalf(errw, "migrate codex-arguments fts prepass rows: %s", err)
+	}
+	ftsRows.Close()
+
 	type updateRow struct {
 		id           string
 		rawJSON      string
@@ -75,16 +101,16 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 	}
 	var matchedRows int
 	var bytesSaved int
+	var ftsMissing int
 
 	lastID := ""
-	batchSize := 1000
+	batchSize := migrateBatchSize
 
 	for {
 		rows, err := db.Query(`
-			SELECT i.rowid, i.id, coalesce(i.text, ''), i.raw_json, i.metadata_json, coalesce(f.rowid, 0), coalesce(f.item_id, ''), coalesce(f.body, '') 
+			SELECT i.id, coalesce(i.text, ''), i.raw_json, i.metadata_json
 			FROM items i
 			JOIN sources s ON i.source_id = s.id
-			LEFT JOIN item_fts f ON f.rowid = i.rowid
 			WHERE s.kind = 'codex' AND i.metadata_json LIKE '%"arguments"%' AND i.id > ?
 			ORDER BY i.id
 			LIMIT ?
@@ -93,21 +119,36 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 			return fatalf(errw, "migrate codex-arguments query: %s", err)
 		}
 
-		var batchUpdates []updateRow
-		hasRows := false
-
+		type itemCandidate struct {
+			id   string
+			text string
+			raw  string
+			meta string
+		}
+		var candidates []itemCandidate
 		for rows.Next() {
-			hasRows = true
-			var itemRowID, ftsRowID int64
-			var id, text, raw, meta, ftsItemID, ftsBody string
-			if err := rows.Scan(&itemRowID, &id, &text, &raw, &meta, &ftsRowID, &ftsItemID, &ftsBody); err != nil {
+			var c itemCandidate
+			if err := rows.Scan(&c.id, &c.text, &c.raw, &c.meta); err != nil {
 				rows.Close()
 				return fatalf(errw, "migrate codex-arguments scan: %s", err)
 			}
-			lastID = id
+			candidates = append(candidates, c)
+			lastID = c.id
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fatalf(errw, "migrate codex-arguments rows: %s", err)
+		}
+		rows.Close()
 
+		if len(candidates) == 0 {
+			break
+		}
+
+		var batchUpdates []updateRow
+		for _, c := range candidates {
 			var metaObj map[string]any
-			decMeta := json.NewDecoder(bytes.NewReader([]byte(meta)))
+			decMeta := json.NewDecoder(bytes.NewReader([]byte(c.meta)))
 			decMeta.UseNumber()
 			if err := decMeta.Decode(&metaObj); err != nil {
 				continue
@@ -122,30 +163,29 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				continue
 			}
 
-			if len(argsStr) <= 4000 || isAlreadyTruncated(argsStr, metaObj) {
+			if len([]rune(argsStr)) <= sources.DefaultTextCap || isAlreadyTruncated(argsStr, metaObj) {
 				continue
 			}
 
-			truncatedArgs := argsStr[:4000] + "\n[truncated]"
+			truncatedArgs := sources.TextFromAny(argsStr, sources.DefaultTextCap)
 			digestBytes := sha256.Sum256([]byte(argsStr))
 			digest := hex.EncodeToString(digestBytes[:])
 
-			metaObj["arguments"] = truncatedArgs
-			metaObj["arguments_digest"] = digest
-
-			// Parse raw_json with json.Decoder and UseNumber to preserve precise float types and integers
+			// Update raw_json first, mirroring the importer's ordering.
 			var rawObj map[string]any
-			decRaw := json.NewDecoder(bytes.NewReader([]byte(raw)))
+			decRaw := json.NewDecoder(bytes.NewReader([]byte(c.raw)))
 			decRaw.UseNumber()
 			if err := decRaw.Decode(&rawObj); err != nil {
 				continue
 			}
 
-			// Update item.metadata and item.text inside the marshaled adapter.Record
+			// Update item.metadata and item.text inside the marshaled adapter.Record.
+			// Ensure embedded metadata doesn't keep a stale provenance envelope.
 			if itemObj, ok := rawObj["item"].(map[string]any); ok {
 				if itemMeta, ok := itemObj["metadata"].(map[string]any); ok {
 					itemMeta["arguments"] = truncatedArgs
 					itemMeta["arguments_digest"] = digest
+					delete(itemMeta, "provenance")
 				}
 				if itemText, ok := itemObj["text"].(string); ok && strings.Contains(itemText, argsStr) {
 					itemObj["text"] = strings.Replace(itemText, argsStr, truncatedArgs, 1)
@@ -154,15 +194,18 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 
 			newRawBytes, err := json.Marshal(rawObj)
 			if err != nil {
-				rows.Close()
 				return fatalf(errw, "migrate codex-arguments marshal raw: %s", err)
 			}
 			newRaw := string(newRawBytes)
 
-			newText := text
-			if strings.Contains(text, argsStr) {
-				newText = strings.Replace(text, argsStr, truncatedArgs, 1)
+			newText := c.text
+			if strings.Contains(c.text, argsStr) {
+				newText = strings.Replace(c.text, argsStr, truncatedArgs, 1)
 			}
+
+			// Update metadata_json with truncated arguments, digest, and recomputed hashes over newText and newRaw.
+			metaObj["arguments"] = truncatedArgs
+			metaObj["arguments_digest"] = digest
 
 			if prov, ok := metaObj["provenance"].(map[string]any); ok {
 				hashes, ok := prov["hashes"].(map[string]any)
@@ -188,71 +231,55 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 
 			newMetaBytes, err := json.Marshal(metaObj)
 			if err != nil {
-				rows.Close()
 				return fatalf(errw, "migrate codex-arguments marshal metadata: %s", err)
 			}
 			newMeta := string(newMetaBytes)
 
-			targetFTSRowID := int64(0)
-			if ftsRowID > 0 && ftsItemID == id {
-				targetFTSRowID = ftsRowID
-			} else {
-				var qRowID int64
-				var qBody string
-				err := db.QueryRow(`SELECT rowid, body FROM item_fts WHERE item_id = ?`, id).Scan(&qRowID, &qBody)
-				if err == nil {
-					targetFTSRowID = qRowID
-					ftsBody = qBody
-				} else if err != sql.ErrNoRows {
-					rows.Close()
-					return fatalf(errw, "migrate codex-arguments fts query: %s", err)
-				}
-			}
-
+			ftsRowID, hasFTS := ftsRowIDs[c.id]
 			ftsUpdated := false
 			newFtsBody := ""
-			if targetFTSRowID > 0 {
-				newFtsBody = ftsBody
-				normOldText := textnorm.Normalize(text)
-				normNewText := textnorm.Normalize(newText)
-				normOldArgs := textnorm.Normalize(argsStr)
-				normNewArgs := textnorm.Normalize(truncatedArgs)
+			if !hasFTS {
+				ftsMissing++
+			} else {
+				var ftsBody string
+				err := db.QueryRow(`SELECT body FROM item_fts WHERE rowid = ?`, ftsRowID).Scan(&ftsBody)
+				if err == nil {
+					newFtsBody = ftsBody
+					normOldText := textnorm.Normalize(c.text)
+					normNewText := textnorm.Normalize(newText)
+					normOldArgs := textnorm.Normalize(argsStr)
+					normNewArgs := textnorm.Normalize(truncatedArgs)
 
-				if normOldText != "" && strings.Contains(ftsBody, normOldText) {
-					newFtsBody = strings.Replace(ftsBody, normOldText, normNewText, 1)
-				} else if normOldArgs != "" && strings.Contains(ftsBody, normOldArgs) {
-					newFtsBody = strings.Replace(ftsBody, normOldArgs, normNewArgs, 1)
-				} else if strings.Contains(ftsBody, argsStr) {
-					newFtsBody = strings.Replace(ftsBody, argsStr, truncatedArgs, 1)
-				}
-				if newFtsBody != ftsBody {
-					ftsUpdated = true
+					if normOldText != "" && strings.Contains(ftsBody, normOldText) {
+						newFtsBody = strings.Replace(ftsBody, normOldText, normNewText, 1)
+					} else if normOldArgs != "" && strings.Contains(ftsBody, normOldArgs) {
+						newFtsBody = strings.Replace(ftsBody, normOldArgs, normNewArgs, 1)
+					} else if strings.Contains(ftsBody, argsStr) {
+						newFtsBody = strings.Replace(ftsBody, argsStr, truncatedArgs, 1)
+					}
+					if newFtsBody != ftsBody {
+						ftsUpdated = true
+					}
+				} else if err == sql.ErrNoRows {
+					ftsMissing++
+				} else {
+					return fatalf(errw, "migrate codex-arguments fts query by rowid: %s", err)
 				}
 			}
 
-			saved := len(raw) + len(meta) + len(text) - len(newRaw) - len(newMeta) - len(newText)
+			saved := len(c.raw) + len(c.meta) + len(c.text) - len(newRaw) - len(newMeta) - len(newText)
 			bytesSaved += saved
 			matchedRows++
 
 			batchUpdates = append(batchUpdates, updateRow{
-				id:           id,
+				id:           c.id,
 				rawJSON:      newRaw,
 				metadataJSON: newMeta,
 				text:         newText,
 				ftsUpdated:   ftsUpdated,
-				ftsRowID:     targetFTSRowID,
+				ftsRowID:     ftsRowID,
 				ftsBody:      newFtsBody,
 			})
-		}
-
-		if err := rows.Err(); err != nil {
-			rows.Close()
-			return fatalf(errw, "migrate codex-arguments rows: %s", err)
-		}
-		rows.Close()
-
-		if !hasRows {
-			break
 		}
 
 		if !isDryRun && len(batchUpdates) > 0 {
@@ -305,6 +332,7 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 			"matched":     matchedRows,
 			"bytes_saved": bytesSaved,
 			"dry_run":     isDryRun,
+			"fts_missing": ftsMissing,
 		}
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
@@ -318,6 +346,9 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 		}
 		fmt.Fprintf(out, "%smatched %d codex rows with duplicate or oversized arguments\n", prefix, matchedRows)
 		fmt.Fprintf(out, "%sestimated bytes saved: %d\n", prefix, bytesSaved)
+		if ftsMissing > 0 {
+			fmt.Fprintf(out, "%sitems missing from fts: %d\n", prefix, ftsMissing)
+		}
 		if isDryRun && matchedRows > 0 {
 			fmt.Fprintf(out, "run with --apply to execute\n")
 		}
@@ -327,7 +358,7 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 }
 
 func isAlreadyTruncated(argsStr string, metaObj map[string]any) bool {
-	if strings.HasSuffix(argsStr, "\n[truncated]") {
+	if strings.HasSuffix(argsStr, sources.TruncationMarker) {
 		return true
 	}
 	if _, hasDigest := metaObj["arguments_digest"]; hasDigest && strings.HasSuffix(argsStr, "[truncated]") {

--- a/engines/evidence-ledger/internal/app/migrate.go
+++ b/engines/evidence-ledger/internal/app/migrate.go
@@ -3,16 +3,23 @@ package app
 import (
 	"bytes"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
+
+	"github.com/escoffier-labs/miseledger/internal/textnorm"
 )
 
 // cmdMigrate dispatches `miseledger migrate <target>`; mirrors cmdPrune.
 func cmdMigrate(args []string, out, errw io.Writer) int {
 	if len(args) == 0 {
 		return fatalf(errw, "usage: miseledger migrate codex-arguments [--dry-run] [--apply] [--json]")
+	}
+	if args[0] == "--help" || args[0] == "-h" || args[0] == "help" {
+		return writeMigrateHelp(out)
 	}
 	switch args[0] {
 	case "codex-arguments":
@@ -22,20 +29,31 @@ func cmdMigrate(args []string, out, errw io.Writer) int {
 	}
 }
 
+func writeMigrateHelp(w io.Writer) int {
+	fmt.Fprintln(w, "usage: miseledger migrate codex-arguments [--dry-run] [--apply] [--json]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Rewrite stored Codex tool-call rows to truncate oversized arguments and remove duplicate arguments.")
+	fmt.Fprintln(w, "Note: Candidate selection performs a full-table LIKE scan across items for matching metadata.")
+	return 0
+}
+
+// cmdMigrateCodexArguments scans for Codex tool-call items whose arguments exceed
+// 4000 characters and truncates them, keeping a SHA-256 digest in metadata.
+// Note: Candidate selection performs a full-table LIKE scan across items for matching metadata.
 func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
-	_, bools, rest, err := splitFlags(args, nil, map[string]bool{"dry-run": true, "apply": true, "json": true})
+	_, bools, rest, err := splitFlags(args, nil, map[string]bool{"dry-run": true, "apply": true, "json": true, "help": true})
 	if err != nil {
 		return fatalf(errw, "migrate codex-arguments: %s", err)
 	}
-	if len(rest) != 0 {
+	if bools["help"] || (len(rest) == 1 && (rest[0] == "help" || rest[0] == "-h")) {
+		return writeMigrateHelp(out)
+	}
+	if len(rest) != 0 || (bools["apply"] && bools["dry-run"]) {
 		return fatalf(errw, "usage: miseledger migrate codex-arguments [--dry-run] [--apply] [--json]")
 	}
 	isDryRun := true
 	if bools["apply"] {
 		isDryRun = false
-	}
-	if bools["dry-run"] {
-		isDryRun = true
 	}
 	isJSON := bools["json"]
 
@@ -45,22 +63,13 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 	}
 	defer db.Close()
 
-	// 1. Get total number of items to migrate to allocate batches.
-	var total int
-	err = db.QueryRow(`
-		SELECT COUNT(*) 
-		FROM items i
-		JOIN sources s ON i.source_id = s.id
-		WHERE s.kind = 'codex' AND i.metadata_json LIKE '%"arguments"%'
-	`).Scan(&total)
-	if err != nil {
-		return fatalf(errw, "migrate codex-arguments count query: %s", err)
-	}
-
 	type updateRow struct {
 		id           string
 		rawJSON      string
 		metadataJSON string
+		text         string
+		ftsUpdated   bool
+		ftsBody      string
 	}
 	var matchedRows int
 	var bytesSaved int
@@ -70,7 +79,7 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 
 	for {
 		rows, err := db.Query(`
-			SELECT i.id, i.raw_json, i.metadata_json 
+			SELECT i.id, coalesce(i.text, ''), i.raw_json, i.metadata_json 
 			FROM items i
 			JOIN sources s ON i.source_id = s.id
 			WHERE s.kind = 'codex' AND i.metadata_json LIKE '%"arguments"%'
@@ -86,13 +95,12 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 
 		for rows.Next() {
 			hasRows = true
-			var id, raw, meta string
-			if err := rows.Scan(&id, &raw, &meta); err != nil {
+			var id, text, raw, meta string
+			if err := rows.Scan(&id, &text, &raw, &meta); err != nil {
 				rows.Close()
 				return fatalf(errw, "migrate codex-arguments scan: %s", err)
 			}
 
-			// Parse metadata using default unmarshal since it doesn't matter for the structure
 			var metaObj map[string]any
 			if err := json.Unmarshal([]byte(meta), &metaObj); err != nil {
 				continue
@@ -107,7 +115,23 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				continue
 			}
 
-			needsTruncate := len(argsStr) > 4000
+			if len(argsStr) <= 4000 || isAlreadyTruncated(argsStr, metaObj) {
+				continue
+			}
+
+			truncatedArgs := argsStr[:4000] + "\n[truncated]"
+			digestBytes := sha256.Sum256([]byte(argsStr))
+			digest := hex.EncodeToString(digestBytes[:])
+
+			metaObj["arguments"] = truncatedArgs
+			metaObj["arguments_digest"] = digest
+
+			newMetaBytes, err := json.Marshal(metaObj)
+			if err != nil {
+				rows.Close()
+				return fatalf(errw, "migrate codex-arguments marshal metadata: %s", err)
+			}
+			newMeta := string(newMetaBytes)
 
 			// Parse raw_json with json.Decoder and UseNumber to preserve precise float types and integers
 			var rawObj map[string]any
@@ -117,48 +141,72 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				continue
 			}
 
-			changedRaw := false
-			if p, ok := rawObj["payload"].(map[string]any); ok {
-				if _, hasArgs := p["arguments"]; hasArgs {
-					delete(p, "arguments")
-					changedRaw = true
+			// Update item.metadata and item.text inside the marshaled adapter.Record
+			if itemObj, ok := rawObj["item"].(map[string]any); ok {
+				if itemMeta, ok := itemObj["metadata"].(map[string]any); ok {
+					itemMeta["arguments"] = truncatedArgs
+					itemMeta["arguments_digest"] = digest
 				}
-			}
-			if _, hasArgs := rawObj["arguments"]; hasArgs {
-				delete(rawObj, "arguments")
-				changedRaw = true
-			}
-
-			changedMeta := false
-			if needsTruncate {
-				if !hasPrefixOrTruncatedCheck(argsStr) {
-					truncatedArgs := argsStr[:4000] + "\n[truncated]"
-					digestBytes := sha256.Sum256([]byte(argsStr))
-					digest := hex.EncodeToString(digestBytes[:])
-
-					metaObj["arguments"] = truncatedArgs
-					metaObj["arguments_digest"] = digest
-					changedMeta = true
+				if itemText, ok := itemObj["text"].(string); ok && strings.Contains(itemText, argsStr) {
+					itemObj["text"] = strings.Replace(itemText, argsStr, truncatedArgs, 1)
 				}
 			}
 
-			if changedRaw || changedMeta {
-				newRawBytes, _ := json.Marshal(rawObj)
-				newMetaBytes, _ := json.Marshal(metaObj)
-
-				newRaw := string(newRawBytes)
-				newMeta := string(newMetaBytes)
-
-				saved := len(raw) + len(meta) - len(newRaw) - len(newMeta)
-				bytesSaved += saved
-				matchedRows++
-
-				batchUpdates = append(batchUpdates, updateRow{
-					id:           id,
-					rawJSON:      newRaw,
-					metadataJSON: newMeta,
-				})
+			newRawBytes, err := json.Marshal(rawObj)
+			if err != nil {
+				rows.Close()
+				return fatalf(errw, "migrate codex-arguments marshal raw: %s", err)
 			}
+			newRaw := string(newRawBytes)
+
+			newText := text
+			if strings.Contains(text, argsStr) {
+				newText = strings.Replace(text, argsStr, truncatedArgs, 1)
+			}
+
+			var ftsBody string
+			ftsUpdated := false
+			newFtsBody := ""
+			err = db.QueryRow(`SELECT body FROM item_fts WHERE item_id = ?`, id).Scan(&ftsBody)
+			if err == nil {
+				newFtsBody = ftsBody
+				normOldText := textnorm.Normalize(text)
+				normNewText := textnorm.Normalize(newText)
+				normOldArgs := textnorm.Normalize(argsStr)
+				normNewArgs := textnorm.Normalize(truncatedArgs)
+
+				if normOldText != "" && strings.Contains(ftsBody, normOldText) {
+					newFtsBody = strings.Replace(ftsBody, normOldText, normNewText, 1)
+				} else if normOldArgs != "" && strings.Contains(ftsBody, normOldArgs) {
+					newFtsBody = strings.Replace(ftsBody, normOldArgs, normNewArgs, 1)
+				} else if strings.Contains(ftsBody, argsStr) {
+					newFtsBody = strings.Replace(ftsBody, argsStr, truncatedArgs, 1)
+				}
+				if newFtsBody != ftsBody {
+					ftsUpdated = true
+				}
+			} else if err != sql.ErrNoRows {
+				rows.Close()
+				return fatalf(errw, "migrate codex-arguments fts query: %s", err)
+			}
+
+			saved := len(raw) + len(meta) + len(text) - len(newRaw) - len(newMeta) - len(newText)
+			bytesSaved += saved
+			matchedRows++
+
+			batchUpdates = append(batchUpdates, updateRow{
+				id:           id,
+				rawJSON:      newRaw,
+				metadataJSON: newMeta,
+				text:         newText,
+				ftsUpdated:   ftsUpdated,
+				ftsBody:      newFtsBody,
+			})
+		}
+
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fatalf(errw, "migrate codex-arguments rows: %s", err)
 		}
 		rows.Close()
 
@@ -172,21 +220,39 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				return fatalf(errw, "migrate codex-arguments tx begin: %s", err)
 			}
 
-			stmt, err := tx.Prepare(`UPDATE items SET raw_json = ?, metadata_json = ? WHERE id = ?`)
+			stmtItems, err := tx.Prepare(`UPDATE items SET raw_json = ?, metadata_json = ?, text = ? WHERE id = ?`)
 			if err != nil {
 				tx.Rollback()
 				return fatalf(errw, "migrate codex-arguments stmt prepare: %s", err)
 			}
 
+			stmtFTS, err := tx.Prepare(`UPDATE item_fts SET body = ? WHERE item_id = ?`)
+			if err != nil {
+				stmtItems.Close()
+				tx.Rollback()
+				return fatalf(errw, "migrate codex-arguments fts stmt prepare: %s", err)
+			}
+
 			for _, upd := range batchUpdates {
-				_, err := stmt.Exec(upd.rawJSON, upd.metadataJSON, upd.id)
+				_, err := stmtItems.Exec(upd.rawJSON, upd.metadataJSON, upd.text, upd.id)
 				if err != nil {
-					stmt.Close()
+					stmtItems.Close()
+					stmtFTS.Close()
 					tx.Rollback()
 					return fatalf(errw, "migrate codex-arguments stmt exec: %s", err)
 				}
+				if upd.ftsUpdated {
+					_, err := stmtFTS.Exec(upd.ftsBody, upd.id)
+					if err != nil {
+						stmtItems.Close()
+						stmtFTS.Close()
+						tx.Rollback()
+						return fatalf(errw, "migrate codex-arguments fts stmt exec: %s", err)
+					}
+				}
 			}
-			stmt.Close()
+			stmtItems.Close()
+			stmtFTS.Close()
 			if err := tx.Commit(); err != nil {
 				return fatalf(errw, "migrate codex-arguments tx commit: %s", err)
 			}
@@ -203,7 +269,9 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 		}
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
-		enc.Encode(res)
+		if err := enc.Encode(res); err != nil {
+			return fatalf(errw, "migrate codex-arguments encode json: %s", err)
+		}
 	} else {
 		prefix := ""
 		if isDryRun {
@@ -219,6 +287,12 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 	return 0
 }
 
-func hasPrefixOrTruncatedCheck(argsStr string) bool {
-	return len(argsStr) > 11 && argsStr[len(argsStr)-11:] == "[truncated]"
+func isAlreadyTruncated(argsStr string, metaObj map[string]any) bool {
+	if strings.HasSuffix(argsStr, "\n[truncated]") {
+		return true
+	}
+	if _, hasDigest := metaObj["arguments_digest"]; hasDigest && strings.HasSuffix(argsStr, "[truncated]") {
+		return true
+	}
+	return false
 }

--- a/engines/evidence-ledger/internal/app/migrate.go
+++ b/engines/evidence-ledger/internal/app/migrate.go
@@ -1,0 +1,224 @@
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// cmdMigrate dispatches `miseledger migrate <target>`; mirrors cmdPrune.
+func cmdMigrate(args []string, out, errw io.Writer) int {
+	if len(args) == 0 {
+		return fatalf(errw, "usage: miseledger migrate codex-arguments [--dry-run] [--apply] [--json]")
+	}
+	switch args[0] {
+	case "codex-arguments":
+		return cmdMigrateCodexArguments(args[1:], out, errw)
+	default:
+		return fatalf(errw, "usage: miseledger migrate codex-arguments [--dry-run] [--apply] [--json]")
+	}
+}
+
+func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
+	_, bools, rest, err := splitFlags(args, nil, map[string]bool{"dry-run": true, "apply": true, "json": true})
+	if err != nil {
+		return fatalf(errw, "migrate codex-arguments: %s", err)
+	}
+	if len(rest) != 0 {
+		return fatalf(errw, "usage: miseledger migrate codex-arguments [--dry-run] [--apply] [--json]")
+	}
+	isDryRun := true
+	if bools["apply"] {
+		isDryRun = false
+	}
+	if bools["dry-run"] {
+		isDryRun = true
+	}
+	isJSON := bools["json"]
+
+	db, _, err := openMigrated()
+	if err != nil {
+		return fatalf(errw, "migrate codex-arguments: %s", err)
+	}
+	defer db.Close()
+
+	// 1. Get total number of items to migrate to allocate batches.
+	var total int
+	err = db.QueryRow(`
+		SELECT COUNT(*) 
+		FROM items i
+		JOIN sources s ON i.source_id = s.id
+		WHERE s.kind = 'codex' AND i.metadata_json LIKE '%"arguments"%'
+	`).Scan(&total)
+	if err != nil {
+		return fatalf(errw, "migrate codex-arguments count query: %s", err)
+	}
+
+	type updateRow struct {
+		id           string
+		rawJSON      string
+		metadataJSON string
+	}
+	var matchedRows int
+	var bytesSaved int
+
+	offset := 0
+	batchSize := 1000
+
+	for {
+		rows, err := db.Query(`
+			SELECT i.id, i.raw_json, i.metadata_json 
+			FROM items i
+			JOIN sources s ON i.source_id = s.id
+			WHERE s.kind = 'codex' AND i.metadata_json LIKE '%"arguments"%'
+			ORDER BY i.id
+			LIMIT ? OFFSET ?
+		`, batchSize, offset)
+		if err != nil {
+			return fatalf(errw, "migrate codex-arguments query: %s", err)
+		}
+
+		var batchUpdates []updateRow
+		hasRows := false
+
+		for rows.Next() {
+			hasRows = true
+			var id, raw, meta string
+			if err := rows.Scan(&id, &raw, &meta); err != nil {
+				rows.Close()
+				return fatalf(errw, "migrate codex-arguments scan: %s", err)
+			}
+
+			// Parse metadata using default unmarshal since it doesn't matter for the structure
+			var metaObj map[string]any
+			if err := json.Unmarshal([]byte(meta), &metaObj); err != nil {
+				continue
+			}
+
+			argsVal, ok := metaObj["arguments"]
+			if !ok {
+				continue
+			}
+			argsStr, ok := argsVal.(string)
+			if !ok {
+				continue
+			}
+
+			needsTruncate := len(argsStr) > 4000
+
+			// Parse raw_json with json.Decoder and UseNumber to preserve precise float types and integers
+			var rawObj map[string]any
+			dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+			dec.UseNumber()
+			if err := dec.Decode(&rawObj); err != nil {
+				continue
+			}
+
+			changedRaw := false
+			if p, ok := rawObj["payload"].(map[string]any); ok {
+				if _, hasArgs := p["arguments"]; hasArgs {
+					delete(p, "arguments")
+					changedRaw = true
+				}
+			}
+			if _, hasArgs := rawObj["arguments"]; hasArgs {
+				delete(rawObj, "arguments")
+				changedRaw = true
+			}
+
+			changedMeta := false
+			if needsTruncate {
+				if !hasPrefixOrTruncatedCheck(argsStr) {
+					truncatedArgs := argsStr[:4000] + "\n[truncated]"
+					digestBytes := sha256.Sum256([]byte(argsStr))
+					digest := hex.EncodeToString(digestBytes[:])
+
+					metaObj["arguments"] = truncatedArgs
+					metaObj["arguments_digest"] = digest
+					changedMeta = true
+				}
+			}
+
+			if changedRaw || changedMeta {
+				newRawBytes, _ := json.Marshal(rawObj)
+				newMetaBytes, _ := json.Marshal(metaObj)
+
+				newRaw := string(newRawBytes)
+				newMeta := string(newMetaBytes)
+
+				saved := len(raw) + len(meta) - len(newRaw) - len(newMeta)
+				bytesSaved += saved
+				matchedRows++
+
+				batchUpdates = append(batchUpdates, updateRow{
+					id:           id,
+					rawJSON:      newRaw,
+					metadataJSON: newMeta,
+				})
+			}
+		}
+		rows.Close()
+
+		if !hasRows {
+			break
+		}
+
+		if !isDryRun && len(batchUpdates) > 0 {
+			tx, err := db.Begin()
+			if err != nil {
+				return fatalf(errw, "migrate codex-arguments tx begin: %s", err)
+			}
+
+			stmt, err := tx.Prepare(`UPDATE items SET raw_json = ?, metadata_json = ? WHERE id = ?`)
+			if err != nil {
+				tx.Rollback()
+				return fatalf(errw, "migrate codex-arguments stmt prepare: %s", err)
+			}
+
+			for _, upd := range batchUpdates {
+				_, err := stmt.Exec(upd.rawJSON, upd.metadataJSON, upd.id)
+				if err != nil {
+					stmt.Close()
+					tx.Rollback()
+					return fatalf(errw, "migrate codex-arguments stmt exec: %s", err)
+				}
+			}
+			stmt.Close()
+			if err := tx.Commit(); err != nil {
+				return fatalf(errw, "migrate codex-arguments tx commit: %s", err)
+			}
+		}
+
+		offset += batchSize
+	}
+
+	if isJSON {
+		res := map[string]any{
+			"matched":     matchedRows,
+			"bytes_saved": bytesSaved,
+			"dry_run":     isDryRun,
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		enc.Encode(res)
+	} else {
+		prefix := ""
+		if isDryRun {
+			prefix = "[dry-run] "
+		}
+		fmt.Fprintf(out, "%smatched %d codex rows with duplicate or oversized arguments\n", prefix, matchedRows)
+		fmt.Fprintf(out, "%sestimated bytes saved: %d\n", prefix, bytesSaved)
+		if isDryRun && matchedRows > 0 {
+			fmt.Fprintf(out, "run with --apply to execute\n")
+		}
+	}
+
+	return 0
+}
+
+func hasPrefixOrTruncatedCheck(argsStr string) bool {
+	return len(argsStr) > 11 && argsStr[len(argsStr)-11:] == "[truncated]"
+}

--- a/engines/evidence-ledger/internal/app/migrate.go
+++ b/engines/evidence-ledger/internal/app/migrate.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/escoffier-labs/miseledger/internal/provenance"
 	"github.com/escoffier-labs/miseledger/internal/textnorm"
 )
 
@@ -69,23 +70,25 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 		metadataJSON string
 		text         string
 		ftsUpdated   bool
+		ftsRowID     int64
 		ftsBody      string
 	}
 	var matchedRows int
 	var bytesSaved int
 
-	offset := 0
+	lastID := ""
 	batchSize := 1000
 
 	for {
 		rows, err := db.Query(`
-			SELECT i.id, coalesce(i.text, ''), i.raw_json, i.metadata_json 
+			SELECT i.rowid, i.id, coalesce(i.text, ''), i.raw_json, i.metadata_json, coalesce(f.rowid, 0), coalesce(f.item_id, ''), coalesce(f.body, '') 
 			FROM items i
 			JOIN sources s ON i.source_id = s.id
-			WHERE s.kind = 'codex' AND i.metadata_json LIKE '%"arguments"%'
+			LEFT JOIN item_fts f ON f.rowid = i.rowid
+			WHERE s.kind = 'codex' AND i.metadata_json LIKE '%"arguments"%' AND i.id > ?
 			ORDER BY i.id
-			LIMIT ? OFFSET ?
-		`, batchSize, offset)
+			LIMIT ?
+		`, lastID, batchSize)
 		if err != nil {
 			return fatalf(errw, "migrate codex-arguments query: %s", err)
 		}
@@ -95,14 +98,18 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 
 		for rows.Next() {
 			hasRows = true
-			var id, text, raw, meta string
-			if err := rows.Scan(&id, &text, &raw, &meta); err != nil {
+			var itemRowID, ftsRowID int64
+			var id, text, raw, meta, ftsItemID, ftsBody string
+			if err := rows.Scan(&itemRowID, &id, &text, &raw, &meta, &ftsRowID, &ftsItemID, &ftsBody); err != nil {
 				rows.Close()
 				return fatalf(errw, "migrate codex-arguments scan: %s", err)
 			}
+			lastID = id
 
 			var metaObj map[string]any
-			if err := json.Unmarshal([]byte(meta), &metaObj); err != nil {
+			decMeta := json.NewDecoder(bytes.NewReader([]byte(meta)))
+			decMeta.UseNumber()
+			if err := decMeta.Decode(&metaObj); err != nil {
 				continue
 			}
 
@@ -126,18 +133,11 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 			metaObj["arguments"] = truncatedArgs
 			metaObj["arguments_digest"] = digest
 
-			newMetaBytes, err := json.Marshal(metaObj)
-			if err != nil {
-				rows.Close()
-				return fatalf(errw, "migrate codex-arguments marshal metadata: %s", err)
-			}
-			newMeta := string(newMetaBytes)
-
 			// Parse raw_json with json.Decoder and UseNumber to preserve precise float types and integers
 			var rawObj map[string]any
-			dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
-			dec.UseNumber()
-			if err := dec.Decode(&rawObj); err != nil {
+			decRaw := json.NewDecoder(bytes.NewReader([]byte(raw)))
+			decRaw.UseNumber()
+			if err := decRaw.Decode(&rawObj); err != nil {
 				continue
 			}
 
@@ -164,11 +164,54 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				newText = strings.Replace(text, argsStr, truncatedArgs, 1)
 			}
 
-			var ftsBody string
+			if prov, ok := metaObj["provenance"].(map[string]any); ok {
+				hashes, ok := prov["hashes"].(map[string]any)
+				if !ok {
+					hashes = make(map[string]any)
+					prov["hashes"] = hashes
+				}
+				hashes["content"] = provenance.ContentSHA256(newText)
+				if _, ok := hashes["content_scope"]; !ok {
+					hashes["content_scope"] = "item.text.utf8.v1"
+				}
+				if _, ok := hashes["content_algorithm"]; !ok {
+					hashes["content_algorithm"] = provenance.HashAlgorithm
+				}
+				hashes["raw"] = provenance.SHA256Bytes([]byte(newRaw))
+				if _, ok := hashes["raw_scope"]; !ok {
+					hashes["raw_scope"] = provenance.RawScope
+				}
+				if _, ok := hashes["raw_algorithm"]; !ok {
+					hashes["raw_algorithm"] = provenance.HashAlgorithm
+				}
+			}
+
+			newMetaBytes, err := json.Marshal(metaObj)
+			if err != nil {
+				rows.Close()
+				return fatalf(errw, "migrate codex-arguments marshal metadata: %s", err)
+			}
+			newMeta := string(newMetaBytes)
+
+			targetFTSRowID := int64(0)
+			if ftsRowID > 0 && ftsItemID == id {
+				targetFTSRowID = ftsRowID
+			} else {
+				var qRowID int64
+				var qBody string
+				err := db.QueryRow(`SELECT rowid, body FROM item_fts WHERE item_id = ?`, id).Scan(&qRowID, &qBody)
+				if err == nil {
+					targetFTSRowID = qRowID
+					ftsBody = qBody
+				} else if err != sql.ErrNoRows {
+					rows.Close()
+					return fatalf(errw, "migrate codex-arguments fts query: %s", err)
+				}
+			}
+
 			ftsUpdated := false
 			newFtsBody := ""
-			err = db.QueryRow(`SELECT body FROM item_fts WHERE item_id = ?`, id).Scan(&ftsBody)
-			if err == nil {
+			if targetFTSRowID > 0 {
 				newFtsBody = ftsBody
 				normOldText := textnorm.Normalize(text)
 				normNewText := textnorm.Normalize(newText)
@@ -185,9 +228,6 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				if newFtsBody != ftsBody {
 					ftsUpdated = true
 				}
-			} else if err != sql.ErrNoRows {
-				rows.Close()
-				return fatalf(errw, "migrate codex-arguments fts query: %s", err)
 			}
 
 			saved := len(raw) + len(meta) + len(text) - len(newRaw) - len(newMeta) - len(newText)
@@ -200,6 +240,7 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				metadataJSON: newMeta,
 				text:         newText,
 				ftsUpdated:   ftsUpdated,
+				ftsRowID:     targetFTSRowID,
 				ftsBody:      newFtsBody,
 			})
 		}
@@ -226,7 +267,7 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				return fatalf(errw, "migrate codex-arguments stmt prepare: %s", err)
 			}
 
-			stmtFTS, err := tx.Prepare(`UPDATE item_fts SET body = ? WHERE item_id = ?`)
+			stmtFTS, err := tx.Prepare(`UPDATE item_fts SET body = ? WHERE rowid = ?`)
 			if err != nil {
 				stmtItems.Close()
 				tx.Rollback()
@@ -241,8 +282,8 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 					tx.Rollback()
 					return fatalf(errw, "migrate codex-arguments stmt exec: %s", err)
 				}
-				if upd.ftsUpdated {
-					_, err := stmtFTS.Exec(upd.ftsBody, upd.id)
+				if upd.ftsUpdated && upd.ftsRowID > 0 {
+					_, err := stmtFTS.Exec(upd.ftsBody, upd.ftsRowID)
 					if err != nil {
 						stmtItems.Close()
 						stmtFTS.Close()
@@ -257,8 +298,6 @@ func cmdMigrateCodexArguments(args []string, out, errw io.Writer) int {
 				return fatalf(errw, "migrate codex-arguments tx commit: %s", err)
 			}
 		}
-
-		offset += batchSize
 	}
 
 	if isJSON {

--- a/engines/evidence-ledger/internal/app/migrate_test.go
+++ b/engines/evidence-ledger/internal/app/migrate_test.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMigrateCodexArguments(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+
+	db, _, err := openMigrated()
+	if err != nil {
+		t.Fatalf("failed to open test db: %s", err)
+	}
+	defer db.Close()
+
+	// Insert dummy sources
+	_, err = db.Exec(`INSERT INTO sources (id, kind, version, created_at, updated_at) VALUES ('s1', 'codex', 'v1', '2023-01-01', '2023-01-01')`)
+	if err != nil {
+		t.Fatalf("insert source: %s", err)
+	}
+	_, err = db.Exec(`INSERT INTO sources (id, kind, version, created_at, updated_at) VALUES ('s2', 'other', 'v1', '2023-01-01', '2023-01-01')`)
+	if err != nil {
+		t.Fatalf("insert source: %s", err)
+	}
+	_, err = db.Exec(`INSERT INTO collections (id, source_id, external_id, kind, created_at, updated_at) VALUES ('c1', 's1', 'c1-ext', 'session', '2023-01-01', '2023-01-01')`)
+	if err != nil {
+		t.Fatalf("insert collection: %s", err)
+	}
+	_, err = db.Exec(`INSERT INTO collections (id, source_id, external_id, kind, created_at, updated_at) VALUES ('c2', 's2', 'c2-ext', 'session', '2023-01-01', '2023-01-01')`)
+	if err != nil {
+		t.Fatalf("insert collection: %s", err)
+	}
+
+	largeArgs := strings.Repeat("a", 5000)
+
+	// Item 1: codex with large arguments, needs migration
+	raw1 := fmt.Sprintf(`{"payload":{"arguments":"%s"}}`, largeArgs)
+	meta1 := fmt.Sprintf(`{"arguments":"%s"}`, largeArgs)
+	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i1', 's1', 'c1', 'ext1', 'tool_call', '2023-01-01', 'h1', ?, ?, 1)`, raw1, meta1)
+	if err != nil {
+		t.Fatalf("insert i1: %s", err)
+	}
+
+	// Item 2: other source with large arguments (should NOT be migrated)
+	raw2 := fmt.Sprintf(`{"payload":{"arguments":"%s"}}`, largeArgs)
+	meta2 := fmt.Sprintf(`{"arguments":"%s"}`, largeArgs)
+	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i2', 's2', 'c2', 'ext2', 'tool_call', '2023-01-01', 'h2', ?, ?, 2)`, raw2, meta2)
+	if err != nil {
+		t.Fatalf("insert i2: %s", err)
+	}
+
+	// Item 3: codex with small arguments (no truncation needed, but should strip from raw_json)
+	raw3 := `{"payload":{"arguments":"small"}}`
+	meta3 := `{"arguments":"small"}`
+	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i3', 's1', 'c1', 'ext3', 'tool_call', '2023-01-01', 'h3', ?, ?, 3)`, raw3, meta3)
+	if err != nil {
+		t.Fatalf("insert i3: %s", err)
+	}
+
+	// Item 4: codex already migrated (arguments truncated, in meta, not in raw)
+	raw4 := `{"payload":{"other":"data"}}`
+	meta4 := `{"arguments":"truncated\n[truncated]","arguments_digest":"deadbeef"}`
+	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i4', 's1', 'c1', 'ext4', 'tool_call', '2023-01-01', 'h4', ?, ?, 4)`, raw4, meta4)
+	if err != nil {
+		t.Fatalf("insert i4: %s", err)
+	}
+
+	// Run dry-run
+	var out, errw bytes.Buffer
+	code := cmdMigrateCodexArguments([]string{"--json"}, &out, &errw)
+	if code != 0 {
+		t.Fatalf("cmd failed: %s", errw.String())
+	}
+	var res map[string]any
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("failed to decode json: %s\nOutput: %s", err, out.String())
+	}
+
+	if res["dry_run"] != true {
+		t.Fatalf("expected dry-run = true")
+	}
+	matched := int(res["matched"].(float64))
+	if matched != 2 {
+		t.Fatalf("expected 2 matched (i1, i3), got %d", matched)
+	}
+
+	// Check i1 unchanged (dry-run)
+	var r1, m1 string
+	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i1'`).Scan(&r1, &m1)
+	if !strings.Contains(r1, largeArgs) {
+		t.Fatalf("dry-run mutated raw_json")
+	}
+
+	// Run apply
+	out.Reset()
+	code = cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+	if code != 0 {
+		t.Fatalf("apply failed: %s", errw.String())
+	}
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("decode err: %s", err)
+	}
+	if res["dry_run"] != false {
+		t.Fatalf("expected dry-run = false")
+	}
+	matched = int(res["matched"].(float64))
+	if matched != 2 {
+		t.Fatalf("expected 2 matched, got %d", matched)
+	}
+
+	// Verify mutations
+	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i1'`).Scan(&r1, &m1)
+	if strings.Contains(r1, largeArgs) {
+		t.Fatalf("raw_json still contains large arguments for i1")
+	}
+	if !strings.Contains(m1, "[truncated]") {
+		t.Fatalf("metadata_json does not contain [truncated] for i1")
+	}
+	if !strings.Contains(m1, "arguments_digest") {
+		t.Fatalf("metadata_json missing arguments_digest for i1")
+	}
+
+	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i2'`).Scan(&r1, &m1)
+	if !strings.Contains(r1, largeArgs) {
+		t.Fatalf("i2 should not be migrated")
+	}
+
+	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i3'`).Scan(&r1, &m1)
+	if strings.Contains(r1, "small") {
+		t.Fatalf("i3 raw_json should not contain 'small' anymore")
+	}
+	if strings.Contains(m1, "[truncated]") {
+		t.Fatalf("i3 metadata_json should NOT be truncated")
+	}
+
+	// Run apply again (idempotent)
+	out.Reset()
+	code = cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("decode err: %s", err)
+	}
+	matched = int(res["matched"].(float64))
+	if matched != 0 {
+		t.Fatalf("expected 0 matched on second run, got %d", matched)
+	}
+}
+
+// TestMigrateCommandRegistered goes through the command table, not the
+// function, so a missing dispatcher entry fails here (it did on 2026-09-03).
+func TestMigrateCommandRegistered(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+
+	got := runJSON(t, "migrate", "codex-arguments", "--json")
+	if got["dry_run"] != true {
+		t.Fatalf("expected dry_run=true from the registered command, got %v", got)
+	}
+	out, errw := &bytes.Buffer{}, &bytes.Buffer{}
+	if code := cmdMigrate(nil, out, errw); code == 0 {
+		t.Fatalf("migrate without a target must fail, got exit 0")
+	}
+	if !strings.Contains(errw.String(), "usage: miseledger migrate codex-arguments") {
+		t.Fatalf("expected usage text, got %q", errw.String())
+	}
+}

--- a/engines/evidence-ledger/internal/app/migrate_test.go
+++ b/engines/evidence-ledger/internal/app/migrate_test.go
@@ -223,6 +223,19 @@ func TestMigrateCodexArguments(t *testing.T) {
 		t.Fatalf("expected match for exec_prefix before migration")
 	}
 
+	// Verify IntegrityMismatch == false before migration for rec1
+	var rec1ID string
+	if err := db.QueryRow(`SELECT id FROM items WHERE external_id = 'codex:call:call-1'`).Scan(&rec1ID); err != nil {
+		t.Fatal(err)
+	}
+	viewBefore, err := inspectStoredItem(db, rec1ID)
+	if err != nil {
+		t.Fatalf("inspectStoredItem before: %s", err)
+	}
+	if viewBefore.IntegrityMismatch {
+		t.Fatalf("expected IntegrityMismatch == false before migration, got mismatches: %+v", viewBefore.Mismatches)
+	}
+
 	// Verify --apply and --dry-run together fail with usage
 	var errw bytes.Buffer
 	code := cmdMigrateCodexArguments([]string{"--apply", "--dry-run"}, io.Discard, &errw)
@@ -342,6 +355,30 @@ func TestMigrateCodexArguments(t *testing.T) {
 	}
 	if strings.Contains(rec1After.Item.Text, "UNICORN_TOKEN_PAST_CAP") {
 		t.Fatalf("rec1 Item.Text still contains UNICORN_TOKEN_PAST_CAP")
+	}
+
+	// Verify inspectStoredItem(db, id).IntegrityMismatch == false after migration
+	viewAfter, err := inspectStoredItem(db, rec1ID)
+	if err != nil {
+		t.Fatalf("inspectStoredItem after: %s", err)
+	}
+	if viewAfter.IntegrityMismatch {
+		t.Fatalf("expected inspectStoredItem(db, id).IntegrityMismatch == false after migration, got mismatches: %+v", viewAfter.Mismatches)
+	}
+
+	// Verify metadata_json decoded with UseNumber preserves integer types
+	var parsedM1Apply map[string]any
+	decM1 := json.NewDecoder(bytes.NewReader([]byte(m1)))
+	decM1.UseNumber()
+	if err := decM1.Decode(&parsedM1Apply); err != nil {
+		t.Fatalf("decode m1: %s", err)
+	}
+	provMap, ok := parsedM1Apply["provenance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected provenance map in metadata_json")
+	}
+	if ver, ok := provMap["schema_version"].(json.Number); !ok || ver.String() != "1" {
+		t.Fatalf("expected schema_version json.Number 1, got %v (%T)", provMap["schema_version"], provMap["schema_version"])
 	}
 
 	// Verify row 2 (other source) untouched

--- a/engines/evidence-ledger/internal/app/migrate_test.go
+++ b/engines/evidence-ledger/internal/app/migrate_test.go
@@ -2,15 +2,204 @@ package app
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
-	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/escoffier-labs/miseledger/internal/adapter"
 )
 
 func TestMigrateCodexArguments(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
+
+	largeArgs := `{"cmd":"exec_prefix ` + strings.Repeat("a", 4200) + ` UNICORN_TOKEN_PAST_CAP"}`
+	ordinal1 := int64(1)
+	meta1 := map[string]any{
+		"harness":    "codex",
+		"event_type": "response_item",
+		"session_id": "s1",
+		"name":       "exec_command",
+		"call_id":    "call-1",
+		"arguments":  largeArgs,
+	}
+	meta1Bytes, _ := json.Marshal(meta1)
+	text1 := "function_call\nexec_command\ncall-1\n" + largeArgs
+
+	rec1 := adapter.Record{
+		Schema: adapter.SchemaV1,
+		Source: adapter.Source{Kind: "codex", Name: "Codex Sessions", Version: "1.0.0"},
+		Collection: adapter.Collection{
+			ExternalID: "codex:session:s1",
+			Kind:       "agent_session",
+			Name:       "s1",
+		},
+		Item: adapter.Item{
+			ExternalID: "codex:call:call-1",
+			Kind:       "tool_call",
+			CreatedAt:  "2026-07-14T19:29:50Z",
+			Text:       text1,
+			Tags:       []string{"agent-session", "codex"},
+			Metadata:   json.RawMessage(meta1Bytes),
+		},
+		Actor: &adapter.Actor{
+			ExternalID: "codex:assistant",
+			Type:       "agent",
+			Name:       "assistant",
+		},
+		Raw: adapter.RawRef{
+			Format:  "json",
+			Hash:    "sha256:preCapHash1",
+			Path:    "/path/to/session1.jsonl",
+			Ordinal: &ordinal1,
+		},
+	}
+
+	ordinal3 := int64(3)
+	smallArgs := `{"cmd":"ls -la"}`
+	meta3 := map[string]any{
+		"harness":    "codex",
+		"event_type": "response_item",
+		"session_id": "s1",
+		"name":       "exec_command",
+		"call_id":    "call-3",
+		"arguments":  smallArgs,
+	}
+	meta3Bytes, _ := json.Marshal(meta3)
+	text3 := "function_call\nexec_command\ncall-3\n" + smallArgs
+
+	rec3 := adapter.Record{
+		Schema: adapter.SchemaV1,
+		Source: adapter.Source{Kind: "codex", Name: "Codex Sessions", Version: "1.0.0"},
+		Collection: adapter.Collection{
+			ExternalID: "codex:session:s1",
+			Kind:       "agent_session",
+			Name:       "s1",
+		},
+		Item: adapter.Item{
+			ExternalID: "codex:call:call-3",
+			Kind:       "tool_call",
+			CreatedAt:  "2026-07-14T19:29:52Z",
+			Text:       text3,
+			Tags:       []string{"agent-session", "codex"},
+			Metadata:   json.RawMessage(meta3Bytes),
+		},
+		Actor: &adapter.Actor{
+			ExternalID: "codex:assistant",
+			Type:       "agent",
+			Name:       "assistant",
+		},
+		Raw: adapter.RawRef{
+			Format:  "json",
+			Hash:    "sha256:preCapHash3",
+			Path:    "/path/to/session1.jsonl",
+			Ordinal: &ordinal3,
+		},
+	}
+
+	ordinal4 := int64(4)
+	migratedArgs := strings.Repeat("b", 4000) + "\n[truncated]"
+	meta4 := map[string]any{
+		"harness":          "codex",
+		"event_type":       "response_item",
+		"session_id":       "s1",
+		"name":             "exec_command",
+		"call_id":          "call-4",
+		"arguments":        migratedArgs,
+		"arguments_digest": "deadbeef1234",
+	}
+	meta4Bytes, _ := json.Marshal(meta4)
+	text4 := "function_call\nexec_command\ncall-4\n" + migratedArgs
+
+	rec4 := adapter.Record{
+		Schema: adapter.SchemaV1,
+		Source: adapter.Source{Kind: "codex", Name: "Codex Sessions", Version: "1.0.0"},
+		Collection: adapter.Collection{
+			ExternalID: "codex:session:s1",
+			Kind:       "agent_session",
+			Name:       "s1",
+		},
+		Item: adapter.Item{
+			ExternalID: "codex:call:call-4",
+			Kind:       "tool_call",
+			CreatedAt:  "2026-07-14T19:29:54Z",
+			Text:       text4,
+			Tags:       []string{"agent-session", "codex"},
+			Metadata:   json.RawMessage(meta4Bytes),
+		},
+		Actor: &adapter.Actor{
+			ExternalID: "codex:assistant",
+			Type:       "agent",
+			Name:       "assistant",
+		},
+		Raw: adapter.RawRef{
+			Format:  "json",
+			Hash:    "sha256:preCapHash4",
+			Path:    "/path/to/session1.jsonl",
+			Ordinal: &ordinal4,
+		},
+	}
+
+	otherLargeArgs := `{"cmd":"other_cmd ` + strings.Repeat("z", 4500) + `"}`
+	ordinal2 := int64(2)
+	meta2 := map[string]any{
+		"harness":   "other",
+		"arguments": otherLargeArgs,
+	}
+	meta2Bytes, _ := json.Marshal(meta2)
+	text2 := "other_call\n" + otherLargeArgs
+
+	rec2 := adapter.Record{
+		Schema: adapter.SchemaV1,
+		Source: adapter.Source{Kind: "other", Name: "Other System", Version: "1.0.0"},
+		Collection: adapter.Collection{
+			ExternalID: "other:session:s2",
+			Kind:       "agent_session",
+			Name:       "s2",
+		},
+		Item: adapter.Item{
+			ExternalID: "other:call:call-2",
+			Kind:       "tool_call",
+			CreatedAt:  "2026-07-14T19:29:51Z",
+			Text:       text2,
+			Tags:       []string{"other"},
+			Metadata:   json.RawMessage(meta2Bytes),
+		},
+		Actor: &adapter.Actor{
+			ExternalID: "other:agent",
+			Type:       "agent",
+			Name:       "agent",
+		},
+		Raw: adapter.RawRef{
+			Format:  "json",
+			Hash:    "sha256:preCapHash2",
+			Path:    "/path/to/session2.jsonl",
+			Ordinal: &ordinal2,
+		},
+	}
+
+	tempDir := t.TempDir()
+	rec1Bytes, _ := json.Marshal(rec1)
+	rec3Bytes, _ := json.Marshal(rec3)
+	rec4Bytes, _ := json.Marshal(rec4)
+	codexPath := filepath.Join(tempDir, "codex.adapter.jsonl")
+	if err := os.WriteFile(codexPath, []byte(string(rec1Bytes)+"\n"+string(rec3Bytes)+"\n"+string(rec4Bytes)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rec2Bytes, _ := json.Marshal(rec2)
+	otherPath := filepath.Join(tempDir, "other.adapter.jsonl")
+	if err := os.WriteFile(otherPath, []byte(string(rec2Bytes)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runOK(t, "import", "adapter", codexPath, "--source", "codex")
+	runOK(t, "import", "adapter", otherPath, "--source", "other")
 
 	db, _, err := openMigrated()
 	if err != nil {
@@ -18,61 +207,46 @@ func TestMigrateCodexArguments(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Insert dummy sources
-	_, err = db.Exec(`INSERT INTO sources (id, kind, version, created_at, updated_at) VALUES ('s1', 'codex', 'v1', '2023-01-01', '2023-01-01')`)
-	if err != nil {
-		t.Fatalf("insert source: %s", err)
+	// Verify FTS before migration contains token past cap
+	var countBefore int
+	if err := db.QueryRow(`SELECT count(*) FROM item_fts WHERE item_fts MATCH 'UNICORN_TOKEN_PAST_CAP'`).Scan(&countBefore); err != nil {
+		t.Fatalf("fts query: %s", err)
 	}
-	_, err = db.Exec(`INSERT INTO sources (id, kind, version, created_at, updated_at) VALUES ('s2', 'other', 'v1', '2023-01-01', '2023-01-01')`)
-	if err != nil {
-		t.Fatalf("insert source: %s", err)
+	if countBefore != 1 {
+		t.Fatalf("expected 1 match for UNICORN_TOKEN_PAST_CAP before migration, got %d", countBefore)
 	}
-	_, err = db.Exec(`INSERT INTO collections (id, source_id, external_id, kind, created_at, updated_at) VALUES ('c1', 's1', 'c1-ext', 'session', '2023-01-01', '2023-01-01')`)
-	if err != nil {
-		t.Fatalf("insert collection: %s", err)
+	var prefixCountBefore int
+	if err := db.QueryRow(`SELECT count(*) FROM item_fts WHERE item_fts MATCH 'exec_prefix'`).Scan(&prefixCountBefore); err != nil {
+		t.Fatalf("fts query: %s", err)
 	}
-	_, err = db.Exec(`INSERT INTO collections (id, source_id, external_id, kind, created_at, updated_at) VALUES ('c2', 's2', 'c2-ext', 'session', '2023-01-01', '2023-01-01')`)
-	if err != nil {
-		t.Fatalf("insert collection: %s", err)
+	if prefixCountBefore < 1 {
+		t.Fatalf("expected match for exec_prefix before migration")
 	}
 
-	largeArgs := strings.Repeat("a", 5000)
-
-	// Item 1: codex with large arguments, needs migration
-	raw1 := fmt.Sprintf(`{"payload":{"arguments":"%s"}}`, largeArgs)
-	meta1 := fmt.Sprintf(`{"arguments":"%s"}`, largeArgs)
-	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i1', 's1', 'c1', 'ext1', 'tool_call', '2023-01-01', 'h1', ?, ?, 1)`, raw1, meta1)
-	if err != nil {
-		t.Fatalf("insert i1: %s", err)
+	// Verify --apply and --dry-run together fail with usage
+	var errw bytes.Buffer
+	code := cmdMigrateCodexArguments([]string{"--apply", "--dry-run"}, io.Discard, &errw)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for --apply --dry-run together")
+	}
+	if !strings.Contains(errw.String(), "usage: miseledger migrate codex-arguments") {
+		t.Fatalf("expected usage message, got: %s", errw.String())
 	}
 
-	// Item 2: other source with large arguments (should NOT be migrated)
-	raw2 := fmt.Sprintf(`{"payload":{"arguments":"%s"}}`, largeArgs)
-	meta2 := fmt.Sprintf(`{"arguments":"%s"}`, largeArgs)
-	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i2', 's2', 'c2', 'ext2', 'tool_call', '2023-01-01', 'h2', ?, ?, 2)`, raw2, meta2)
-	if err != nil {
-		t.Fatalf("insert i2: %s", err)
+	// Verify --help documents full-table LIKE scan
+	var helpOut bytes.Buffer
+	code = cmdMigrateCodexArguments([]string{"--help"}, &helpOut, io.Discard)
+	if code != 0 {
+		t.Fatalf("expected 0 exit for --help")
 	}
-
-	// Item 3: codex with small arguments (no truncation needed, but should strip from raw_json)
-	raw3 := `{"payload":{"arguments":"small"}}`
-	meta3 := `{"arguments":"small"}`
-	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i3', 's1', 'c1', 'ext3', 'tool_call', '2023-01-01', 'h3', ?, ?, 3)`, raw3, meta3)
-	if err != nil {
-		t.Fatalf("insert i3: %s", err)
-	}
-
-	// Item 4: codex already migrated (arguments truncated, in meta, not in raw)
-	raw4 := `{"payload":{"other":"data"}}`
-	meta4 := `{"arguments":"truncated\n[truncated]","arguments_digest":"deadbeef"}`
-	_, err = db.Exec(`INSERT INTO items (id, source_id, collection_id, external_id, kind, created_at, content_hash, raw_json, metadata_json, ingest_seq) VALUES ('i4', 's1', 'c1', 'ext4', 'tool_call', '2023-01-01', 'h4', ?, ?, 4)`, raw4, meta4)
-	if err != nil {
-		t.Fatalf("insert i4: %s", err)
+	if !strings.Contains(helpOut.String(), "LIKE scan") {
+		t.Fatalf("expected help to document full-table LIKE scan, got: %s", helpOut.String())
 	}
 
 	// Run dry-run
-	var out, errw bytes.Buffer
-	code := cmdMigrateCodexArguments([]string{"--json"}, &out, &errw)
+	var out bytes.Buffer
+	errw.Reset()
+	code = cmdMigrateCodexArguments([]string{"--json"}, &out, &errw)
 	if code != 0 {
 		t.Fatalf("cmd failed: %s", errw.String())
 	}
@@ -85,19 +259,26 @@ func TestMigrateCodexArguments(t *testing.T) {
 		t.Fatalf("expected dry-run = true")
 	}
 	matched := int(res["matched"].(float64))
-	if matched != 2 {
-		t.Fatalf("expected 2 matched (i1, i3), got %d", matched)
+	if matched != 1 {
+		t.Fatalf("expected 1 matched (only rec1), got %d", matched)
 	}
 
-	// Check i1 unchanged (dry-run)
-	var r1, m1 string
-	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i1'`).Scan(&r1, &m1)
-	if !strings.Contains(r1, largeArgs) {
-		t.Fatalf("dry-run mutated raw_json")
+	// Check rec1 unchanged (dry-run)
+	var r1, m1, t1 string
+	if err := db.QueryRow(`SELECT raw_json, metadata_json, text FROM items WHERE external_id = 'codex:call:call-1'`).Scan(&r1, &m1, &t1); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r1, "UNICORN_TOKEN_PAST_CAP") || !strings.Contains(m1, "UNICORN_TOKEN_PAST_CAP") || !strings.Contains(t1, "UNICORN_TOKEN_PAST_CAP") {
+		t.Fatalf("dry-run mutated row 1")
+	}
+	var parsedM1Dry map[string]any
+	if err := json.Unmarshal([]byte(m1), &parsedM1Dry); err != nil || parsedM1Dry["arguments"] != largeArgs {
+		t.Fatalf("dry-run mutated metadata_json: %v", parsedM1Dry["arguments"])
 	}
 
 	// Run apply
 	out.Reset()
+	errw.Reset()
 	code = cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
 	if code != 0 {
 		t.Fatalf("apply failed: %s", errw.String())
@@ -109,38 +290,105 @@ func TestMigrateCodexArguments(t *testing.T) {
 		t.Fatalf("expected dry-run = false")
 	}
 	matched = int(res["matched"].(float64))
-	if matched != 2 {
-		t.Fatalf("expected 2 matched, got %d", matched)
+	if matched != 1 {
+		t.Fatalf("expected 1 matched, got %d", matched)
 	}
 
-	// Verify mutations
-	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i1'`).Scan(&r1, &m1)
-	if strings.Contains(r1, largeArgs) {
-		t.Fatalf("raw_json still contains large arguments for i1")
+	// Verify mutations on row 1
+	if err := db.QueryRow(`SELECT raw_json, metadata_json, text FROM items WHERE external_id = 'codex:call:call-1'`).Scan(&r1, &m1, &t1); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(r1, "UNICORN_TOKEN_PAST_CAP") {
+		t.Fatalf("raw_json still contains UNICORN_TOKEN_PAST_CAP for rec1")
+	}
+	if strings.Contains(m1, "UNICORN_TOKEN_PAST_CAP") {
+		t.Fatalf("metadata_json still contains UNICORN_TOKEN_PAST_CAP for rec1")
+	}
+	if strings.Contains(t1, "UNICORN_TOKEN_PAST_CAP") {
+		t.Fatalf("text still contains UNICORN_TOKEN_PAST_CAP for rec1")
 	}
 	if !strings.Contains(m1, "[truncated]") {
-		t.Fatalf("metadata_json does not contain [truncated] for i1")
+		t.Fatalf("metadata_json does not contain [truncated] for rec1")
 	}
-	if !strings.Contains(m1, "arguments_digest") {
-		t.Fatalf("metadata_json missing arguments_digest for i1")
+	if !strings.Contains(t1, "[truncated]") {
+		t.Fatalf("text does not contain [truncated] for rec1")
+	}
+	expectedDigest := sha256.Sum256([]byte(largeArgs))
+	expectedDigestHex := hex.EncodeToString(expectedDigest[:])
+	if !strings.Contains(m1, expectedDigestHex) {
+		t.Fatalf("metadata_json missing arguments_digest for rec1")
 	}
 
-	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i2'`).Scan(&r1, &m1)
-	if !strings.Contains(r1, largeArgs) {
-		t.Fatalf("i2 should not be migrated")
+	// Verify raw_json shape matches adapter.Record and raw fields untouched
+	var rec1After adapter.Record
+	if err := json.Unmarshal([]byte(r1), &rec1After); err != nil {
+		t.Fatalf("unmarshal rec1 raw_json as adapter.Record: %s", err)
+	}
+	if rec1After.Raw.Format != "json" || rec1After.Raw.Hash != "sha256:preCapHash1" || rec1After.Raw.Path != "/path/to/session1.jsonl" || *rec1After.Raw.Ordinal != 1 {
+		t.Fatalf("raw field was mutated: %+v", rec1After.Raw)
+	}
+	var rec1MetaAfter map[string]any
+	if err := json.Unmarshal(rec1After.Item.Metadata, &rec1MetaAfter); err != nil {
+		t.Fatalf("unmarshal rec1 Item.Metadata: %s", err)
+	}
+	if !strings.Contains(rec1MetaAfter["arguments"].(string), "[truncated]") {
+		t.Fatalf("rec1 Item.Metadata arguments not truncated: %v", rec1MetaAfter["arguments"])
+	}
+	if rec1MetaAfter["arguments_digest"] != expectedDigestHex {
+		t.Fatalf("rec1 Item.Metadata arguments_digest mismatch: %v", rec1MetaAfter["arguments_digest"])
+	}
+	if !strings.Contains(rec1After.Item.Text, "[truncated]") {
+		t.Fatalf("rec1 Item.Text not truncated")
+	}
+	if strings.Contains(rec1After.Item.Text, "UNICORN_TOKEN_PAST_CAP") {
+		t.Fatalf("rec1 Item.Text still contains UNICORN_TOKEN_PAST_CAP")
 	}
 
-	db.QueryRow(`SELECT raw_json, metadata_json FROM items WHERE id = 'i3'`).Scan(&r1, &m1)
-	if strings.Contains(r1, "small") {
-		t.Fatalf("i3 raw_json should not contain 'small' anymore")
+	// Verify row 2 (other source) untouched
+	var r2, m2, t2 string
+	if err := db.QueryRow(`SELECT raw_json, metadata_json, text FROM items WHERE external_id = 'other:call:call-2'`).Scan(&r2, &m2, &t2); err != nil {
+		t.Fatal(err)
 	}
-	if strings.Contains(m1, "[truncated]") {
-		t.Fatalf("i3 metadata_json should NOT be truncated")
+	var parsedM2 map[string]any
+	if err := json.Unmarshal([]byte(m2), &parsedM2); err != nil || parsedM2["arguments"] != otherLargeArgs {
+		t.Fatalf("rec2 should not be migrated, got %v", parsedM2["arguments"])
+	}
+
+	// Verify row 3 (small arguments) untouched
+	var r3, m3, t3 string
+	if err := db.QueryRow(`SELECT raw_json, metadata_json, text FROM items WHERE external_id = 'codex:call:call-3'`).Scan(&r3, &m3, &t3); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r3, "small") && !strings.Contains(r3, "ls -la") {
+		t.Fatalf("rec3 raw_json missing small arguments")
+	}
+	if strings.Contains(m3, "[truncated]") || strings.Contains(t3, "[truncated]") {
+		t.Fatalf("rec3 should NOT be truncated")
+	}
+
+	// Verify FTS after migration: token past cap must be gone, token before cap remains
+	var countAfter int
+	if err := db.QueryRow(`SELECT count(*) FROM item_fts WHERE item_fts MATCH 'UNICORN_TOKEN_PAST_CAP'`).Scan(&countAfter); err != nil {
+		t.Fatalf("fts query after migration: %s", err)
+	}
+	if countAfter != 0 {
+		t.Fatalf("expected 0 matches for UNICORN_TOKEN_PAST_CAP after migration, got %d", countAfter)
+	}
+	var prefixCountAfter int
+	if err := db.QueryRow(`SELECT count(*) FROM item_fts WHERE item_fts MATCH 'exec_prefix'`).Scan(&prefixCountAfter); err != nil {
+		t.Fatalf("fts query after migration: %s", err)
+	}
+	if prefixCountAfter < 1 {
+		t.Fatalf("expected exec_prefix to still match in FTS after migration")
 	}
 
 	// Run apply again (idempotent)
 	out.Reset()
+	errw.Reset()
 	code = cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+	if code != 0 {
+		t.Fatalf("second apply failed: %s", errw.String())
+	}
 	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
 		t.Fatalf("decode err: %s", err)
 	}
@@ -166,5 +414,12 @@ func TestMigrateCommandRegistered(t *testing.T) {
 	}
 	if !strings.Contains(errw.String(), "usage: miseledger migrate codex-arguments") {
 		t.Fatalf("expected usage text, got %q", errw.String())
+	}
+	out.Reset()
+	if code := cmdMigrate([]string{"--help"}, out, errw); code != 0 {
+		t.Fatalf("migrate --help must exit 0, got %d", code)
+	}
+	if !strings.Contains(out.String(), "LIKE scan") {
+		t.Fatalf("expected LIKE scan in help, got %s", out.String())
 	}
 }

--- a/engines/evidence-ledger/internal/app/migrate_test.go
+++ b/engines/evidence-ledger/internal/app/migrate_test.go
@@ -5,13 +5,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/escoffier-labs/miseledger/internal/adapter"
+	"github.com/escoffier-labs/miseledger/internal/sources"
 )
 
 func TestMigrateCodexArguments(t *testing.T) {
@@ -381,6 +384,23 @@ func TestMigrateCodexArguments(t *testing.T) {
 		t.Fatalf("expected schema_version json.Number 1, got %v (%T)", provMap["schema_version"], provMap["schema_version"])
 	}
 
+	// Verify embedded metadata in raw_json equals metadata_json minus importer-added fields (tags, provenance)
+	storedMetaMinusImporter := make(map[string]any)
+	for k, v := range parsedM1Apply {
+		if k != "tags" && k != "provenance" {
+			storedMetaMinusImporter[k] = v
+		}
+	}
+	var rec1MetaNumbers map[string]any
+	decRec1Meta := json.NewDecoder(bytes.NewReader(rec1After.Item.Metadata))
+	decRec1Meta.UseNumber()
+	if err := decRec1Meta.Decode(&rec1MetaNumbers); err != nil {
+		t.Fatalf("decode rec1 Item.Metadata with UseNumber: %s", err)
+	}
+	if !reflect.DeepEqual(rec1MetaNumbers, storedMetaMinusImporter) {
+		t.Fatalf("embedded metadata in raw_json does not match metadata_json minus importer fields:\nembedded: %+v\nstored: %+v", rec1MetaNumbers, storedMetaMinusImporter)
+	}
+
 	// Verify row 2 (other source) untouched
 	var r2, m2, t2 string
 	if err := db.QueryRow(`SELECT raw_json, metadata_json, text FROM items WHERE external_id = 'other:call:call-2'`).Scan(&r2, &m2, &t2); err != nil {
@@ -458,5 +478,464 @@ func TestMigrateCommandRegistered(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "LIKE scan") {
 		t.Fatalf("expected LIKE scan in help, got %s", out.String())
+	}
+}
+
+func TestMigrateCodexArguments_FTSDifferentRowID(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+
+	largeArgs := `{"cmd":"fts_diff_prefix ` + strings.Repeat("x", 4200) + ` FTS_DIFF_UNICORN_TOKEN"}`
+	ordinal := int64(1)
+	meta := map[string]any{
+		"harness":    "codex",
+		"event_type": "response_item",
+		"session_id": "s_fts",
+		"name":       "exec_command",
+		"call_id":    "call-fts",
+		"arguments":  largeArgs,
+	}
+	metaBytes, _ := json.Marshal(meta)
+	text := "function_call\nexec_command\ncall-fts\n" + largeArgs
+
+	rec := adapter.Record{
+		Schema: adapter.SchemaV1,
+		Source: adapter.Source{Kind: "codex", Name: "Codex Sessions", Version: "1.0.0"},
+		Collection: adapter.Collection{
+			ExternalID: "codex:session:s_fts",
+			Kind:       "agent_session",
+			Name:       "s_fts",
+		},
+		Item: adapter.Item{
+			ExternalID: "codex:call:call-fts",
+			Kind:       "tool_call",
+			CreatedAt:  "2026-07-14T19:29:50Z",
+			Text:       text,
+			Tags:       []string{"agent-session", "codex"},
+			Metadata:   json.RawMessage(metaBytes),
+		},
+		Actor: &adapter.Actor{
+			ExternalID: "codex:assistant",
+			Type:       "agent",
+			Name:       "assistant",
+		},
+		Raw: adapter.RawRef{
+			Format:  "json",
+			Hash:    "sha256:preCapHashFTS",
+			Path:    "/path/to/fts.jsonl",
+			Ordinal: &ordinal,
+		},
+	}
+
+	tempDir := t.TempDir()
+	recBytes, _ := json.Marshal(rec)
+	codexPath := filepath.Join(tempDir, "codex.adapter.jsonl")
+	if err := os.WriteFile(codexPath, append(recBytes, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", codexPath, "--source", "codex")
+
+	db, _, err := openMigrated()
+	if err != nil {
+		t.Fatalf("failed to open test db: %s", err)
+	}
+	defer db.Close()
+
+	var itemRowID int64
+	var itemID string
+	if err := db.QueryRow(`SELECT rowid, id FROM items WHERE external_id = 'codex:call:call-fts'`).Scan(&itemRowID, &itemID); err != nil {
+		t.Fatal(err)
+	}
+
+	var ftsRowIDBefore int64
+	var ftsBodyBefore string
+	if err := db.QueryRow(`SELECT rowid, body FROM item_fts WHERE item_id = ?`, itemID).Scan(&ftsRowIDBefore, &ftsBodyBefore); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete and re-insert the FTS row so its rowid is different from item's rowid
+	if _, err := db.Exec(`DELETE FROM item_fts WHERE item_id = ?`, itemID); err != nil {
+		t.Fatal(err)
+	}
+	// Insert dummy rows to advance the FTS rowid sequence
+	for i := 0; i < 5; i++ {
+		if _, err := db.Exec(`INSERT INTO item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) VALUES ('dummy', 'other', 'col', 'item', 'actor', 'dummy')`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Re-insert FTS row for itemID
+	if _, err := db.Exec(`INSERT INTO item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) VALUES (?, 'codex', 'agent_session', 'tool_call', 'agent', ?)`, itemID, ftsBodyBefore); err != nil {
+		t.Fatal(err)
+	}
+
+	var ftsRowIDAfterReinsert int64
+	if err := db.QueryRow(`SELECT rowid FROM item_fts WHERE item_id = ?`, itemID).Scan(&ftsRowIDAfterReinsert); err != nil {
+		t.Fatal(err)
+	}
+	if ftsRowIDAfterReinsert == itemRowID {
+		t.Fatalf("expected fts rowid (%d) to differ from item rowid (%d)", ftsRowIDAfterReinsert, itemRowID)
+	}
+
+	// Run migration with --apply
+	var out, errw bytes.Buffer
+	code := cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+	if code != 0 {
+		t.Fatalf("apply failed: %s", errw.String())
+	}
+	var res map[string]any
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("failed to decode json: %s", err)
+	}
+	if matched := int(res["matched"].(float64)); matched != 1 {
+		t.Fatalf("expected 1 matched, got %d", matched)
+	}
+	if ftsMiss := int(res["fts_missing"].(float64)); ftsMiss != 0 {
+		t.Fatalf("expected 0 fts_missing, got %d", ftsMiss)
+	}
+
+	// Assert the FTS body is still updated despite different rowid
+	var ftsBodyAfter string
+	if err := db.QueryRow(`SELECT body FROM item_fts WHERE item_id = ?`, itemID).Scan(&ftsBodyAfter); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(ftsBodyAfter, "FTS_DIFF_UNICORN_TOKEN") {
+		t.Fatalf("expected FTS_DIFF_UNICORN_TOKEN to be removed from fts body, got: %s", ftsBodyAfter)
+	}
+	if !strings.Contains(ftsBodyAfter, "[truncated]") {
+		t.Fatalf("expected fts body to contain [truncated]")
+	}
+	var countPast int
+	if err := db.QueryRow(`SELECT count(*) FROM item_fts WHERE item_fts MATCH 'FTS_DIFF_UNICORN_TOKEN'`).Scan(&countPast); err != nil {
+		t.Fatal(err)
+	}
+	if countPast != 0 {
+		t.Fatalf("expected 0 matches for FTS_DIFF_UNICORN_TOKEN in FTS, got %d", countPast)
+	}
+	var countPrefix int
+	if err := db.QueryRow(`SELECT count(*) FROM item_fts WHERE item_fts MATCH 'fts_diff_prefix'`).Scan(&countPrefix); err != nil {
+		t.Fatal(err)
+	}
+	if countPrefix != 1 {
+		t.Fatalf("expected 1 match for fts_diff_prefix in FTS, got %d", countPrefix)
+	}
+}
+
+func TestMigrateCodexArguments_MultibyteRunes(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+
+	// 4,100 CJK runes and 4,100 emoji runes
+	cjkRunes := strings.Repeat("世界", 2050)
+	emojiRunes := strings.Repeat("🚀✨", 2050)
+
+	for _, tc := range []struct {
+		name      string
+		arguments string
+		callID    string
+	}{
+		{name: "cjk", arguments: `{"text":"` + cjkRunes + `"}`, callID: "call-cjk"},
+		{name: "emoji", arguments: `{"text":"` + emojiRunes + `"}`, callID: "call-emoji"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ordinal := int64(1)
+			meta := map[string]any{
+				"harness":    "codex",
+				"event_type": "response_item",
+				"session_id": "s_" + tc.name,
+				"name":       "exec_command",
+				"call_id":    tc.callID,
+				"arguments":  tc.arguments,
+			}
+			metaBytes, _ := json.Marshal(meta)
+			text := "function_call\nexec_command\n" + tc.callID + "\n" + tc.arguments
+
+			rec := adapter.Record{
+				Schema: adapter.SchemaV1,
+				Source: adapter.Source{Kind: "codex", Name: "Codex Sessions", Version: "1.0.0"},
+				Collection: adapter.Collection{
+					ExternalID: "codex:session:" + tc.name,
+					Kind:       "agent_session",
+					Name:       tc.name,
+				},
+				Item: adapter.Item{
+					ExternalID: "codex:call:" + tc.callID,
+					Kind:       "tool_call",
+					CreatedAt:  "2026-07-14T19:29:50Z",
+					Text:       text,
+					Tags:       []string{"agent-session", "codex"},
+					Metadata:   json.RawMessage(metaBytes),
+				},
+				Actor: &adapter.Actor{
+					ExternalID: "codex:assistant",
+					Type:       "agent",
+					Name:       "assistant",
+				},
+				Raw: adapter.RawRef{
+					Format:  "json",
+					Hash:    "sha256:preCap" + tc.name,
+					Path:    "/path/to/" + tc.name + ".jsonl",
+					Ordinal: &ordinal,
+				},
+			}
+
+			tempDir := t.TempDir()
+			recBytes, _ := json.Marshal(rec)
+			codexPath := filepath.Join(tempDir, tc.name+".adapter.jsonl")
+			if err := os.WriteFile(codexPath, append(recBytes, '\n'), 0644); err != nil {
+				t.Fatal(err)
+			}
+			runOK(t, "import", "adapter", codexPath, "--source", "codex")
+
+			var out, errw bytes.Buffer
+			code := cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+			if code != 0 {
+				t.Fatalf("apply failed: %s", errw.String())
+			}
+
+			db, _, err := openMigrated()
+			if err != nil {
+				t.Fatalf("failed to open test db: %s", err)
+			}
+			defer db.Close()
+
+			var rawJSON, metadataJSON, storedText string
+			if err := db.QueryRow(`SELECT raw_json, metadata_json, text FROM items WHERE external_id = ?`, "codex:call:"+tc.callID).Scan(&rawJSON, &metadataJSON, &storedText); err != nil {
+				t.Fatal(err)
+			}
+
+			// Assert no U+FFFD in raw_json, metadata_json, or text
+			if strings.Contains(rawJSON, "\ufffd") || strings.Contains(rawJSON, "\uFFFD") {
+				t.Fatalf("raw_json contains U+FFFD")
+			}
+			if strings.Contains(metadataJSON, "\ufffd") || strings.Contains(metadataJSON, "\uFFFD") {
+				t.Fatalf("metadata_json contains U+FFFD")
+			}
+			if strings.Contains(storedText, "\ufffd") || strings.Contains(storedText, "\uFFFD") {
+				t.Fatalf("text contains U+FFFD")
+			}
+
+			// Assert byte-identical output to what the adapter helper produces
+			expectedTruncated := sources.TextFromAny(tc.arguments, sources.DefaultTextCap)
+			if strings.Contains(expectedTruncated, "\ufffd") {
+				t.Fatalf("expectedTruncated from sources.TextFromAny contains U+FFFD")
+			}
+
+			var parsedMeta map[string]any
+			if err := json.Unmarshal([]byte(metadataJSON), &parsedMeta); err != nil {
+				t.Fatalf("unmarshal metadata_json: %s", err)
+			}
+			migratedArgs, ok := parsedMeta["arguments"].(string)
+			if !ok {
+				t.Fatalf("arguments not found in metadata_json")
+			}
+			if migratedArgs != expectedTruncated {
+				t.Fatalf("migrated arguments not byte-identical to adapter helper:\ngot:  %q\nwant: %q", migratedArgs, expectedTruncated)
+			}
+
+			var recAfter adapter.Record
+			if err := json.Unmarshal([]byte(rawJSON), &recAfter); err != nil {
+				t.Fatalf("unmarshal raw_json: %s", err)
+			}
+			var rawMetaAfter map[string]any
+			if err := json.Unmarshal(recAfter.Item.Metadata, &rawMetaAfter); err != nil {
+				t.Fatalf("unmarshal Item.Metadata: %s", err)
+			}
+			if rawMetaAfter["arguments"] != expectedTruncated {
+				t.Fatalf("raw_json arguments not byte-identical to adapter helper:\ngot:  %q\nwant: %q", rawMetaAfter["arguments"], expectedTruncated)
+			}
+		})
+	}
+}
+
+func TestMigrateCodexArguments_KeysetPaging(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+
+	origBatchSize := migrateBatchSize
+	migrateBatchSize = 2
+	defer func() { migrateBatchSize = origBatchSize }()
+
+	tempDir := t.TempDir()
+	codexPath := filepath.Join(tempDir, "paging.adapter.jsonl")
+
+	var records []string
+	for i := 1; i <= 5; i++ {
+		ordinal := int64(i)
+		callID := fmt.Sprintf("call-paging-%02d", i)
+		largeArgs := fmt.Sprintf(`{"cmd":"paging_%d %s UNICORN_%d"}`, i, strings.Repeat("a", 4200), i)
+		meta := map[string]any{
+			"harness":    "codex",
+			"event_type": "response_item",
+			"session_id": "s_paging",
+			"name":       "exec_command",
+			"call_id":    callID,
+			"arguments":  largeArgs,
+		}
+		metaBytes, _ := json.Marshal(meta)
+		text := fmt.Sprintf("function_call\nexec_command\n%s\n%s", callID, largeArgs)
+		rec := adapter.Record{
+			Schema: adapter.SchemaV1,
+			Source: adapter.Source{Kind: "codex", Name: "Codex Sessions", Version: "1.0.0"},
+			Collection: adapter.Collection{
+				ExternalID: "codex:session:s_paging",
+				Kind:       "agent_session",
+				Name:       "s_paging",
+			},
+			Item: adapter.Item{
+				ExternalID: "codex:call:" + callID,
+				Kind:       "tool_call",
+				CreatedAt:  fmt.Sprintf("2026-07-14T19:29:%02dZ", i),
+				Text:       text,
+				Tags:       []string{"agent-session", "codex"},
+				Metadata:   json.RawMessage(metaBytes),
+			},
+			Actor: &adapter.Actor{
+				ExternalID: "codex:assistant",
+				Type:       "agent",
+				Name:       "assistant",
+			},
+			Raw: adapter.RawRef{
+				Format:  "json",
+				Hash:    fmt.Sprintf("sha256:preCapPaging%d", i),
+				Path:    "/path/to/paging.jsonl",
+				Ordinal: &ordinal,
+			},
+		}
+		b, _ := json.Marshal(rec)
+		records = append(records, string(b))
+	}
+	if err := os.WriteFile(codexPath, []byte(strings.Join(records, "\n")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", codexPath, "--source", "codex")
+
+	var out, errw bytes.Buffer
+	code := cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+	if code != 0 {
+		t.Fatalf("apply failed: %s", errw.String())
+	}
+	var res map[string]any
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("failed to decode json: %s", err)
+	}
+	matched := int(res["matched"].(float64))
+	if matched != 5 {
+		t.Fatalf("expected 5 matched rows across paged batches, got %d", matched)
+	}
+
+	db, _, err := openMigrated()
+	if err != nil {
+		t.Fatalf("failed to open test db: %s", err)
+	}
+	defer db.Close()
+
+	for i := 1; i <= 5; i++ {
+		callID := fmt.Sprintf("call-paging-%02d", i)
+		var metaJSON, itemText string
+		if err := db.QueryRow(`SELECT metadata_json, text FROM items WHERE external_id = ?`, "codex:call:"+callID).Scan(&metaJSON, &itemText); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(metaJSON, "[truncated]") || !strings.Contains(itemText, "[truncated]") {
+			t.Fatalf("row %d was not truncated", i)
+		}
+	}
+
+	out.Reset()
+	errw.Reset()
+	code = cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+	if code != 0 {
+		t.Fatalf("second apply failed: %s", errw.String())
+	}
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if matched := int(res["matched"].(float64)); matched != 0 {
+		t.Fatalf("expected 0 matched on second apply, got %d", matched)
+	}
+}
+
+func TestMigrateCodexArguments_FTSMissing(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+
+	largeArgs := `{"cmd":"exec_prefix ` + strings.Repeat("a", 4200) + ` UNICORN_TOKEN_PAST_CAP"}`
+	ordinal := int64(1)
+	meta := map[string]any{
+		"harness":    "codex",
+		"event_type": "response_item",
+		"session_id": "s_miss",
+		"name":       "exec_command",
+		"call_id":    "call-miss",
+		"arguments":  largeArgs,
+	}
+	metaBytes, _ := json.Marshal(meta)
+	text := "function_call\nexec_command\ncall-miss\n" + largeArgs
+
+	rec := adapter.Record{
+		Schema: adapter.SchemaV1,
+		Source: adapter.Source{Kind: "codex", Name: "Codex Sessions", Version: "1.0.0"},
+		Collection: adapter.Collection{
+			ExternalID: "codex:session:s_miss",
+			Kind:       "agent_session",
+			Name:       "s_miss",
+		},
+		Item: adapter.Item{
+			ExternalID: "codex:call:call-miss",
+			Kind:       "tool_call",
+			CreatedAt:  "2026-07-14T19:29:50Z",
+			Text:       text,
+			Tags:       []string{"agent-session", "codex"},
+			Metadata:   json.RawMessage(metaBytes),
+		},
+		Actor: &adapter.Actor{
+			ExternalID: "codex:assistant",
+			Type:       "agent",
+			Name:       "assistant",
+		},
+		Raw: adapter.RawRef{
+			Format:  "json",
+			Hash:    "sha256:preCapMiss",
+			Path:    "/path/to/miss.jsonl",
+			Ordinal: &ordinal,
+		},
+	}
+
+	tempDir := t.TempDir()
+	recBytes, _ := json.Marshal(rec)
+	codexPath := filepath.Join(tempDir, "miss.adapter.jsonl")
+	if err := os.WriteFile(codexPath, append(recBytes, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", codexPath, "--source", "codex")
+
+	db, _, err := openMigrated()
+	if err != nil {
+		t.Fatalf("failed to open test db: %s", err)
+	}
+	defer db.Close()
+
+	// Delete from item_fts completely
+	var itemID string
+	if err := db.QueryRow(`SELECT id FROM items WHERE external_id = 'codex:call:call-miss'`).Scan(&itemID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DELETE FROM item_fts WHERE item_id = ?`, itemID); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errw bytes.Buffer
+	code := cmdMigrateCodexArguments([]string{"--apply", "--json"}, &out, &errw)
+	if code != 0 {
+		t.Fatalf("apply failed: %s", errw.String())
+	}
+	var res map[string]any
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if matched := int(res["matched"].(float64)); matched != 1 {
+		t.Fatalf("expected 1 matched, got %d", matched)
+	}
+	if ftsMissing := int(res["fts_missing"].(float64)); ftsMissing != 1 {
+		t.Fatalf("expected 1 fts_missing, got %d", ftsMissing)
 	}
 }

--- a/engines/evidence-ledger/internal/sources/codex/codex.go
+++ b/engines/evidence-ledger/internal/sources/codex/codex.go
@@ -84,8 +84,8 @@ func normalize(ev sources.RawEvent) (rec adapter.Record, warning string, skipped
 	// Create a copy of payload and ev.Object to compute text without the huge arguments
 	// so that we don't bleed huge arguments into the `text` field, which ruins the truncation.
 	var truncatedArgs = arguments
-	if len(truncatedArgs) > 4000 {
-		truncatedArgs = truncatedArgs[:4000] + "\n[truncated]"
+	if len([]rune(truncatedArgs)) > sources.DefaultTextCap {
+		truncatedArgs = sources.TextFromAny(truncatedArgs, sources.DefaultTextCap)
 		truncated = true
 	}
 

--- a/engines/evidence-ledger/internal/sources/source.go
+++ b/engines/evidence-ledger/internal/sources/source.go
@@ -664,13 +664,19 @@ func NestedString(v any, keys ...string) string {
 	return ""
 }
 
+const (
+	DefaultTextCap   = 4000
+	TruncationMarker = "\n[truncated]"
+)
+
 func TextFromAny(v any, max int) string {
 	if max <= 0 {
-		max = 4000
+		max = DefaultTextCap
 	}
 	text := strings.TrimSpace(textFromAny(v, 0))
-	if len(text) > max {
-		return text[:max] + "\n[truncated]"
+	runes := []rune(text)
+	if len(runes) > max {
+		return string(runes[:max]) + TruncationMarker
 	}
 	return text
 }


### PR DESCRIPTION
Refs #1414 (migration half; the adapter half landed in #1425)

Rows imported before #1425 still hold the full Codex tool-call `arguments` in `metadata_json` and a second copy inside `raw_json`. This adds `miseledger migrate codex-arguments`:

- dry-run by default, reports matched rows and estimated bytes; `--apply` rewrites in batches of 1,000 inside transactions with `busy_timeout(10s)` from `archive.Open`; `--json` output in the `prune policy` shape family
- truncates stored arguments to the #1425 cap with the same marker, keeps the full-argument digest in metadata, and rewrites `item.metadata` in place inside `raw_json`; `id`, `external_id`, `content_hash`, `raw_path`, `raw_ordinal`, `raw_hash` are untouched so re-imports stay deduplicated and references keep resolving
- idempotent: a second `--apply` matches zero rows
- `docs/RETENTION_POLICY.md` documents the operator sequence `prune policy --apply --export <path>`, then `migrate codex-arguments --apply`, then `compact`

Tests: old-shape rows migrate, new-shape rows untouched, dry run writes nothing, second apply is a no-op, and `TestMigrateCommandRegistered` drives the real command table.

Implemented by Jules session 9583084088717181163 (launched through `brigade run cloud launch`). The session's changeset did not register the subcommand in `app.go`'s command table and was not gofmt-clean; the conductor added the `cmdMigrate` dispatcher, the command-table entry, the dispatcher test, and ran gofmt.

Verification (Brigade receipt `20260903-025620-work-verify-44564d`): gofmt clean on touched files, `go vet ./internal/app/`, `go test ./internal/app/...` ok, run under the go 1.25 toolchain pinned by go.mod. The `evidence-ledger-test` CI job is the gate.

Not in this PR: the engine release that ships #1425 and this command to installed `miseledger` binaries (0.6.0 is the floor pin in `evidence_runtime.py`); that is a separate operator step and is why the issue stays open.

Co-Authored-By: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>

## Review follow-up

Addressed SENDBACK review findings:
1. **`raw_json` shape**: Production `raw_json` contains the marshaled `adapter.Record` where arguments reside at `item.metadata.arguments`. The migration now parses `raw_json`, rewrites `item.metadata.arguments` and `item.metadata.arguments_digest` to match `metadata_json` exactly, preserves all other keys byte-for-byte, and leaves `raw` (`raw_hash`, `raw_path`, `raw_ordinal`) untouched.
2. **`text` parity & FTS sync**: Pre-#1425 rows stored uncapped arguments in `items.text` and `item_fts`. The migration truncates the arguments segment in `items.text` and updates `item_fts.body` to match. Verified that tokens past the 4,000-char cap are purged from FTS search after migration.
3. **Real shape test fixtures**: Rewrote `TestMigrateCodexArguments` to use real `adapter.Record` fixtures imported via the production adapter import pipeline. Asserted on stored `raw_json`, `metadata_json`, `text` bytes, and FTS token elimination. Kept `TestMigrateCommandRegistered`.
4. **Nits**: Mutually exclusive `--apply --dry-run` now errors with usage matching `prune policy`; checked `rows.Err()`, `json.Marshal`, and encoder errors; documented in `--help` and doc comments that candidate selection is a full-table `LIKE` scan.

Verification (Brigade receipt `20260903-031101-work-verify-0964a8`): `check-ledger-go.sh` clean under Go 1.25 (`gofmt`, `go vet`, `go test ./internal/app/...` all ok).

## Review follow-up 2

Addressed second-round review findings:
1. **Provenance hashes**: After computing the truncated text and rewritten `raw_json`, the migration updates `metadata.provenance.hashes` (`hashes.content = provenance.ContentSHA256(newText)` and `hashes.raw = provenance.SHA256Bytes([]byte(newRaw))`), matching the scopes from fresh ingestion. Added assertions in `TestMigrateCodexArguments` verifying `inspectStoredItem(db, id).IntegrityMismatch == false` before and after migration.
2. **Keyset paging & rowid FTS updates**: Switched from growing `OFFSET` queries to keyset pagination (`WHERE ... AND i.id > ? ORDER BY i.id LIMIT ?`) carrying `lastID` across 1,000-row batches. Avoided linear scans over unindexed `item_fts.item_id` by resolving FTS `rowid` (via `LEFT JOIN item_fts f ON f.rowid = i.rowid` with fallback) and updating `item_fts` by `rowid`. Maintained the `isAlreadyTruncated` guard so repeated `--apply` invocations match zero rows.
3. **Integer preservation in metadata**: Decoded `metadata_json` with `json.NewDecoder(bytes.NewReader(...))` and `UseNumber()` matching `raw_json`, preventing integer fields (such as `schema_version`) from re-marshaling as floating-point numbers. Added assertions for integer preservation.

Verification (Brigade receipt `20260903-032439-work-verify-601559`): `check-ledger-go.sh` clean under Go 1.25 (`gofmt`, `go vet`, `go test ./internal/app/...` all ok).

## Review follow-up 3

Addressed third-round review findings:
1. **FTS lookup prepass**: Replaced the `LEFT JOIN item_fts` and fallback per-row scan (`WHERE item_id = ?`) with a single prepass before the batch loop: `SELECT rowid, item_id FROM item_fts WHERE source_kind = 'codex'` into an `item_id -> rowid` map (one scan, bounded memory). Rows are updated in FTS directly by `rowid`. Rows absent from the map get no FTS update and are tracked in the JSON output as `fts_missing`. Added a test (`TestMigrateCodexArguments_FTSDifferentRowID`) where an item's FTS row has a different rowid than the item's rowid (via delete and re-insert) and asserted that `body` is still correctly updated.
2. **Cap parity in runes**: Exported `DefaultTextCap` (4000) and `TruncationMarker` (`\n[truncated]`) from `internal/sources` and updated `sources.TextFromAny` to count runes rather than bytes. Both the Codex adapter and `migrate.go` now reuse `sources.TextFromAny(..., sources.DefaultTextCap)`, ensuring the cap, unit (runes), and marker use the identical code path. Added multibyte tests (`TestMigrateCodexArguments_MultibyteRunes`) for 4,100 CJK and emoji runes asserting no U+FFFD and byte-identical output to `sources.TextFromAny`.
3. **Provenance ordering**: Mirrored the importer's ordering (`importer.go` ~520-560) by computing the final `raw_json` bytes first (with `item.metadata` updated and any embedded provenance removed), then computing `hashes.raw` over the final raw bytes and updating the envelope in `metadata_json`. Asserted in `TestMigrateCodexArguments` that `inspectStoredItem` reports `IntegrityMismatch == false` and additionally that embedded metadata in `raw_json` equals `metadata_json` minus importer-added fields (`tags`, `provenance`).
4. **Docs retention sequence**: Updated `docs/RETENTION_POLICY.md` to document the sequence with `--export <path>`: `prune policy --apply --export <path>`, then `migrate codex-arguments --apply`, then `compact`.
5. **Keyset paging test**: Exposed `migrateBatchSize` at package level and added `TestMigrateCodexArguments_KeysetPaging` exercising pagination across multiple batches (batch size 2 with 5 rows). Added `TestMigrateCodexArguments_FTSMissing` asserting `fts_missing` reporting.

Verification (Brigade receipt `20260903-033748-work-verify-e33d9d`): `check-ledger-go.sh` clean under Go 1.25 (`gofmt`, `go vet`, `go test ./internal/app/...` all ok).