### PR TITLE
test(fleet): anchor the review_after hold fixture to the wall clock

### DIFF
--- a/tests/test_fleet_routing.py
+++ b/tests/test_fleet_routing.py
@@ -868,7 +868,9 @@ def test_evaluate_work_item_uses_canonical_exclusion_and_does_not_default_missin
         **not_burn,
         "work_id": "wl-3",
         "burn_eligible": True,
-        "review_after": _iso(_now() + timedelta(days=1)),
+        # exclusion_bucket compares review_after against the real clock, so the
+        # hold must be anchored to wall time rather than the frozen test clock.
+        "review_after": _iso(datetime.now(timezone.utc) + timedelta(days=1)),
         "attempt_count": 0,
     }
     delayed = fleet_hub_routing.evaluate_work_item(future)


### PR DESCRIPTION
## Summary

`test_evaluate_work_item_uses_canonical_exclusion_and_does_not_default_missing_attempts` builds its `review_after` hold from the module's frozen clock (2026-09-05 12:00 UTC plus one day), but `worklore_store.exclusion_bucket` compares that stamp against real time. The fixture expired at 2026-09-06 12:00 UTC and the test has failed on every CI shard since, including on unrelated PRs (#1465). This anchors that one stamp to `datetime.now(timezone.utc)`; the two other frozen-clock future stamps in the file are `observed_at` values consumed under the frozen clock and are unaffected.

## Verification

```text
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_fleet_routing.py"]' --capture brigade-work
```

37 passed, receipt `20260906-122200-work-verify-881b20`.

Closes #1469