### PR TITLE
fix(governance): keep observed-run provider attribution unknown without dated evidence

### DIFF
--- a/docs/governance-inventory.md
+++ b/docs/governance-inventory.md
@@ -51,11 +51,13 @@ Brigade does not infer them from a model name or an external provider.
 Observed use comes only from a schema-versioned `worker-results.json` whose
 `producer_run_id` matches its containing run directory, plus a schema-versioned
 companion `run.json` for the timestamp. Legacy or unbound records are reported
-as bounded errors rather than observed facts. Seat names are joined to the
-configured workspace roster for provider attribution. An unconfigured seat
-remains explicitly unknown. When a valid node-local Fleet model-policy LKG is
-present, the model-provider registry labels its cached time, revision,
-admissions, and denials. It never contacts Fleet to create this projection.
+as bounded errors rather than observed facts. Observed-run `provider` stays
+`unknown`, with an explicit unknown reason, unless the worker row itself carries
+dated, authenticated provider attribution. Current roster or Fleet configuration
+is not observed history and is never copied into `provider`. When a valid
+node-local Fleet model-policy LKG is present, the model-provider registry labels
+its cached time, revision, admissions, and denials. It never contacts Fleet to
+create this projection.
 
 ## Privacy and input handling
 

--- a/src/brigade/governance_inventory.py
+++ b/src/brigade/governance_inventory.py
@@ -560,11 +560,16 @@ def _open_runs_directory(target: Path) -> int:
     return runs_fd
 
 
+_OBSERVED_PROVIDER_UNKNOWN = _unknown(
+    "provider attribution requires dated, authenticated provider evidence in the run receipt; "
+    "current configuration is not observed history"
+)
+
+
 def _observed_runs(
     target: Path,
     since: datetime | None,
     until: datetime | None,
-    configured_agents: dict[str, Any],
     budget: _InputBudget,
 ) -> dict[str, Any]:
     try:
@@ -670,22 +675,8 @@ def _observed_runs(
                     ):
                         errors.append("run-receipts: worker-results-malformed-row")
                         continue
