### PR TITLE
fix(hub): bump SCHEMA_VERSION to 22 so live hubs gain model_policy.brigade_model

### DIFF
--- a/src/brigade/fleet_hub.py
+++ b/src/brigade/fleet_hub.py
@@ -123,7 +123,7 @@ from .fleet_hub_status import (
     latest_status as latest_status,
 )
 
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 DEFAULT_PORT = 3774
 MAX_BODY_BYTES = 8 * 1024 * 1024
 

--- a/tests/test_fleet_model_roster.py
+++ b/tests/test_fleet_model_roster.py
@@ -993,3 +993,23 @@ def test_validate_roster_rows_requires_strict_authority_metadata_when_present():
         fleet_policy={"active": True, "version": 4, "digest": "sha256:" + ("ab" * 32), "token": "secret"},
     )
     assert fleet_model_roster.validate_roster_rows(extra) == "malformed-roster"
+
+
+def test_v21_database_gains_brigade_model_column_on_init(tmp_path):
+    """#1483 added model_policy.brigade_model. A live hub already at user_version 21
+    skipped the ALTER because _init_schema returns early at the current version;
+    the version bump to 22 makes init_db migrate it."""
+    db = tmp_path / "hub.db"
+    conn = fleet_hub.init_db(db)
+    conn.execute("ALTER TABLE model_policy DROP COLUMN brigade_model")
+    conn.execute("PRAGMA user_version=21")
+    conn.commit()
+    conn.close()
+    stale = sqlite3.connect(db)
+    assert "brigade_model" not in [row[1] for row in stale.execute("PRAGMA table_info(model_policy)")]
+    stale.close()
+    migrated = fleet_hub.init_db(db)
+    columns = [row[1] for row in migrated.execute("PRAGMA table_info(model_policy)")]
+    assert "brigade_model" in columns
+    assert migrated.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION
+    migrated.close()

--- a/tests/test_run_preference.py
+++ b/tests/test_run_preference.py
@@ -217,7 +217,7 @@ def test_hub_preference_v18_row_survives_v19_migration(tmp_path) -> None:
     old.commit()
     old.close()
     conn = fleet_hub.init_db(path)
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION == 21
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == fleet_hub.SCHEMA_VERSION == 22
     pref = fleet_hub.get_run_preference(conn)
     assert pref["impl"] == "coder" and pref["notes"] == "kept"
     assert pref["research"] is None and pref["security"] is None and pref["scout"] is None

--- a/tests/test_worklore_store.py
+++ b/tests/test_worklore_store.py
@@ -2718,10 +2718,10 @@ def test_the_legacy_quota_reconciliation_runs_once_not_on_every_start(tmp_path):
 
 
 def test_fleet_hub_schema_is_v18_for_the_recoverable_link_ceiling(tmp_path):
-    assert fleet_hub.SCHEMA_VERSION == 21
+    assert fleet_hub.SCHEMA_VERSION == 22
     conn = fleet_hub.init_db(tmp_path / "hub.db")
     try:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 21
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 22
         columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(work_import_keys)")}
         assert "refused" in columns
         assert conn.execute("SELECT COUNT(*) FROM work_schema_meta").fetchone()[0] >= 1


### PR DESCRIPTION
## What broke

After deploying `e35f5e20` (#1483) to the hub, every `/models` read returned `500 hub database error: no such column: brigade_model`, so `brigade fleet models list`, `models doctor`, and any `brigade run` admission fell back to an expired LKG and reported `hub-unavailable`.

## Why

#1483 added `brigade_model` to `model_policy` in `_SCHEMA` and to `fleet_hub_model_roster._ROSTER_COLUMNS` (the additive ALTER list), but left `SCHEMA_VERSION` at 21. `_init_schema` returns early when `PRAGMA user_version` already equals `SCHEMA_VERSION`, so a hub database already at 21 never ran `ensure_schema` and never gained the column. Fresh databases (every test) got it from `_SCHEMA`, which is why the suite was green.

## Fix

`SCHEMA_VERSION` 21 to 22, the two tests that pin it, and a regression test that builds a database, drops `brigade_model`, pins `user_version` back to 21, and asserts a second `init_db` restores the column and lands on the current version.

The live hub was repaired by hand in the meantime (an idempotent `ensure_schema` call on the hub DB), so this PR changes nothing there beyond moving `user_version` to 22 on the next restart.

## Rule worth keeping

Any additive column on a hub table needs a `SCHEMA_VERSION` bump, or live databases silently skip it. Filed as a durable note in the handoff.

## Verify

Receipt `20260906-134058-work-verify-e0af2e`, 299 passed across roster, preference, worklore store, hub policy, model admission, and models list tests; lint, format, mypy, snapshots clean.