### PR TITLE
fix(grokbot): bounded report-not-allowed on hub completion with report_text

### DIFF
--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -1421,6 +1421,26 @@ def _require_report_job(record: dict[str, Any]) -> None:
         raise GrokbotJobError("invalid-artifact")
 
 
+def _job_artifact_kind(spec: dict[str, Any], job: dict[str, Any] | None = None) -> object:
+    artifact = spec.get("artifact")
+    if isinstance(artifact, dict) and artifact.get("kind") is not None:
+        return artifact.get("kind")
+    if job is None:
+        return None
+    nested = job.get("artifact")
+    if isinstance(nested, dict) and nested.get("kind") is not None:
+        return nested.get("kind")
+    return job.get("artifact_kind")
+
+
+def _require_hub_report_job(snapshot: dict[str, Any], job_id: str) -> None:
+    kind = _job_artifact_kind(snapshot)
+    if kind is None:
+        kind = _job_artifact_kind({}, _hub_job(job_id))
+    if kind != "report":
+        raise GrokbotJobError("report-not-allowed")
+
+
 def _validated_completion(record: dict[str, Any], artifact: object) -> dict[str, Any]:
     if record["state"] != "running":
         raise GrokbotJobError("invalid-transition")
@@ -1747,6 +1767,7 @@ def _complete_report_via_hub(
     target: Path, job_id: str, bot_id: str, lease_id: str, artifact: dict[str, Any], report_bytes: bytes
 ) -> dict[str, Any]:
     snapshot = _load_task_snapshot(target, job_id)
+    _require_hub_report_job(snapshot, job_id)
     validated = _validate_completion_artifact(artifact, snapshot)
     if hashlib.sha256(report_bytes).hexdigest() != validated["sha256"]:
         raise GrokbotJobError("digest-mismatch")

--- a/src/brigade/grokbot_mcp.py
+++ b/src/brigade/grokbot_mcp.py
@@ -352,7 +352,13 @@ class GrokbotAdapter:
         except AdapterError as exc:
             journal_tool_call(name, arguments, "refused", exc.reason)
             raise AdapterError(exc.reason) from None
-        except (grokbot_jobs.GrokbotJobError, ValueError, OSError):
+        except grokbot_jobs.GrokbotJobError as exc:
+            if exc.reason == "report-not-allowed":
+                journal_tool_call(name, arguments, "refused", exc.reason)
+                raise AdapterError(exc.reason) from None
+            journal_tool_call(name, arguments, "refused", None)
+            raise AdapterError() from None
+        except (ValueError, OSError):
             journal_tool_call(name, arguments, "refused", None)
             raise AdapterError() from None
         journal_tool_call(name, arguments, "ok", None)

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -1602,7 +1602,9 @@ def test_hub_complete_report_rejects_non_report_kind_without_writing(
     spec = grokbot_jobs._validate_spec({**_spec(), "artifact": {"kind": artifact_kind}})
     job_id = "grokbot-" + hashlib.sha256(f"hub-report-{artifact_kind}".encode()).hexdigest()[:24]
     artifact_path = tmp_path / ".brigade" / "cloud" / "grokbot" / "artifacts" / f"{job_id}.md"
-    grokbot_jobs._store_task_snapshot(tmp_path, job_id, spec, grokbot_jobs._idempotency_key_hash(f"hub-{artifact_kind}"))
+    grokbot_jobs._store_task_snapshot(
+        tmp_path, job_id, spec, grokbot_jobs._idempotency_key_hash(f"hub-{artifact_kind}")
+    )
     monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target=None: True)
     running = _hub_running_job(job_id, role="implementation-worker", artifact_kind=artifact_kind)
     hub_complete_calls: list[str] = []

