### PR TITLE
fix(routing): evaluate review_after against the routing clock, not the wall clock

### DIFF
--- a/src/brigade/fleet_hub_routing.py
+++ b/src/brigade/fleet_hub_routing.py
@@ -188,7 +188,7 @@ def evaluate_work_item(item: Mapping[str, Any] | None) -> dict[str, Any]:
     if not isinstance(source_policies, list):
         return {"ok": False, "reason": "work-held", "detail": "source-policy"}
     try:
-        bucket = exclusion_bucket(item, source_policies)
+        bucket = exclusion_bucket(item, source_policies, now=_now())
     except Exception:
         return {"ok": False, "reason": "work-held", "detail": "worklore-unavailable"}
     if bucket is not None:

--- a/src/brigade/worklore_store.py
+++ b/src/brigade/worklore_store.py
@@ -458,7 +458,7 @@ def _load_json_list(raw: object) -> list[Any]:
     return parsed if isinstance(parsed, list) else []
 
 
-def _review_after_future(value: object) -> bool:
+def _review_after_future(value: object, *, now: datetime | None = None) -> bool:
     if value is None or value == "":
         return False
     if not isinstance(value, str):
@@ -467,7 +467,7 @@ def _review_after_future(value: object) -> bool:
         parsed = as_datetime(value)
     except ValueError:
         return True
-    return parsed > datetime.now(timezone.utc)
+    return parsed > (now if now is not None else datetime.now(timezone.utc))
 
 
 def _empty_link_summary() -> dict[str, Any]:
@@ -665,8 +665,17 @@ def _parse_patch(item: Mapping[str, Any], raw: object) -> dict[str, Any]:
     return parse_create(merged)
 
 
-def exclusion_bucket(item: Mapping[str, Any], source_policies: Sequence[str]) -> str | None:
-    """Return the first burn-queue exclusion bucket an item falls into, or None when it is eligible."""
+def exclusion_bucket(
+    item: Mapping[str, Any],
+    source_policies: Sequence[str],
+    *,
+    now: datetime | None = None,
+) -> str | None:
+    """Return the first burn-queue exclusion bucket an item falls into, or None when it is eligible.
+
+    ``now`` lets a caller with its own clock (fleet routing) evaluate ``review_after``
+    against that clock instead of the wall clock.
+    """
     if item["status"] != "ready":
         return "not-ready"
     if not item["burn_eligible"]:
@@ -681,7 +690,7 @@ def exclusion_bucket(item: Mapping[str, Any], source_policies: Sequence[str]) ->
         return "blocker"
     if int(item["attempt_count"]) >= 2:
         return "attempt-limit"
-    if _review_after_future(item.get("review_after")):
+    if _review_after_future(item.get("review_after"), now=now):
         return "review-after"
     if any(policy != "eligible" for policy in source_policies):
         return "source-policy"


### PR DESCRIPTION
## What

`tests/test_fleet_routing.py::test_evaluate_work_item_uses_canonical_exclusion_and_does_not_default_missing_attempts` started failing on main at 2026-09-06T12:00Z. It pins `fleet_hub_routing._now()` to 2026-09-05T12:00Z and sets `review_after` one day later, but `worklore_store._review_after_future` compared that stamp to the real wall clock, so "one day in the future" became the past at noon today. Every test shard fails on it from now on.

## Fix

`exclusion_bucket` and `_review_after_future` take an optional `now`, and `fleet_hub_routing.evaluate_work_item` passes its own `_now()`. Routing now judges `review_after` on the same clock it uses for `spend_by`, telemetry freshness, and reservations. The worklore-side caller keeps the wall clock, so burn-queue behavior is unchanged.

Not a test weakening: the test is untouched; the code under test was reading a different clock than the one the test controls.

## Verify

Receipt `20260906-124659-work-verify-da28c9`, 490 passed across `test_fleet_routing.py` and all six `test_worklore_*.py` files; lint, format, mypy, and snapshots clean.

Brigade Code graph is not indexed in this fresh worktree; callers were confirmed by grep: `exclusion_bucket` is called from `worklore_store` (line 1778) and `fleet_hub_routing` (line 191), `_review_after_future` only from `exclusion_bucket`.