### PR TITLE
fix(approval): validate receipt digests on one snapshot before tree filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `path`, and refuses stale or malformed stored digest evidence. Legacy
   digestless exports remain supported. Export receipt lookup is strict and
   bounded. Approval collector integration remains deferred. (#1404)
+- Approval v1 and v2 collectors now require a stored receipt digest on every
+  matching verify receipt, validate the digest before any tree fingerprint
+  filter, and re-derive the Test Result attestation from the same snapshot so
+  `receipt.json` is read exactly once. (#1404)
 - Attestation, cosign bundle, and approval verification now reject oversized,
   duplicate-name, non-finite, malformed-Unicode, over-nested, and cyclic JSON
   inputs before signature processing. DSSE accepts both standard and URL-safe

--- a/docs/attestation-receipt-digests.md
+++ b/docs/attestation-receipt-digests.md
@@ -32,6 +32,14 @@ construction is detected instead of silently emitted as a stale subject digest.
 
 The loader uses a target-relative pathname and a no-follow final receipt-file
 read. It does not retain no-follow descriptors for every ancestor directory,
-so it does not close concurrent ancestor replacement races. Approval collector
-integration, including its receipt-selection and producer-binding rules,
-remains deferred.
+so it does not close concurrent ancestor replacement races.
+
+## Approval collectors
+
+Both approval v1 and v2 require a stored receipt digest on every matching verify
+receipt. They validate the digest before applying any tree fingerprint filter,
+so a mismatched or missing digest is reported as a receipt error rather than
+silently skipped as a non-matching tree. After validation, both collectors use
+the same `ReceiptSnapshot` for identity checks and pass the snapshot receipt to
+Test Result re-derivation, so `receipt.json` is read exactly once and
+re-derivation cannot disagree with the collector's digest.

--- a/src/brigade/approval.py
+++ b/src/brigade/approval.py
@@ -12,7 +12,16 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from . import approval_v2, attestation, attestation_input, localio, run_events, run_journal, run_projector
+from . import (
+    approval_v2,
+    attestation,
+    attestation_input,
+    attestation_receipt,
+    localio,
+    run_events,
+    run_journal,
+    run_projector,
+)
 
 HUMAN_APPROVAL_PREDICATE_TYPE = "https://brigade.dev/attestation/human-approval/v1"
 HUMAN_APPROVAL_V2_PREDICATE_TYPE = approval_v2.HUMAN_APPROVAL_PREDICATE_TYPE
@@ -214,24 +223,31 @@ def collect_verify_receipts(
             continue
         if receipt.get("producer_run_id") != producer_run_id:
             continue
+        try:
+            snapshot = attestation_receipt.snapshot_stored_receipt(receipt)
+        except attestation_receipt.ReceiptDigestError as exc:
+            if "receipt has no stored digest" in str(exc):
+                raise ApprovalError("matching verify receipt has no valid receipt_sha256") from exc
+            raise ApprovalError("matching verify receipt digest does not match receipt content") from exc
+        receipt = snapshot.receipt
         receipt_tree = receipt.get("tree_fingerprint")
         if tree_fingerprint is not None and receipt_tree != tree_fingerprint:
             continue
         verify_run_id = receipt.get("run_id")
-        digests = receipt.get("digests")
-        receipt_sha256 = digests.get("receipt_sha256") if isinstance(digests, Mapping) else None
+        receipt_sha256 = snapshot.digest
         if not isinstance(verify_run_id, str) or not _RUN_ID_RE.fullmatch(verify_run_id):
             raise ApprovalError("matching verify receipt has an invalid run_id")
-        if not isinstance(receipt_sha256, str) or not _HEX64_RE.fullmatch(receipt_sha256):
-            raise ApprovalError("matching verify receipt has no valid receipt_sha256")
         keyids: set[str] = set()
+        digests = receipt.get("digests")
         hmac_keyid = digests.get("key_id") if isinstance(digests, Mapping) else None
         if isinstance(hmac_keyid, str) and hmac_keyid:
             keyids.add(hmac_keyid)
         attestation_path = receipt_path.parent / "attestation.json"
         attestation_unparseable = False
         if attestation_path.exists():
-            verified_attestation = attestation.verify_attestation(attestation_path, target=target)
+            verified_attestation = attestation.verify_attestation(
+                attestation_path, target=target, receipt=snapshot.receipt
+            )
             if verified_attestation.status == attestation.STATUS_SIGNED_OK and verified_attestation.keyid:
                 keyids.add(verified_attestation.keyid)
             else:

--- a/src/brigade/approval_v2.py
+++ b/src/brigade/approval_v2.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from . import agent_request, attestation, attestation_input, localio, run_journal
+from . import agent_request, attestation, attestation_input, attestation_receipt, localio, run_journal
 
 HUMAN_APPROVAL_PREDICATE_TYPE = "https://brigade.dev/attestation/human-approval/v2"
 SOD_POLICY_NAME = "brigade.sod.v2"
@@ -267,6 +267,11 @@ def collect_test_result_evidence(
         receipt = _load_json_object(receipt_path, "verify receipt")
         if receipt.get("producer_run_id") != producer_run_id:
             continue
+        try:
+            snapshot = attestation_receipt.snapshot_stored_receipt(receipt)
+        except attestation_receipt.ReceiptDigestError as exc:
+            raise ApprovalV2Error("matching verify receipt identity or digest is invalid") from exc
+        receipt = snapshot.receipt
         verify_run_id = receipt.get("run_id")
         baseline_commit = receipt.get("baseline_commit")
         tree_fingerprint = receipt.get("tree_fingerprint")
@@ -276,8 +281,7 @@ def collect_test_result_evidence(
             other_tree_receipt_found = True
             continue
         patch_sha256 = receipt.get("changes_patch_sha256")
-        digests = receipt.get("digests")
-        receipt_sha256 = digests.get("receipt_sha256") if isinstance(digests, Mapping) else None
+        receipt_sha256 = snapshot.digest
         patch_path = receipt_path.parent / "changes.patch"
         if (
             not isinstance(verify_run_id, str)
@@ -289,7 +293,6 @@ def collect_test_result_evidence(
             or not _HEX64_RE.fullmatch(patch_sha256)
             or not isinstance(receipt_sha256, str)
             or not _HEX64_RE.fullmatch(receipt_sha256)
-            or receipt_sha256 != localio.canonical_json_digest(receipt, exclude_keys={"digests"})
             or patch_path.is_symlink()
             or not patch_path.is_file()
             or localio.file_sha256(patch_path) != patch_sha256
@@ -303,6 +306,7 @@ def collect_test_result_evidence(
             target=target,
             expected_predicate_type=attestation.IN_TOTO_TEST_RESULT_PREDICATE_TYPE,
             require_receipt=True,
+            receipt=snapshot.receipt,
         )
         predicate = statement.get("predicate")
         brigade_meta = envelope.get("brigade")

--- a/src/brigade/attestation.py
+++ b/src/brigade/attestation.py
@@ -520,6 +520,7 @@ def verify_attestation(
     namespace: str = ATTESTATION_NAMESPACE,
     expected_predicate_type: str = IN_TOTO_TEST_RESULT_PREDICATE_TYPE,
     require_receipt: bool = False,
+    receipt: Mapping[str, Any] | None = None,
 ) -> AttestationVerifyResult:
     """Verify an attestation envelope against OpenSSH allowed_signers policy."""
     binary = shutil.which("ssh-keygen")
@@ -773,6 +774,36 @@ def verify_attestation(
 
         # 7. Check target receipt re-derivation when local evidence is requested.
         if target is not None and run_id and expected_predicate_type == IN_TOTO_TEST_RESULT_PREDICATE_TYPE:
+            if receipt is not None:
+                try:
+                    rederived_statement = build_statement(receipt)
+                    rederived_bytes = canonical_statement_bytes(rederived_statement)
+                    if rederived_bytes != payload_bytes:
+                        return AttestationVerifyResult(
+                            status=STATUS_SUBJECT_MISMATCH,
+                            principal=verified_principal,
+                            keyid=actual_keyid,
+                            subject=subject,
+                            run_id=run_id,
+                            rederived=False,
+                        )
+                except Exception:
+                    return AttestationVerifyResult(
+                        status=STATUS_SUBJECT_MISMATCH,
+                        principal=verified_principal,
+                        keyid=actual_keyid,
+                        subject=subject,
+                        run_id=run_id,
+                        rederived=False,
+                    )
+                return AttestationVerifyResult(
+                    status=STATUS_SIGNED_OK,
+                    principal=verified_principal,
+                    keyid=actual_keyid,
+                    subject=subject,
+                    run_id=run_id,
+                    rederived=True,
+                )
             resolved_target = target.expanduser().resolve()
             run_dir = resolved_target / ".brigade" / "work" / "verify-runs" / run_id
             receipt_file = run_dir / "receipt.json"

--- a/src/brigade/attestation_receipt.py
+++ b/src/brigade/attestation_receipt.py
@@ -77,6 +77,14 @@ def snapshot_receipt(receipt: Mapping[str, Any]) -> ReceiptSnapshot:
     return ReceiptSnapshot(receipt=snapshot, digest=digest)
 
 
+def snapshot_stored_receipt(receipt: Mapping[str, Any]) -> ReceiptSnapshot:
+    """Snapshot a receipt and require a stored writer digest."""
+    snapshot = snapshot_receipt(receipt)
+    if not isinstance(snapshot.receipt.get("digests"), Mapping) or "receipt_sha256" not in snapshot.receipt["digests"]:
+        raise ReceiptDigestError("receipt has no stored digest")
+    return snapshot
+
+
 def load_selected_receipt(target: Path, run_id: str) -> SelectedReceipt:
     """Strictly load one verify receipt without placing filesystem data in it."""
     root = target / ".brigade" / "work" / "verify-runs"

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -18,6 +18,7 @@ from brigade import (
     approval,
     approval_v2,
     attestation,
+    attestation_input,
     cli,
     localio,
     run_audit,
@@ -40,6 +41,41 @@ PATCH = hashlib.sha256(PATCH_BYTES).hexdigest()
 def _write_json(path: Path, payload: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_bad_verify_receipt(
+    target: Path,
+    *,
+    verify_id: str = VERIFY_ID,
+    producer_run_id: str = RUN_ID,
+    tree_fingerprint: str = TREE,
+    bad_digest: str | None = "0" * 64,
+    pop_digests: bool = False,
+) -> None:
+    """Write a verify receipt whose stored digest is intentionally wrong or absent."""
+    receipt_dir = target / ".brigade" / "work" / "verify-runs" / verify_id
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    receipt: dict[str, Any] = {
+        "schema_version": 2,
+        "run_id": verify_id,
+        "producer_run_id": producer_run_id,
+        "target": str(target),
+        "status": "completed",
+        "started_at": "2026-09-03T12:00:00Z",
+        "completed_at": "2026-09-03T12:00:05Z",
+        "baseline_commit": BASELINE,
+        "tree_fingerprint": tree_fingerprint,
+        "changes_patch_sha256": PATCH,
+        "commands": [],
+    }
+    if pop_digests:
+        receipt.pop("digests", None)
+    else:
+        receipt["digests"] = {
+            "algorithm": "sha256",
+            "receipt_sha256": bad_digest or "0" * 64,
+        }
+    _write_json(receipt_dir / "receipt.json", receipt)
 
 
 def _write_verify_receipt(
@@ -412,6 +448,36 @@ def test_v1_approval_verification_stays_receipt_bound(tmp_path: Path) -> None:
 
     assert verified.status == "APPROVED"
     assert verified.binding == "receipt"
+
+
+def test_v1_collect_receipts_raises_digest_mismatch_before_tree_filter(tmp_path: Path) -> None:
+    target = tmp_path / "workspace"
+    target.mkdir()
+    _write_bad_verify_receipt(target, tree_fingerprint="9" * 40, bad_digest="0" * 64)
+
+    with pytest.raises(approval.ApprovalError, match="matching verify receipt digest does not match receipt content"):
+        approval.collect_verify_receipts(target, RUN_ID, tree_fingerprint=TREE)
+
+
+@pytest.mark.parametrize(
+    ("bad_digest", "pop_digests", "message"),
+    [
+        ("0" * 64, False, "digest does not match receipt content"),
+        (None, True, "has no valid receipt_sha256"),
+    ],
+)
+def test_v1_collect_receipts_raises_for_invalid_digest_when_tree_matches(
+    tmp_path: Path,
+    bad_digest: str | None,
+    pop_digests: bool,
+    message: str,
+) -> None:
+    target = tmp_path / "workspace"
+    target.mkdir()
+    _write_bad_verify_receipt(target, tree_fingerprint=TREE, bad_digest=bad_digest, pop_digests=pop_digests)
+
+    with pytest.raises(approval.ApprovalError, match=message):
+        approval.collect_verify_receipts(target, RUN_ID, tree_fingerprint=TREE)
 
 
 def test_v1_backdated_approval_after_ship_is_late_by_common_sequence_rule(tmp_path: Path) -> None:
@@ -1035,6 +1101,35 @@ def test_v2_exact_test_result_set_makes_missing_or_extra_receipt_stale(
 
     assert cli.main(["receipts", "verify", "--target", str(target)]) == 0
     assert "APPROVAL-STALE (allow)" in capsys.readouterr().out
+
+
+def test_v2_collect_test_result_evidence_raises_digest_mismatch_before_tree_filter(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "workspace"
+    target.mkdir()
+    _write_bad_verify_receipt(target, tree_fingerprint="9" * 40, bad_digest="0" * 64)
+
+    with pytest.raises(approval_v2.ApprovalV2Error, match="matching verify receipt identity or digest is invalid"):
+        approval_v2.collect_test_result_evidence(target, RUN_ID, final_tree=TREE)
+
+
+def test_v2_collect_test_result_evidence_reads_receipt_json_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target, _key, _signers = _workspace(tmp_path)
+    reads = 0
+    original_read = attestation_input.read_json_object
+
+    def _counting_read(path: Path) -> Any:
+        nonlocal reads
+        if path.name == "receipt.json":
+            reads += 1
+        return original_read(path)
+
+    monkeypatch.setattr(attestation_input, "read_json_object", _counting_read)
+    approval_v2.collect_test_result_evidence(target, RUN_ID, final_tree=TREE)
+    assert reads == 1
 
 
 def test_deny_stays_non_exit_changing_when_the_tree_is_stale(tmp_path: Path, capsys: pytest.CaptureFixture[str]):

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -456,6 +456,34 @@ def test_subject_mismatch_detected_when_target_receipt_differs(tmp_path: Path) -
     assert res_mismatch.status == attestation.STATUS_SUBJECT_MISMATCH
 
 
+def test_verify_attestation_with_receipt_parameter_skips_receipt_json_read(tmp_path: Path) -> None:
+    key_path, signers_path = attestation.keygen(tmp_path, principal="alice-signer")
+    receipt = _sample_receipt(tmp_path)
+    _write_receipt_to_disk(receipt)
+
+    envelope = attestation.export_attestation(receipt, key_path=key_path)
+    receipt_path = Path(receipt["path"]) / "receipt.json"
+    receipt_path.unlink()
+
+    result = attestation.verify_attestation(
+        envelope,
+        allowed_signers_path=signers_path,
+        target=tmp_path,
+        receipt=receipt,
+    )
+    assert result.status == attestation.STATUS_SIGNED_OK
+    assert result.rederived is True
+
+    result_missing = attestation.verify_attestation(
+        envelope,
+        allowed_signers_path=signers_path,
+        target=tmp_path,
+        require_receipt=True,
+    )
+    assert result_missing.status == attestation.STATUS_EVIDENCE_MISSING
+    assert result_missing.rederived is False
+
+
 def _write_receipt_to_disk(receipt: dict[str, Any]) -> None:
     run_dir = Path(receipt["path"])
     run_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_attestation_receipt.py
+++ b/tests/test_attestation_receipt.py
@@ -59,6 +59,20 @@ def test_snapshot_computes_digest_when_receipt_has_no_stored_digest() -> None:
     assert snapshot.digest == localio.canonical_json_digest(receipt, exclude_keys={"digests"})
 
 
+def test_snapshot_stored_receipt_requires_receipt_sha256() -> None:
+    receipt = _stamp(_receipt())
+    assert attestation_receipt.snapshot_stored_receipt(receipt).digest == receipt["digests"]["receipt_sha256"]
+
+    no_digests = _receipt()
+    no_digests.pop("digests")
+    with pytest.raises(attestation_receipt.ReceiptDigestError, match="receipt has no stored digest"):
+        attestation_receipt.snapshot_stored_receipt(no_digests)
+
+    missing_sha = _receipt()
+    with pytest.raises(attestation_receipt.ReceiptDigestError, match="receipt has no stored digest"):
+        attestation_receipt.snapshot_stored_receipt(missing_sha)
+
+
 def test_selected_receipt_keeps_directory_metadata_outside_receipt_content(tmp_path: Path) -> None:
     receipt = _receipt()
     receipt.pop("path")


### PR DESCRIPTION
## Summary

- Approval v1 and v2 collectors snapshot each receipt attributed to the run and validate its stored writer digest before any tree filtering, so a stale or malformed digest on a sibling receipt refuses approval evidence instead of being skipped.
- Every later field is read from that snapshot, and it is passed to `verify_attestation(receipt=...)` so Test Result re-derivation uses the same bytes instead of a second `receipt.json` read.
- New `attestation_receipt.snapshot_stored_receipt` requires a stored digest; Test Result export is unchanged.

## Verification

```text
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_approval.py","tests/test_attestation.py","tests/test_attestation_receipt.py","tests/test_agent_request.py","tests/test_attestation_input_integration.py","tests/test_cosign_attestation.py"]' --capture brigade-work
```

Result: 196 passed, 1 skipped (cosign absent locally). Brigade receipt `20260906-014058-work-verify-305ef9`. Strict tracked content guard receipt `20260906-014305-work-verify-2b71e3`.

Built by the `cursor_worker` seat (kimi-k2.7) under Brigade run `daaec3e2.20260906-013246-defc34db` from the spec in the conductor worktree.

Part of #1404