### PR TITLE
feat(seat-health): real Antigravity probes for auth, model reachability, and version

### DIFF
--- a/src/brigade/aboyeur/orchestrator.py
+++ b/src/brigade/aboyeur/orchestrator.py
@@ -380,6 +380,8 @@ def resolve_orchestrator_health_routing(
     else:
         detail = f"seat {requested} is unhealthy [{typed_cause}]{rejected_detail}"
     failure = unhealthy_result.failure
+    if failure is not None and failure.detail:
+        detail = f"{detail}: {seat_health.safe_detail(failure.detail)}"
     return OrchestratorHealthRoutingDecision(
         roster=effective,
         warning="\n".join(warnings) or None,

--- a/src/brigade/seat_health.py
+++ b/src/brigade/seat_health.py
@@ -39,6 +39,11 @@ MODEL_REACHABILITY_TIMEOUT_SECONDS = 15.0
 HEALTHY_CACHE_TTL_SECONDS = 5 * 60.0
 UNHEALTHY_CACHE_TTL_SECONDS = 30.0
 DETAIL_LIMIT = 240
+# agy 1.1.25 was installed when #1418 added these prompt-free probes. Keep
+# that reviewed version as the floor because earlier releases were not checked
+# to support both `agy models` and `agy --version` in automation.
+_ANTIGRAVITY_MIN_VERSION = (1, 1, 25)
+_ANTIGRAVITY_PROBE_TIMEOUT_SECONDS = 2.0
 _MODEL_SMOKE_MARKER = "BRIGADE_SEAT_HEALTH_EXACT_MARKER"
 _MODEL_SMOKE_PROMPT = (
     "Return exactly BRIGADE_SEAT_HEALTH_EXACT_MARKER and nothing else. Do not use tools. Do not write files."
@@ -428,6 +433,8 @@ class SeatHealthProbe:
                 if auth.state == "unauthenticated":
                     return SeatHealthCheck(name, "failed", auth.detail, cause_code="auth-required")
                 return SeatHealthCheck(name, "degraded", auth.detail, cause_code="auth-status-unavailable")
+            if seat.cli == "antigravity":
+                return self._antigravity_auth_check(seat, timeout_seconds)
             return SeatHealthCheck(
                 name,
                 "degraded",
@@ -447,6 +454,8 @@ class SeatHealthProbe:
                     f"requires {seat.transport_version}; found {version or detail}",
                     cause_code="version-mismatch",
                 )
+            if seat.cli == "antigravity":
+                return self._antigravity_version_check(seat, timeout_seconds)
             return SeatHealthCheck(
                 name, "degraded", "adapter has no reviewed version gate", cause_code="probe-incomplete"
             )
@@ -522,6 +531,8 @@ class SeatHealthProbe:
             )
         if seat.model is None:
             return SeatHealthCheck("model-reachability", "degraded", "seat has no exact model declaration")
+        if seat.cli == "antigravity":
+            return self._antigravity_model_check(seat, timeout_seconds)
         # Roster doctor retains its established inventory rendering below.  It
         # asks the shared coordinator for all other facts without duplicating a
         # provider inventory call, and it deliberately never sends a smoke
@@ -581,6 +592,91 @@ class SeatHealthProbe:
         finally:
             _remove_temp_repo(root)
 
+    def _antigravity_auth_check(self, seat: Any, timeout_seconds: float) -> SeatHealthCheck:
+        result, detail = _antigravity_models(seat, timeout_seconds)
+        if result is None:
+            return SeatHealthCheck("authentication-entitlement", "failed", detail, cause_code="models-command-failed")
+        output = f"{result.stdout}\n{result.stderr}"
+        if _antigravity_auth_error(output):
+            return SeatHealthCheck(
+                "authentication-entitlement",
+                "failed",
+                "agy models reported authentication is required",
+                cause_code="auth-required",
+            )
+        if result.code != 0:
+            return SeatHealthCheck(
+                "authentication-entitlement",
+                "failed",
+                f"agy models exited {result.code}",
+                cause_code="models-command-failed",
+            )
+        model_ids = _antigravity_model_ids(output)
+        if not model_ids:
+            return SeatHealthCheck(
+                "authentication-entitlement",
+                "failed",
+                "agy models returned no model lines",
+                cause_code="model-list-empty",
+            )
+        return SeatHealthCheck("authentication-entitlement", "passed", f"agy models listed {len(model_ids)} model(s)")
+
+    def _antigravity_version_check(self, seat: Any, timeout_seconds: float) -> SeatHealthCheck:
+        identity = _resolve_agent_executable(seat)
+        try:
+            result = proc.run(
+                [identity.command, "--version"], timeout=min(timeout_seconds, _ANTIGRAVITY_PROBE_TIMEOUT_SECONDS)
+            )
+        except OSError as exc:
+            return SeatHealthCheck("version-gates", "failed", safe_detail(str(exc)), cause_code="version-unavailable")
+        output = f"{result.stdout}\n{result.stderr}"
+        match = re.search(r"\b(\d+)\.(\d+)\.(\d+)\b", output)
+        if result.code != 0:
+            return SeatHealthCheck(
+                "version-gates", "failed", f"agy --version exited {result.code}", cause_code="version-unavailable"
+            )
+        if match is None:
+            return SeatHealthCheck(
+                "version-gates",
+                "failed",
+                "agy --version returned no semantic version",
+                cause_code="version-unavailable",
+            )
+        version = tuple(int(part) for part in match.groups())
+        if version < _ANTIGRAVITY_MIN_VERSION:
+            required = ".".join(str(part) for part in _ANTIGRAVITY_MIN_VERSION)
+            found = ".".join(str(part) for part in version)
+            return SeatHealthCheck(
+                "version-gates", "failed", f"requires agy {required}; found {found}", cause_code="version-mismatch"
+            )
+        return SeatHealthCheck("version-gates", "passed", f"agy version {'.'.join(match.groups())}")
+
+    def _antigravity_model_check(self, seat: Any, timeout_seconds: float) -> SeatHealthCheck:
+        result, detail = _antigravity_models(seat, timeout_seconds)
+        if result is None:
+            return SeatHealthCheck("model-reachability", "failed", detail, cause_code="models-command-failed")
+        output = f"{result.stdout}\n{result.stderr}"
+        if _antigravity_auth_error(output):
+            return SeatHealthCheck(
+                "model-reachability",
+                "failed",
+                "agy models reported authentication is required",
+                cause_code="auth-required",
+            )
+        if result.code != 0:
+            return SeatHealthCheck(
+                "model-reachability", "failed", f"agy models exited {result.code}", cause_code="models-command-failed"
+            )
+        model = agents._antigravity_model_pin(seat.model)
+        if _model_id_is_listed(model, output):
+            return SeatHealthCheck("model-reachability", "passed", f"agy models lists requested model {model}")
+        return SeatHealthCheck(
+            "model-reachability",
+            "failed",
+            f"requested model {model} is not listed by agy models",
+            cause_code="model-not-listed",
+        )
+
     def _app_server_model_smoke(self, seat: Any, roster: Any, root: Path, timeout_seconds: float) -> SeatHealthCheck:
         try:
             with _app_server(root) as server:
@@ -592,6 +688,37 @@ class SeatHealthProbe:
             )
         cause = "timeout" if result.timed_out else "model-unavailable"
         return _model_smoke_result(result.ok, result.text, result.detail, cause, result.timed_out)
+
+
+def _antigravity_models(seat: Any, timeout_seconds: float) -> tuple[proc.Result | None, str]:
+    identity = _resolve_agent_executable(seat)
+    try:
+        return (
+            proc.run([identity.command, "models"], timeout=min(timeout_seconds, _ANTIGRAVITY_PROBE_TIMEOUT_SECONDS)),
+            "",
+        )
+    except OSError as exc:
+        return None, safe_detail(str(exc))
+
+
+def _antigravity_auth_error(output: str) -> bool:
+    lowered = output.lower()
+    return any(marker in lowered for marker in ("authentication required", "not authenticated", "not logged in"))
+
+
+def _antigravity_model_ids(output: str) -> tuple[str, ...]:
+    ignored = frozenset({"available", "model", "models", "no", "none"})
+    model_ids: list[str] = []
+    for line in output.splitlines():
+        token = line.strip().split(maxsplit=1)[0] if line.strip() else ""
+        if token.lower() not in ignored and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:/-]*", token):
+            model_ids.append(token)
+    return tuple(model_ids)
+
+
+def _model_id_is_listed(model: str, output: str) -> bool:
+    token = re.compile(rf"(?<!\S){re.escape(model)}(?=\s|$|\()")
+    return any(token.search(line) is not None for line in output.splitlines())
 
 
 def seat_fingerprint(seat: Any, roster: Any, *, executable_version: str | None = None) -> str:
@@ -719,6 +846,7 @@ def _failure_for(check: SeatHealthCheck) -> WorkerFailure:
         "entitlement-denied": FailureClass.ENTITLEMENT_DENIED,
         "version-mismatch": FailureClass.VERSION_GATE,
         "model-unavailable": FailureClass.MODEL_UNAVAILABLE,
+        "model-not-listed": FailureClass.MODEL_UNAVAILABLE,
         "missing-transport": FailureClass.TRANSPORT_UNAVAILABLE,
         "app-server-unavailable": FailureClass.TRANSPORT_UNAVAILABLE,
         "initialize-no-progress": FailureClass.TRANSPORT_HANG,

--- a/src/brigade/seat_health.py
+++ b/src/brigade/seat_health.py
@@ -622,11 +622,11 @@ class SeatHealthProbe:
         return SeatHealthCheck("authentication-entitlement", "passed", f"agy models listed {len(model_ids)} model(s)")
 
     def _antigravity_version_check(self, seat: Any, timeout_seconds: float) -> SeatHealthCheck:
-        identity = _resolve_agent_executable(seat)
+        argv, env, env_error = _antigravity_probe_invocation(seat, "--version")
+        if env_error:
+            return SeatHealthCheck("version-gates", "failed", env_error, cause_code="version-unavailable")
         try:
-            result = proc.run(
-                [identity.command, "--version"], timeout=min(timeout_seconds, _ANTIGRAVITY_PROBE_TIMEOUT_SECONDS)
-            )
+            result = proc.run(argv, timeout=min(timeout_seconds, _ANTIGRAVITY_PROBE_TIMEOUT_SECONDS), env=env)
         except OSError as exc:
             return SeatHealthCheck("version-gates", "failed", safe_detail(str(exc)), cause_code="version-unavailable")
         output = f"{result.stdout}\n{result.stderr}"
@@ -667,7 +667,7 @@ class SeatHealthProbe:
             return SeatHealthCheck(
                 "model-reachability", "failed", f"agy models exited {result.code}", cause_code="models-command-failed"
             )
-        model = agents._antigravity_model_pin(seat.model)
+        model = _canonical_antigravity_model_id(seat.model)
         if _model_id_is_listed(model, output):
             return SeatHealthCheck("model-reachability", "passed", f"agy models lists requested model {model}")
         return SeatHealthCheck(
@@ -691,10 +691,12 @@ class SeatHealthProbe:
 
 
 def _antigravity_models(seat: Any, timeout_seconds: float) -> tuple[proc.Result | None, str]:
-    identity = _resolve_agent_executable(seat)
+    argv, env, env_error = _antigravity_probe_invocation(seat, "models")
+    if env_error:
+        return None, env_error
     try:
         return (
-            proc.run([identity.command, "models"], timeout=min(timeout_seconds, _ANTIGRAVITY_PROBE_TIMEOUT_SECONDS)),
+            proc.run(argv, timeout=min(timeout_seconds, _ANTIGRAVITY_PROBE_TIMEOUT_SECONDS), env=env),
             "",
         )
     except OSError as exc:
@@ -719,6 +721,26 @@ def _antigravity_model_ids(output: str) -> tuple[str, ...]:
 def _model_id_is_listed(model: str, output: str) -> bool:
     token = re.compile(rf"(?<!\S){re.escape(model)}(?=\s|$|\()")
     return any(token.search(line) is not None for line in output.splitlines())
+
+
+def _canonical_antigravity_model_id(model: str) -> str:
+    normalized = re.sub(r"[()]+", "", model.strip().lower())
+    normalized = re.sub(r"[\s_-]+", "-", normalized).strip("-")
+    return agents._antigravity_model_pin(normalized)
+
+
+def _antigravity_probe_invocation(seat: Any, subcommand: str) -> tuple[list[str], dict[str, str] | None, str]:
+    seat_env = getattr(seat, "env", None)
+    child_env: dict[str, str] | None = None
+    if seat_env is not None:
+        overrides, env_error = agents.resolve_env_overrides(seat_env)
+        if overrides is None:
+            return [], None, env_error
+        child_env = dict(os.environ)
+        child_env.update(overrides)
+    identity = _resolve_agent_executable(seat)
+    command = getattr(seat, "command", None) or ()
+    return [identity.command, *command[1:], subcommand], child_env, ""
 
 
 def seat_fingerprint(seat: Any, roster: Any, *, executable_version: str | None = None) -> str:

--- a/tests/test_aboyeur_orchestrator_health_routing.py
+++ b/tests/test_aboyeur_orchestrator_health_routing.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import replace
 
 from brigade import aboyeur
 from brigade import agents
@@ -25,6 +26,18 @@ class PerSeatFakeAdapter:
 class RaisingProbe:
     def probe_roster(self, *args, **kwargs):
         raise RuntimeError("probe failed")
+
+
+class ModelNotListedAdapter:
+    def check(self, name, *, seat, roster, workspace, timeout_seconds):
+        if seat.name == "coder" and name == "model-reachability":
+            return SeatHealthCheck(
+                name,
+                "failed",
+                "requested model gemini-3.8-flash-low is not listed",
+                cause_code="model-not-listed",
+            )
+        return SeatHealthCheck(name, "passed", "ok")
 
 
 def _roster(*, fallback: tuple[str, ...] = (), worker_fallback: tuple[str, ...] = ()):
@@ -326,6 +339,38 @@ def test_unhealthy_direct_worker_without_fallback_aborts(monkeypatch, tmp_path, 
 
     routing = json.loads((output_dir / "seat-routing.json").read_text())
     assert routing["decisions"] == [expected]
+
+
+def test_model_not_listed_probe_refuses_direct_worker_before_dispatch(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(
+        aboyeur, "dispatch", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("dispatched"))
+    )
+    _install_probe(monkeypatch, ModelNotListedAdapter())
+    output_dir = tmp_path / "run-model-not-listed"
+    roster_value = _roster()
+    roster_value = replace(
+        roster_value,
+        agents={
+            **roster_value.agents,
+            "coder": replace(roster_value.agents["coder"], model="gemini-3.8-flash-low"),
+        },
+    )
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            roster_value,
+            worker="coder",
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 2
+    )
+
+    stderr = capsys.readouterr().err
+    assert "error: seat coder is unhealthy [model-unavailable]" in stderr
+    assert "requested model gemini-3.8-flash-low is not listed" in stderr
 
 
 def test_direct_worker_fallback_prints_requested_and_effective(monkeypatch, tmp_path, capsys):

--- a/tests/test_seat_health.py
+++ b/tests/test_seat_health.py
@@ -2,6 +2,8 @@ import json
 import time
 from dataclasses import replace
 
+import pytest
+
 from brigade import roster
 from brigade import seat_health
 from brigade import proc
@@ -61,6 +63,77 @@ def test_probe_normalizes_auth_version_model_transport_hang_and_timeout_failures
         assert result.failure is not None
         assert result.failure.failure_class.value == expected
         assert "secret-value" not in result.failure.payload()["detail"]
+
+
+def test_antigravity_prompt_free_probes_pass_for_listed_model(monkeypatch):
+    seat = roster.Agent("agy", "antigravity", "work", model="gemini-3.8-flash")
+    roster_value = roster.Roster("agy", {"agy": seat}, sandbox="read-only")
+    calls = []
+
+    monkeypatch.setattr(
+        seat_health.agents,
+        "resolve_agent_executable",
+        lambda cli: proc.ExecutableIdentity("agy", None, "fixture", True, "fixture"),
+    )
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        if argv == ["agy", "models"]:
+            return proc.Result(0, "gemini-3.8-flash-low (Gemini Flash)", "")
+        if argv == ["agy", "--version"]:
+            return proc.Result(0, "agy 1.1.25", "")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(seat_health.proc, "run", fake_run)
+
+    result = SeatHealthProbe().probe(seat, roster_value, allow_model_smoke=False)
+
+    assert result.status == "healthy"
+    assert {check.name: check.status for check in result.checks} == {
+        "declaration": "passed",
+        "executable-identity": "passed",
+        "authentication-entitlement": "passed",
+        "transport-liveness": "passed",
+        "version-gates": "passed",
+        "model-reachability": "passed",
+        "isolation-compatibility": "passed",
+    }
+    assert all(timeout <= 2.0 for _, kwargs in calls for timeout in [kwargs.get("timeout", 0.0)])
+
+
+@pytest.mark.parametrize(
+    ("models", "models_code", "version", "check_name", "cause_code"),
+    [
+        ("Error: authentication required", 1, "1.1.25", "authentication-entitlement", "auth-required"),
+        ("gemini-3.8-pro-low (Gemini Pro)", 0, "1.1.25", "model-reachability", "model-not-listed"),
+        ("gemini-3.8-flash-low (Gemini Flash)", 0, "1.1.24", "version-gates", "version-mismatch"),
+    ],
+)
+def test_antigravity_prompt_free_probes_report_auth_model_and_version_failures(
+    monkeypatch, models, models_code, version, check_name, cause_code
+):
+    seat = roster.Agent("agy", "antigravity", "work", model="gemini-3.8-flash")
+    roster_value = roster.Roster("agy", {"agy": seat}, sandbox="read-only")
+    monkeypatch.setattr(
+        seat_health.agents,
+        "resolve_agent_executable",
+        lambda cli: proc.ExecutableIdentity("agy", None, "fixture", True, "fixture"),
+    )
+    monkeypatch.setattr(
+        seat_health.proc,
+        "run",
+        lambda argv, **kwargs: proc.Result(
+            models_code if argv[-1] == "models" else 0,
+            models if argv[-1] == "models" else f"agy {version}",
+            "",
+        ),
+    )
+
+    result = SeatHealthProbe().probe(seat, roster_value, allow_model_smoke=False)
+    check = next(item for item in result.checks if item.name == check_name)
+
+    assert check.status == "failed"
+    assert check.cause_code == cause_code
 
 
 def test_probe_roster_includes_fallbacks_and_cache_ttls(monkeypatch):

--- a/tests/test_seat_health.py
+++ b/tests/test_seat_health.py
@@ -101,6 +101,70 @@ def test_antigravity_prompt_free_probes_pass_for_listed_model(monkeypatch):
     assert all(timeout <= 2.0 for _, kwargs in calls for timeout in [kwargs.get("timeout", 0.0)])
 
 
+@pytest.mark.parametrize("requested_model", ("Gemini 3.8 Flash (Low)", "Gemini 3.8 Flash"))
+def test_antigravity_model_probe_matches_display_name_and_model_override(monkeypatch, requested_model):
+    declared = roster.Agent("agy", "antigravity", "work", model="gemini-3.8-pro-low")
+    seat = replace(declared, model=requested_model)  # Effective seat after a --model override.
+    roster_value = roster.Roster("agy", {"agy": seat}, sandbox="read-only")
+    monkeypatch.setattr(
+        seat_health.agents,
+        "resolve_agent_executable",
+        lambda cli: proc.ExecutableIdentity("agy", None, "fixture", True, "fixture"),
+    )
+    monkeypatch.setattr(
+        seat_health.proc,
+        "run",
+        lambda argv, **kwargs: proc.Result(
+            0,
+            "gemini-3.8-flash-low (Gemini Flash)" if argv[-1] == "models" else "agy 1.1.25",
+            "",
+        ),
+    )
+
+    result = SeatHealthProbe().probe(seat, roster_value, allow_model_smoke=False)
+
+    model_check = next(check for check in result.checks if check.name == "model-reachability")
+    assert model_check.status == "passed"
+
+
+def test_antigravity_prompt_free_probes_use_agent_command_prefix_and_environment(monkeypatch):
+    seat = roster.Agent(
+        "agy",
+        "antigravity",
+        "work",
+        command=("agy-wrapper", "--profile", "seat-profile"),
+        env={"AGY_PROFILE": "seat-profile"},
+        model="gemini-3.8-flash",
+    )
+    roster_value = roster.Roster("agy", {"agy": seat}, sandbox="read-only")
+    calls = []
+    monkeypatch.setattr(
+        seat_health.agents,
+        "resolve_agent_executable",
+        lambda cli, command=None: proc.ExecutableIdentity("agy-wrapper", None, "fixture", True, "fixture"),
+    )
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return proc.Result(
+            0,
+            "gemini-3.8-flash-low (Gemini Flash)" if argv[-1] == "models" else "agy 1.1.25",
+            "",
+        )
+
+    monkeypatch.setattr(seat_health.proc, "run", fake_run)
+
+    result = SeatHealthProbe(collect_executable_version=False).probe(seat, roster_value, allow_model_smoke=False)
+
+    assert result.status == "healthy"
+    assert [argv for argv, _ in calls] == [
+        ["agy-wrapper", "--profile", "seat-profile", "models"],
+        ["agy-wrapper", "--profile", "seat-profile", "--version"],
+        ["agy-wrapper", "--profile", "seat-profile", "models"],
+    ]
+    assert all(kwargs["env"]["AGY_PROFILE"] == "seat-profile" for _, kwargs in calls)
+
+
 @pytest.mark.parametrize(
     ("models", "models_code", "version", "check_name", "cause_code"),
     [


### PR DESCRIPTION
## What

Seat-health reported the Antigravity seat as "degraded, probe-incomplete" on authentication, version gate, and model reachability, and the run then failed minutes later on a problem a probe could have caught.

- Authentication probe: runs `agy models` (no prompt, two-second bound) and passes on exit 0 with at least one model line, otherwise fails with a clear cause code.
- Model reachability: the seat's effective model id (after any `--model` override) must appear in the `agy models` output, else `model-not-listed`.
- Version gate: parses `agy --version` against a recorded minimum with the reason in a comment.
- Dispatch refusal: `model-not-listed` refuses the seat before dispatch with the probe detail, like other hard probe failures.

Closes #1418.

## Verification

```
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_seat_health.py","tests/test_aboyeur_orchestrator_health_routing.py","tests/test_agents.py"]' --capture brigade-work
216 passed
```

Built by the `coder` seat (GPT-5.6 Terra) under `brigade run` after a Jules cloud session stopped at plan generation and a Grok seat hit an exhausted balance.

## Brigade receipts

- Implementation review/fix run: `7e3fc591.20260903-173502-a221ab21`
- Conductor focused verification: `20260903-174126-work-verify-551469` (exit 0)
- Conductor diff check: `20260903-174146-work-verify-64f004` (exit 0)

