### PR TITLE
fix(grokbot): restore idempotent manifest replay

### DIFF
--- a/src/brigade/fleet_hub_grokbot.py
+++ b/src/brigade/fleet_hub_grokbot.py
@@ -36,6 +36,7 @@ ACTOR_KINDS = frozenset({"feed", "control", "operator", "implementation-worker",
 ARTIFACT_KINDS = frozenset({"draft-pr", "branch", "report"})
 WORK_STATES = frozenset({"queued", "claimed", "running"})
 TERMINAL_STATES = frozenset({"completed", "failed", "expired", "canceled"})
+IDEMPOTENT_ENQUEUE_REPLAY_STATES = frozenset({"completed", "expired", "canceled"})
 HUB_STATES = WORK_STATES | TERMINAL_STATES
 CREATE_ACTIONS = frozenset({"enqueue"})
 OPERATOR_ACTIONS = frozenset({"list", "status", "whoami", "cancel", "expire", "report-metadata"})
@@ -315,14 +316,19 @@ def handle_grokbot(
     try:
         replayed, mismatch = _replay_operation(conn, request)
         if mismatch:
-            conn.rollback()
-            return 409, {_result_flag(action): False, "error": "operation-mismatch"}
+            recovered = _terminal_enqueue_replay(conn, request, policy) if action == "enqueue" else None
+            if recovered is None:
+                conn.rollback()
+                return 409, {_result_flag(action): False, "error": "operation-mismatch"}
+            conn.commit()
+            return 200, recovered
         if replayed is not None:
             if action == "enqueue":
                 current = _require_job(conn, request["job_id"])
                 if current.get("queue_id") != policy["queue_id"]:
                     conn.rollback()
                     raise FleetHubForbidden("job is outside this actor's queue")
+                replayed = {**replayed, "idempotent": True, "job": _job_payload(current)}
             else:
                 current = _scoped_job(conn, request["job_id"], policy)
                 if action in LEASE_ACTIONS or action == "claim":
@@ -538,6 +544,34 @@ def _scoped_job(conn: sqlite3.Connection, job_id: str, policy: dict[str, Any]) -
     if policy["actor_kind"] in ROLE_VALUES and job["role"] != policy["role"]:
         raise FleetHubForbidden("job is outside this actor's role")
     return job
+
+
+def _terminal_enqueue_replay(
+    conn: sqlite3.Connection, request: dict[str, Any], policy: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Replay enqueue of a finished job when the stored operation digest drifted.
+
+    Completing, expiring, or canceling a job does not consume its idempotency
+    key. A later ``feed --apply`` of the same manifest must skip that row as
+    ``idempotent: true`` and keep walking. Additive request fields (for example
+    ``queue_ttl_seconds`` after #1409) change the stored enqueue digest and
+    would otherwise 409 ``operation-mismatch`` before ``_enqueue`` can see the
+    existing row. Queued and failed rows keep the mismatch refusal.
+    """
+    existing = conn.execute(
+        f"SELECT {_JOB_COLUMNS} FROM grokbot_jobs WHERE idempotency_key_hash = ?",
+        (request["idempotency_key_hash"],),
+    ).fetchone()
+    if existing is None:
+        return None
+    job = _job_dict(existing)
+    if job.get("queue_id") != policy["queue_id"] or job.get("owner_node") != policy["queue_owner_node_id"]:
+        return None
+    if job["state"] not in IDEMPOTENT_ENQUEUE_REPLAY_STATES:
+        return None
+    if job["task_digest"] != request["task_digest"] or job["job_id"] != request["job_id"]:
+        return None
+    return {"enqueued": True, "idempotent": True, "job": _job_payload(job)}
 
 
 def _enqueue(conn: sqlite3.Connection, request: dict[str, Any], policy: dict[str, Any]) -> tuple[int, dict[str, Any]]:

--- a/src/brigade/grokbot_feed.py
+++ b/src/brigade/grokbot_feed.py
@@ -49,10 +49,40 @@ WORKER_FALLBACK_DONE_PREDICATE = "Implement only the approved issue"
 class FeedError(ValueError):
     """A rejected feed request with a stable machine-readable reason."""
 
-    def __init__(self, reason: str, index: int | None = None):
-        self.reason = reason
+    def __init__(self, reason: str, index: int | None = None, *, detail: str | None = None):
         self.index = index
+        self.detail = detail
+        if detail is not None:
+            reason = f"{reason} index={index} {detail}" if index is not None else f"{reason} {detail}"
+        self.reason = reason
         super().__init__(reason)
+
+
+# Hub refusals the Fleet Hub client already bounded. Safe to name on stderr.
+_BOUNDED_HUB_QUEUE_REASONS = frozenset(
+    {
+        "invalid-request",
+        "invalid-artifact",
+        "invalid-state",
+        "refused",
+        "revision-conflict",
+        "operation-mismatch",
+        "lease-conflict",
+        "lease-expired",
+        "job-expired",
+        "idempotency-conflict",
+        "auth-failed",
+        "missing-digest",
+        "digest-mismatch",
+    }
+)
+
+
+def _queue_error(exc: grokbot_jobs.GrokbotJobError, index: int) -> FeedError:
+    """Translate a queue failure, naming only hub-bounded refusal reasons."""
+    if exc.reason in _BOUNDED_HUB_QUEUE_REASONS:
+        return FeedError("queue-error", index=index, detail=exc.reason)
+    return FeedError("queue-error", index=index)
 
 
 def worker_instructions(*, header: str, issue_number: int, base_ref: str, verification_commands: list[str]) -> str:
@@ -117,6 +147,8 @@ def apply(target: Path, manifest: Path, limit: int = DEFAULT_LIMIT) -> dict[str,
             handle = grokbot_jobs.enqueue(target, spec, key)
         except (KeyboardInterrupt, SystemExit):
             raise
+        except grokbot_jobs.GrokbotJobError as exc:
+            raise _queue_error(exc, index) from exc
         except Exception as exc:
             raise FeedError("queue-error", index=index) from exc
         jobs.append(

--- a/tests/test_fleet_hub_grokbot_expiry.py
+++ b/tests/test_fleet_hub_grokbot_expiry.py
@@ -53,9 +53,9 @@ def _enroll(conn: sqlite3.Connection) -> None:
         assert status == 200, payload
 
 
-def _enqueue(conn: sqlite3.Connection, job_id: str = JOB_ID) -> dict[str, object]:
-    digest = "b" * 64
-    body = {
+def _enqueue_body(job_id: str = JOB_ID, *, digest: str | None = None) -> dict[str, object]:
+    digest = digest or "b" * 64
+    return {
         "action": "enqueue",
         "job_id": job_id,
         "role": "implementation-worker",
@@ -67,7 +67,12 @@ def _enqueue(conn: sqlite3.Connection, job_id: str = JOB_ID) -> dict[str, object
         "artifact_kind": "draft-pr",
         "operation_id": f"op-enqueue-{job_id[-4:]}",
     }
-    status, payload = fleet_hub_grokbot.handle_grokbot(conn, body, caller_node=FEED_NODE)
+
+
+def _enqueue(conn: sqlite3.Connection, job_id: str = JOB_ID, *, digest: str | None = None) -> dict[str, object]:
+    status, payload = fleet_hub_grokbot.handle_grokbot(
+        conn, _enqueue_body(job_id, digest=digest), caller_node=FEED_NODE
+    )
     assert status == 200, payload
     return payload["job"]
 
@@ -338,3 +343,99 @@ def test_fail_after_the_execution_deadline_answers_job_expired(conn):
 
     assert status == 409
     assert payload == {"failed": False, "error": "job-expired"}
+
+
+def _drift_enqueue_digest(conn: sqlite3.Connection, job_id: str = JOB_ID) -> None:
+    """Simulate an additive request field so the stored enqueue digest no longer matches."""
+    conn.execute(
+        "UPDATE grokbot_operations SET request_digest=? WHERE job_id=? AND action='enqueue'",
+        ("0" * 64, job_id),
+    )
+    conn.commit()
+
+
+def _complete(conn: sqlite3.Connection, job_id: str = JOB_ID) -> None:
+    claimed = fleet_hub_grokbot.handle_grokbot(conn, _claim_body(job_id), caller_node=WORKER_NODE)
+    assert claimed[0] == 200, claimed[1]
+    generation = claimed[1]["lease_generation"]
+    started = fleet_hub_grokbot.handle_grokbot(
+        conn,
+        {
+            "action": "start",
+            "job_id": job_id,
+            "lease_id": "lease-a",
+            "expected_item_revision": claimed[1]["job"]["item_revision"],
+            "lease_generation": generation,
+            "operation_id": "op-start-1",
+        },
+        caller_node=WORKER_NODE,
+    )
+    assert started[0] == 200, started[1]
+    completed = fleet_hub_grokbot.handle_grokbot(
+        conn,
+        {
+            "action": "complete",
+            "job_id": job_id,
+            "lease_id": "lease-a",
+            "expected_item_revision": started[1]["job"]["item_revision"],
+            "lease_generation": generation,
+            "operation_id": "op-complete-1",
+            "artifact": {"kind": "draft-pr", "ref": "https://github.com/example/brigade/pull/9"},
+        },
+        caller_node=WORKER_NODE,
+    )
+    assert completed[0] == 200, completed[1]
+    assert completed[1]["job"]["state"] == "completed"
+
+
+def _cancel_queued(conn: sqlite3.Connection, job_id: str = JOB_ID) -> None:
+    status, payload = fleet_hub_grokbot.handle_grokbot(
+        conn,
+        {"action": "cancel", "job_id": job_id, "expected_item_revision": 1, "operation_id": "op-cancel-1"},
+        caller_node=OPERATOR_NODE,
+    )
+    assert status == 200, payload
+    assert payload["job"]["state"] == "canceled"
+
+
+def _expire_queued(conn: sqlite3.Connection, job_id: str = JOB_ID) -> None:
+    _backdate(conn, job_id, seconds=fleet_hub_grokbot.DEFAULT_QUEUE_TTL_SECONDS + 60)
+    assert fleet_hub_grokbot.sweep_expired_jobs(conn) == [job_id]
+
+
+@pytest.mark.parametrize("terminalize", ["completed", "expired", "canceled"])
+def test_enqueue_replays_terminal_jobs_as_idempotent_and_admits_a_later_entry(conn, terminalize: str):
+    """#1411: a completed/expired/canceled row must replay as idempotent so later keys can enqueue."""
+    _enqueue(conn)
+    if terminalize == "completed":
+        _complete(conn)
+    elif terminalize == "expired":
+        _expire_queued(conn)
+    else:
+        _cancel_queued(conn)
+    assert _state(conn) == terminalize
+    _drift_enqueue_digest(conn)
+
+    status, payload = fleet_hub_grokbot.handle_grokbot(conn, _enqueue_body(), caller_node=FEED_NODE)
+
+    assert status == 200, payload
+    assert payload["enqueued"] is True
+    assert payload["idempotent"] is True
+    assert payload["job"]["job_id"] == JOB_ID
+    assert payload["job"]["state"] == terminalize
+
+    later = _enqueue(conn, "grokbot-" + "d" * 24, digest="d" * 64)
+    assert later["state"] == "queued"
+    assert later["job_id"] != JOB_ID
+    assert conn.execute("SELECT COUNT(*) FROM grokbot_jobs").fetchone()[0] == 2
+
+
+def test_enqueue_digest_drift_on_a_queued_job_stays_operation_mismatch(conn):
+    _enqueue(conn)
+    _drift_enqueue_digest(conn)
+
+    status, payload = fleet_hub_grokbot.handle_grokbot(conn, _enqueue_body(), caller_node=FEED_NODE)
+
+    assert status == 409
+    assert payload == {"enqueued": False, "error": "operation-mismatch"}
+    assert _state(conn) == "queued"

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -6,6 +6,7 @@ import json
 import os
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -894,3 +895,195 @@ def test_worker_instructions_name_every_verification_command():
     assert "  - ruff check .\n  - pytest -q tests/test_one.py\n" in instructions
     assert "a branch cut from release/2.0 named cursor/issue-12-<slug>" in instructions
     assert "Fixes #12" in instructions
+
+
+FEED_NODE = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+WORKER_NODE = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+OPERATOR_NODE = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+HUB_QUEUE_ID = "grokbot-feed-terminal-replay"
+
+
+def _enroll_hub_actor(connection, node: str, kind: str, role: str | None = None) -> None:
+    body = {
+        "action": "enroll-actor",
+        "enroll_node_id": node,
+        "queue_owner_node_id": FEED_NODE,
+        "queue_id": HUB_QUEUE_ID,
+        "actor_kind": kind,
+        "enabled": True,
+    }
+    if role is not None:
+        body["role"] = role
+    status, payload = fleet_hub_grokbot.handle_grokbot(connection, body, caller_node=None)
+    assert status == 200, payload
+
+
+def _bind_hub_enqueue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    connection = fleet_hub.init_db(tmp_path / "fleet.db")
+    _enroll_hub_actor(connection, FEED_NODE, "feed")
+    _enroll_hub_actor(connection, WORKER_NODE, "implementation-worker", "implementation-worker")
+    _enroll_hub_actor(connection, OPERATOR_NODE, "operator")
+
+    def enqueue(**fields: object) -> fleet_client_grokbot.GrokbotHubDecision:
+        status, payload = fleet_hub_grokbot.handle_grokbot(
+            connection,
+            {"action": "enqueue", **fields},
+            caller_node=FEED_NODE,
+        )
+        return fleet_client_grokbot.GrokbotHubDecision(
+            granted=status == 200 and payload.get("enqueued") is True,
+            reason=payload.get("error", "") if isinstance(payload, dict) else "invalid-response",
+            job=payload.get("job") if isinstance(payload, dict) else None,
+            idempotent=payload.get("idempotent") is True if isinstance(payload, dict) else False,
+        )
+
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    monkeypatch.setattr(fleet_client_grokbot, "enqueue", enqueue)
+    return connection
+
+
+def _drift_hub_enqueue_digest(connection, job_id: str) -> None:
+    connection.execute(
+        "UPDATE grokbot_operations SET request_digest=? WHERE job_id=? AND action='enqueue'",
+        ("0" * 64, job_id),
+    )
+    connection.commit()
+
+
+def _complete_hub_job(connection, job_id: str) -> None:
+    claimed = fleet_hub_grokbot.handle_grokbot(
+        connection,
+        {
+            "action": "claim",
+            "job_id": job_id,
+            "lease_id": "lease-a",
+            "expected_item_revision": 1,
+            "lease_seconds": 300,
+            "operation_id": "op-claim-1",
+        },
+        caller_node=WORKER_NODE,
+    )
+    assert claimed[0] == 200, claimed[1]
+    generation = claimed[1]["lease_generation"]
+    started = fleet_hub_grokbot.handle_grokbot(
+        connection,
+        {
+            "action": "start",
+            "job_id": job_id,
+            "lease_id": "lease-a",
+            "expected_item_revision": claimed[1]["job"]["item_revision"],
+            "lease_generation": generation,
+            "operation_id": "op-start-1",
+        },
+        caller_node=WORKER_NODE,
+    )
+    assert started[0] == 200, started[1]
+    completed = fleet_hub_grokbot.handle_grokbot(
+        connection,
+        {
+            "action": "complete",
+            "job_id": job_id,
+            "lease_id": "lease-a",
+            "expected_item_revision": started[1]["job"]["item_revision"],
+            "lease_generation": generation,
+            "operation_id": "op-complete-1",
+            "artifact": {"kind": "draft-pr", "ref": "https://github.com/example/brigade/pull/9"},
+        },
+        caller_node=WORKER_NODE,
+    )
+    assert completed[0] == 200, completed[1]
+
+
+def _cancel_hub_job(connection, job_id: str) -> None:
+    status, payload = fleet_hub_grokbot.handle_grokbot(
+        connection,
+        {"action": "cancel", "job_id": job_id, "expected_item_revision": 1, "operation_id": "op-cancel-1"},
+        caller_node=OPERATOR_NODE,
+    )
+    assert status == 200, payload
+    assert payload["job"]["state"] == "canceled"
+
+
+def _expire_hub_job(connection, job_id: str) -> None:
+    queued_at = datetime.now(timezone.utc) - timedelta(seconds=fleet_hub_grokbot.DEFAULT_QUEUE_TTL_SECONDS + 60)
+    stamp = queued_at.isoformat().replace("+00:00", "Z")
+    connection.execute(
+        "UPDATE grokbot_jobs SET queued_at=?, created_at=?, updated_at=? WHERE job_id=?",
+        (stamp, stamp, stamp, job_id),
+    )
+    connection.commit()
+    assert fleet_hub_grokbot.sweep_expired_jobs(connection) == [job_id]
+
+
+@pytest.mark.parametrize("terminalize", ["completed", "expired", "canceled"])
+def test_apply_replays_terminal_hub_jobs_and_creates_the_next_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, terminalize: str
+):
+    connection = _bind_hub_enqueue(tmp_path, monkeypatch)
+    try:
+        manifest = _write_manifest(
+            tmp_path / "feed.json",
+            _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+        )
+        first = grokbot_feed.apply(tmp_path, manifest, limit=1)
+        job_id = first["jobs"][0]["job_id"]
+        if terminalize == "completed":
+            _complete_hub_job(connection, job_id)
+        elif terminalize == "expired":
+            _expire_hub_job(connection, job_id)
+        else:
+            _cancel_hub_job(connection, job_id)
+        _drift_hub_enqueue_digest(connection, job_id)
+
+        result = grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+        assert result["created"] == 1
+        assert result["skipped"] == 1
+        assert result["jobs"][0]["job_id"] == job_id
+        assert result["jobs"][0]["idempotent"] is True
+        assert result["jobs"][0]["state"] == terminalize
+        assert result["jobs"][1]["idempotent"] is False
+        assert result["jobs"][1]["state"] == "queued"
+        assert result["jobs"][1]["job_id"] != job_id
+        assert connection.execute("SELECT COUNT(*) FROM grokbot_jobs").fetchone()[0] == 2
+        _assert_redacted(result)
+    finally:
+        connection.close()
+
+
+def test_apply_surfaces_bounded_hub_error_detail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    def boom(target: Path, spec: dict, idempotency_key: str, now=None):
+        raise grokbot_jobs.GrokbotJobError("operation-mismatch")
+
+    monkeypatch.setattr(grokbot_jobs, "enqueue", boom)
+
+    with pytest.raises(grokbot_feed.FeedError) as exc:
+        grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+    assert exc.value.reason == "queue-error index=0 operation-mismatch"
+    assert exc.value.index == 0
+    assert exc.value.detail == "operation-mismatch"
+    assert not _queue_root(tmp_path).exists()
+
+
+def test_cli_feed_reports_bounded_hub_error_detail(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch):
+    manifest = _write_manifest(
+        tmp_path / "feed.json",
+        _manifest(_entry("task-a", _spec(label="First")), _entry("task-b", _spec(label="Second"))),
+    )
+
+    def boom(target: Path, spec: dict, idempotency_key: str, now=None):
+        raise grokbot_jobs.GrokbotJobError("operation-mismatch")
+
+    monkeypatch.setattr(grokbot_jobs, "enqueue", boom)
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply", "--limit", "1") == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "error: queue-error index=0 operation-mismatch"
+    assert SECRET_INSTRUCTIONS not in captured.err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1411

Restore idempotent replay for completed, expired, and canceled Grok Bot jobs so `feed --apply` reports the existing item as `idempotent: true` and continues enqueueing later new entries. Bounded hub error bodies are surfaced in CLI output (not only `queue-error index=N`).

Job id: `grokbot-edae1dfec1b2a5198c96ed62`

## Done predicate

- [x] Idempotent replay is restored for completed, expired, and canceled Grok Bot jobs: `feed --apply` reports the existing item as idempotent and continues enqueueing later new entries.
- [x] Bounded hub error bodies are surfaced in CLI output (not only `queue-error index=N`).
- [x] Failing-first regression tests cover completed/expired/canceled replay plus a later new entry, and bounded error detail.
- [x] Every envelope verification command below exits 0.
- [x] Exactly one DRAFT PR titled `fix(grokbot): restore idempotent manifest replay` against `main`, body starts with `Fixes #1411`, includes this done predicate, every verification command with exit code, the Brigade verify receipt id, and job id `grokbot-edae1dfec1b2a5198c96ed62`.

## What and why

After the hub gained `queue_ttl_seconds` (#1409), replaying a combined feed whose first entry already completed 409'd `operation-mismatch` because the stored enqueue digest no longer matched. `_terminal_enqueue_replay` treats completed, expired, and canceled rows with matching job id / task digest / key as `idempotent: true` so later unknown keys still enqueue. Queued digest mismatch stays a conflict. Feed CLI now prints bounded hub reasons as `queue-error index=N <reason>`.

## Type of change

- [x] Bug fix

## Verification commands

```
python -m pytest -q tests/test_grokbot_feed.py tests/test_fleet_hub_grokbot_expiry.py
```
exit 0 — 68 passed in 7.00s

```
ruff check src/brigade/fleet_hub_grokbot.py src/brigade/grokbot_feed.py tests/test_grokbot_feed.py tests/test_fleet_hub_grokbot_expiry.py
```
exit 0 — All checks passed!

```
ruff format --check src/brigade/fleet_hub_grokbot.py src/brigade/grokbot_feed.py tests/test_grokbot_feed.py tests/test_fleet_hub_grokbot_expiry.py
```
exit 0 — 4 files already formatted

```
mypy
```
exit 0 — Success: no issues found in 566 source files

```
git diff --check
```
exit 0 — no whitespace errors

work-verify receipt: `20260903-175720-work-verify-92d77b`
status: completed; `./scripts/verify-focused tests/test_grokbot_feed.py tests/test_fleet_hub_grokbot_expiry.py` exit 0

`brigade code sync` / `affected` were not run: `brigade code doctor` reported `graphtrail is not installed`.

CHANGELOG.md was not updated: ownership for this job forbids editing it.

## Checklist

- [x] Focused pytest selectors pass locally (68 passed)
- [x] Added or updated tests covering the change
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` (out of ownership for this job)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-417515f3-6e99-496f-a157-32d9a5d0d349?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-417515f3-6e99-496f-a157-32d9a5d0d349&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