--- a/tests/test_grokbot_jobs.py
+++ b/tests/test_grokbot_jobs.py
@@ -1581,6 +1581,107 @@ def test_hub_complete_report_accepts_claimed_and_cleans_failed_orphan_only(tmp_p
     assert artifact_path.read_bytes() == report.encode()
 
 
+def _hub_running_job(job_id: str, *, role: str, artifact_kind: str) -> dict[str, object]:
+    return {
+        "job_id": job_id,
+        "state": "running",
+        "role": role,
+        "artifact_kind": artifact_kind,
+        "item_revision": 3,
+        "lease_generation": 1,
+        "private_snapshot_id": job_id,
+    }
+
+
+@pytest.mark.parametrize("artifact_kind", ["draft-pr", "branch"])
+def test_hub_complete_report_rejects_non_report_kind_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, artifact_kind: str
+):
+    from brigade import fleet_client_grokbot
+
+    spec = grokbot_jobs._validate_spec({**_spec(), "artifact": {"kind": artifact_kind}})
+    job_id = "grokbot-" + hashlib.sha256(f"hub-report-{artifact_kind}".encode()).hexdigest()[:24]
+    artifact_path = tmp_path / ".brigade" / "cloud" / "grokbot" / "artifacts" / f"{job_id}.md"
+    grokbot_jobs._store_task_snapshot(tmp_path, job_id, spec, grokbot_jobs._idempotency_key_hash(f"hub-{artifact_kind}"))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target=None: True)
+    running = _hub_running_job(job_id, role="implementation-worker", artifact_kind=artifact_kind)
+    hub_complete_calls: list[str] = []
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "status",
+        lambda *args, **kwargs: fleet_client_grokbot.GrokbotHubDecision(True, "ok", job=running),
+    )
+
+    def record_complete(*args: object, **kwargs: object):
+        hub_complete_calls.append("complete")
+        return fleet_client_grokbot.GrokbotHubDecision(True, "ok", job={**running, "state": "completed"})
+
+    monkeypatch.setattr(fleet_client_grokbot, "complete", record_complete)
+    artifact = (
+        {"kind": "draft-pr", "url": "https://github.com/example/brigade/pull/1", "branch": "grokbot/job"}
+        if artifact_kind == "draft-pr"
+        else {"kind": "branch", "branch": "grokbot/job", "commit": "a" * 40}
+    )
+
+    with pytest.raises(grokbot_jobs.GrokbotJobError, match="^report-not-allowed$") as exc:
+        grokbot_jobs.complete_report(
+            tmp_path,
+            job_id,
+            "grokbot-implementation-worker",
+            "lease-a",
+            artifact,
+            REPORT_TEXT,
+        )
+
+    assert exc.value.reason == "report-not-allowed"
+    assert REPORT_TEXT not in str(exc.value)
+    assert not artifact_path.exists()
+    assert grokbot_jobs.get_job(tmp_path, job_id)["state"] == "running"
+    assert hub_complete_calls == []
+
+
+def test_hub_complete_report_still_completes_report_jobs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from brigade import fleet_client_grokbot
+
+    spec = grokbot_jobs._validate_spec(
+        {
+            **_spec(),
+            "role": "repository-scout",
+            "artifact": {"kind": "report"},
+        }
+    )
+    job_id = "grokbot-" + hashlib.sha256(b"hub-report-ok").hexdigest()[:24]
+    report = "Private scout findings."
+    digest = hashlib.sha256(report.encode()).hexdigest()
+    artifact_path = tmp_path / ".brigade" / "cloud" / "grokbot" / "artifacts" / f"{job_id}.md"
+    grokbot_jobs._store_task_snapshot(tmp_path, job_id, spec, grokbot_jobs._idempotency_key_hash("hub-report-ok"))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target=None: True)
+    running = _hub_running_job(job_id, role="repository-scout", artifact_kind="report")
+    completed = {**running, "state": "completed", "artifact_digest": digest, "artifact_size": len(report.encode())}
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "status",
+        lambda *args, **kwargs: fleet_client_grokbot.GrokbotHubDecision(True, "ok", job=running),
+    )
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "complete",
+        lambda *args, **kwargs: fleet_client_grokbot.GrokbotHubDecision(True, "ok", job=completed),
+    )
+
+    result = grokbot_jobs.complete_report(
+        tmp_path,
+        job_id,
+        "grokbot-repository-scout",
+        "lease-a",
+        {"kind": "report", "path": "docs/scout.md", "sha256": digest},
+        report,
+    )
+
+    assert result["state"] == "completed"
+    assert artifact_path.read_bytes() == report.encode()
+
+
 def test_hub_report_snapshot_requires_digest(tmp_path: Path, monkeypatch):
     from brigade import fleet_client_grokbot
 

