### PR TITLE
feat(grokbot): per-role webhook targets for the enqueue wake

### DIFF
--- a/docs/grokbot-operating-guide.md
+++ b/docs/grokbot-operating-guide.md
@@ -177,7 +177,15 @@ bounded wake body so a webhook-triggered Grok Bot routine can claim the new
 job immediately.
 
 Store the webhook URL and a sender-key *file path* (never the key itself) in
-an owner-only file at `.brigade/cloud/grokbot/wake.json`:
+an owner-only file at `.brigade/cloud/grokbot/wake.json`. Top-level
+`webhook_url` and `sender_key_file` stay required and are the default. An
+optional `webhooks` object may override the target per role
+(`implementation-worker`, `repository-scout`). Each value is either a URL
+string or an object with `webhook_url` and optional `sender_key_file`.
+`notify_enqueue` uses the role entry first and falls back to the default.
+An invalid or partial map is ignored and the default is still used. The
+accepted top-level keys are only `schema`, `webhook_url`, `sender_key_file`,
+and `webhooks`.
 
 ```json
 {
@@ -187,20 +195,37 @@ an owner-only file at `.brigade/cloud/grokbot/wake.json`:
 }
 ```
 
+```json
+{
+  "schema": "brigade.grokbot.wake.v1",
+  "webhook_url": "https://api2.cursor.sh/automations/webhook/",
+  "sender_key_file": "/etc/brigade/grokbot-wake.key",
+  "webhooks": {
+    "implementation-worker": "https://api2.cursor.sh/automations/webhook/",
+    "repository-scout": {
+      "webhook_url": "https://api2.cursor.sh/automations/webhook/",
+      "sender_key_file": "/etc/brigade/grokbot-scout-wake.key"
+    }
+  }
+}
+```
+
 ```bash
 chmod 600 /etc/brigade/grokbot-wake.key
+chmod 600 /etc/brigade/grokbot-scout-wake.key
 chmod 600 /path/to/target/.brigade/cloud/grokbot/wake.json
 ```
 
 The sender key is read from that 0600 file at POST time and sent as both
-`Authorization: Bearer <key>` and `X-Automation-Key: <key>`. It never enters
-queue state, receipts, the notify log, stdout, or stderr. The POST body is
-exactly `{job_id, role, label, repository}`: no instructions, no verification
-commands, and no paths. Treat those four fields as untrusted context, then
-run the claim skill for that role. The request uses the standard library,
-waits at most eight seconds, and is not retried. HTTP 200 means the routine
-woke. Any other status, a timeout, or a missing/invalid config leaves the
-enqueue result unchanged. The local notify log
+`Authorization: Bearer <key>` and `X-Automation-Key: <key>`. Every key file,
+including a per-role `sender_key_file`, must be owner-only 0600. The key
+never enters queue state, receipts, the notify log, stdout, or stderr. The
+POST body is exactly `{job_id, role, label, repository}`: no instructions,
+no verification commands, and no paths. Treat those four fields as untrusted
+context, then run the claim skill for that role. The request uses the
+standard library, waits at most eight seconds, and is not retried. HTTP 200
+means the routine woke. Any other status, a timeout, or a missing/invalid
+config leaves the enqueue result unchanged. The local notify log
 `.brigade/cloud/grokbot/wake-notify.jsonl` records the HTTP status code only
 (`0` when no status arrived).
 

--- a/src/brigade/grokbot_feed.py
+++ b/src/brigade/grokbot_feed.py
@@ -30,6 +30,10 @@ WAKE_SCHEMA = "brigade.grokbot.wake.v1"
 WAKE_CONFIG_NAME = "wake.json"
 WAKE_LOG_NAME = "wake-notify.jsonl"
 WAKE_REQUIRED_KEYS = frozenset({"schema", "webhook_url", "sender_key_file"})
+WAKE_OPTIONAL_KEYS = frozenset({"webhooks"})
+WAKE_ACCEPTED_KEYS = WAKE_REQUIRED_KEYS | WAKE_OPTIONAL_KEYS
+WAKE_WEBHOOK_ROLES = frozenset({"implementation-worker", "repository-scout"})
+WAKE_ROLE_ENTRY_KEYS = frozenset({"webhook_url", "sender_key_file"})
 WAKE_BODY_KEYS = ("job_id", "role", "label", "repository")
 WAKE_TIMEOUT_SECONDS = 8
 WAKE_URL_MAXIMUM = 2048
@@ -351,8 +355,9 @@ def notify_enqueue(target: Path, job: dict[str, Any]) -> None:
         config = _load_wake_config(target)
         if config is None:
             return
