### PR TITLE
docs(grokbot): document the queue-to-first-result measurement

### DIFF
--- a/docs/grokbot-operating-guide.md
+++ b/docs/grokbot-operating-guide.md
@@ -235,6 +235,48 @@ A 60-minute drain remains useful as a safety net: if a POST failed, the
 routine can still list the queue and claim anything that was missed. Do not
 rely on a short poll as the primary wake.
 
+### Measuring the queue
+
+Hillclimb uses two per-job latencies for `implementation-worker` work, read
+from hub tables `grokbot_jobs` and `grokbot_operations` with read-only
+queries. Queue-to-first-result is `claimed_at` minus `created_at`. Queue-to-done
+is the `complete` operation `timestamp` minus `created_at`. Paste either query
+against the hub sqlite database; do not write.
+
+```sql
+SELECT job_id,
+       (strftime('%s', replace(claimed_at, 'Z', ''))
+        - strftime('%s', replace(created_at, 'Z', '')))
+         AS queue_to_first_result_seconds
+FROM grokbot_jobs
+WHERE role = 'implementation-worker'
+  AND claimed_at IS NOT NULL
+ORDER BY created_at;
+```
+
+```sql
+SELECT j.job_id,
+       (strftime('%s', replace(o.timestamp, 'Z', ''))
+        - strftime('%s', replace(j.created_at, 'Z', '')))
+         AS queue_to_done_seconds
+FROM grokbot_jobs AS j
+JOIN grokbot_operations AS o
+  ON o.job_id = j.job_id AND o.action = 'complete'
+WHERE j.role = 'implementation-worker'
+ORDER BY j.created_at;
+```
+
+Keep `decision.tsv` under the queue workspace `.brigade` directory on the
+operator host. One row per attempt: date, change, metric before, metric after,
+noise band, accept or revert. Accept one measured change per iteration;
+revert anything that stays inside the noise band.
+
+Frozen baselines from 2026-09-06: poll path 5 minutes to 4 hours 14 minutes
+to claim; webhook path 31 seconds to claim and 6 minutes 8 seconds to PR.
+Those samples include an observed 60-minute completion hold after the PR
+existed. The job-contract stop rule (complete when the PR exists instead of
+waiting out the time cap) removes that hold.
+
 ### Leases
 
 A lease runs from 30 seconds to 3600 seconds and defaults to 300 seconds. The


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #1400

Done predicate: PR is open and ready for review; Measuring the queue in `docs/grokbot-operating-guide.md` has no hosts, container ids, IPs, or non-repository paths; `brigade guard audit . --scope tracked --strict --baseline .content-guard-baseline.json` and `git diff --check` both exit 0.

Verification:

- `brigade guard audit . --scope tracked --strict --baseline .content-guard-baseline.json` — exit 0
- `git diff --check` — exit 0
- `brigade work verify run --target . --argv-json '["brigade","guard","audit",".","--scope","tracked","--strict","--baseline",".content-guard-baseline.json"]' --capture brigade-work` — exit 0

Guard audit transcript:

```
content-guard audit: .

Summary
  scope:               tracked
  files scanned:       2127
  files with findings: 47
  total findings:      261
  blocked:             false

By action
  allow    187
  warn     74

By category
  infrastructure   91
  pii              119
  secret           27
  tooling          24

By rule (top 10)
  email                            50
  private-ipv4                     45
  example-email-reserved           34
  home-path                        27
  ignored-file-allow               24
  loopback-ipv4                    24
  api-key-assignment               17
  localhost-port                   17
  bearer-token                     7
  us-phone                         5

Top offenders (top 5)
    75  tests/guard/test_engine.py
    24  tests/guard/test_allow_values.py
    18  tests/guard/test_audit.py
    16  tests/guard/test_cli.py
    16  tests/guard/test_rules.py
```

Brigade verify receipt id: `20260906-152013-work-verify-d01aac`

job id: `grokbot-78922e3a1e0d5e99c12e71a1`

The Measuring the queue subsection needed no edit (generic “operator host” / `.brigade` path only). Loopback binds in the connector pack table remain accepted via `.content-guard-baseline.json` under the CI `guard audit --strict --baseline` check.

## What and why

Documents queue-to-first-result / queue-to-done measurement for Hillclimb. This follow-up records the correct content-guard command (tracked audit with baseline) so the PR can leave draft.

Closes #1400

## Type of change

- [x] Docs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5662bdf-6f6f-47f7-973c-cddb13995404?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5662bdf-6f6f-47f7-973c-cddb13995404&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