--- a/tests/test_grokbot_mcp.py
+++ b/tests/test_grokbot_mcp.py
@@ -1622,6 +1622,71 @@ def test_hub_authority_mcp_does_not_call_generic_fleet_paths(tmp_path: Path, mon
     assert calls == []
 
 
+def test_hub_complete_with_report_text_on_draft_pr_returns_report_not_allowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from brigade import fleet_client_grokbot
+
+    spec = grokbot_jobs._validate_spec(_spec("implementation-worker"))
+    job_id = "grokbot-" + hashlib.sha256(b"mcp-draft-pr-report").hexdigest()[:24]
+    grokbot_jobs._store_task_snapshot(tmp_path, job_id, spec, grokbot_jobs._idempotency_key_hash("mcp-draft"))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target=None: True)
+    running = {
+        "job_id": job_id,
+        "state": "running",
+        "role": "implementation-worker",
+        "artifact_kind": "draft-pr",
+        "item_revision": 3,
+        "lease_generation": 1,
+        "private_snapshot_id": job_id,
+    }
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "status",
+        lambda *args, **kwargs: fleet_client_grokbot.GrokbotHubDecision(True, "ok", job=running),
+    )
+    monkeypatch.setattr(
+        fleet_client_grokbot,
+        "whoami",
+        lambda: fleet_client_grokbot.GrokbotHubDecision(
+            True,
+            "ok",
+            job={"actor_kind": "implementation-worker", "role": "implementation-worker"},
+        ),
+    )
+
+    def refuse_complete(*args: object, **kwargs: object):
+        raise AssertionError("hub complete must not run")
+
+    monkeypatch.setattr(fleet_client_grokbot, "complete", refuse_complete)
+    adapter = _adapter(tmp_path, hub_token="listener-node-token")
+
+    with pytest.raises(grokbot_mcp.AdapterError) as error:
+        adapter.call_tool(
+            "grokbot_queue_complete",
+            {
+                "job_id": job_id,
+                "lease_id": "lease-a",
+                "artifact": {
+                    "kind": "draft-pr",
+                    "url": "https://github.com/example/brigade/pull/1",
+                    "branch": "grokbot/job",
+                },
+                "report_text": REPORT_TEXT,
+            },
+        )
+
+    payload = error.value.public_error()
+    rendered = json.dumps(payload)
+    assert error.value.reason == "report-not-allowed"
+    assert payload == {"error": {"code": "invalid_request", "message": "report-not-allowed"}}
+    assert "Traceback" not in rendered
+    assert "UnexpectedToolError" not in rendered
+    assert REPORT_TEXT not in rendered
+    assert not (tmp_path / ".brigade" / "cloud" / "grokbot" / "artifacts" / f"{job_id}.md").exists()
+    assert adapter.call_tool("grokbot_queue_status", {"job_id": job_id})["state"] == "running"
+
+
 def _write_hub_token_file(path: Path, token: str) -> Path:
     path.write_text(token + "\n", encoding="utf-8")
     path.chmod(0o600)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1472

Hub-path completion with report_text on a non-report (draft-pr/branch) job returns bounded GrokbotJobError('report-not-allowed') without KeyError, without creating an artifact file, and without completing the job; report jobs still complete; MCP surfaces the same bounded reason.

## What and why

`_complete_report_via_hub` validated the completion artifact and then read `validated["sha256"]`, which draft-pr and branch artifacts do not carry. The local `complete_report` path already refused non-report jobs. The hub path now reads the spec artifact kind from the local task snapshot (falling back to the hub job row) before validation and raises `GrokbotJobError("report-not-allowed")` without touching artifact storage or the hub. The MCP adapter maps that reason onto the same bounded `AdapterError` envelope used for other named refusals, so the Bot can retry `grokbot_queue_complete` without `report_text`.

## Verification

- `python -m pytest -q tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py` — exit 0
- `ruff check src/brigade/grokbot_jobs.py src/brigade/grokbot_mcp.py tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py` — exit 0
- `ruff format --check src/brigade/grokbot_jobs.py src/brigade/grokbot_mcp.py tests/test_grokbot_jobs.py tests/test_grokbot_mcp.py` — exit 0
- `mypy` — exit 0
- `git diff --check` — exit 0
- `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_grokbot_jobs.py","tests/test_grokbot_mcp.py"]' --capture brigade-work` — exit 0

Last ten lines of pytest:

```
........................................................................ [ 59%]
........................................s..ss.....s..................... [ 88%]
......s.....................                                             [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/test_grokbot_mcp.py:1023: requires the grokbot extra
SKIPPED [1] tests/test_grokbot_mcp.py:1139: requires the grokbot extra
SKIPPED [1] tests/test_grokbot_mcp.py:1186: requires the grokbot extra
SKIPPED [1] tests/test_grokbot_mcp.py:1342: requires the grokbot extra
SKIPPED [1] tests/test_grokbot_mcp.py:1978: requires the grokbot extra
239 passed, 5 skipped in 19.15s
```

Brigade verify receipt id: `20260906-132438-work-verify-0e0293`

job id: grokbot-6c569174fda0cabadf0cf2f9
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd49b7f0-118c-4aba-a2a2-164543d74b82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd49b7f0-118c-4aba-a2a2-164543d74b82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