-        key = _read_wake_sender_key(Path(config["sender_key_file"]))
-        status = _post_wake(config["webhook_url"], key, _wake_body(job))
+        url, key_file = _wake_target_for_role(config, job.get("role"))
+        key = _read_wake_sender_key(Path(key_file))
+        status = _post_wake(url, key, _wake_body(job))
         _append_wake_status(target, status)
     except (KeyboardInterrupt, SystemExit):
         raise
@@ -367,7 +372,59 @@ def _wake_body(job: dict[str, Any]) -> dict[str, str]:
     return body
 
 
-def _load_wake_config(target: Path) -> dict[str, str] | None:
+def _wake_target_for_role(config: dict[str, Any], role: object) -> tuple[str, str]:
+    url = str(config["webhook_url"])
+    key_file = str(config["sender_key_file"])
+    webhooks = config.get("webhooks")
+    if not isinstance(role, str) or not isinstance(webhooks, dict):
+        return url, key_file
+    entry = webhooks.get(role)
+    if not isinstance(entry, dict):
+        return url, key_file
+    return str(entry["webhook_url"]), str(entry["sender_key_file"])
+
+
+def _expand_wake_key_file(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    expanded = Path(value).expanduser()
+    if not expanded.is_absolute():
+        return None
+    return str(expanded)
+
+
+def _parse_wake_webhooks(value: object, default_key_file: str) -> dict[str, dict[str, str]] | None:
+    """Normalize optional per-role targets. None means ignore the map."""
+    if not isinstance(value, dict):
+        return None
+    parsed: dict[str, dict[str, str]] = {}
+    for role, entry in value.items():
+        if role not in WAKE_WEBHOOK_ROLES:
+            return None
+        if isinstance(entry, str):
+            if not _valid_wake_url(entry):
+                return None
+            parsed[role] = {"webhook_url": entry, "sender_key_file": default_key_file}
+            continue
+        if not isinstance(entry, dict):
+            return None
+        keys = set(entry)
+        if "webhook_url" not in keys or not keys.issubset(WAKE_ROLE_ENTRY_KEYS):
+            return None
+        url = entry.get("webhook_url")
+        if not isinstance(url, str) or not _valid_wake_url(url):
+            return None
+        if "sender_key_file" in entry:
+            key_file = _expand_wake_key_file(entry.get("sender_key_file"))
+            if key_file is None:
+                return None
+        else:
+            key_file = default_key_file
+        parsed[role] = {"webhook_url": url, "sender_key_file": key_file}
+    return parsed
+
+
+def _load_wake_config(target: Path) -> dict[str, Any] | None:
     path = wake_config_path(target)
     try:
         info = path.lstat()
@@ -386,20 +443,23 @@ def _load_wake_config(target: Path) -> dict[str, str] | None:
         payload = json.loads(_read_owner_regular_file(path, maximum=4096))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, FeedError):
         return None
-    if not isinstance(payload, dict) or set(payload) != WAKE_REQUIRED_KEYS:
+    if not isinstance(payload, dict):
+        return None
+    keys = set(payload)
+    if not WAKE_REQUIRED_KEYS.issubset(keys) or not keys.issubset(WAKE_ACCEPTED_KEYS):
         return None
     if payload.get("schema") != WAKE_SCHEMA:
         return None
     url = payload.get("webhook_url")
-    key_file = payload.get("sender_key_file")
-    if not isinstance(url, str) or not _valid_wake_url(url):
+    key_file = _expand_wake_key_file(payload.get("sender_key_file"))
+    if not isinstance(url, str) or not _valid_wake_url(url) or key_file is None:
         return None
-    if not isinstance(key_file, str) or not key_file:
-        return None
-    expanded = Path(key_file).expanduser()
-    if not expanded.is_absolute():
-        return None
-    return {"schema": WAKE_SCHEMA, "webhook_url": url, "sender_key_file": str(expanded)}
+    config: dict[str, Any] = {"schema": WAKE_SCHEMA, "webhook_url": url, "sender_key_file": key_file}
+    if "webhooks" in payload:
+        webhooks = _parse_wake_webhooks(payload.get("webhooks"), key_file)
+        if webhooks:
+            config["webhooks"] = webhooks
+    return config
 
 
 def _valid_wake_url(value: object) -> bool:

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -28,6 +28,7 @@ SECRET_INSTRUCTIONS = "SECRET_INSTRUCTION_DO_NOT_PRINT"
 SECRET_VERIFY = "SECRET_VERIFY_CMD"
 SECRET_OWNERSHIP = "SECRET_OWNERSHIP_PATH/file.py"
 SECRET_WAKE_KEY = "SECRET_WAKE_SENDER_KEY_DO_NOT_PRINT"
