### PR TITLE
fix(fleet): launch the reviewed native model binding instead of the hub canonical slug

### DIFF
--- a/src/brigade/aboyeur_model_policy.py
+++ b/src/brigade/aboyeur_model_policy.py
@@ -125,7 +125,13 @@ def _local_cli_matches_hub_binding(aboyeur: Any, agent: Agent, binding: Mapping[
     return aboyeur.agents.command_for(local) == instance_id
 
 
-def _set_remediation_detail(row: Mapping[str, Any], revision: object, *, fallback_seat: str | None = None) -> str:
+def _set_remediation_detail(
+    row: Mapping[str, Any],
+    revision: object,
+    *,
+    fallback_seat: str | None = None,
+    brigade_model: str | None = None,
+) -> str:
     """Return a remediation block for a versioned roster seat row."""
     provider = row.get("provider")
     model = row.get("model")
@@ -142,6 +148,7 @@ def _set_remediation_detail(row: Mapping[str, Any], revision: object, *, fallbac
         t3_instance_id=fleet_model_admission._t3_instance_id_from_row(row),
         t3_service_tier=fleet_model_admission._t3_service_tier_from_row(row),
         revision=revision,
+        brigade_model=brigade_model,
     )
 
 
@@ -433,14 +440,17 @@ def _resolve_versioned(
             policy_provider = row.get("provider")
             policy_model = row.get("model")
             policy_reasoning = row.get("reasoning")
-            launch_model = fleet_model_roster.brigade_launch_model(row) or policy_model
+            launch_groups = fleet_model_roster.consumer_launch_groups(raw_snapshot, "brigade-run", seat)
+            launch_model = (
+                fleet_model_roster.effective_brigade_launch_model(row, launch_groups=launch_groups) or policy_model
+            )
             decision["policy_provider"] = policy_provider
             decision["policy_model"] = policy_model
             decision["launch_model"] = launch_model
             decision["policy_enabled"] = row.get("enabled") is True
-            binding = fleet_model_admission._binding_for("brigade-run", row)
+            binding = fleet_model_admission._binding_for("brigade-run", row, launch_groups=launch_groups)
             policy_floor = None
-            for identity in fleet_model_roster.binding_launch_models(row):
+            for identity in fleet_model_roster.binding_launch_models(row, launch_groups=launch_groups):
                 policy_floor = fleet_model_roster.retired_reason(
                     str(policy_provider or ""), identity, retired_rows or None
                 )
@@ -456,7 +466,9 @@ def _resolve_versioned(
             elif cleaned_override is not None and seat == worker and cleaned_override not in allowed_models:
                 outcome = "mismatch"
                 detail = f"--model {cleaned_override!r} does not match Hub model {policy_model!r}"
-                detail += _set_remediation_detail(row, revision, fallback_seat=seat)
+                # Re-running `set` with the canonical slug would only re-pin the
+                # slug the adapter already rejects. Name the native binding fix.
+                detail += _set_remediation_detail(row, revision, fallback_seat=seat, brigade_model=cleaned_override)
             elif not isinstance(policy_reasoning, str) or not policy_reasoning:
                 outcome = "binding-missing"
                 detail = "registry entry is missing exact reasoning"

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -209,6 +209,19 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_models_set.add_argument("--notes", default=None, help="Optional operator note (stored as safe policy metadata).")
     p_models_set.add_argument("--reasoning", default=None, help="Exact reasoning value for the seat.")
     p_models_set.add_argument("--brigade-cli", default=None, dest="brigade_cli", help="Exact Brigade CLI binding.")
+    launch_model = p_models_set.add_mutually_exclusive_group()
+    launch_model.add_argument(
+        "--brigade-model",
+        default=None,
+        dest="brigade_model",
+        help="Exact native model id the Brigade adapter launches (e.g. opencode/muse-spark-1.3-contributor-free).",
+    )
+    launch_model.add_argument(
+        "--clear-brigade-model",
+        action="store_true",
+        dest="clear_brigade_model",
+        help="Drop the native launch binding so the canonical model is launched.",
+    )
     p_models_set.add_argument(
         "--t3-instance-id", default=None, dest="t3_instance_id", help="Exact T3 instance binding."
     )
@@ -1416,7 +1429,8 @@ def _dispatch_models_list(args: argparse.Namespace) -> int:
             continue
         if selected_seat is not None and seat_name != selected_seat:
             continue
-        binding = fleet_model_admission._binding_for(consumer, seat)
+        launch_groups = fleet_model_roster.consumer_launch_groups(roster, consumer, seat_name)
+        binding = fleet_model_admission._binding_for(consumer, seat, launch_groups=launch_groups)
         binding_value = binding.get("instance_id") if isinstance(binding, dict) else None
         filtered.append(
             {
@@ -1477,6 +1491,10 @@ def _dispatch_models_set(args: argparse.Namespace) -> int:
             kwargs["reasoning"] = args.reasoning
         if args.brigade_cli is not None:
             kwargs["brigade_cli"] = args.brigade_cli
+        if args.clear_brigade_model:
+            kwargs["brigade_model"] = ""
+        elif args.brigade_model is not None:
+            kwargs["brigade_model"] = args.brigade_model
         if args.t3_instance_id is not None:
             kwargs["t3_instance_id"] = args.t3_instance_id
         if args.t3_service_tier is not None:
@@ -1489,10 +1507,14 @@ def _dispatch_models_set(args: argparse.Namespace) -> int:
     if args.json:
         print(_json.dumps(policy, indent=2, sort_keys=True))
         return 0
-    print(
+    line = (
         f"model policy {policy.get('provider')}/{policy.get('model')} ({policy.get('seat')}): "
         f"{'enabled' if policy.get('enabled') else 'disabled'}"
     )
+    launch = policy.get("brigade_model")
+    if isinstance(launch, str) and launch:
+        line += f"; brigade launch model {launch}"
+    print(line)
     return 0
 
 

--- a/src/brigade/fleet_client_cloud.py
+++ b/src/brigade/fleet_client_cloud.py
@@ -100,6 +100,7 @@ _MODEL_POLICY_FIELDS = frozenset(
         "notes",
         "reasoning",
         "brigade_cli",
+        "brigade_model",
         "t3_instance_id",
         "t3_service_tier",
     }
@@ -219,9 +220,10 @@ def _preserved_field(
         return current
     bindings = existing.get("bindings")
     if isinstance(bindings, dict):
-        if key == "brigade_cli":
+        if key in {"brigade_cli", "brigade_model"}:
             brigade = bindings.get("brigade")
-            bound = brigade.get("cli") if isinstance(brigade, dict) else None
+            nested = "cli" if key == "brigade_cli" else "model"
+            bound = brigade.get(nested) if isinstance(brigade, dict) else None
         elif key in {"t3_instance_id", "t3_service_tier"}:
             t3_fleet = bindings.get("t3_fleet")
             nested_key = "instance_id" if key == "t3_instance_id" else "service_tier"
@@ -448,6 +450,7 @@ def set_model_policy(
     notes: str | None = None,
     reasoning: str | None = None,
     brigade_cli: str | None = None,
+    brigade_model: str | None = None,
     t3_instance_id: str | None = None,
     t3_service_tier: str | None = None,
     expected_revision: int,
@@ -473,6 +476,7 @@ def set_model_policy(
         existing = _existing_seat(snapshot, seat)
         resolved_reasoning = _preserved_field(reasoning, existing, "reasoning", default="none")
         resolved_cli = _preserved_field(brigade_cli, existing, "brigade_cli")
+        resolved_launch_model = _preserved_field(brigade_model, existing, "brigade_model")
         resolved_t3 = _preserved_field(t3_instance_id, existing, "t3_instance_id")
         resolved_tier = _preserved_field(t3_service_tier, existing, "t3_service_tier")
         body = {
@@ -485,6 +489,7 @@ def set_model_policy(
             "notes": notes,
             "reasoning": resolved_reasoning,
             "brigade_cli": resolved_cli,
+            "brigade_model": resolved_launch_model,
             "t3_instance_id": resolved_t3,
             "t3_service_tier": resolved_tier,
             "expected_revision": revision,

--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -329,6 +329,7 @@ CREATE TABLE IF NOT EXISTS model_policy (
     enabled INTEGER NOT NULL,
     limit_count INTEGER,
     brigade_cli TEXT NOT NULL DEFAULT '',
+    brigade_model TEXT NOT NULL DEFAULT '',
     t3_instance_id TEXT NOT NULL DEFAULT '',
     t3_service_tier TEXT NOT NULL DEFAULT '',
     notes TEXT,

--- a/src/brigade/fleet_hub_model_roster.py
+++ b/src/brigade/fleet_hub_model_roster.py
@@ -15,6 +15,7 @@ from .fleet_hub import FleetHubConflict, FleetHubError, FleetHubForbidden
 _ROSTER_COLUMNS = (
     "reasoning TEXT NOT NULL DEFAULT 'none'",
     "brigade_cli TEXT NOT NULL DEFAULT ''",
+    "brigade_model TEXT NOT NULL DEFAULT ''",
     "t3_instance_id TEXT NOT NULL DEFAULT ''",
     "t3_service_tier TEXT NOT NULL DEFAULT ''",
 )
@@ -77,6 +78,7 @@ _SET_FIELDS = frozenset(
         "notes",
         "reasoning",
         "brigade_cli",
+        "brigade_model",
         "t3_instance_id",
         "t3_service_tier",
     }
@@ -174,6 +176,26 @@ def _optional_binding(raw: Any, field: str) -> str:
     if raw is None:
         return ""
     return fleet_hub._model_policy_name(raw, field) if raw != "" else ""
+
+
+def _optional_launch_identity(raw: Any, field: str) -> str:
+    """Bounded native launch id (``provider/model`` is legal), or '' to clear it.
+
+    A launch identity is handed to the adapter verbatim, so it is rejected
+    rather than sanitized: control characters and surrounding whitespace are
+    refused instead of being stripped into a different id than the operator
+    reviewed.
+    """
+    if raw is None or raw == "":
+        return ""
+    if not isinstance(raw, str):
+        raise FleetHubError(f"model policy field {field!r} must be a string")
+    if _CONTROL_RE.search(raw):
+        raise FleetHubError(f"model policy field {field!r} is not a valid launch identity")
+    value = fleet_hub._model_identity_name(raw, field)
+    if value != raw:
+        raise FleetHubError(f"model policy field {field!r} is not a valid launch identity")
+    return value
 
 
 def _expected_revision(raw: Any) -> int:
@@ -279,7 +301,7 @@ def _consumer_defaults(conn: sqlite3.Connection) -> dict[str, str | None]:
 def raw_seats(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     rows = conn.execute(
         "SELECT seat, provider, model, reasoning, enabled, limit_count, "
-        "brigade_cli, t3_instance_id, t3_service_tier FROM model_policy ORDER BY seat"
+        "brigade_cli, t3_instance_id, t3_service_tier, brigade_model FROM model_policy ORDER BY seat"
     ).fetchall()
     return [
         {
@@ -290,12 +312,20 @@ def raw_seats(conn: sqlite3.Connection) -> list[dict[str, Any]]:
             "reasoning": row[3],
             "limit": row[5],
             "bindings": {
-                "brigade": {"cli": row[6] or ""},
+                "brigade": _brigade_binding(row[6], row[9]),
                 "t3_fleet": {"instance_id": row[7] or "", "service_tier": row[8] or None},
             },
         }
         for row in rows
     ]
+
+
+def _brigade_binding(cli: Any, launch_model: Any) -> dict[str, Any]:
+    """Brigade launch group for a roster row. ``model`` appears only when bound."""
+    binding: dict[str, Any] = {"cli": cli or ""}
+    if isinstance(launch_model, str) and launch_model:
+        binding["model"] = launch_model
+    return binding
 
 
 def _seats(conn: sqlite3.Connection) -> list[dict[str, Any]]:
@@ -465,6 +495,7 @@ def _validate_set(raw: Any) -> dict[str, Any]:
         "notes": fleet_hub._safe_cloud_text(raw.get("notes"), "notes"),
         "reasoning": fleet_hub._model_policy_name(reasoning, "reasoning"),
         "brigade_cli": _optional_binding(raw.get("brigade_cli"), "brigade_cli"),
+        "brigade_model": _optional_launch_identity(raw.get("brigade_model"), "brigade_model"),
         "t3_instance_id": _optional_binding(raw.get("t3_instance_id"), "t3_instance_id"),
         "t3_service_tier": _optional_binding(raw.get("t3_service_tier"), "t3_service_tier"),
     }
@@ -483,11 +514,12 @@ def _write_set(conn: sqlite3.Connection, request: dict[str, Any]) -> dict[str, A
         return denied
     conn.execute(
         "INSERT INTO model_policy "
-        "(seat, provider, model, reasoning, enabled, limit_count, brigade_cli, t3_instance_id, "
-        "t3_service_tier, notes, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+        "(seat, provider, model, reasoning, enabled, limit_count, brigade_cli, brigade_model, t3_instance_id, "
+        "t3_service_tier, notes, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
         "ON CONFLICT(seat) DO UPDATE SET provider=excluded.provider, model=excluded.model, "
         "reasoning=excluded.reasoning, enabled=excluded.enabled, limit_count=excluded.limit_count, "
-        "brigade_cli=excluded.brigade_cli, t3_instance_id=excluded.t3_instance_id, "
+        "brigade_cli=excluded.brigade_cli, brigade_model=excluded.brigade_model, "
+        "t3_instance_id=excluded.t3_instance_id, "
         "t3_service_tier=excluded.t3_service_tier, notes=excluded.notes, updated_at=excluded.updated_at",
         (
             request["seat"],
@@ -497,6 +529,7 @@ def _write_set(conn: sqlite3.Connection, request: dict[str, Any]) -> dict[str, A
             int(request["enabled"]),
             request["limit"],
             request["brigade_cli"],
+            request["brigade_model"],
             request["t3_instance_id"],
             request["t3_service_tier"],
             request["notes"],
@@ -514,6 +547,7 @@ def _write_set(conn: sqlite3.Connection, request: dict[str, Any]) -> dict[str, A
             "notes": request["notes"],
             "reasoning": request["reasoning"],
             "brigade_cli": request["brigade_cli"],
+            "brigade_model": request["brigade_model"] or None,
             "t3_instance_id": request["t3_instance_id"],
             "t3_service_tier": request["t3_service_tier"] or None,
         },

--- a/src/brigade/fleet_hub_roster_page.py
+++ b/src/brigade/fleet_hub_roster_page.py
@@ -48,6 +48,7 @@ class SeatRow:
     limit: int | None
     enabled: bool
     brigade_cli: str
+    brigade_model: str
     t3_instance_id: str
     t3_service_tier: str
     notes: str | None
@@ -132,7 +133,7 @@ def load_view(
     seats: list[SeatRow] = []
     for row in conn.execute(
         "SELECT seat, provider, model, reasoning, enabled, limit_count, brigade_cli, t3_instance_id, "
-        "t3_service_tier, notes FROM model_policy ORDER BY seat"
+        "t3_service_tier, notes, brigade_model FROM model_policy ORDER BY seat"
     ).fetchall():
         seats.append(
             SeatRow(
@@ -143,6 +144,7 @@ def load_view(
                 limit=None if row[5] is None else int(row[5]),
                 enabled=bool(row[4]),
                 brigade_cli=str(row[6] or ""),
+                brigade_model=str(row[10] or ""),
                 t3_instance_id=str(row[7] or ""),
                 t3_service_tier=str(row[8] or ""),
                 notes=row[9],
@@ -668,6 +670,7 @@ def apply(
                     "enabled": target[row.seat],
                     "limit": row.limit,
                     "brigade_cli": row.brigade_cli,
+                    "brigade_model": row.brigade_model,
                     "t3_instance_id": row.t3_instance_id,
                     "t3_service_tier": row.t3_service_tier,
                     "notes": row.notes,

--- a/src/brigade/fleet_model_admission.py
+++ b/src/brigade/fleet_model_admission.py
@@ -751,25 +751,20 @@ def _resolve_from_roster(
             },
         )
     match = next((item for item in seats if isinstance(item, dict) and item.get("seat") == seat_name), None)
+    groups = fleet_model_roster.consumer_launch_groups(roster, consumer, str(seat_name))
     if match is None:
         reason = "seat-missing"
     elif not match.get("enabled"):
         reason = "seat-disabled"
     elif any(
         fleet_model_roster.retired_reason(str(match.get("provider") or ""), identity, retired_rows)
-        for identity in fleet_model_roster.binding_launch_models(match)
+        for identity in fleet_model_roster.binding_launch_models(match, launch_groups=groups)
     ):
         reason = "retired-model"
     elif not isinstance(match.get("reasoning"), str) or not str(match.get("reasoning") or "").strip():
         reason = "binding-missing"
     else:
-        launch_map = roster.get("consumer_launch_bindings")
-        groups = None
-        if isinstance(launch_map, Mapping):
-            consumer_map = launch_map.get(consumer)
-            if isinstance(consumer_map, Mapping):
-                groups = consumer_map.get(seat_name)
-        binding = _binding_for(consumer, match, launch_groups=groups if isinstance(groups, Mapping) else None)
+        binding = _binding_for(consumer, match, launch_groups=groups)
         if binding is None:
             reason = "binding-missing"
         else:
@@ -1681,6 +1676,7 @@ def _set_command_remediation(
     t3_service_tier: str | None,
     revision: object,
     consumer: str = "brigade-run",
+    brigade_model: str | None = None,
 ) -> str:
     """Human-readable 'brigade fleet models set' command for a seat row."""
     rev = revision if isinstance(revision, int) else "N"
@@ -1701,6 +1697,8 @@ def _set_command_remediation(
             cmd_parts.append(f"--brigade-cli {cli}")
         else:
             cmd_parts.append("--brigade-cli CLI")
+        if isinstance(brigade_model, str) and brigade_model:
+            cmd_parts.append(f"--brigade-model {brigade_model}")
     cmd_parts.append(f"--expect-revision {rev}")
     return f"bind it with: {' '.join(cmd_parts)}\nsee current rows: brigade fleet models list --seat {seat}"
 

--- a/src/brigade/fleet_model_roster.py
+++ b/src/brigade/fleet_model_roster.py
@@ -363,22 +363,30 @@ def parse_fleet_policy_authority(raw: Any) -> tuple[dict[str, Any] | None, str |
     return {"active": raw["active"], "version": version, "digest": digest}, None
 
 
-def binding_launch_models(seat: Mapping[str, Any]) -> tuple[str, ...]:
+def binding_launch_models(
+    seat: Mapping[str, Any],
+    *,
+    launch_groups: Mapping[str, Any] | None = None,
+) -> tuple[str, ...]:
     """Canonical seat.model plus trusted native/brigade launch-model leaves."""
     models: list[str] = []
     canonical = seat.get("model")
     if isinstance(canonical, str) and canonical:
         models.append(canonical)
-    bindings = seat.get("bindings") if isinstance(seat.get("bindings"), Mapping) else {}
-    if not isinstance(bindings, Mapping):
-        return tuple(models)
-    for group in ("brigade", "native"):
-        body = bindings.get(group)
-        if not isinstance(body, Mapping):
-            continue
-        launch = body.get("model")
-        if isinstance(launch, str) and launch and launch not in models:
-            models.append(launch)
+    sources: list[Mapping[str, Any]] = []
+    bindings = seat.get("bindings")
+    if isinstance(bindings, Mapping):
+        sources.append(bindings)
+    if isinstance(launch_groups, Mapping):
+        sources.append(launch_groups)
+    for source in sources:
+        for group in ("brigade", "native"):
+            body = source.get(group)
+            if not isinstance(body, Mapping):
+                continue
+            launch = body.get("model")
+            if isinstance(launch, str) and launch and launch not in models:
+                models.append(launch)
     return tuple(models)
 
 
@@ -392,3 +400,33 @@ def brigade_launch_model(seat: Mapping[str, Any]) -> str | None:
         return None
     model = brigade.get("model")
     return model if isinstance(model, str) and model else None
+
+
+def consumer_launch_groups(roster: Mapping[str, Any], consumer: str, seat: str) -> Mapping[str, Any] | None:
+    """One seat's signed ``consumer_launch_bindings`` groups, or None when unprojected."""
+    launch_map = roster.get("consumer_launch_bindings")
+    if not isinstance(launch_map, Mapping):
+        return None
+    consumer_map = launch_map.get(consumer)
+    if not isinstance(consumer_map, Mapping):
+        return None
+    groups = consumer_map.get(seat)
+    return groups if isinstance(groups, Mapping) else None
+
+
+def effective_brigade_launch_model(
+    seat: Mapping[str, Any],
+    *,
+    launch_groups: Mapping[str, Any] | None = None,
+) -> str | None:
+    """Reviewed native launch id for brigade-run: consumer projection first, then the seat row.
+
+    The value is always an explicit binding leaf. Nothing here derives a native
+    id from the canonical slug by delimiter or alias rewriting.
+    """
+    if isinstance(launch_groups, Mapping):
+        brigade = compact_launch_groups(launch_groups).get("brigade") or {}
+        projected = brigade.get("model")
+        if isinstance(projected, str) and projected:
+            return projected
+    return brigade_launch_model(seat)

--- a/src/brigade/fleet_policy_migration.py
+++ b/src/brigade/fleet_policy_migration.py
@@ -205,8 +205,12 @@ def _legacy_bindings(seat: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
     cli = brigade.get("cli") or None
     instance_id = t3_fleet.get("instance_id") or None
     service_tier = t3_fleet.get("service_tier") or None
+    brigade_binding: dict[str, Any] = {"cli": cli}
+    launch_model = brigade.get("model")
+    if isinstance(launch_model, str) and launch_model:
+        brigade_binding["model"] = launch_model
     return {
-        "brigade": {"cli": cli},
+        "brigade": brigade_binding,
         "t3_fleet": {"instance_id": instance_id, "service_tier": service_tier},
     }
 

--- a/tests/test_fleet_native_launch_binding.py
+++ b/tests/test_fleet_native_launch_binding.py
@@ -1,0 +1,539 @@
+"""Native brigade-run launch bindings: exact adapter argv, canonical Hub identity.
+
+A seat can carry a canonical hyphen slug the Hub admits and a reviewed native id
+the CLI actually accepts (`opencode run -m opencode/muse-spark-1.3-contributor-free`).
+Only the launched argument changes; admission, the lease request, and the proof
+identity stay on the canonical slug.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+import pytest
+
+from brigade import (
+    aboyeur,
+    agents,
+    cli,
+    fleet_client,
+    fleet_hub,
+    fleet_hub_model_roster,
+    fleet_hub_policy,
+    fleet_model_admission,
+    fleet_model_roster,
+    fleet_policy,
+    fleet_policy_migration,
+    fleet_session_bootstrap,
+)
+from brigade.roster import Agent, Roster
+
+NODE_A = "11111111-1111-4111-8111-111111111111"
+SEAT = "muse13"
+PROVIDER = "opencode"
+CANONICAL = "opencode-muse-spark-1.3-contributor-free"
+NATIVE = "opencode/muse-spark-1.3-contributor-free"
+REPO = "repo/public"
+DIGEST = "sha256:" + ("ab" * 32)
+
+
+def _seat_row() -> dict[str, object]:
+    return {
+        "seat": SEAT,
+        "provider": PROVIDER,
+        "model": CANONICAL,
+        "reasoning": "high",
+        "enabled": True,
+        "bindings": {
+            "brigade": {"cli": "opencode"},
+            "t3_fleet": {"instance_id": "opencode", "service_tier": None},
+        },
+    }
+
+
+def _snapshot(*, native: str | None = NATIVE) -> dict[str, object]:
+    snapshot: dict[str, object] = {
+        "schema": fleet_model_roster.ROSTER_SCHEMA,
+        "state": "authoritative",
+        "source": "hub",
+        "revision": 2,
+        "roster_revision": 2,
+        "document_sha256": DIGEST,
+        "expires_at": "2099-08-30T14:15:00Z",
+        "seats": [_seat_row()],
+        "consumer_defaults": {"brigade-run": SEAT},
+        "retired_models": [],
+        "fleet_policy": {"active": True, "version": 2, "digest": DIGEST},
+    }
+    if native is not None:
+        snapshot["consumer_launch_bindings"] = {
+            "brigade-run": {
+                SEAT: {
+                    "brigade": {"cli": "opencode", "model": native},
+                    "t3_fleet": {},
+                    "native": {},
+                }
+            }
+        }
+    return snapshot
+
+
+def _roster() -> Roster:
+    return Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan", model="opus-5"),
+            SEAT: Agent(SEAT, "opencode", "code", model=CANONICAL),
+        },
+    )
+
+
+def test_projected_native_binding_launches_exact_adapter_argv():
+    snapshot = _snapshot()
+    resolution = aboyeur.resolve_fleet_model_policy(_roster(), worker=SEAT, snapshot=snapshot)
+    assert resolution.error is None
+    agent = resolution.roster.agents[SEAT]
+    assert agent.model == NATIVE
+    assert agents.build_argv("opencode", "do work", model=agent.model) == [
+        "opencode",
+        "run",
+        "-m",
+        NATIVE,
+        "do work",
+    ]
+    decision = next(item for item in resolution.receipt["decisions"] if item["seat"] == SEAT)
+    assert decision["policy_model"] == CANONICAL
+    assert decision["launch_model"] == NATIVE
+    admission = decision["model_admission"]
+    assert admission["model"] == CANONICAL
+    assert admission["binding"]["model"] == NATIVE
+    assert admission["binding"]["instance_id"] == "opencode"
+
+
+def test_admission_decision_keeps_canonical_model_with_native_binding():
+    decision = fleet_model_admission._resolve_from_roster(_snapshot(), consumer="brigade-run", seat=SEAT, source="hub")
+    assert decision.ok is True
+    assert decision.payload["model"] == CANONICAL
+    assert decision.payload["binding"]["model"] == NATIVE
+
+
+def test_seat_without_native_binding_keeps_canonical_argv():
+    snapshot = _snapshot(native=None)
+    resolution = aboyeur.resolve_fleet_model_policy(_roster(), worker=SEAT, snapshot=snapshot)
+    assert resolution.error is None
+    agent = resolution.roster.agents[SEAT]
+    assert agent.model == CANONICAL
+    assert agents.build_argv("opencode", "do work", model=agent.model) == [
+        "opencode",
+        "run",
+        "-m",
+        CANONICAL,
+        "do work",
+    ]
+    decision = next(item for item in resolution.receipt["decisions"] if item["seat"] == SEAT)
+    assert decision["launch_model"] == CANONICAL
+    assert "model" not in decision["model_admission"]["binding"]
+
+
+def test_native_launch_is_never_inferred_from_the_canonical_slug():
+    """No delimiter or alias rewriting: an unbound seat launches the slug verbatim."""
+    row = _seat_row()
+    assert fleet_model_roster.effective_brigade_launch_model(row) is None
+    assert (
+        fleet_model_roster.effective_brigade_launch_model(row, launch_groups={"brigade": {"cli": "opencode"}}) is None
+    )
+    groups = {"brigade": {"cli": "opencode", "model": NATIVE}}
+    assert fleet_model_roster.effective_brigade_launch_model(row, launch_groups=groups) == NATIVE
+
+
+def test_retired_floor_covers_a_projected_native_launch_model():
+    snapshot = _snapshot(native="openai/gpt-5.5")
+    snapshot["seats"] = [{**_seat_row(), "provider": "openai", "model": "model-ok-1"}]
+    decision = fleet_model_admission._resolve_from_roster(snapshot, consumer="brigade-run", seat=SEAT, source="hub")
+    assert decision.ok is False
+    assert decision.reason == "retired-model"
+
+
+def test_lease_request_keeps_canonical_model_and_records_native_launch(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _Lease:
+        granted = True
+        lease_id = "lease-1"
+        holder = "holder-1"
+        reason = ""
+
+    def _acquire(seat, provider, model, **kwargs):
+        captured["seat"] = seat
+        captured["provider"] = provider
+        captured["model"] = model
+        captured["launch_model"] = kwargs.get("launch_model")
+        return _Lease()
+
+    monkeypatch.setattr(fleet_client, "acquire_model_lease", _acquire)
+    monkeypatch.setattr(
+        fleet_model_admission,
+        "admit_model",
+        lambda **kwargs: fleet_model_admission.ModelAdmissionDecision(True, 0, "admitted", {}),
+    )
+    ctx = fleet_session_bootstrap.LaunchContext(
+        session_id="session-native-1",
+        consumer="brigade-run",
+        provider=PROVIDER,
+        model=NATIVE,
+        instance_id="opencode",
+        version=2,
+        digest=DIGEST,
+        instructions="",
+        sources={},
+        loaded_at="2026-09-06T00:00:00Z",
+        repo_identity=REPO,
+        selected={"seat": SEAT, "model": CANONICAL, "launch_model": NATIVE},
+    )
+    ctx.applied = True
+    ctx.context_hash = "sha256:" + ("cd" * 32)
+    fleet_session_bootstrap.authorize_launch(ctx, cli_ref="opencode", model=NATIVE)
+    assert captured["model"] == CANONICAL
+    assert captured["launch_model"] == NATIVE
+
+
+def test_model_override_denial_names_the_native_binding_fix():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster(), worker=SEAT, model_override=NATIVE, snapshot=_snapshot(native=None)
+    )
+    assert resolution.error is not None
+    assert "does not match Hub model" in resolution.error
+    assert f"--brigade-model {NATIVE}" in resolution.error
+    assert f"brigade fleet models set {PROVIDER} {CANONICAL} {SEAT}" in resolution.error
+
+
+def test_bound_native_override_is_admitted_without_remediation():
+    resolution = aboyeur.resolve_fleet_model_policy(_roster(), worker=SEAT, model_override=NATIVE, snapshot=_snapshot())
+    assert resolution.error is None
+    assert resolution.roster.agents[SEAT].model == NATIVE
+
+
+# --- Hub write path -------------------------------------------------------
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    connection = fleet_hub.init_db(tmp_path / "fleet.db")
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _set_seat(conn, *, brigade_model: object = NATIVE, expected_revision: int = 1) -> dict[str, object]:
+    body: dict[str, object] = {
+        "action": "set",
+        "expected_revision": expected_revision,
+        "seat": SEAT,
+        "provider": PROVIDER,
+        "model": CANONICAL,
+        "reasoning": "high",
+        "enabled": True,
+        "limit": 1,
+        "brigade_cli": "opencode",
+        "t3_instance_id": "opencode",
+        "t3_service_tier": "",
+        "notes": "",
+    }
+    if brigade_model is not None:
+        body["brigade_model"] = brigade_model
+    status, payload = fleet_hub_model_roster.handle_model_policy(conn, body)
+    assert status == 200, payload
+    return payload
+
+
+def _set_default(conn, *, consumer: str, expected_revision: int) -> None:
+    status, payload = fleet_hub_model_roster.handle_model_policy(
+        conn,
+        {
+            "action": "set-default",
+            "expected_revision": expected_revision,
+            "consumer": consumer,
+            "seat": SEAT,
+        },
+    )
+    assert status == 200, payload
+
+
+def _document() -> dict[str, object]:
+    return {
+        "schema": fleet_policy.POLICY_SCHEMA,
+        "defaults": {"data": {"allow_training": True}},
+        "machines": {"worker-linux-1": {"os": "linux", "concurrency": 2, "node_id": NODE_A}},
+        "seats": {},
+        "consumers": {
+            "brigade-run": {"reload": "refreshable", "coverage": "unverified", "notes": "kept-brigade"},
+            "t3-fleet": {"reload": "none", "coverage": "unverified", "notes": "kept-t3"},
+        },
+        "repositories": {REPO: {"privacy": "public"}},
+    }
+
+
+def _activate(conn) -> None:
+    fleet_hub_policy.save_policy(conn, _document(), expected_version=1, actor="operator", reason="seed")
+    preview = fleet_policy_migration.preview_migration(
+        conn,
+        expected_policy_version=fleet_hub_policy.current_policy(conn)["revision"],
+        expected_roster_revision=int(
+            conn.execute("SELECT revision FROM model_roster_meta WHERE singleton=1").fetchone()[0]
+        ),
+        annotations={"seats": {SEAT: {"pinned": False, "training_allowed": True}}},
+    )
+    assert preview["ok"] is True, preview
+    fleet_policy_migration.activate_migration(
+        conn,
+        expected_policy_version=preview["sources"]["policy_revision"],
+        expected_roster_revision=preview["sources"]["roster_revision"],
+        preview_digest=preview["preview_digest"],
+        actor="operator",
+        reason="adopt",
+        annotations=preview.get("annotations"),
+    )
+
+
+def test_models_set_brigade_model_round_trips_to_the_signed_roster(conn):
+    policy = _set_seat(conn)
+    assert policy["policy"]["brigade_model"] == NATIVE
+    assert policy["policy"]["model"] == CANONICAL
+    seats = fleet_hub_model_roster.raw_seats(conn)
+    assert seats[0]["model"] == CANONICAL
+    assert seats[0]["bindings"]["brigade"] == {"cli": "opencode", "model": NATIVE}
+    assert (
+        fleet_model_roster.validate_roster_rows(
+            {
+                "seats": seats,
+                "consumer_defaults": {"brigade-run": SEAT},
+                "retired_models": [],
+            }
+        )
+        is None
+    )
+
+
+def test_clearing_brigade_model_restores_the_canonical_launch(conn):
+    _set_seat(conn)
+    _set_seat(conn, brigade_model="", expected_revision=2)
+    seats = fleet_hub_model_roster.raw_seats(conn)
+    assert seats[0]["bindings"]["brigade"] == {"cli": "opencode"}
+    assert fleet_model_roster.brigade_launch_model(seats[0]) is None
+
+
+def test_operator_roster_page_toggle_keeps_the_native_binding(conn):
+    """Enabling or disabling a seat on the deck must not silently drop the binding."""
+    from brigade import fleet_command_deck, fleet_hub_roster_page
+
+    _set_seat(conn)
+    view = fleet_hub_roster_page.load_view(conn, fleet_command_deck.DeckConfig())
+    row = next(item for item in view.seats if item.seat == SEAT)
+    assert row.brigade_model == NATIVE
+    fleet_hub_roster_page.fleet_hub_model_roster._write_set(
+        conn,
+        {
+            "seat": row.seat,
+            "provider": row.provider,
+            "model": row.model,
+            "reasoning": row.reasoning,
+            "enabled": False,
+            "limit": row.limit,
+            "brigade_cli": row.brigade_cli,
+            "brigade_model": row.brigade_model,
+            "t3_instance_id": row.t3_instance_id,
+            "t3_service_tier": row.t3_service_tier,
+            "notes": row.notes,
+        },
+    )
+    seats = fleet_hub_model_roster.raw_seats(conn)
+    assert seats[0]["enabled"] is False
+    assert seats[0]["bindings"]["brigade"]["model"] == NATIVE
+
+
+def test_brigade_model_projects_through_bindings_cli(conn, monkeypatch):
+    _set_seat(conn)
+    _set_default(conn, consumer="brigade-run", expected_revision=2)
+    _set_default(conn, consumer="t3-fleet", expected_revision=3)
+    _activate(conn)
+    projected = fleet_hub_model_roster.project_consumer_launch_bindings(conn)
+    assert projected["brigade-run"][SEAT]["brigade"]["model"] == NATIVE
+    roster = fleet_hub_model_roster.project_roster(conn, audience_node_id=NODE_A)
+    assert roster["consumer_launch_bindings"]["brigade-run"][SEAT]["brigade"]["model"] == NATIVE
+    seat_row = next(item for item in roster["seats"] if item["seat"] == SEAT)
+    assert seat_row["model"] == CANONICAL
+
+    monkeypatch.setattr(
+        fleet_model_admission,
+        "fetch_versioned_roster",
+        lambda **kwargs: fleet_model_admission.ModelAdmissionDecision(True, 0, "hub", {**roster, "source": "hub"}),
+    )
+    out = StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", StringIO())
+    rc = cli.main(["fleet", "models", "bindings", "--consumer", "brigade-run", "--json"])
+    assert rc == 0
+    payload = json.loads(out.getvalue())
+    assert payload["bindings"][SEAT]["model"] == CANONICAL
+    assert payload["bindings"][SEAT]["brigade"] == {"cli": "opencode", "model": NATIVE}
+
+
+def test_cleared_brigade_model_disappears_from_the_projection(conn):
+    _set_seat(conn)
+    _set_seat(conn, brigade_model="", expected_revision=2)
+    _set_default(conn, consumer="brigade-run", expected_revision=3)
+    _set_default(conn, consumer="t3-fleet", expected_revision=4)
+    _activate(conn)
+    projected = fleet_hub_model_roster.project_consumer_launch_bindings(conn)
+    assert "model" not in projected["brigade-run"][SEAT]["brigade"]
+
+
+@pytest.mark.parametrize(
+    "native",
+    (
+        "opencode/muse\x00spark",
+        "opencode/muse\nspark",
+        "a" * 257,
+        "/leading-separator",
+        "opencode/muse spark",
+    ),
+)
+def test_hub_rejects_unsafe_native_launch_ids(conn, native):
+    with pytest.raises(fleet_hub.FleetHubError):
+        fleet_hub_model_roster._validate_set(
+            {
+                "action": "set",
+                "expected_revision": 1,
+                "seat": SEAT,
+                "provider": PROVIDER,
+                "model": CANONICAL,
+                "reasoning": "high",
+                "enabled": True,
+                "brigade_model": native,
+            }
+        )
+
+
+def test_signed_roster_rejects_unsafe_projected_native_ids():
+    for native in ("opencode/muse\x00spark", "a" * 257, "opencode/muse spark"):
+        bad = {
+            "brigade-run": {
+                SEAT: {"brigade": {"cli": "opencode", "model": native}, "t3_fleet": {}, "native": {}},
+            }
+        }
+        assert fleet_model_roster.validate_consumer_launch_bindings(bad) == "malformed-roster"
+
+
+def test_models_set_cli_sends_and_clears_the_native_binding(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def _set_model_policy(provider, model, seat, **kwargs):
+        calls.append({"provider": provider, "model": model, "seat": seat, **kwargs})
+        return {"provider": provider, "model": model, "seat": seat, "enabled": True, **kwargs}
+
+    monkeypatch.setattr(fleet_client, "set_model_policy", _set_model_policy)
+    monkeypatch.setattr("sys.stdout", StringIO())
+    monkeypatch.setattr("sys.stderr", StringIO())
+    assert (
+        cli.main(
+            [
+                "fleet",
+                "models",
+                "set",
+                PROVIDER,
+                CANONICAL,
+                SEAT,
+                "--enable",
+                "--reasoning",
+                "high",
+                "--brigade-cli",
+                "opencode",
+                "--brigade-model",
+                NATIVE,
+                "--expect-revision",
+                "2",
+            ]
+        )
+        == 0
+    )
+    assert calls[-1]["brigade_model"] == NATIVE
+    assert (
+        cli.main(
+            [
+                "fleet",
+                "models",
+                "set",
+                PROVIDER,
+                CANONICAL,
+                SEAT,
+                "--enable",
+                "--clear-brigade-model",
+                "--expect-revision",
+                "3",
+            ]
+        )
+        == 0
+    )
+    assert calls[-1]["brigade_model"] == ""
+
+
+def test_models_set_cli_rejects_setting_and_clearing_together(monkeypatch):
+    monkeypatch.setattr("sys.stdout", StringIO())
+    monkeypatch.setattr("sys.stderr", StringIO())
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            [
+                "fleet",
+                "models",
+                "set",
+                PROVIDER,
+                CANONICAL,
+                SEAT,
+                "--enable",
+                "--brigade-model",
+                NATIVE,
+                "--clear-brigade-model",
+                "--expect-revision",
+                "2",
+            ]
+        )
+    assert excinfo.value.code != 0
+
+
+def test_client_preserves_and_clears_the_native_binding(monkeypatch):
+    posted: list[dict[str, object]] = []
+    existing = {
+        "seats": [
+            {
+                "seat": SEAT,
+                "provider": PROVIDER,
+                "model": CANONICAL,
+                "reasoning": "high",
+                "enabled": True,
+                "bindings": {
+                    "brigade": {"cli": "opencode", "model": NATIVE},
+                    "t3_fleet": {"instance_id": "opencode", "service_tier": None},
+                },
+            }
+        ],
+        "revision": 4,
+    }
+    monkeypatch.setattr(
+        fleet_client,
+        "load_fleet_settings",
+        lambda: {"hub_url": "https://hub.invalid", "admin_token": "admin-token"},
+    )
+    monkeypatch.setattr(fleet_client, "_get_models_blocking", lambda *args, **kwargs: existing)
+
+    def _post(hub, token, body, **kwargs):
+        posted.append(body)
+        return 200, {"policy": {"seat": SEAT, "provider": PROVIDER, "model": CANONICAL, "enabled": True}}
+
+    monkeypatch.setattr(fleet_client, "_post_model_policy_blocking", _post)
+    fleet_client.set_model_policy(PROVIDER, CANONICAL, SEAT, enabled=True, expected_revision=4)
+    assert posted[-1]["brigade_model"] == NATIVE
+    fleet_client.set_model_policy(PROVIDER, CANONICAL, SEAT, enabled=True, brigade_model="", expected_revision=4)
+    assert posted[-1]["brigade_model"] == ""
+    assert posted[-1]["model"] == CANONICAL


### PR DESCRIPTION
Closes #1445.

## What

`brigade run` launched a seat with the hub's canonical model slug as the adapter argument. For OpenCode that means `opencode run -m opencode-muse-spark-1.3-contributor-free`, which OpenCode rejects, and passing `--model opencode/muse-spark-1.3-contributor-free` was denied with a remediation that re-pinned the same slug.

## How

- At dispatch, `aboyeur_model_policy._resolve_versioned` takes the brigade-run seat model from the effective `bindings.brigade.model` (the signed `consumer_launch_bindings` projection first, then the seat row) via `fleet_model_roster.effective_brigade_launch_model`, and falls back to the canonical slug only when no binding exists. Nothing derives a native id from the slug by delimiter or alias rewriting.
- Admission, the model lease `request.model`, and the proof identity keep the canonical slug. Only `Agent.model`, and therefore the argv, changes; the native id lands in the existing `launch_model` fields.
- `brigade fleet models set --brigade-model <native id>` records the binding on the `model_policy` row (new additive `brigade_model` column); `--clear-brigade-model` drops it. Launch identities are rejected rather than sanitized: control characters, surrounding whitespace, or anything `_model_identity_name` would alter is refused, so the stored id is the one the operator reviewed.
- The `--model` mismatch denial now names `brigade fleet models set ... --brigade-model <native id>`.
- `fleet_hub_roster_page` threads the new column through `SeatRow` and its `_write_set` request so the deck's enable/disable toggle does not drop the binding; `fleet_policy_migration._legacy_bindings` carries it into the policy document.

## Verify

Focused gate receipt `20260906-124242-work-verify-d6556f`, 481 passed (new `tests/test_fleet_native_launch_binding.py` plus admission, roster, models list, run transport, roster page, migration, authority proof, hub policy, deck, ratchet, preference, worklore). Worker receipt `20260906-124052-work-verify-58aa29`, 492 passed.

## Look hardest at

- `fleet_hub_model_roster._optional_launch_identity`: reject-not-sanitize is deliberate because `fleet_hub._safe_cloud_text` strips control characters silently.
- `fleet_hub.py` sits at 1998 of the 2000-line ratchet ceiling after the schema line; the next change there needs a split first.

## Not in this PR

`tests/test_fleet_routing.py::test_evaluate_work_item_uses_canonical_exclusion_and_does_not_default_missing_attempts` started failing on main at 2026-09-06T12:00Z because it pins `_now()` to 2026-09-05 and asserts a `review_after` one day later is still in the future. Separate fix incoming.