### PR TITLE
feat(fleet): route from the Worklore queue with brigade fleet work next

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -28,7 +28,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade dogfood` (extras): 1 command path(s)
 - `brigade evidence`: 12 command path(s)
 - `brigade extras`: 3 command path(s)
-- `brigade fleet`: 54 command path(s)
+- `brigade fleet`: 55 command path(s)
 - `brigade friction` (extras): 3 command path(s)
 - `brigade governance`: 1 command path(s)
 - `brigade guard`: 1 command path(s)
@@ -239,6 +239,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade fleet work create`
 - `brigade fleet work link`
 - `brigade fleet work list`
+- `brigade fleet work next`
 - `brigade fleet work patch`
 - `brigade fleet work show`
 - `brigade fleet work sync-brigade`

--- a/src/brigade/cli/fleet.py
+++ b/src/brigade/cli/fleet.py
@@ -10,6 +10,7 @@ import sys
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from .. import worklore_brigade_sync, worklore_github_sync
 
@@ -458,6 +459,13 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_work_burn.add_argument("--cursor", default=None, help="Page cursor from a previous burn read.")
     p_work_burn.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
     p_work_burn.set_defaults(func=_dispatch_work_burn)
+    p_work_next = work_sub.add_parser(
+        "next", help="Show the first eligible burn item with a dry-run route (read-only, never reserves)."
+    )
+    p_work_next.add_argument("--consumer", default="brigade-run", help="Routing consumer (default brigade-run).")
+    p_work_next.add_argument("--workload", default="general", help="Routing workload (default general).")
+    p_work_next.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    p_work_next.set_defaults(func=_dispatch_work_next)
     p_work_patch = work_sub.add_parser(
         "patch", help="Patch scheduling fields on a Worklore item (operator node token)."
     )
@@ -1763,6 +1771,49 @@ def _dispatch_work_burn(args: argparse.Namespace) -> int:
         args,
         lambda: worklore_client.burn_queue(limit=getattr(args, "limit", None), cursor=getattr(args, "cursor", None)),
     )
+
+
+def _dispatch_work_next(args: argparse.Namespace) -> int:
+    import json as _json
+
+    from .. import fleet_client_policy
+
+    try:
+        payload = fleet_client_policy.work_next(
+            consumer=getattr(args, "consumer", None) or "brigade-run",
+            workload=getattr(args, "workload", None) or "general",
+        )
+    except fleet_client_policy.FleetPolicyClientError as exc:
+        if bool(getattr(args, "json", False)):
+            print(_json.dumps({"error": {"code": exc.code, "message": str(exc)}}, sort_keys=True))
+        else:
+            print(f"error: {exc.code}: {exc}", file=sys.stderr)
+        return 1
+    except fleet_client_policy.FleetClientError as exc:
+        if bool(getattr(args, "json", False)):
+            print(_json.dumps({"error": {"code": "network", "message": str(exc)}}, sort_keys=True))
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if bool(getattr(args, "json", False)):
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return 0 if payload.get("work_id") else 1
+    raw_item = payload.get("item")
+    item: dict[str, Any] = raw_item if isinstance(raw_item, dict) else {}
+    raw_route = payload.get("route")
+    route: dict[str, Any] = raw_route if isinstance(raw_route, dict) else {}
+    raw_selected = route.get("selected")
+    selected: dict[str, Any] = raw_selected if isinstance(raw_selected, dict) else {}
+    work_id = payload.get("work_id") or item.get("work_id")
+    if not work_id:
+        print(f"no eligible work: {route.get('reason') or 'empty queue'}")
+        return 1
+    title = _safe_table_cell(item.get("title") or "")
+    machine = _safe_table_cell(selected.get("machine") or "-")
+    seat = _safe_table_cell(selected.get("seat") or "-")
+    reason = _safe_table_cell(route.get("reason") or "-")
+    print(f'{work_id} "{title}" -> {machine} / {seat} ({reason})')
+    return 0
 
 
 def _dispatch_work_patch(args: argparse.Namespace) -> int:

--- a/src/brigade/fleet_client_policy.py
+++ b/src/brigade/fleet_client_policy.py
@@ -338,6 +338,14 @@ def route_work(
     return post_policy(body, admin=False)
 
 
+def work_next(*, consumer: str = "brigade-run", workload: str = "general") -> dict[str, Any]:
+    """Read-only next eligible burn item with a dry-run route. Never reserves or dispatches."""
+    return post_policy(
+        {"action": "work-next", "consumer": consumer, "workload": workload},
+        admin=False,
+    )
+
+
 def renew_reservation(*, reservation_id: str, decision_id: str, session_id: str) -> dict[str, Any]:
     return post_policy(
         {

--- a/src/brigade/fleet_hub_policy_api.py
+++ b/src/brigade/fleet_hub_policy_api.py
@@ -31,6 +31,7 @@ NODE_ACTIONS = frozenset(
         "prepare",
         "acknowledge",
         "route",
+        "work-next",
         "reservation-renew",
         "reservation-release",
         "telemetry-observe",
@@ -627,6 +628,16 @@ def _ack_payload(
     return {key: payload[key] for key in ACK_PUBLIC_KEYS}
 
 
+def _work_next(conn: Any, body: Mapping[str, Any]) -> dict[str, Any]:
+    """Read-only next-burn-item lookup. Never reserves, persists, or dispatches."""
+    unknown = sorted(set(body).difference({"action", "consumer", "workload"}))
+    if unknown:
+        raise _error("invalid-request", f"unknown work-next field(s): {', '.join(unknown)}")
+    consumer = _text(body.get("consumer"), "consumer", required=False) or "brigade-run"
+    workload = _text(body.get("workload"), "workload", required=False) or "general"
+    return fleet_hub_routing.work_next(conn, consumer=consumer, workload=workload)
+
+
 def handle_policy(
     conn: Any,
     raw: Any,
@@ -779,6 +790,10 @@ def handle_policy(
                 raise _error("auth-failed", "a node token is required to route", status=403)
             routed = {key: value for key, value in body.items() if key != "action"}
             status_payload = (200, fleet_hub_routing.public_route(fleet_hub_routing.route(conn, routed, caller_node)))
+        elif action == "work-next":
+            if caller_node is None:
+                raise _error("auth-failed", "a node token is required to read the next burn item", status=403)
+            status_payload = (200, _work_next(conn, body))
         elif action == "reservation-renew":
             if caller_node is None:
                 raise _error("auth-failed", "a node token is required to renew a reservation", status=403)

--- a/src/brigade/fleet_hub_routing.py
+++ b/src/brigade/fleet_hub_routing.py
@@ -25,7 +25,12 @@ from .fleet_model_roster import canonical_json
 ROUTE_SCHEMA = "brigade.fleet_route.v1"
 RESERVATION_SCHEMA = "brigade.fleet_reservation.v1"
 CONTROL_PLANE_SCHEMA = "brigade.fleet_control_plane.v1"
-WORKLORE_INTEGRATION = "pending-root"
+WORK_NEXT_SCHEMA = "brigade.fleet_work_next.v1"
+WORKLORE_INTEGRATION = "work-next"
+# One work-next read walks the burn order and stops at the first eligible item.
+# The scan budget matches the burn page budget; only the first
+# WORK_NEXT_CONSIDERED_MAX exclusions are reported, the scan itself continues.
+WORK_NEXT_CONSIDERED_MAX = 100
 TELEMETRY_STATUSES = ("available", "busy", "draining", "unavailable", "unknown")
 CREDENTIAL_STATES = ("ok", "missing", "stale", "error")
 INTENT_STATES = ("pending", "accepted", "unknown", "released")
@@ -998,6 +1003,81 @@ def _revalidate(conn: sqlite3.Connection, request: Mapping[str, Any], caller_nod
     return _public(stored)
 
 
+def _collect_candidates(
+    conn: sqlite3.Connection,
+    *,
+    document: Mapping[str, Any],
+    routing: Mapping[str, Any],
+    workload: str,
+    requirements: Mapping[str, Any],
+    resolution: Mapping[str, Any],
+    now: datetime,
+    machine: str | None = None,
+    seat: str | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any] | None, str | None]:
+    """Evaluate every seat/machine pair. Never writes; shared by ``route`` and dry-run previews."""
+    start_seat = seat or (resolution.get("effective", {}).get("roles", {}) or {}).get("impl")
+    seats = _chain(start_seat, document["seats"], "fallback")
+    if not seats:
+        return [], [], None, "unknown-role"
+    candidates: list[dict[str, Any]] = []
+    eligible: list[dict[str, Any]] = []
+    for seat_name in seats:
+        seat_record = document["seats"][seat_name]
+        machine_names = list(seat_record.get("eligible_machines") or []) or list(document["machines"])
+        if machine and machine not in machine_names:
+            machine_names = [machine, *machine_names]
+        if machine and machine in machine_names:
+            ordered = [machine] + [name for name in machine_names if name != machine]
+        else:
+            preferred = None
+            for name in machine_names:
+                record = document["machines"].get(name) or {}
+                if workload in (record.get("preferred_workloads") or []):
+                    preferred = name
+                    break
+            start_machine = preferred or (machine_names[0] if machine_names else None)
+            chained = _chain(
+                start_machine,
+                {name: document["machines"][name] for name in machine_names if name in document["machines"]},
+                "fallback",
+            )
+            extra = [name for name in machine_names if name not in chained]
+            ordered = chained + extra
+        ordered = sorted(
+            ordered,
+            key=lambda name: _rank(document, name, workload) if name in document["machines"] else (9, 9, 0),
+        )
+        for machine_name in ordered:
+            row = _evaluate_pair(
+                conn,
+                document=document,
+                routing=routing,
+                machine_name=machine_name,
+                seat_name=seat_name,
+                workload=workload,
+                requirements=requirements,
+                resolution=resolution,
+                now=now,
+            )
+            candidates.append(row)
+            if row["eligible"]:
+                eligible.append(row)
+    selected_row = None
+    if machine or seat:
+        matching = [
+            row for row in eligible if (not machine or row["machine"] == machine) and (not seat or row["seat"] == seat)
+        ]
+        if not matching:
+            return candidates, eligible, None, "machine-override-ineligible"
+        selected_row = matching[0]
+    elif eligible:
+        selected_row = eligible[0]
+    if selected_row is None:
+        return candidates, eligible, None, "no-eligible-candidate"
+    return candidates, eligible, selected_row, None
+
+
 def route(conn: sqlite3.Connection, request: Any, caller_node: str) -> dict[str, Any]:
     """Select a machine/seat under the current policy, or record a structured denial."""
     ensure_schema(conn)
@@ -1148,108 +1228,25 @@ def route(conn: sqlite3.Connection, request: Any, caller_node: str) -> dict[str,
             parsed["repo_identity"],
             override_reason=parsed["override_reason"],
         )
-        start_seat = parsed["seat"] or (resolution.get("effective", {}).get("roles", {}) or {}).get("impl")
-        seats = _chain(start_seat, document["seats"], "fallback")
-        if not seats:
+        candidates, _eligible, selected_row, denial = _collect_candidates(
+            conn,
+            document=document,
+            routing=routing,
+            workload=parsed["workload"],
+            requirements=requirements,
+            resolution=resolution,
+            now=now,
+            machine=parsed["machine"],
+            seat=parsed["seat"],
+        )
+        if denial is not None:
             payload = _store_decision(
                 conn,
                 request=parsed,
                 caller_node=caller,
                 current=current,
                 selected=None,
-                reason="unknown-role",
-                candidates=[],
-                override_reason=parsed["override_reason"],
-                reservation_id=None,
-                expires_at=None,
-                decision_id=_mint("dec-"),
-                generation=generation,
-            )
-            if opened:
-                conn.commit()
-            return payload
-        candidates: list[dict[str, Any]] = []
-        eligible: list[dict[str, Any]] = []
-        for seat_name in seats:
-            seat = document["seats"][seat_name]
-            machine_names = list(seat.get("eligible_machines") or []) or list(document["machines"])
-            if parsed["machine"] and parsed["machine"] not in machine_names:
-                machine_names = [parsed["machine"], *machine_names]
-            if parsed["machine"] and parsed["machine"] in machine_names:
-                ordered = [parsed["machine"]] + [name for name in machine_names if name != parsed["machine"]]
-            else:
-                preferred = None
-                for name in machine_names:
-                    record = document["machines"].get(name) or {}
-                    if parsed["workload"] in (record.get("preferred_workloads") or []):
-                        preferred = name
-                        break
-                start_machine = preferred or (machine_names[0] if machine_names else None)
-                chained = _chain(
-                    start_machine,
-                    {name: document["machines"][name] for name in machine_names if name in document["machines"]},
-                    "fallback",
-                )
-                extra = [name for name in machine_names if name not in chained]
-                ordered = chained + extra
-            ordered = sorted(
-                ordered,
-                key=lambda name: (
-                    _rank(document, name, parsed["workload"]) if name in document["machines"] else (9, 9, 0)
-                ),
-            )
-            for machine_name in ordered:
-                row = _evaluate_pair(
-                    conn,
-                    document=document,
-                    routing=routing,
-                    machine_name=machine_name,
-                    seat_name=seat_name,
-                    workload=parsed["workload"],
-                    requirements=requirements,
-                    resolution=resolution,
-                    now=now,
-                )
-                candidates.append(row)
-                if row["eligible"]:
-                    eligible.append(row)
-        selected_row = None
-        if parsed["machine"] or parsed["seat"]:
-            matching = [
-                row
-                for row in eligible
-                if (not parsed["machine"] or row["machine"] == parsed["machine"])
-                and (not parsed["seat"] or row["seat"] == parsed["seat"])
-            ]
-            if not matching:
-                payload = _store_decision(
-                    conn,
-                    request=parsed,
-                    caller_node=caller,
-                    current=current,
-                    selected=None,
-                    reason="machine-override-ineligible",
-                    candidates=candidates,
-                    override_reason=parsed["override_reason"],
-                    reservation_id=None,
-                    expires_at=None,
-                    decision_id=_mint("dec-"),
-                    generation=generation,
-                )
-                if opened:
-                    conn.commit()
-                return payload
-            selected_row = matching[0]
-        elif eligible:
-            selected_row = eligible[0]
-        if selected_row is None:
-            payload = _store_decision(
-                conn,
-                request=parsed,
-                caller_node=caller,
-                current=current,
-                selected=None,
-                reason="no-eligible-candidate",
+                reason=denial,
                 candidates=candidates,
                 override_reason=parsed["override_reason"],
                 reservation_id=None,
@@ -1260,6 +1257,7 @@ def route(conn: sqlite3.Connection, request: Any, caller_node: str) -> dict[str,
             if opened:
                 conn.commit()
             return payload
+        assert selected_row is not None
         decision_id = _mint("dec-")
         reservation_id = _mint("rsv-")
         expires_at = _iso(now + timedelta(seconds=int(routing["reservation_ttl_seconds"])))
@@ -1316,6 +1314,146 @@ def route(conn: sqlite3.Connection, request: Any, caller_node: str) -> dict[str,
         if opened:
             conn.rollback()
         raise
+
+
+def preview_route_for_work(
+    conn: sqlite3.Connection,
+    *,
+    consumer: str,
+    workload: str,
+) -> dict[str, Any]:
+    """Dry-run candidate evaluation for one work item.
+
+    Runs the same pair evaluation as :func:`route` but never writes: no
+    ``fleet_reservations`` row, no persisted decision, no claim.
+    """
+    ensure_schema(conn)
+    consumer_name = _bounded(consumer, "consumer")
+    workload_name = _bounded(workload, "workload")
+    assert consumer_name is not None and workload_name is not None
+    current = fleet_hub_policy.current_policy(conn)
+    document = current["document"]
+    routing = document.get("routing") or fleet_policy.empty_routing()
+    now = _now()
+    if consumer_name not in (document.get("consumers") or {}):
+        return {"selected": None, "candidates": [], "reason": "enrollment-required"}
+    if not routing.get("enabled"):
+        return {"selected": None, "candidates": [], "reason": "routing-disabled"}
+    requirements = (routing.get("workload_requirements") or {}).get(workload_name)
+    if requirements is None:
+        return {"selected": None, "candidates": [], "reason": "unknown-workload"}
+    resolution = fleet_policy.resolve_policy(document, consumer_name, None)
+    candidates, _eligible, selected_row, denial = _collect_candidates(
+        conn,
+        document=document,
+        routing=routing,
+        workload=workload_name,
+        requirements=requirements,
+        resolution=resolution,
+        now=now,
+    )
+    if denial is not None:
+        return {"selected": None, "candidates": candidates, "reason": denial}
+    assert selected_row is not None
+    return {
+        "selected": {"machine": selected_row["machine"], "seat": selected_row["seat"]},
+        "candidates": candidates,
+        "reason": "selected",
+    }
+
+
+def _work_next_summary(item: Mapping[str, Any], work_id: str) -> dict[str, Any]:
+    """Bounded item facts for work-next. Never carries description, prompt, or body text."""
+    try:
+        rank = int(item.get("burn_rank") or 0)
+    except (TypeError, ValueError):
+        rank = 0
+    title = item.get("title")
+    return {
+        "work_id": work_id,
+        "title": str(title)[:240] if title is not None else "",
+        "kind": str(item.get("kind") or ""),
+        "status": str(item.get("status") or ""),
+        "priority": str(item.get("priority") or ""),
+        "burn_rank": rank,
+    }
+
+
+def _work_next_empty(reason: str) -> dict[str, Any]:
+    return {
+        "schema": WORK_NEXT_SCHEMA,
+        "work_id": None,
+        "item": None,
+        "route": {"selected": None, "candidates": [], "reason": reason},
+        "considered": [],
+    }
+
+
+def work_next(
+    conn: sqlite3.Connection,
+    *,
+    consumer: str = "brigade-run",
+    workload: str = "general",
+    caller_node: str = "",
+) -> dict[str, Any]:
+    """First eligible burn item in burn order with a dry-run route decision.
+
+    Read-only: no ``fleet_reservations`` row, no persisted decision, no claim,
+    and no Worklore transition. Items the lookup cannot produce are reported as
+    the structured ``unknown``/``unreadable`` bucket, never invented as eligible.
+    """
+    ensure_schema(conn)
+    consumer_name = _bounded(consumer, "consumer")
+    workload_name = _bounded(workload, "workload")
+    assert consumer_name is not None and workload_name is not None
+    try:
+        from .worklore_store import BURN_SCAN_MAX, _BURN_ORDER_SQL
+    except Exception:
+        return _work_next_empty("worklore-unavailable")
+    try:
+        rows = conn.execute(
+            f"SELECT work_id FROM work_items ORDER BY {_BURN_ORDER_SQL} LIMIT ?",
+            (int(BURN_SCAN_MAX),),
+        ).fetchall()
+    except sqlite3.Error:
+        return _work_next_empty("worklore-unavailable")
+    considered: list[dict[str, str]] = []
+    for row in rows:
+        work_id = str(row[0])
+        try:
+            item = _lookup_work(conn, work_id)
+        except Exception:
+            item = None
+        if item is None:
+            bucket = "unreadable" if _lookup_failed(conn, work_id) else "unknown"
+            if len(considered) < WORK_NEXT_CONSIDERED_MAX:
+                considered.append({"work_id": work_id, "bucket": bucket})
+            continue
+        verdict = evaluate_work_item(item)
+        if verdict["ok"]:
+            preview = preview_route_for_work(conn, consumer=consumer_name, workload=workload_name)
+            return {
+                "schema": WORK_NEXT_SCHEMA,
+                "work_id": work_id,
+                "item": _work_next_summary(item, work_id),
+                "route": preview,
+                "considered": considered,
+            }
+        if len(considered) < WORK_NEXT_CONSIDERED_MAX:
+            considered.append(
+                {"work_id": work_id, "bucket": str(verdict.get("detail") or verdict.get("reason") or "work-held")}
+            )
+    payload = _work_next_empty("no-eligible-work")
+    payload["considered"] = considered
+    return payload
+
+
+def _lookup_failed(conn: sqlite3.Connection, work_id: str) -> bool:
+    """True when the id names a row the lookup could not produce (unreadable vs unknown)."""
+    try:
+        return conn.execute("SELECT 1 FROM work_items WHERE work_id = ?", (work_id,)).fetchone() is not None
+    except sqlite3.Error:
+        return False
 
 
 def _reservation_request(raw: Any) -> dict[str, str]:

--- a/tests/test_fleet_work_next.py
+++ b/tests/test_fleet_work_next.py
@@ -1,0 +1,459 @@
+"""fleet work next: read-only first-eligible burn item with a dry-run route."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brigade import fleet_client_policy, fleet_hub, fleet_hub_policy, fleet_hub_policy_api, fleet_hub_routing
+from brigade import fleet_policy, fleet_quota, worklore_store
+
+NODE_LINUX = "11111111-1111-4111-8111-111111111111"
+NODE_LINUX_2 = "22222222-2222-4222-8222-222222222222"
+NODE_WINDOWS = "33333333-3333-4333-8333-333333333333"
+NODE_CLOUD = "44444444-4444-4444-8444-444444444444"
+CONTROLLER = "55555555-5555-4555-8555-555555555555"
+ADMIN_TOKEN = "test-admin-token-work-next"
+
+
+def _now() -> datetime:
+    return datetime(2026, 9, 5, 12, 0, tzinfo=timezone.utc)
+
+
+def _iso(stamp: datetime | None = None) -> str:
+    return (stamp or fleet_hub_routing._now()).isoformat()
+
+
+def _document() -> dict:
+    return {
+        "schema": fleet_policy.POLICY_SCHEMA,
+        "defaults": {
+            "roles": {"impl": "seat-grok"},
+            "data": {"allow_training": False},
+            "execution": {"concurrency": 1},
+        },
+        "routing": {
+            "enabled": True,
+            "telemetry_ttl_seconds": 300,
+            "reservation_ttl_seconds": 300,
+            "quota_reserve_percent": 4,
+            "workload_requirements": {
+                "general": {"os": "linux", "capabilities": ["general"]},
+            },
+            "quota_pools": {
+                "pool-grok": {
+                    "account_id": "acct-generic-grok",
+                    "provider": "xai",
+                    "reserve_percent": 4,
+                    "freshness_seconds": 300,
+                },
+            },
+        },
+        "machines": {
+            "worker-linux-1": {
+                "os": "linux",
+                "capabilities": ["general"],
+                "preferred_workloads": ["general"],
+                "priority": 200,
+                "concurrency": 1,
+                "fallback": ["worker-linux-2"],
+                "node_id": NODE_LINUX,
+            },
+            "worker-linux-2": {
+                "os": "linux",
+                "capabilities": ["general"],
+                "priority": 100,
+                "concurrency": 1,
+                "node_id": NODE_LINUX_2,
+            },
+            "worker-windows-1": {
+                "os": "windows",
+                "capabilities": ["gui"],
+                "priority": 50,
+                "concurrency": 1,
+                "node_id": NODE_WINDOWS,
+            },
+            "worker-cloud-1": {
+                "os": "linux",
+                "capabilities": ["general", "cloud"],
+                "priority": 10,
+                "concurrency": 2,
+                "node_id": NODE_CLOUD,
+            },
+            "origin-windows-1": {
+                "os": "windows",
+                "priority": 0,
+                "concurrency": 0,
+                "prohibited_workloads": ["general"],
+                "node_id": CONTROLLER,
+            },
+        },
+        "seats": {
+            "seat-grok": {
+                "provider": "xai",
+                "model": "model-grok-1",
+                "eligible_machines": ["worker-linux-1", "worker-linux-2", "worker-cloud-1"],
+                "concurrency": 2,
+                "quota_pool": "pool-grok",
+            },
+        },
+        "consumers": {"brigade-run": {"reload": "refreshable"}},
+        "repositories": {"repo/public": {"privacy": "public"}},
+    }
+
+
+def _quota_obs(observation_id: str) -> dict:
+    stamp_dt = fleet_hub_routing._now()
+    stamp = stamp_dt.isoformat()
+    return {
+        "observation_id": observation_id,
+        "account_id": "acct-generic-grok",
+        "pool_id": "pool-grok",
+        "provider": "xai",
+        "source": "crossusage-probe",
+        "source_ref": f"ref-{observation_id}",
+        "collected_at": stamp,
+        "provider_time": stamp,
+        "expires_at": (stamp_dt + timedelta(seconds=300)).isoformat(),
+        "status": "current",
+        "windows": [
+            {
+                "window_id": "hourly",
+                "label": "hourly",
+                "used": 10.0,
+                "limit": 100.0,
+                "unit": "percent",
+                "resets_at": (stamp_dt + timedelta(seconds=3600)).isoformat(),
+                "period_duration_ms": 3_600_000,
+            }
+        ],
+    }
+
+
+def _fresh_quota(conn) -> None:
+    stamp = _iso()
+    token = stamp.replace(":", "").replace("-", "").replace("+", "").replace(".", "")
+    fleet_quota.ingest_observations(
+        conn,
+        {
+            "schema": fleet_quota.QUOTA_SCHEMA,
+            "collected_at": stamp,
+            "observations": [_quota_obs(f"obs-grok-{token}")],
+        },
+    )
+
+
+def _observe(conn, node_id: str, *, usable_seats: list | None = None) -> dict:
+    return fleet_hub_routing.observe_machine(
+        conn,
+        {
+            "node_id": node_id,
+            "observed_at": _iso(),
+            "ttl_seconds": 300,
+            "status": "available",
+            "load": 0.0,
+            "running": {"session_ids": [], "run_ids": []},
+            "active_claims": [],
+            "usable_seats": ["seat-grok"] if usable_seats is None else usable_seats,
+            "credential_state": "ok",
+        },
+        caller_node=node_id,
+    )
+
+
+def _observe_fleet(conn) -> None:
+    _observe(conn, NODE_LINUX)
+    _observe(conn, NODE_LINUX_2)
+    _observe(conn, NODE_CLOUD)
+    _observe(conn, NODE_WINDOWS, usable_seats=[])
+
+
+def _seed(conn, title: str, *, rank: int = 100, **extra) -> str:
+    body: dict = {
+        "title": title,
+        "kind": "fleet",
+        "acceptance": ["done when complete"],
+        "burn_eligible": True,
+        "execution_mode": "agent",
+        "burn_rank": rank,
+    }
+    body.update(extra)
+    item = worklore_store.create_item(conn, body, actor_id="admin")
+    ready = worklore_store.transition(conn, item["work_id"], to_status="ready", expected_version=1, actor_id="admin")
+    return str(ready["work_id"])
+
+
+def _counts(conn) -> tuple[int, int]:
+    reservations = conn.execute("SELECT COUNT(*) FROM fleet_reservations").fetchone()[0]
+    decisions = conn.execute("SELECT COUNT(*) FROM fleet_route_decisions").fetchone()[0]
+    return int(reservations), int(decisions)
+
+
+@pytest.fixture()
+def conn(tmp_path, monkeypatch):
+    monkeypatch.setattr(fleet_hub_routing, "_now", _now)
+    monkeypatch.setattr(fleet_quota, "_now", _now)
+    connection = fleet_hub.init_db(tmp_path / "fleet.db")
+    try:
+        fleet_hub_policy.save_policy(connection, _document(), expected_version=1, actor="operator", reason="test")
+        _fresh_quota(connection)
+        _observe_fleet(connection)
+        yield connection
+    finally:
+        connection.close()
+
+
+def test_selects_first_eligible_in_burn_order(conn):
+    first = _seed(conn, "Second seeded", rank=20)
+    second = _seed(conn, "First seeded", rank=5)
+    assert first != second
+    result = fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    assert result["schema"] == fleet_hub_routing.WORK_NEXT_SCHEMA
+    assert result["work_id"] == second
+    assert result["item"]["work_id"] == second
+    assert result["item"]["title"] == "First seeded"
+    assert "description" not in result["item"]
+    assert "prompt" not in result["item"]
+    assert "body" not in result["item"]
+    assert result["route"]["selected"] == {"machine": "worker-linux-1", "seat": "seat-grok"}
+    assert result["route"]["reason"] == "selected"
+    assert result["route"]["candidates"]
+    assert result["considered"] == []
+
+
+def test_excluded_items_are_reported_as_buckets(conn):
+    blocked = _seed(conn, "Blocked item", rank=1, blocker="waiting on vendor")
+    eligible = _seed(conn, "Eligible item", rank=2)
+    result = fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    assert result["work_id"] == eligible
+    assert result["considered"] == [{"work_id": blocked, "bucket": "blocker"}]
+    assert result["route"]["selected"] == {"machine": "worker-linux-1", "seat": "seat-grok"}
+
+
+def test_source_policy_exclusion_is_respected(conn):
+    work_id = _seed(conn, "Imported item", rank=1)
+    conn.execute(
+        "INSERT INTO work_links (link_id, work_id, link_type, external_key, display_ref, url, external_state, "
+        "external_updated_at, source_policy, source_acceptance_json, synced_at, stale_at, adapter_id, owner_node) "
+        "VALUES (?, ?, 'github', 'org/repo#1', NULL, NULL, NULL, '2026-09-05T11:00:00+00:00', 'closed', '[]', "
+        "'2026-09-05T11:00:00+00:00', NULL, 'github', 'node-a')",
+        (f"lnk-{work_id}", work_id),
+    )
+    conn.commit()
+    eligible = _seed(conn, "Native item", rank=2)
+    result = fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    assert result["work_id"] == eligible
+    assert result["considered"] == [{"work_id": work_id, "bucket": "source-policy"}]
+
+
+def test_unreadable_lookup_is_never_eligible(conn):
+    _seed(conn, "Only item", rank=1)
+    fleet_hub_routing.set_work_item_lookup(lambda _conn, _work_id: None)
+    try:
+        result = fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    finally:
+        fleet_hub_routing.set_work_item_lookup(None)
+    assert result["work_id"] is None
+    assert result["item"] is None
+    assert result["route"]["reason"] == "no-eligible-work"
+    assert len(result["considered"]) == 1
+    assert result["considered"][0]["bucket"] == "unreadable"
+
+
+def test_empty_queue_reports_no_eligible_work(conn):
+    result = fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    assert result["schema"] == fleet_hub_routing.WORK_NEXT_SCHEMA
+    assert result["work_id"] is None
+    assert result["item"] is None
+    assert result["route"] == {"selected": None, "candidates": [], "reason": "no-eligible-work"}
+    assert result["considered"] == []
+
+
+def test_unenrolled_consumer_is_not_routed(conn):
+    _seed(conn, "Only item", rank=1)
+    result = fleet_hub_routing.work_next(conn, consumer="stranger", workload="general")
+    assert result["work_id"] is not None
+    assert result["route"]["reason"] == "enrollment-required"
+    assert result["route"]["selected"] is None
+
+
+def test_work_next_persists_nothing(conn):
+    _seed(conn, "Only item", rank=1)
+    before = _counts(conn)
+    fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    fleet_hub_routing.preview_route_for_work(conn, consumer="brigade-run", workload="general")
+    status, payload = fleet_hub_policy_api.handle_policy(
+        conn, {"action": "work-next"}, caller_node=CONTROLLER, is_admin=False
+    )
+    assert status == 200
+    assert payload["schema"] == fleet_hub_routing.WORK_NEXT_SCHEMA
+    assert _counts(conn) == before
+
+
+def test_policy_api_requires_a_node_token(conn):
+    _seed(conn, "Only item", rank=1)
+    with pytest.raises(fleet_hub_policy_api.FleetPolicyApiError) as excinfo:
+        fleet_hub_policy_api.handle_policy(conn, {"action": "work-next"}, caller_node=None, is_admin=False)
+    assert excinfo.value.status == 403
+    assert excinfo.value.code == "auth-failed"
+    status, payload = fleet_hub_policy_api.handle_policy(
+        conn,
+        {"action": "work-next", "consumer": "brigade-run", "workload": "general"},
+        caller_node=CONTROLLER,
+        is_admin=False,
+    )
+    assert status == 200
+    assert payload["work_id"] is not None
+    with pytest.raises(fleet_hub_policy_api.FleetPolicyApiError) as excinfo:
+        fleet_hub_policy_api.handle_policy(
+            conn, {"action": "work-next", "bogus": True}, caller_node=CONTROLLER, is_admin=False
+        )
+    assert excinfo.value.code == "invalid-request"
+
+
+@contextmanager
+def _hub(tmp_path):
+    server = fleet_hub.make_server(
+        "127.0.0.1", 0, tmp_path / "fleet.db", ADMIN_TOKEN
+    )  # content-guard: allow loopback-ipv4
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield "127.0.0.1", server.server_address[1], tmp_path / "fleet.db"  # content-guard: allow loopback-ipv4
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _request(hub, method: str, path: str, *, token: str | None = None, body: dict | None = None):
+    host, port, _db = hub
+    connection = http.client.HTTPConnection(host, port, timeout=5)
+    headers = {"Content-Type": "application/json"} if body is not None else {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    connection.request(
+        method, path, body=json.dumps(body).encode("utf-8") if body is not None else None, headers=headers
+    )
+    response = connection.getresponse()
+    raw = response.read().decode("utf-8")
+    payload = json.loads(raw) if raw else {}
+    connection.close()
+    return response.status, payload
+
+
+def test_http_auth_node_token_ok_no_token_denied(tmp_path, monkeypatch):
+    monkeypatch.setattr(fleet_hub_routing, "_now", _now)
+    monkeypatch.setattr(fleet_quota, "_now", _now)
+    with _hub(tmp_path) as hub:
+        db = fleet_hub.open_db(hub[2])
+        try:
+            fleet_hub_policy.save_policy(db, _document(), expected_version=1, actor="operator", reason="test")
+            _node, node_token = fleet_hub.add_node(db, CONTROLLER, "controller")
+        finally:
+            db.close()
+        status, _payload = _request(hub, "POST", "/policy", body={"action": "work-next"})
+        assert status in (401, 403)
+        status, payload = _request(hub, "POST", "/policy", token=node_token, body={"action": "work-next"})
+        assert status == 200, payload
+        assert payload["schema"] == fleet_hub_routing.WORK_NEXT_SCHEMA
+        assert payload["route"]["reason"] == "no-eligible-work"
+
+
+def test_cli_json_reports_item_machine_seat_and_reason(monkeypatch, capsys):
+    from brigade import cli
+
+    payload = {
+        "schema": fleet_hub_routing.WORK_NEXT_SCHEMA,
+        "work_id": "wl-abc123",
+        "item": {"work_id": "wl-abc123", "title": "Seeded item", "kind": "fleet"},
+        "route": {
+            "selected": {"machine": "worker-linux-1", "seat": "seat-grok"},
+            "candidates": [],
+            "reason": "selected",
+        },
+        "considered": [],
+    }
+    seen: dict = {}
+
+    def _fake(**kwargs):
+        seen.update(kwargs)
+        return payload
+
+    monkeypatch.setattr(fleet_client_policy, "work_next", _fake)
+    assert cli.main(["fleet", "work", "next", "--json"]) == 0
+    assert seen == {"consumer": "brigade-run", "workload": "general"}
+    out = json.loads(capsys.readouterr().out)
+    assert out["work_id"] == "wl-abc123"
+    assert out["route"]["selected"] == {"machine": "worker-linux-1", "seat": "seat-grok"}
+
+
+def test_cli_table_names_item_machine_seat_and_reason(monkeypatch, capsys):
+    from brigade import cli
+
+    monkeypatch.setattr(
+        fleet_client_policy,
+        "work_next",
+        lambda **kwargs: {
+            "schema": fleet_hub_routing.WORK_NEXT_SCHEMA,
+            "work_id": "wl-abc123",
+            "item": {"work_id": "wl-abc123", "title": "Seeded item"},
+            "route": {
+                "selected": {"machine": "worker-linux-1", "seat": "seat-grok"},
+                "candidates": [],
+                "reason": "selected",
+            },
+            "considered": [{"work_id": "wl-zzz", "bucket": "blocker"}],
+        },
+    )
+    assert cli.main(["fleet", "work", "next"]) == 0
+    out = capsys.readouterr().out
+    assert "wl-abc123" in out
+    assert "worker-linux-1" in out
+    assert "seat-grok" in out
+    assert "selected" in out
+
+
+def test_cli_empty_queue_exits_nonzero(monkeypatch, capsys):
+    from brigade import cli
+
+    monkeypatch.setattr(
+        fleet_client_policy,
+        "work_next",
+        lambda **kwargs: {
+            "schema": fleet_hub_routing.WORK_NEXT_SCHEMA,
+            "work_id": None,
+            "item": None,
+            "route": {"selected": None, "candidates": [], "reason": "no-eligible-work"},
+            "considered": [],
+        },
+    )
+    assert cli.main(["fleet", "work", "next"]) == 1
+    assert "no eligible work" in capsys.readouterr().out
+
+
+def test_snapshot_reports_work_next_integration(conn):
+    assert fleet_hub_routing.snapshot(conn)["worklore_integration"] == "work-next"
+
+
+def test_considered_length_is_bounded(conn, monkeypatch):
+    for index in range(120):
+        _seed(conn, f"Blocked {index:03d}", rank=index + 1, blocker="waiting")
+    result = fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    assert result["work_id"] is None
+    assert len(result["considered"]) == fleet_hub_routing.WORK_NEXT_CONSIDERED_MAX
+    assert all(entry["bucket"] == "blocker" for entry in result["considered"])
+
+
+def test_row_count_unchanged_after_work_next(conn):
+    _seed(conn, "Only item", rank=1)
+    tables = ("fleet_reservations", "fleet_route_decisions", "work_items", "work_events")
+    before = {name: conn.execute(f"SELECT COUNT(*) FROM {name}").fetchone()[0] for name in tables}
+    fleet_hub_routing.work_next(conn, consumer="brigade-run", workload="general")
+    after = {name: conn.execute(f"SELECT COUNT(*) FROM {name}").fetchone()[0] for name in tables}
+    assert after == before


### PR DESCRIPTION
## What

`brigade fleet work next [--consumer brigade-run] [--workload general] [--json]` returns the first eligible Worklore burn item together with a dry-run route decision. Nothing dispatches, reserves, or mutates.

## Why

Worklore is live on the hub (47 items, 6 on the burn page) and the routing authority can already judge an item (`evaluate_work_item`: burn eligibility, attempts, blocker, `spend_by`, `review_after` on the routing clock since #1485), but nothing asked the router to pick the next one. `fleet_hub_routing.WORKLORE_INTEGRATION` sat at `pending-root`.

## How

- `fleet_hub_routing`: `route()`'s seat/machine loop is extracted into `_collect_candidates` (behavior-preserving, same denial reasons); `preview_route_for_work` reuses it without writing `fleet_reservations`, a decision, or a claim; `work_next` walks `work_items` in `_BURN_ORDER_SQL` order up to `BURN_SCAN_MAX`, feeds each id through the `set_work_item_lookup` seam, and returns `{schema: brigade.fleet_work_next.v1, work_id, item, route: {selected, candidates, reason}, considered: [{work_id, bucket}]}` with `considered` capped at 100. `WORKLORE_INTEGRATION` is now `work-next`.
- `fleet_hub_policy_api`: `work-next` joins `NODE_ACTIONS` (node token only, never admin-only) with a validator that rejects unknown fields.
- Client and CLI: `fleet_client_policy.work_next` and the `fleet work next` command; command inventory regenerated (fleet 54 to 55 paths).

## Verify

Coordinator gate `20260906-164506-work-verify-e4b497`: 308 passed over the new `tests/test_fleet_work_next.py` (15 tests: selection order, blocker and source-policy buckets, unreadable-seam bucket, empty queue, unenrolled consumer, reservations and decisions unchanged after the call, API 403/200, live HTTP 401/403/200, CLI JSON, table, exit 1, bounded `considered`) plus routing, worklore store and HTTP, policy API and CLI, deck, and ratchet. Worker receipt `20260906-164120-work-verify-aff568`, 294 passed.

## Look hardest at

- `_collect_candidates` extraction: `route()` must produce byte-identical decisions; `tests/test_fleet_routing.py` passes unchanged.
- `work_next` scans up to 2000 rows with per-row link-summary probes; fine at today's queue size, noted for a cursor later.
- `fleet_hub_routing.py` is at 1831 of the 2000-line ratchet.