+SECRET_WAKE_ROLE_KEY = "SECRET_WAKE_ROLE_KEY_DO_NOT_PRINT"
 
 
 def _spec(*, label: str = "Approved worker task") -> dict[str, object]:
@@ -709,20 +710,24 @@ def _write_wake_key(path: Path, value: str = SECRET_WAKE_KEY) -> Path:
     return path
 
 
-def _write_wake_config(target: Path, url: str, key_file: Path) -> Path:
+def _write_wake_config(
+    target: Path,
+    url: str,
+    key_file: Path,
+    *,
+    webhooks: dict[str, object] | None = None,
+) -> Path:
     root = _queue_root(target)
     root.mkdir(parents=True, exist_ok=True)
     path = grokbot_feed.wake_config_path(target)
-    path.write_text(
-        json.dumps(
-            {
-                "schema": grokbot_feed.WAKE_SCHEMA,
-                "webhook_url": url,
-                "sender_key_file": str(key_file),
-            }
-        ),
-        encoding="utf-8",
-    )
+    payload: dict[str, object] = {
+        "schema": grokbot_feed.WAKE_SCHEMA,
+        "webhook_url": url,
+        "sender_key_file": str(key_file),
+    }
+    if webhooks is not None:
+        payload["webhooks"] = webhooks
+    path.write_text(json.dumps(payload), encoding="utf-8")
     path.chmod(0o600)
     return path
 
@@ -734,12 +739,22 @@ def _notify_log_text(target: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _assert_wake_secret_absent(*payloads: object) -> None:
+def _assert_wake_secret_absent(*payloads: object, secrets: tuple[str, ...] = (SECRET_WAKE_KEY,)) -> None:
     for payload in payloads:
         text = payload if isinstance(payload, str) else json.dumps(payload)
-        assert SECRET_WAKE_KEY not in text
+        for secret in secrets:
+            assert secret not in text
         assert "X-Automation-Key" not in text
         assert "Authorization" not in text
+
+
+def _wake_job(*, role: str, label: str = "Wake job") -> dict[str, str]:
+    return {
+        "job_id": "grokbot-" + "a" * 24,
+        "role": role,
+        "label": label,
+        "repository": "example/brigade",
+    }
 
 
 def test_apply_wake_notify_posts_bounded_body_on_success(tmp_path: Path):
@@ -853,6 +868,158 @@ def test_cli_feed_apply_omits_wake_key_from_output(tmp_path: Path, capsys):
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_wake_role_entry_wins_over_default(tmp_path: Path, capsys):
+    default = _WakeRecorder()
+    role = _WakeRecorder()
+    default_server = _start_wake_server(default)
+    role_server = _start_wake_server(role)
+    try:
+        default_url = f"http://127.0.0.1:{default_server.server_address[1]}/wake"
+        role_url = f"http://127.0.0.1:{role_server.server_address[1]}/scout"
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(
+            tmp_path,
+            default_url,
+            key_file,
+            webhooks={"repository-scout": role_url},
+        )
+        job = _wake_job(role="repository-scout", label="Scout")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        assert default.requests == []
+        assert len(role.requests) == 1
+        request = role.requests[0]
+        assert request["path"] == "/scout"
+        assert request["authorization"] == f"Bearer {SECRET_WAKE_KEY}"
+        assert json.loads(request["body"]) == job
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 200}
+        _assert_wake_secret_absent(captured.out, captured.err, log)
+    finally:
+        default_server.shutdown()
+        default_server.server_close()
+        role_server.shutdown()
+        role_server.server_close()
+
+
+def test_wake_default_used_when_role_is_missing(tmp_path: Path, capsys):
+    default = _WakeRecorder()
+    scout = _WakeRecorder()
+    default_server = _start_wake_server(default)
+    scout_server = _start_wake_server(scout)
+    try:
+        default_url = f"http://127.0.0.1:{default_server.server_address[1]}/wake"
+        scout_url = f"http://127.0.0.1:{scout_server.server_address[1]}/scout"
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(
+            tmp_path,
+            default_url,
+            key_file,
+            webhooks={"repository-scout": scout_url},
+        )
+        job = _wake_job(role="implementation-worker")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        assert scout.requests == []
+        assert len(default.requests) == 1
+        assert json.loads(default.requests[0]["body"]) == job
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 200}
+        _assert_wake_secret_absent(captured.out, captured.err, log)
+    finally:
+        default_server.shutdown()
+        default_server.server_close()
+        scout_server.shutdown()
+        scout_server.server_close()
+
+
+def test_wake_invalid_map_ignored_default_still_used(tmp_path: Path, capsys):
+    default = _WakeRecorder()
+    other = _WakeRecorder()
+    default_server = _start_wake_server(default)
+    other_server = _start_wake_server(other)
+    try:
+        default_url = f"http://127.0.0.1:{default_server.server_address[1]}/wake"
+        other_url = f"http://127.0.0.1:{other_server.server_address[1]}/other"
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(
+            tmp_path,
+            default_url,
+            key_file,
+            webhooks={
+                "implementation-worker": {"sender_key_file": str(key_file)},
+                "not-a-role": other_url,
+            },
+        )
+        job = _wake_job(role="implementation-worker")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        assert other.requests == []
+        assert len(default.requests) == 1
+        assert json.loads(default.requests[0]["body"]) == job
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 200}
+        _assert_wake_secret_absent(captured.out, captured.err, log)
+    finally:
+        default_server.shutdown()
+        default_server.server_close()
+        other_server.shutdown()
+        other_server.server_close()
+
+
+def test_wake_per_role_sender_key_file_honored(tmp_path: Path, capsys):
+    default = _WakeRecorder()
+    role = _WakeRecorder()
+    default_server = _start_wake_server(default)
+    role_server = _start_wake_server(role)
+    try:
+        default_url = f"http://127.0.0.1:{default_server.server_address[1]}/wake"
+        role_url = f"http://127.0.0.1:{role_server.server_address[1]}/scout"
+        default_key = _write_wake_key(tmp_path / "wake.key")
+        role_key = _write_wake_key(tmp_path / "scout.key", SECRET_WAKE_ROLE_KEY)
+        _write_wake_config(
+            tmp_path,
+            default_url,
+            default_key,
+            webhooks={
+                "repository-scout": {
+                    "webhook_url": role_url,
+                    "sender_key_file": str(role_key),
+                }
+            },
+        )
+        job = _wake_job(role="repository-scout", label="Scout")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        assert default.requests == []
+        assert len(role.requests) == 1
+        request = role.requests[0]
+        assert request["authorization"] == f"Bearer {SECRET_WAKE_ROLE_KEY}"
+        assert request["automation_key"] == SECRET_WAKE_ROLE_KEY
+        assert json.loads(request["body"]) == job
+        log = _notify_log_text(tmp_path)
+        assert json.loads(log.strip()) == {"status": 200}
+        _assert_wake_secret_absent(
+            captured.out,
+            captured.err,
+            log,
+            secrets=(SECRET_WAKE_KEY, SECRET_WAKE_ROLE_KEY),
+        )
+    finally:
+        default_server.shutdown()
+        default_server.server_close()
+        role_server.shutdown()
+        role_server.server_close()
 
 
 READY_PR_CONTRACT = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1449

