### PR TITLE
test: isolate Windows home variables in the pytest home fixture (Fixes #1474)

### DIFF
--- a/tests/_home.py
+++ b/tests/_home.py
@@ -1,0 +1,40 @@
+"""Shared home-directory isolation helpers for the test suite.
+
+On Windows ``Path.home()`` and ``os.path.expanduser`` read ``USERPROFILE``
+before ``HOME``, with ``HOMEDRIVE``/``HOMEPATH`` as fallback. Tests that only
+set ``HOME`` therefore populate one temp home while the code under test reads
+another. Use :func:`set_home` for ``monkeypatch`` based isolation and
+:func:`home_env` for subprocess env dicts so the pair cannot drift.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _split(home: str) -> tuple[str, str, str]:
+    drive, tail = os.path.splitdrive(home)
+    return home, drive, tail if drive else home
+
+
+def set_home(monkeypatch, home: Path | str) -> Path:
+    """Point HOME, USERPROFILE, HOMEDRIVE and HOMEPATH at ``home``."""
+    path = Path(home)
+    home_str, drive, homepath = _split(str(path))
+    monkeypatch.setenv("HOME", home_str)
+    monkeypatch.setenv("USERPROFILE", home_str)
+    monkeypatch.setenv("HOMEDRIVE", drive)
+    monkeypatch.setenv("HOMEPATH", homepath)
+    return path
+
+
+def home_env(home: Path | str) -> dict[str, str]:
+    """Return a HOME/USERPROFILE/HOMEDRIVE/HOMEPATH env mapping for ``home``."""
+    home_str, drive, homepath = _split(str(home))
+    return {
+        "HOME": home_str,
+        "USERPROFILE": home_str,
+        "HOMEDRIVE": drive,
+        "HOMEPATH": homepath,
+    }

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -21,6 +21,7 @@ def linux_env(root: Path) -> dict[str, str]:
     home.mkdir(parents=True, exist_ok=True)
     return {
         "HOME": str(home),
+        "USERPROFILE": str(home),
         "XDG_DATA_HOME": str(root / "xdg-data"),
         "XDG_CACHE_HOME": str(root / "xdg-cache"),
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -108,6 +109,15 @@ def _isolate_user_brigade_dir(tmp_path_factory, monkeypatch):
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("BRIGADE_USER_DIR", str(user_dir))
     monkeypatch.setenv("BRIGADE_HOME", str(user_dir))
+    # On Windows Path.home() and os.path.expanduser read USERPROFILE before
+    # HOME, with HOMEDRIVE/HOMEPATH as fallback. Point all of them at the
+    # same temp home so the suite never touches the operator real home.
+    # The split keeps one code path: on POSIX the drive is empty and
+    # HOMEPATH is the full path, which is harmless.
+    drive, tail = os.path.splitdrive(str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("HOMEDRIVE", drive)
+    monkeypatch.setenv("HOMEPATH", tail if drive else str(home))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
-import os
 import sys
 from pathlib import Path
 
 import pytest
 
+from tests._home import set_home
 from tests.support import PRIVATE_DIRECTORY_MODE
 
 SRC = Path(__file__).resolve().parents[1] / "src"
@@ -106,18 +106,9 @@ def _isolate_user_brigade_dir(tmp_path_factory, monkeypatch):
     home = tmp_path_factory.mktemp("operator_home")
     user_dir = home / ".brigade"
     user_dir.mkdir(mode=PRIVATE_DIRECTORY_MODE)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, home)
     monkeypatch.setenv("BRIGADE_USER_DIR", str(user_dir))
     monkeypatch.setenv("BRIGADE_HOME", str(user_dir))
-    # On Windows Path.home() and os.path.expanduser read USERPROFILE before
-    # HOME, with HOMEDRIVE/HOMEPATH as fallback. Point all of them at the
-    # same temp home so the suite never touches the operator real home.
-    # The split keeps one code path: on POSIX the drive is empty and
-    # HOMEPATH is the full path, which is harmless.
-    drive, tail = os.path.splitdrive(str(home))
-    monkeypatch.setenv("USERPROFILE", str(home))
-    monkeypatch.setenv("HOMEDRIVE", drive)
-    monkeypatch.setenv("HOMEPATH", tail if drive else str(home))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_agent_notify_station_contracts.py
+++ b/tests/test_agent_notify_station_contracts.py
@@ -89,7 +89,7 @@ def test_notify_makefile_install_fails_closed_without_home():
 def test_notify_makefile_install_empty_home_aborts():
     if shutil.which("make") is None:
         pytest.skip("GNU make not available")
-    env = {**os.environ, "HOME": ""}
+    env = {**os.environ, "HOME": "", "USERPROFILE": ""}
     r = subprocess.run(
         ["make", "-n", "install"],
         cwd=NOTIFY,
@@ -105,7 +105,7 @@ def test_notify_makefile_install_nonempty_home_dry_run_succeeds(tmp_path):
     if shutil.which("make") is None:
         pytest.skip("GNU make not available")
     home = str(tmp_path / "home")
-    env = {**os.environ, "HOME": home}
+    env = {**os.environ, "HOME": home, "USERPROFILE": home}
     r = subprocess.run(
         ["make", "-n", "install"],
         cwd=NOTIFY,

--- a/tests/test_agent_request.py
+++ b/tests/test_agent_request.py
@@ -12,6 +12,7 @@ import pytest
 
 from brigade import aboyeur, agent_request, attestation, run_events, run_journal, runguard
 from brigade.roster import Agent, Roster
+from tests._home import set_home
 
 
 if not shutil.which("ssh-keygen"):
@@ -186,7 +187,7 @@ def test_safe_key_path_rejects_symlink_after_tilde_expansion(tmp_path: Path, mon
     private_key = home / "private-key"
     private_key.write_text("private")
     (home / "linked-key").symlink_to(private_key)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
 
     with pytest.raises(agent_request.AgentRequestError, match="regular private key"):
         agent_request._safe_key_path(Path("~/linked-key"))

--- a/tests/test_authority_store_hmac.py
+++ b/tests/test_authority_store_hmac.py
@@ -13,6 +13,7 @@ import pytest
 from brigade import authority_broker, authority_key, authority_marker, cli, scanner_isolation
 from brigade.security_cmd import AUTHORITY_STORE_ISOLATION_EXTERNAL_KEY
 from brigade.work_cmd import constants, helpers, ledger
+from tests._home import set_home
 
 
 def _disable_external_key_isolation(tmp_path: Path) -> None:
@@ -1431,7 +1432,7 @@ def test_default_home_brigade_marker_is_created_and_blocks_strip(
 
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.delenv("BRIGADE_USER_DIR", raising=False)
     workspace = tmp_path / "ws"
     workspace.mkdir()

--- a/tests/test_center_agent_activity.py
+++ b/tests/test_center_agent_activity.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from brigade import center_cmd, grokbot_jobs
 from brigade.center_cmd import agent_activity as activity_records
 from brigade.center_cmd.dashboard.views import agent_activity
+from tests._home import set_home
 
 
 def _write_json(path, payload):
@@ -67,7 +68,7 @@ def test_center_activity_observes_codex_and_cursor_session_files_without_transcr
     cursor.mkdir(parents=True)
     (codex / "rollout-safe-session.jsonl").write_text('{"type":"response_item","payload":{"text":"private prompt"}}\n')
     (cursor / "session-one.jsonl").write_text('{"role":"user","message":"private transcript"}\n')
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
 
     assert center_cmd.activity(target=tmp_path, json_output=True) == 0
@@ -101,7 +102,7 @@ def test_center_activity_projects_grokbot_queue_without_private_instructions(tmp
         now=now,
     )["job_id"]
     home = tmp_path / "empty-home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
 
     records = activity_records.collect(tmp_path, now=now)
@@ -161,7 +162,7 @@ def test_center_activity_marks_merged_grokbot_draft_pr_succeeded(tmp_path, monke
         },
     )
     home = tmp_path / "empty-home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
 
     records = activity_records.collect(tmp_path, now=now + timedelta(hours=30))
@@ -342,7 +343,7 @@ def test_codex_session_extracts_task_label_from_cwd_folder(tmp_path, capsys, mon
         )
         + "\n"
     )
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
     _write_json(
         tmp_path / ".brigade" / "center" / "agent-activity-sources.json",
@@ -375,7 +376,7 @@ def test_codex_session_falls_back_to_first_user_prompt_when_cwd_is_generic(tmp_p
         )
         + "\n"
     )
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
 
     records = activity_records.collect(tmp_path)
@@ -403,7 +404,7 @@ def test_external_sources_redact_journal_text_and_missing_local_sources_are_stal
         tmp_path / ".brigade" / "center" / "agent-activity-sources.json",
         {"sources": [{"provider": "t3", "host": "fleet-east", "journal": "fleet/t3.jsonl"}]},
     )
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
 
     assert center_cmd.activity(target=tmp_path, json_output=True) == 0
@@ -586,7 +587,7 @@ def test_zombie_running_run_without_lock_renders_stale_last_seen(tmp_path, monke
     now = datetime.now(timezone.utc)
     home = tmp_path / "empty-home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
     started = now - timedelta(hours=45)
     run = tmp_path / ".brigade" / "runs" / "zombie-run"
@@ -619,7 +620,7 @@ def test_blocked_45h_run_is_older_history_not_live(tmp_path, monkeypatch):
     now = datetime.now(timezone.utc)
     home = tmp_path / "empty-home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
     started = now - timedelta(hours=45)
     run = tmp_path / ".brigade" / "runs" / "blocked-old"
@@ -691,7 +692,7 @@ def test_live_lock_keeps_recent_running_run(tmp_path, monkeypatch):
     now = datetime.now(timezone.utc)
     home = tmp_path / "empty-home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
     monkeypatch.setattr("brigade.runguard.run_lock_state", lambda workspace, run_dir: "live")
     started = now - timedelta(minutes=4)
@@ -716,7 +717,7 @@ def test_heartbeat_over_two_hours_is_stale_even_with_live_lock(tmp_path, monkeyp
     now = datetime.now(timezone.utc)
     home = tmp_path / "empty-home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
     monkeypatch.setattr("brigade.runguard.run_lock_state", lambda workspace, run_dir: "live")
     started = now - timedelta(hours=3)

--- a/tests/test_claude_hooks_compaction_marker.py
+++ b/tests/test_claude_hooks_compaction_marker.py
@@ -26,7 +26,7 @@ def _wired_claude(tmp_path: Path) -> Path:
 def _cache_env(tmp_path: Path) -> dict[str, str]:
     cache = tmp_path / "xdg-cache"
     cache.mkdir(parents=True, exist_ok=True)
-    return {"XDG_CACHE_HOME": str(cache), "HOME": str(tmp_path / "home")}
+    return {"XDG_CACHE_HOME": str(cache), "HOME": str(tmp_path / "home"), "USERPROFILE": str(tmp_path / "home")}
 
 
 def _payload(target: Path, event: str, *, session_id: str = "session-1", **extra):

--- a/tests/test_claude_hooks_user_scope.py
+++ b/tests/test_claude_hooks_user_scope.py
@@ -24,6 +24,7 @@ from brigade.claude_hooks.package import (
     managed_user_command,
 )
 from brigade.claude_hooks.paths import resolve_claude_home
+from tests._home import set_home
 
 
 FOREIGN_SETTINGS = {
@@ -61,7 +62,7 @@ def claude_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     claude = home / ".claude-config"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude))
     assert resolve_claude_home() == claude.resolve()
     return claude
@@ -205,7 +206,7 @@ def test_resolve_claude_home_falls_back_to_dot_claude(tmp_path: Path, monkeypatc
     home.mkdir()
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     assert resolve_claude_home() == (home / ".claude").resolve()
 
 

--- a/tests/test_claude_hooks_user_target.py
+++ b/tests/test_claude_hooks_user_target.py
@@ -14,6 +14,7 @@ from brigade.claude_hooks.package import PACKAGE_REF, is_managed_handler, manage
 from brigade.claude_hooks import runtime
 from brigade.install import install_selection
 from brigade.selection import Selection
+from tests._home import set_home
 
 
 def _wired_claude(tmp_path: Path) -> Path:
@@ -325,7 +326,7 @@ def test_project_install_refuses_home_directory(tmp_path: Path, monkeypatch, cap
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home.resolve()))
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
 
     assert hooks_install(target=home, scope="project") == 2
     assert "user settings" in capsys.readouterr().err
@@ -343,7 +344,7 @@ def test_user_scope_pin_writes_target_into_script(tmp_path: Path, monkeypatch):
     claude = home / ".claude-config"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude))
     workspace = _wired_claude(tmp_path)
 
@@ -362,7 +363,7 @@ def test_user_scope_refuses_home_pin(tmp_path: Path, monkeypatch, capsys):
     claude = home / ".claude-config"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home.resolve()))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude))
 
     assert hooks_install(target=home, scope="user") == 2
@@ -389,7 +390,7 @@ def test_status_flags_scope_widened_when_project_settings_are_user_settings(tmp_
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home.resolve()))
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     settings = home / ".claude" / "settings.json"
     settings.parent.mkdir(parents=True)
     settings.write_text("{}\n")

--- a/tests/test_component_bins.py
+++ b/tests/test_component_bins.py
@@ -7,6 +7,7 @@ import stat
 from pathlib import Path
 
 from brigade import component_bins
+from tests._home import set_home
 
 _SHA = "0" * 64
 
@@ -43,7 +44,12 @@ def _write_installed_state(data_home: Path, components: dict[str, Path]) -> None
 
 
 def _env(tmp_path: Path, **extra: str) -> dict[str, str]:
-    return {"HOME": str(tmp_path), "XDG_DATA_HOME": str(tmp_path / "data"), **extra}
+    return {
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+        "XDG_DATA_HOME": str(tmp_path / "data"),
+        **extra,
+    }
 
 
 def test_managed_path_returns_installed_executable(tmp_path):
@@ -95,7 +101,7 @@ def test_resolve_falls_back_to_supplied_path(tmp_path, monkeypatch):
 
 def test_resolve_falls_back_to_legacy_location(tmp_path, monkeypatch):
     legacy = _write_executable(tmp_path / ".cargo" / "bin" / "graphtrail")
-    monkeypatch.setenv("HOME", str(tmp_path / "host-home"))
+    set_home(monkeypatch, str(tmp_path / "host-home"))
     monkeypatch.setenv("PATH", str(tmp_path / "elsewhere"))
     env = _env(tmp_path, PATH=str(tmp_path / "empty"))
     assert component_bins.resolve("graphtrail", env=env) == str(legacy)
@@ -110,16 +116,17 @@ def test_resolve_unknown_name_uses_path_only(tmp_path, monkeypatch):
 
 def test_resolve_override_tilde_uses_supplied_home(tmp_path, monkeypatch):
     override_bin = _write_executable(tmp_path / "supplied-home" / "tools" / "graphtrail")
-    monkeypatch.setenv("HOME", str(tmp_path / "host-home"))
+    set_home(monkeypatch, str(tmp_path / "host-home"))
     env = _env(tmp_path, GRAPHTRAIL_BIN="~/tools/graphtrail")
     env["HOME"] = str(tmp_path / "supplied-home")
+    env["USERPROFILE"] = str(tmp_path / "supplied-home")
     assert component_bins.resolve("graphtrail", env=env) == str(override_bin)
 
 
 def test_resolve_argv_rewrites_engine_head(tmp_path, monkeypatch):
     managed = _write_executable(tmp_path / "managed" / "miseledger")
     _write_installed_state(tmp_path / "data", {"miseledger": managed})
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     assert component_bins.resolve_argv(("miseledger", "doctor", "--json")) == [
         str(managed),
@@ -162,7 +169,7 @@ def test_resolve_agent_notify_prefers_managed_over_legacy_go_bin(tmp_path, monke
 
 def test_resolve_agent_notify_falls_back_to_legacy_go_bin(tmp_path, monkeypatch):
     legacy = _write_executable(tmp_path / "go" / "bin" / "agent-notify")
-    monkeypatch.setenv("HOME", str(tmp_path / "host-home"))
+    set_home(monkeypatch, str(tmp_path / "host-home"))
     monkeypatch.setenv("PATH", str(tmp_path / "elsewhere"))
     env = _env(tmp_path, PATH=str(tmp_path / "empty"))
     assert component_bins.resolve("agent-notify", env=env) == str(legacy)
@@ -178,7 +185,7 @@ def test_resolve_agent_notify_falls_back_to_supplied_path(tmp_path, monkeypatch)
 def test_resolve_argv_rewrites_agent_notify_head(tmp_path, monkeypatch):
     managed = _write_executable(tmp_path / "managed" / "agent-notify")
     _write_installed_state(tmp_path / "data", {"agent-notify": managed})
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     assert component_bins.resolve_argv(("agent-notify", "version", "--json")) == [
         str(managed),

--- a/tests/test_component_paths.py
+++ b/tests/test_component_paths.py
@@ -12,7 +12,7 @@ _VALID_SHA = "a" * 64
 
 
 def test_unsupported_system_raises_actionable_error():
-    env = {"HOME": "/home/alice"}
+    env = {"HOME": "/home/alice", "USERPROFILE": "/home/alice"}
     with pytest.raises(
         ValueError,
         match="unsupported component path platform system 'freebsd'; supported systems: darwin, linux, windows",
@@ -26,7 +26,7 @@ def test_unsupported_system_raises_actionable_error():
 
 
 def test_linux_defaults_use_xdg_paths():
-    env = {"HOME": "/home/alice"}
+    env = {"HOME": "/home/alice", "USERPROFILE": "/home/alice"}
     data = component_paths.data_root(env=env, system="linux")
     cache = component_paths.cache_root(env=env, system="linux")
     config = component_paths.config_root(env=env, system="linux")
@@ -38,6 +38,7 @@ def test_linux_defaults_use_xdg_paths():
 def test_linux_honors_xdg_overrides():
     env = {
         "HOME": "/home/alice",
+        "USERPROFILE": "/home/alice",
         "XDG_DATA_HOME": "/data",
         "XDG_CACHE_HOME": "/cache",
         "XDG_CONFIG_HOME": "/config",
@@ -48,7 +49,7 @@ def test_linux_honors_xdg_overrides():
 
 
 def test_macos_defaults_use_library_paths():
-    env = {"HOME": "/Users/alice"}
+    env = {"HOME": "/Users/alice", "USERPROFILE": "/Users/alice"}
     data = component_paths.data_root(env=env, system="darwin")
     cache = component_paths.cache_root(env=env, system="darwin")
     assert data == "/Users/alice/Library/Application Support"
@@ -57,7 +58,7 @@ def test_macos_defaults_use_library_paths():
 
 @patch("brigade.component_paths.host_platform.system", return_value="Darwin")
 def test_default_detection_uses_platform_system_for_macos(_mock_system):
-    env = {"HOME": "/Users/alice"}
+    env = {"HOME": "/Users/alice", "USERPROFILE": "/Users/alice"}
     data = component_paths.data_root(env=env)
     cache = component_paths.cache_root(env=env)
     assert data == "/Users/alice/Library/Application Support"
@@ -94,7 +95,11 @@ def test_component_paths_never_use_repo_brigade(tmp_path):
     repo = tmp_path / "project"
     repo.mkdir()
     (repo / ".brigade").mkdir()
-    env = {"HOME": str(tmp_path / "home"), "XDG_DATA_HOME": str(tmp_path / "xdg-data")}
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "USERPROFILE": str(tmp_path / "home"),
+        "XDG_DATA_HOME": str(tmp_path / "xdg-data"),
+    }
     data = component_paths.data_root(env=env, system="linux")
     installed = component_paths.installed_state_path(data)
     previous = component_paths.installed_previous_state_path(data)
@@ -112,7 +117,7 @@ def test_component_paths_never_use_repo_brigade(tmp_path):
 
 
 def test_installed_previous_state_path_uses_brigade_subdir():
-    env = {"HOME": "/home/alice"}
+    env = {"HOME": "/home/alice", "USERPROFILE": "/home/alice"}
     data = component_paths.data_root(env=env, system="linux")
     path = component_paths.installed_previous_state_path(data)
     assert path.endswith("brigade/installed.previous.json")

--- a/tests/test_conftest_home_isolation.py
+++ b/tests/test_conftest_home_isolation.py
@@ -1,0 +1,11 @@
+import os
+from pathlib import Path
+
+
+def test_home_isolation_points_at_pytest_temp(tmp_path_factory):
+    base = tmp_path_factory.getbasetemp().resolve()
+    home = Path.home().resolve()
+    expanded = Path(os.path.expanduser("~")).resolve()
+    assert home.is_relative_to(base)
+    assert expanded.is_relative_to(base)
+    assert os.environ["BRIGADE_HOME"] == str(Path.home() / ".brigade")

--- a/tests/test_conftest_home_isolation.py
+++ b/tests/test_conftest_home_isolation.py
@@ -9,3 +9,15 @@ def test_home_isolation_points_at_pytest_temp(tmp_path_factory):
     assert home.is_relative_to(base)
     assert expanded.is_relative_to(base)
     assert os.environ["BRIGADE_HOME"] == str(Path.home() / ".brigade")
+
+
+def test_no_direct_setenv_home_outside_helper():
+    root = Path(__file__).resolve().parent
+    offenders = []
+    for path in sorted(root.glob("*.py")):
+        if path.name in {"_home.py", "test_conftest_home_isolation.py"}:
+            continue
+        text = path.read_text()
+        if 'setenv("HOME"' in text or "setenv('HOME'" in text:
+            offenders.append(path.name)
+    assert not offenders, f"use tests._home.set_home instead of setenv HOME in: {offenders}"

--- a/tests/test_cursor_install_state_migration.py
+++ b/tests/test_cursor_install_state_migration.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 from brigade import __version__ as BRIGADE_VERSION
 from brigade import cli, harness_profile_cmd, harness_profiles
+from tests._home import set_home
 
 
 def _use_home(monkeypatch, tmp_path: Path) -> Path:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     return home
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -14,6 +14,7 @@ from brigade import doctor as doctor_mod
 from brigade.install import install_selection
 from brigade.memory_cmd import MemoryCareConfig
 from brigade.selection import Selection
+from tests._home import set_home
 
 
 def test_doctor_passes_against_workspace_profile(tmp_target: Path, capsys):
@@ -678,7 +679,7 @@ def test_doctor_openclaw_reports_manual_when_config_missing(tmp_target: Path, mo
             includes=[],
         ),
     )
-    monkeypatch.setenv("HOME", str(tmp_target))  # so ~/.openclaw resolves into the temp dir
+    set_home(monkeypatch, str(tmp_target))  # so ~/.openclaw resolves into the temp dir
     monkeypatch.setattr(Path, "home", lambda: tmp_target)
     rc = doctor_mod.run(target=tmp_target, harness="openclaw", full=True, operator=True)
     out = capsys.readouterr().out
@@ -914,7 +915,7 @@ def test_doctor_openclaw_reports_cron_memory_jobs(tmp_target: Path, monkeypatch,
             }
         )
     )
-    monkeypatch.setenv("HOME", str(tmp_target))
+    set_home(monkeypatch, str(tmp_target))
     monkeypatch.setattr(Path, "home", lambda: tmp_target)
 
     rc = doctor_mod.run(target=tmp_target, harness="openclaw", full=True, operator=True)
@@ -1227,7 +1228,7 @@ def _write_openclaw_cron(tmp_target: Path, jobs: list[dict], monkeypatch) -> Non
         entry.setdefault("command", FAKE_CRON_COMMAND)
         payload_jobs.append(entry)
     (cron_dir / "jobs.json").write_text(json.dumps({"jobs": payload_jobs}))
-    monkeypatch.setenv("HOME", str(tmp_target))
+    set_home(monkeypatch, str(tmp_target))
     monkeypatch.setattr(Path, "home", lambda: tmp_target)
 
 
@@ -1508,7 +1509,7 @@ def test_doctor_no_collision_with_shipped_scanners_toml(tmp_target: Path, monkey
     openclaw_dir = tmp_target / ".openclaw"
     (openclaw_dir / "cron").mkdir(parents=True)
     (openclaw_dir / "cron" / "jobs.json").write_text(json.dumps({"jobs": []}))
-    monkeypatch.setenv("HOME", str(tmp_target))
+    set_home(monkeypatch, str(tmp_target))
     monkeypatch.setattr(Path, "home", lambda: tmp_target)
 
     results = _run_producer_collision_check(tmp_target)

--- a/tests/test_doctor_agent.py
+++ b/tests/test_doctor_agent.py
@@ -12,6 +12,7 @@ from brigade import doctor_agent
 from brigade import outcome_cmd
 from brigade.install import install_selection
 from brigade.selection import Selection
+from tests._home import set_home
 
 
 def _expected_init_command(target: Path, *, selection: Selection | None = None) -> str:
@@ -124,7 +125,7 @@ def test_doctor_agent_dormant_loop_clears_after_verify(tmp_path: Path, capsys):
 def test_doctor_agent_silences_absent_harness_checks(tmp_path: Path, capsys, monkeypatch):
     target = _wire(tmp_path, harnesses=["claude", "openclaw"])
     # Ensure OpenClaw host artifacts are absent inside the temp HOME.
-    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    set_home(monkeypatch, str(tmp_path / "empty-home"))
     (tmp_path / "empty-home").mkdir()
     capsys.readouterr()
 
@@ -174,7 +175,7 @@ def test_doctor_agent_suppressed_harness_warn_json_summary(tmp_path: Path, capsy
         ),
     ]
     monkeypatch.setattr(doctor_mod, "_gather_checks", lambda _ctx: checks)
-    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    set_home(monkeypatch, str(tmp_path / "empty-home"))
     (tmp_path / "empty-home").mkdir()
     capsys.readouterr()
 
@@ -186,7 +187,7 @@ def test_doctor_agent_suppressed_harness_warn_json_summary(tmp_path: Path, capsy
 
 
 def test_doctor_agent_bootstrap_missing_init_command_uses_selection(tmp_path: Path, capsys, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    set_home(monkeypatch, str(tmp_path / "empty-home"))
     (tmp_path / "empty-home").mkdir()
     target = _wire(tmp_path, harnesses=["claude"])
     selection = Selection(
@@ -287,7 +288,7 @@ def test_doctor_agent_extract_commands_and_harness_detection(tmp_path: Path, mon
     (target / ".claude").mkdir()
     assert doctor_agent.harness_artifacts_present(target, "claude")
     # OpenClaw detection reads host config under HOME, not the target tree.
-    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    set_home(monkeypatch, str(tmp_path / "empty-home"))
     (tmp_path / "empty-home").mkdir()
     assert not doctor_agent.harness_artifacts_present(target, "openclaw")
     assert doctor_agent.extract_commands("run `brigade security init --target .` now") == [

--- a/tests/test_error_refusal_copy.py
+++ b/tests/test_error_refusal_copy.py
@@ -19,6 +19,7 @@ from brigade.work_cmd import edges as edges_mod
 from brigade.work_cmd.session import briefing as briefing_mod
 
 from tests.work_cmd_test_helpers import _init_git_repo
+from tests._home import set_home
 
 
 _BYPASS_TOKENS = (
@@ -97,7 +98,7 @@ def test_workflow_rules_missing_templates_remediation_omits_force(tmp_path):
 def test_mcp_user_scope_stdio_gate_omits_allow_flag(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed_mcp(repo)

--- a/tests/test_fleet_sync.py
+++ b/tests/test_fleet_sync.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from brigade import fleet_client, fleet_hub
+from tests._home import set_home
 
 NODE_A = "11111111-1111-4111-8111-111111111111"
 NODE_B = "22222222-2222-4222-8222-222222222222"
@@ -1365,7 +1366,7 @@ def test_session_routes_auth_and_node_identity(hub_server):
 def test_session_admin_writes_include_local_node_id(monkeypatch, session_snapshot, tmp_path):
     home = tmp_path / "operator"
     _plant_home_identity(home, NODE_A)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setenv("BRIGADE_HOME", str(home / ".brigade"))
     calls = _record_hub_calls(monkeypatch, node_token=None, admin_token=ADMIN_TOKEN)
     assert fleet_client.upsert_session(session_snapshot) is True

--- a/tests/test_governance_inventory.py
+++ b/tests/test_governance_inventory.py
@@ -11,6 +11,7 @@ import pytest
 
 from brigade import cli, fleet_model_roster, governance_inventory, receipt_schema, run_receipts
 from brigade.run_transport import WorkerResult
+from tests._home import set_home
 
 
 NOW = datetime(2026, 9, 4, 17, 30, tzinfo=timezone.utc)
@@ -628,7 +629,7 @@ def test_workspace_inventory_never_falls_back_to_the_user_roster(tmp_path, monke
         home / ".brigade" / "roster.toml",
         'orchestrator = "home"\n\n[agents.home]\ncli = "codex"\nrole = "worker"\nmodel = "gpt-5.6"\n',
     )
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     target = tmp_path / "workspace"
     target.mkdir()
 

--- a/tests/test_harness_conformance_probe.py
+++ b/tests/test_harness_conformance_probe.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from tests._home import set_home
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -305,7 +306,7 @@ def test_redact_bounded_output_preserves_prefix_when_redaction_expands_at_cap(pr
 def test_redact_text_removes_real_and_temporary_home_segments(probe, monkeypatch, tmp_path: Path) -> None:
     real_home = str(tmp_path / "real-home")
     temp_home = str(tmp_path / "temp-home")
-    monkeypatch.setenv("HOME", real_home)
+    set_home(monkeypatch, real_home)
     sample = f"config={real_home}/.config\nsandbox={temp_home}/probe"
     result = probe.redact_text(sample, temp_home)
     assert real_home not in result
@@ -315,7 +316,7 @@ def test_redact_text_removes_real_and_temporary_home_segments(probe, monkeypatch
 
 def test_redact_text_removes_inherited_path_home_segments(probe, monkeypatch, tmp_path: Path) -> None:
     home_segment = str(tmp_path / "operator" / "bin")
-    monkeypatch.setenv("HOME", str(tmp_path / "operator"))
+    set_home(monkeypatch, str(tmp_path / "operator"))
     monkeypatch.setenv("PATH", f"{home_segment}{os.pathsep}/usr/bin")
     result = probe.redact_text(f"PATH includes {home_segment}", None)
     assert home_segment not in result
@@ -618,7 +619,7 @@ def test_hermes_home_directory_only_never_counts_as_runtime_conformance(
     home = tmp_path / "home"
     (home / ".hermes").mkdir(parents=True)
     (home / ".config" / "hermes").mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     with mock.patch.object(probe.shutil, "which", return_value=None):
         result = probe.probe_fixture(fixture, schema, run_version=True, timeout_seconds=1.0)
     for section in (result["availability"], result["version_probe"]):
@@ -732,7 +733,7 @@ def test_antigravity_home_directory_only_never_counts_as_runtime_conformance(
     home = tmp_path / "home"
     (home / ".antigravity").mkdir(parents=True)
     (home / ".config" / "antigravity").mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     with mock.patch.object(probe.shutil, "which", return_value=None):
         result = probe.probe_fixture(fixture, schema, run_version=True, timeout_seconds=1.0)
     for section in (result["availability"], result["version_probe"]):
@@ -886,7 +887,7 @@ def test_run_deep_probes_executes_safe_discovery_spec(probe, schema, monkeypatch
     )
     real_home = tmp_path / "real-home"
     real_home.mkdir()
-    monkeypatch.setenv("HOME", str(real_home))
+    set_home(monkeypatch, str(real_home))
     monkeypatch.setenv("USERPROFILE", str(real_home))
     process = _fake_version_process()
     with (
@@ -1179,7 +1180,7 @@ def test_run_deep_probes_nonzero_exit_preserves_bounded_output(probe, schema, mo
     )
     real_home = tmp_path / "real-home"
     real_home.mkdir()
-    monkeypatch.setenv("HOME", str(real_home))
+    set_home(monkeypatch, str(real_home))
     process = _fake_version_process(exit_code=2)
     with (
         mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
@@ -1300,7 +1301,7 @@ def test_run_deep_probes_output_overflow_redacts_unterminated_json_at_boundary(p
 def test_run_deep_probes_sandbox_routes_writes_away_from_real_home(probe, schema, monkeypatch, tmp_path: Path) -> None:
     real_home = tmp_path / "real-home"
     real_home.mkdir()
-    monkeypatch.setenv("HOME", str(real_home))
+    set_home(monkeypatch, str(real_home))
     monkeypatch.setenv("USERPROFILE", str(real_home))
     helper = tmp_path / "probe-home-check"
     helper.write_text(

--- a/tests/test_harness_user_scope.py
+++ b/tests/test_harness_user_scope.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import pytest
 
 from brigade import harness_profile_cmd, harness_profiles, mcp_cmd, skills_cmd
+from tests._home import set_home
 
 
 def _use_home(monkeypatch, tmp_path: Path) -> Path:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     # Harness CLI calls must not spawn the detached update-notify cache writer.
     monkeypatch.setenv("BRIGADE_NO_UPDATE_CHECK", "1")
     return home

--- a/tests/test_harness_user_scope_slice2.py
+++ b/tests/test_harness_user_scope_slice2.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from brigade import harness_profiles, mcp_cmd, skills_cmd
+from tests._home import set_home
 
 # Per-harness native user surfaces (relative to the temporary home).
 SURFACES = {
@@ -62,7 +63,7 @@ def _use_home(monkeypatch, tmp_path: Path) -> Path:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     # Harness CLI calls must not spawn the detached update-notify cache writer.
     monkeypatch.setenv("BRIGADE_NO_UPDATE_CHECK", "1")
     return home

--- a/tests/test_instruction_profiles.py
+++ b/tests/test_instruction_profiles.py
@@ -6,13 +6,14 @@ import json
 from pathlib import Path
 
 from brigade import brief_sections, harness_profile_cmd, harness_profiles, managed_block
+from tests._home import set_home
 
 
 def _use_home(monkeypatch, tmp_path: Path) -> Path:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     return home
 
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from brigade import cli, doctor, mcp_cmd, operator_cmd, registry
+from tests._home import set_home
 
 
 def _seed(target):
@@ -28,7 +29,7 @@ def _seed(target):
 def test_user_scope_antigravity_writes_home(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed(repo)
@@ -47,7 +48,7 @@ def test_user_scope_antigravity_writes_home(tmp_path, monkeypatch):
 def test_cursor_user_scope_uses_home_config_and_reports_paths(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed(repo)
@@ -78,7 +79,7 @@ def test_cursor_user_scope_uses_home_config_and_reports_paths(tmp_path, monkeypa
 def test_broad_user_scope_does_not_select_cursor_global_config(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed(repo)
@@ -93,7 +94,7 @@ def test_broad_user_scope_does_not_select_cursor_global_config(tmp_path, monkeyp
 def test_cursor_user_scope_accepts_global_target_alias(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)
@@ -128,7 +129,7 @@ def test_cursor_user_scope_normalizes_repo_graphtrail_pin_and_preserves_config(t
             }
         )
     )
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)
@@ -176,7 +177,7 @@ def test_cursor_user_scope_normalizes_repo_graphtrail_pin_and_preserves_config(t
 def test_cursor_user_scope_preserves_relative_graphtrail_pin(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)
@@ -202,7 +203,7 @@ def test_cursor_user_scope_preserves_relative_graphtrail_pin(tmp_path, monkeypat
 def test_cursor_user_scope_preserves_remote_graphtrail_shape(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)
@@ -247,7 +248,7 @@ def test_cursor_user_scope_rejects_invalid_existing_config(tmp_path, monkeypatch
     cursor_config = home / ".cursor" / "mcp.json"
     cursor_config.parent.mkdir(parents=True)
     cursor_config.write_text(invalid)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed(repo)
@@ -269,7 +270,7 @@ def test_cursor_user_scope_import_reads_home_config(tmp_path, monkeypatch, capsy
     cursor_config = home / ".cursor" / "mcp.json"
     cursor_config.parent.mkdir(parents=True)
     cursor_config.write_text(json.dumps({"mcpServers": {"global": {"command": "global-mcp"}}}))
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)
@@ -292,7 +293,7 @@ def test_cursor_user_scope_import_reads_home_config(tmp_path, monkeypatch, capsy
 def test_user_scope_grok_writes_home(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed(repo)
@@ -342,7 +343,7 @@ def test_codex_user_stdio_no_args_never_stays_conflicted(tmp_path, monkeypatch, 
     """
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)
@@ -474,7 +475,7 @@ def test_mcp_station_doctor_info_when_uninitialized(tmp_path):
 def _seed_user_home(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     _seed(repo)
@@ -539,7 +540,7 @@ def test_user_scope_stdio_sync_interactive_decline_aborts(tmp_path, monkeypatch,
 def test_user_scope_remote_only_sync_does_not_gate(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)

--- a/tests/test_mcp_url_only_import.py
+++ b/tests/test_mcp_url_only_import.py
@@ -8,6 +8,7 @@ import json
 
 from brigade import mcp_adapters as A
 from brigade import mcp_cmd
+from tests._home import set_home
 
 
 def _invalid_stdio_url(server: A.CanonicalServer) -> bool:
@@ -90,7 +91,7 @@ def _seed_openclaw_remote(home, url_only_raw):
 def test_doctor_no_false_stdio_without_command_for_pure_url_remote(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)
@@ -117,7 +118,7 @@ def test_doctor_no_false_stdio_without_command_for_pure_url_remote(tmp_path, mon
 def test_import_then_sync_never_emits_stdio_plus_url(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     repo = tmp_path / "repo"
     repo.mkdir()
     mcp_cmd.init(target=repo, json_output=True)

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -90,6 +90,7 @@ def _git_env(repo: Path) -> dict:
         "GIT_COMMITTER_NAME": "t",
         "GIT_COMMITTER_EMAIL": "t@example.com",
         "HOME": str(repo),
+        "USERPROFILE": str(repo),
         "XDG_CONFIG_HOME": str(repo / ".config"),
         # The embedded CLI starts a detached update refresh unless it is opted
         # out. It inherits this test's temporary HOME, so letting it run can

--- a/tests/test_projection_kernel.py
+++ b/tests/test_projection_kernel.py
@@ -12,6 +12,7 @@ import pytest
 
 from brigade.projection import kernel as projection
 from brigade.projection.fixture import mixed_workspace
+from tests._home import set_home
 
 
 def _digest(data: bytes | None) -> str:
@@ -300,7 +301,7 @@ def test_unfinished_recovery_blocks_only_overlapping_destinations(tmp_path: Path
 def test_receipt_redacts_paths_secrets_and_omits_contents(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home" / "operator"
     home.mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
     workspace = home / "proj"
     workspace.mkdir()

--- a/tests/test_receipt_signing.py
+++ b/tests/test_receipt_signing.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from brigade import cli, localio, receipt_signing, runbook_cmd, work_cmd
 from tests.support import PRIVATE_FILE_MODE, assert_private_mode
+from tests._home import set_home
 
 
 def _write_key(path: Path, value: str) -> None:
@@ -40,7 +41,7 @@ def test_receipts_keygen_writes_private_key_and_refuses_without_force(tmp_path, 
 def test_work_verify_receipt_without_key_keeps_unsigned_digest_shape(tmp_path, capsys, monkeypatch):
     monkeypatch.setenv("BRIGADE_RECEIPT_SIGNING_KEY_FILE", str(tmp_path / "missing-key"))
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
 
     assert (
         work_cmd.verify_run(target=tmp_path, commands=[f"{sys.executable} -c \"print('ok')\""], json_output=True) == 0
@@ -55,7 +56,7 @@ def test_work_verify_receipt_signs_receipt_sha256_when_key_exists(tmp_path, caps
     key_path = tmp_path / ".brigade" / "receipt-signing-key"
     _write_key(key_path, "01" * 32)
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
 
     assert (
         work_cmd.verify_run(target=tmp_path, commands=[f"{sys.executable} -c \"print('ok')\""], json_output=True) == 0

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -10,6 +10,7 @@ from brigade import status as status_mod
 from brigade.install import install_selection
 from brigade.selection import Selection
 from brigade.station import Station
+from tests._home import set_home
 
 
 @pytest.mark.parametrize(
@@ -150,7 +151,7 @@ def _write_update_cache(cache_home: Path, **state) -> Path:
 
 
 def _run_status(tmp_target: Path, cache_home: Path, monkeypatch, capsys, *, json_output: bool = False) -> str:
-    monkeypatch.setenv("HOME", str(cache_home))
+    set_home(monkeypatch, str(cache_home))
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home / "cache"))
     capsys.readouterr()
     assert status_mod.run(tmp_target, json_output=json_output) == 0

--- a/tests/test_update_notify.py
+++ b/tests/test_update_notify.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from brigade import __version__, update_notify
+from tests._home import set_home
 
 
 class _Tty(io.StringIO):
@@ -15,7 +16,11 @@ class _Tty(io.StringIO):
 
 
 def _env(tmp_path: Path, **extra: str) -> dict[str, str]:
-    env = {"HOME": str(tmp_path), "XDG_CACHE_HOME": str(tmp_path / "cache")}
+    env = {
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+    }
     env.update(extra)
     return env
 
@@ -309,7 +314,7 @@ def _run_brief(tmp_path, cache_home: Path, monkeypatch, capsys) -> str:
 
     from tests.work_cmd_test_helpers import _init_git_repo
 
-    monkeypatch.setenv("HOME", str(cache_home))
+    set_home(monkeypatch, str(cache_home))
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home / "cache"))
     _init_git_repo(tmp_path)
     dogfood_cmd.init(target=tmp_path)

--- a/tests/test_verify_brigade_skill.py
+++ b/tests/test_verify_brigade_skill.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._home import home_env
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILL_DIR = REPO_ROOT / "registry" / "skills" / "verify-brigade"
 CONTROL = SKILL_DIR / "control-brigade.py"
@@ -98,7 +100,7 @@ def sandbox(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
     temp = tmp_path / "sandbox-tmp"
     home.mkdir()
     temp.mkdir()
-    return home, temp, {"HOME": str(home), "TMPDIR": str(temp)}
+    return home, temp, {**home_env(home), "TMPDIR": str(temp)}
 
 
 def test_control_brigade_is_an_executable_helper():
@@ -482,7 +484,7 @@ def test_a_relative_tmpdir_cannot_move_the_temp_base_onto_the_checkout(tmp_path)
     landing = REPO_ROOT / "verify-brigade"
     assert not landing.exists(), "probe precondition: the checkout has no state root"
 
-    code, payload = control("doctor", root=None, env_extra={"HOME": str(home), "TMPDIR": "."}, cwd=REPO_ROOT)
+    code, payload = control("doctor", root=None, env_extra={**home_env(home), "TMPDIR": "."}, cwd=REPO_ROOT)
     assert code == 1, payload
     assert payload["ok"] is False
     assert payload["action"] == "doctor"
@@ -498,7 +500,7 @@ def test_a_temp_base_inside_the_checkout_is_still_refused(tmp_path):
     temp = checkout / "scratch"
     temp.mkdir()
 
-    code, payload = control("doctor", root=None, env_extra={"HOME": str(home), "TMPDIR": str(temp)}, script=script)
+    code, payload = control("doctor", root=None, env_extra={**home_env(home), "TMPDIR": str(temp)}, script=script)
     assert code == 1, payload
     assert payload["ok"] is False
     assert "inside the Brigade checkout" in payload["error"], payload
@@ -512,7 +514,7 @@ def test_a_temp_base_inside_the_operator_home_is_still_allowed(tmp_path):
     temp = home / "scratch"
     temp.mkdir()
 
-    code, payload = control("doctor", root=None, env_extra={"HOME": str(home), "TMPDIR": str(temp)})
+    code, payload = control("doctor", root=None, env_extra={**home_env(home), "TMPDIR": str(temp)})
     assert code in {0, 3}, payload
     assert payload["action"] == "doctor"
     assert "error" not in payload, payload

--- a/tests/test_wiring_resolve_target.py
+++ b/tests/test_wiring_resolve_target.py
@@ -9,6 +9,7 @@ from brigade import cli
 from brigade.config import Config, write_config
 from brigade.selection import Selection
 from brigade.wiring import resolve_wired_target
+from tests._home import set_home
 
 
 def _write_config(target: Path, harnesses: list[str]) -> None:
@@ -29,7 +30,7 @@ def test_home_roster_without_config_is_not_a_wired_target(tmp_path: Path, monkey
     (roster / "roster.toml").write_text("# user-level roster\n")
     plain = home / "plain"
     plain.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
 
     assert resolve_wired_target(str(home), harness=None) is None
     assert resolve_wired_target(str(plain), harness=None) is None
@@ -55,7 +56,7 @@ def test_home_roster_does_not_shadow_child_project(tmp_path: Path, monkeypatch):
     repo = home / "repos" / "app"
     repo.mkdir(parents=True)
     _write_config(repo, ["grok"])
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
 
     assert resolve_wired_target(str(repo), harness="grok") == repo.resolve()
     assert resolve_wired_target(str(home), harness="grok") is None

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -23,6 +23,7 @@ from tests.work_cmd_test_helpers import (
     _init_git_repo,
 )
 from tests.support import PRIVATE_FILE_MODE
+from tests._home import set_home
 
 
 def _init_git_repo_with_head(path):
@@ -1654,7 +1655,7 @@ def test_work_verify_receipt_digests_recompute_from_payload_and_logs(tmp_path, c
     _init_git_repo(tmp_path)
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
     monkeypatch.setenv("PATH", str(tmp_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
 
     assert (
         work_cmd.verify_run(
@@ -1701,7 +1702,7 @@ def test_work_verify_receipt_compacts_prior_nested_evidence(tmp_path, capsys, mo
         },
     )
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
 
     assert (
         work_cmd.verify_run(
@@ -1727,7 +1728,7 @@ def test_work_verify_receipt_captures_git_state_before_digest(tmp_path, capsys, 
     _init_git_repo_with_head(tmp_path)
     (tmp_path / "dirty.txt").write_text("dirty\n")
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
 
     assert (
         work_cmd.verify_run(
@@ -1753,7 +1754,7 @@ def test_work_verify_receipt_captures_git_state_before_digest(tmp_path, capsys, 
 
 def test_work_verify_receipt_omits_git_state_outside_git_repo(tmp_path, capsys, monkeypatch):
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
 
     assert (
         work_cmd.verify_run(
@@ -1967,7 +1968,7 @@ def test_work_verify_graphtrail_delta_missing_binary_fails_open(tmp_path, capsys
     _init_git_repo(tmp_path)
     monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
     monkeypatch.setenv("PATH", str(tmp_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
 
     assert (
         work_cmd.verify_run(target=tmp_path, commands=[f"{sys.executable} -c \"print('ok')\""], json_output=True) == 0


### PR DESCRIPTION
Fixes #1474

## What

- `tests/conftest.py`: the autouse home fixture now sets `USERPROFILE`, `HOMEDRIVE`, and `HOMEPATH` to the same temp home it already used for `HOME`, so `Path.home()` and `os.path.expanduser` resolve inside the pytest temp root on Windows too.
- `tests/test_conftest_home_isolation.py`: guard test asserting `Path.home()` and `expanduser("~")` resolve under the pytest base temp and that `BRIGADE_HOME` matches `Path.home() / ".brigade"`.

No `src/` changes. The seven tests that already set `USERPROFILE` themselves were checked and still pass.

## Verification

Focused gate through Brigade (ruff, format, version sync, snapshots, mypy, selected tests):

```
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_conftest_home_isolation.py","tests/test_harness_conformance_probe.py","tests/test_runguard.py","tests/test_evidence_cmd.py"]' --capture brigade-work
run: 20260906-162245-work-verify-f183f9
status: completed  exit=0
```

Windows confirmation on the fleet host is recorded in a follow-up comment.

Implemented by the `muse13` seat via `brigade run`; reviewed and landed by the conductor.