-                    configured = configured_agents.get(seat)
-                    if (
-                        isinstance(configured, dict)
-                        and model == configured.get("model")
-                        and isinstance(configured.get("provider"), str)
-                    ):
-                        provider = configured["provider"]
-                        unknown = configured.get("unknown", {}).get("provider") if provider == "unknown" else None
-                    elif isinstance(configured, dict):
-                        provider = "unknown"
-                        unknown = _unknown(
-                            "observed model does not match the authenticated Fleet model fact for this configured seat"
-                        )
-                    else:
-                        provider = "unknown"
-                        unknown = _unknown("observed seat is not configured in the workspace roster")
+                    # Current roster or Fleet configuration is not observed history.
+                    provider, unknown = "unknown", _OBSERVED_PROVIDER_UNKNOWN
                     aggregate = observations.setdefault(
                         (seat, provider, model),
                         {"first_seen": observed_at, "last_seen": observed_at, "run_count": 0, "unknown": unknown},
@@ -739,10 +730,9 @@ def build_inventory(
         and isinstance(item.get("provider"), str)
     }
     agents = _agent_registry(target, budget, provider_facts)
-    configured_agents = {item["name"]: item for item in agents["items"] if isinstance(item.get("name"), str)}
     inventory = {
         "generated_at": _iso(clock),
-        "observed_runs": _observed_runs(target, parsed_since, parsed_until, configured_agents, budget),
+        "observed_runs": _observed_runs(target, parsed_since, parsed_until, budget),
         "registries": {
             "agents": agents,
             "mcp_servers": _mcp_registry(target, budget),

--- a/tests/test_governance_inventory.py
+++ b/tests/test_governance_inventory.py
@@ -121,7 +121,10 @@ def test_inventory_is_deterministic_and_never_exports_secret_or_path(tmp_path, m
             "seat": "research",
             "unknown": {
                 "provider_attribution": {
-                    "reason": "no authenticated Fleet provider fact is available for this configured seat",
+                    "reason": (
+                        "provider attribution requires dated, authenticated provider evidence in the run receipt; "
+                        "current configuration is not observed history"
+                    ),
                     "value": "unknown",
                 }
             },
@@ -214,12 +217,73 @@ def test_observed_runs_use_worker_results_and_authenticated_provider_attribution
             "first_seen": "2026-09-03T10:00:00Z",
             "last_seen": "2026-09-03T10:00:00Z",
             "model": "gpt-5.6-luna",
-            "provider": "openai",
+            "provider": "unknown",
             "run_count": 1,
             "seat": "research",
-            "unknown": {},
+            "unknown": {
+                "provider_attribution": {
+                    "reason": (
+                        "provider attribution requires dated, authenticated provider evidence in the run receipt; "
+                        "current configuration is not observed history"
+                    ),
+                    "value": "unknown",
+                }
+            },
         }
     ]
+
+
+def test_observed_runs_do_not_inherit_a_reconfigured_provider(tmp_path, monkeypatch):
+    target = _configured_target(tmp_path)
+    monkeypatch.setattr(
+        governance_inventory,
+        "_fleet_policy",
+        lambda _now: {
+            "admissions": [{"model": "gpt-5.6-luna", "provider": "openai", "seat": "research"}],
+            "denials": [],
+            "source": {},
+            "unknown": {},
+        },
+    )
+
+    recorded_under_a = governance_inventory.build_inventory(target=target, now=NOW)
+    research_under_a = next(
+        item for item in recorded_under_a["registries"]["agents"]["items"] if item["name"] == "research"
+    )
+    assert research_under_a["provider"] == "openai"
+    assert recorded_under_a["observed_runs"]["items"]
+
+    monkeypatch.setattr(
+        governance_inventory,
+        "_fleet_policy",
+        lambda _now: {
+            "admissions": [{"model": "gpt-5.6-luna", "provider": "anthropic", "seat": "research"}],
+            "denials": [],
+            "source": {},
+            "unknown": {},
+        },
+    )
+
+    after_reconfigure = governance_inventory.build_inventory(target=target, now=NOW)
+    research_under_b = next(
+        item for item in after_reconfigure["registries"]["agents"]["items"] if item["name"] == "research"
+    )
+    observed = after_reconfigure["observed_runs"]["items"][0]
+
+    assert research_under_b["provider"] == "anthropic"
+    assert observed["seat"] == "research"
+    assert observed["model"] == "gpt-5.6-luna"
+    assert observed["provider"] != "anthropic"
+    assert observed["provider"] == "unknown"
+    assert observed["unknown"] == {
+        "provider_attribution": {
+            "reason": (
+                "provider attribution requires dated, authenticated provider evidence in the run receipt; "
+                "current configuration is not observed history"
+            ),
+            "value": "unknown",
+        }
+    }
 
 
 def test_observed_runs_require_an_authenticated_model_match_for_provider_attribution(tmp_path, monkeypatch):
@@ -255,7 +319,10 @@ def test_observed_runs_require_an_authenticated_model_match_for_provider_attribu
     assert observed[0]["provider"] == "unknown"
     assert observed[0]["unknown"] == {
         "provider_attribution": {
-            "reason": "observed model does not match the authenticated Fleet model fact for this configured seat",
+            "reason": (
+                "provider attribution requires dated, authenticated provider evidence in the run receipt; "
+                "current configuration is not observed history"
+            ),
             "value": "unknown",
         }
     }
@@ -329,7 +396,10 @@ def test_observed_provider_without_a_configured_seat_is_explicitly_unknown(tmp_p
     assert observed[0]["provider"] == "unknown"
     assert observed[0]["unknown"] == {
         "provider_attribution": {
-            "reason": "observed seat is not configured in the workspace roster",
+            "reason": (
+                "provider attribution requires dated, authenticated provider evidence in the run receipt; "
+                "current configuration is not observed history"
+            ),
             "value": "unknown",
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1443

Observed runs keep provider `unknown` (with an explicit unknown reason such as "provider attribution requires dated, authenticated provider evidence in the run receipt; current configuration is not observed history") unless the worker row itself carries dated, authenticated provider attribution.

## Verification

- `python -m pytest -q tests/test_governance_inventory.py` — exit 0
- `ruff check src/brigade/governance_inventory.py tests/test_governance_inventory.py` — exit 0
- `ruff format --check src/brigade/governance_inventory.py tests/test_governance_inventory.py` — exit 0
- `mypy` — exit 0
- `git diff --check` — exit 0
- `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_governance_inventory.py"]' --capture brigade-work` — exit 0

Pytest transcript (last ten lines):

```
......................................                                   [100%]
38 passed in 1.83s
```

Observed_runs item after a seat is reconfigured from provider A (`openai`) to provider B (`anthropic`) with the same model string:

Before (defect: historical run inherited current provider B):

```json
{
  "first_seen": "2026-09-03T10:00:00Z",
  "last_seen": "2026-09-03T10:00:00Z",
  "model": "gpt-5.6-luna",
  "provider": "anthropic",
  "run_count": 1,
  "seat": "research",
  "unknown": {}
}
```

After (provider stays unknown; current configuration is not copied into `provider`):

```json
{
  "first_seen": "2026-09-03T10:00:00Z",
  "last_seen": "2026-09-03T10:00:00Z",
  "model": "gpt-5.6-luna",
  "provider": "unknown",
  "run_count": 1,
  "seat": "research",
  "unknown": {
    "provider_attribution": {
      "reason": "provider attribution requires dated, authenticated provider evidence in the run receipt; current configuration is not observed history",
      "value": "unknown"
    }
  }
}
```

Brigade verify receipt id: `20260906-002529-work-verify-c5011d`

Job id: `grokbot-562dbe575d03906548186ca5`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11f6f81a-ecfb-4c62-aea8-86d49a762e3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11f6f81a-ecfb-4c62-aea8-86d49a762e3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