wake.json may declare optional per-role webhook targets under webhooks; notify_enqueue prefers the role entry and falls back to the default webhook_url/sender_key_file; tests and docs cover the map form; secrets never appear in logs.

## Verification

| Command | Exit code |
| --- | --- |
| `python -m pytest -q tests/test_grokbot_feed.py tests/test_grokbot_build_feed.py` | 0 |
| `ruff check src/brigade/grokbot_feed.py tests/test_grokbot_feed.py` | 0 |
| `ruff format --check src/brigade/grokbot_feed.py tests/test_grokbot_feed.py` | 0 |
| `mypy` | 0 |
| `git diff --check` | 0 |
| `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_grokbot_feed.py"]' --capture brigade-work` | 0 |

Pytest transcript (last ten lines):

```
........................................................................ [ 52%]
..................................................................       [100%]
138 passed in 13.89s
```

Example `wake.json` map form (placeholder values):

```json
{
  "schema": "brigade.grokbot.wake.v1",
  "webhook_url": "https://example.invalid/automations/webhook/default",
  "sender_key_file": "/etc/brigade/grokbot-wake.key",
  "webhooks": {
    "implementation-worker": "https://example.invalid/automations/webhook/builder",
    "repository-scout": {
      "webhook_url": "https://example.invalid/automations/webhook/scout",
      "sender_key_file": "/etc/brigade/grokbot-scout-wake.key"
    }
  }
}
```

Brigade verify receipt id: `20260906-102213-work-verify-f349ee`

Job id: `grokbot-9353d03eeb0738460499c090`

## Notes

`brigade code sync .`, `brigade code affected`, and `brigade code impact` were attempted before edits and failed with `error: graphtrail is not installed; run \`brigade setup\``. Implementation stayed inside the three ownership paths.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68185ae8-a58d-4237-bc66-0c5cb4958150?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68185ae8-a58d-4237-bc66-0c5cb4958150&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

