### PR TITLE
feat(run): resolve a hub-only worker seat from the versioned hub roster row

### DIFF
--- a/src/brigade/aboyeur_model_policy.py
+++ b/src/brigade/aboyeur_model_policy.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Mapping
 
 from . import fleet_model_admission, fleet_model_roster
-from .roster import Agent, Roster
+from .roster import Agent, Roster, is_cli_allowed
 
 
 def _aboyeur():
@@ -125,6 +125,91 @@ def _local_cli_matches_hub_binding(aboyeur: Any, agent: Agent, binding: Mapping[
     return aboyeur.agents.command_for(local) == instance_id
 
 
+def _hub_seat_row(snapshot: Mapping[str, Any], seat_name: str) -> dict[str, Any] | None:
+    """Return the Hub roster row for a seat, or None when the Hub carries no such row."""
+    raw_seats = snapshot.get("seats")
+    if not isinstance(raw_seats, list):
+        return None
+    for item in raw_seats:
+        if isinstance(item, Mapping) and item.get("seat") == seat_name:
+            return dict(item)
+    return None
+
+
+def synthesize_hub_worker(
+    aboyeur: Any,
+    roster: Roster,
+    snapshot: Mapping[str, Any],
+    seat_name: str,
+) -> tuple[Agent | None, str | None]:
+    """Build a hub-derived Agent for a seat absent from the local roster.
+
+    Returns ``(agent, error)``: ``agent`` is set on success with the canonical
+    slug as its model (``_resolve_versioned`` then applies
+    ``effective_brigade_launch_model`` exactly as the local-seat path does);
+    ``error`` names the ``brigade fleet models set ...`` remediation (or the
+    ``limits.allow_models`` edit) when the Hub row exists but cannot be used;
+    both are None when the Hub carries no such row. Callers only invoke this
+    for seats missing locally, so a locally declared seat always wins. The
+    native launch id is only ever read from an explicit binding leaf; nothing
+    is inferred from the slug.
+    """
+    row = _hub_seat_row(snapshot, seat_name)
+    if row is None:
+        return None, None
+    revision = snapshot.get("roster_revision", snapshot.get("revision"))
+    provider = row.get("provider")
+    canonical = row.get("model")
+    if not isinstance(provider, str) or not provider or not isinstance(canonical, str) or not canonical:
+        return None, (
+            f"hub seat {seat_name!r} registry entry is missing exact provider/model "
+            f"in roster revision {revision if isinstance(revision, int) else 'N'}; "
+            f"repair it with: brigade fleet models set PROVIDER MODEL {seat_name} "
+            f"--brigade-cli CLI --expect-revision {revision if isinstance(revision, int) else 'N'}"
+        )
+    if row.get("enabled") is not True:
+        return None, (
+            f"hub seat {seat_name!r} is disabled in roster revision "
+            f"{revision if isinstance(revision, int) else 'N'}; enable it with:"
+            + _set_remediation_detail(row, revision, fallback_seat=seat_name)
+        )
+    launch_groups = fleet_model_roster.consumer_launch_groups(snapshot, "brigade-run", seat_name)
+    binding = fleet_model_admission._binding_for("brigade-run", row, launch_groups=launch_groups)
+    raw_cli = binding.get("instance_id") if isinstance(binding, Mapping) else None
+    if not isinstance(raw_cli, str) or not raw_cli:
+        return None, (
+            f"hub seat {seat_name!r} has no brigade-run cli binding "
+            f"in roster revision {revision if isinstance(revision, int) else 'N'}; "
+            "nothing to launch without an explicit binding leaf (the native id is never "
+            "inferred from the slug); bind it with:" + _set_remediation_detail(row, revision, fallback_seat=seat_name)
+        )
+    resolved_cli = _cli_from_binding(aboyeur, raw_cli)
+    if resolved_cli is None:
+        return None, (
+            f"hub seat {seat_name!r} binds {raw_cli!r}, which is not a supported Brigade harness; rebind it with:"
+            + _set_remediation_detail(row, revision, fallback_seat=seat_name)
+        )
+    if not is_cli_allowed(resolved_cli, roster):
+        detail = _set_remediation_detail(row, revision, fallback_seat=seat_name)
+        return None, (
+            f"hub seat {seat_name!r} uses {resolved_cli!r}, which is not allowed by limits.allow_models "
+            f"({', '.join(roster.allow_models)}); add {resolved_cli!r} to limits.allow_models in "
+            f"{roster.resolution.path if roster.resolution is not None else 'the local roster'}"
+            + (f"; or rebind the Hub row:{detail}" if detail else "")
+        )
+    reasoning = row.get("reasoning")
+    return (
+        Agent(
+            name=seat_name,
+            cli=resolved_cli,
+            role=f"hub-derived worker ({provider}/{canonical})",
+            model=canonical,
+            reasoning=reasoning if isinstance(reasoning, str) and reasoning else None,
+        ),
+        None,
+    )
+
+
 def _set_remediation_detail(
     row: Mapping[str, Any],
     revision: object,
@@ -162,6 +247,7 @@ def resolve_fleet_model_policy(
     """Resolve one immutable Fleet Hub policy snapshot into an effective roster."""
     aboyeur = _aboyeur()
     effective = roster
+    raw_snapshot = dict(snapshot) if snapshot is not None else aboyeur.fleet_client.load_model_policy_snapshot()
     cleaned_override: str | None = None
     if model_override is not None:
         cleaned_override = model_override.strip()
@@ -171,13 +257,22 @@ def resolve_fleet_model_policy(
                 receipt={"state": "invalid", "authoritative": False, "models": [], "decisions": []},
                 error="--model requires --worker so the overridden seat is unambiguous",
             )
-        agent = roster.agents.get(worker)
+        agent = effective.agents.get(worker)
         if agent is None:
-            return aboyeur.FleetModelPolicyResolution(
-                roster=roster,
-                receipt={"state": "invalid", "authoritative": False, "models": [], "decisions": []},
-                error=f"unknown worker: {worker}",
-            )
+            # Validation-only synthesis: _resolve_versioned performs the real
+            # admission below, so error-path rosters never carry an unadmitted
+            # hub-derived seat.
+            hub_error: str | None = None
+            if _is_versioned_snapshot(raw_snapshot):
+                hub_agent, hub_error = synthesize_hub_worker(aboyeur, effective, raw_snapshot, worker)
+                if hub_agent is not None:
+                    agent = hub_agent
+            if agent is None:
+                return aboyeur.FleetModelPolicyResolution(
+                    roster=roster,
+                    receipt={"state": "invalid", "authoritative": False, "models": [], "decisions": []},
+                    error=hub_error or f"unknown worker: {worker}",
+                )
         if not cleaned_override:
             return aboyeur.FleetModelPolicyResolution(
                 roster=roster,
@@ -192,7 +287,6 @@ def resolve_fleet_model_policy(
                 error=f"seat {worker!r} uses {cli!r}, which does not support a per-run model override",
             )
 
-    raw_snapshot = dict(snapshot) if snapshot is not None else aboyeur.fleet_client.load_model_policy_snapshot()
     if _is_versioned_snapshot(raw_snapshot):
         return _resolve_versioned(
             aboyeur,
@@ -416,6 +510,27 @@ def _resolve_versioned(
         [dict(row) for row in raw_retired if isinstance(row, Mapping)] if isinstance(raw_retired, list) else []
     )
     seat_rows = {row.get("seat"): row for row in seats if isinstance(row.get("seat"), str) and row.get("seat")}
+    if worker is not None and worker not in effective.agents:
+        hub_agent, hub_error = synthesize_hub_worker(aboyeur, effective, raw_snapshot, worker)
+        if hub_agent is not None:
+            effective = replace(effective, agents={**effective.agents, worker: hub_agent})
+        else:
+            receipt["decisions"] = []
+            receipt["admissions"] = []
+            if hub_error is not None:
+                return aboyeur.FleetModelPolicyResolution(
+                    roster=effective,
+                    receipt=receipt,
+                    error=hub_error,
+                )
+            return aboyeur.FleetModelPolicyResolution(
+                roster=effective,
+                receipt=receipt,
+                error=(
+                    f"unknown worker: {worker} (absent from the local roster and from Hub roster "
+                    f"revision {revision}; see current rows: brigade fleet models list --seat {worker})"
+                ),
+            )
     kept_agents = dict(effective.agents)
     decisions: list[dict[str, object]] = []
     denied: dict[str, str] = {}

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -1278,10 +1278,53 @@ def _detached_child_argv(args, *, run_cwd: Path, roster_resolution, output_dir: 
     return argv
 
 
+def _hub_synthesized_agent(worker: str, loaded_roster) -> tuple[object | None, str | None]:
+    """Resolve a worker absent from the local roster from the Hub roster row.
+
+    Returns ``(agent, error)`` mirroring ``synthesize_hub_worker``: ``agent``
+    is set when the Hub row yields a usable seat (full admission still happens
+    later in Fleet model-policy resolution); ``error`` carries the Hub
+    remediation when the row exists but cannot be used; both None when the Hub
+    carries no such row. A missing Hub keeps the generic unknown-worker error;
+    an unreachable Hub refuses honestly instead of guessing.
+    """
+    from .. import aboyeur_model_policy as hub_seats
+
+    try:
+        from .. import fleet_client as fleet_client_mod
+
+        snapshot = fleet_client_mod.load_model_policy_snapshot()
+    except Exception:
+        return None, (
+            f"fleet model policy hub is unavailable; cannot resolve worker {worker!r} "
+            "without the Hub roster; refusing new dispatch"
+        )
+    if not isinstance(snapshot, dict) or not hub_seats._is_versioned_snapshot(snapshot):
+        state = (
+            snapshot.get("state")
+            if isinstance(snapshot, dict) and isinstance(snapshot.get("state"), str)
+            else "unavailable"
+        )
+        if state == "unconfigured":
+            return None, None
+        return None, (
+            f"fleet model policy hub is unavailable ({state}); cannot resolve worker {worker!r} "
+            "without the Hub roster; refusing new dispatch"
+        )
+    from .. import aboyeur as aboyeur_mod
+
+    return hub_seats.synthesize_hub_worker(aboyeur_mod, loaded_roster, snapshot, worker)
+
+
 def _direct_worker_error(worker: str, loaded_roster, roster_mod, *, read_only: bool = False) -> str | None:
     agent = loaded_roster.agents.get(worker)
     if agent is None:
-        return f"unknown worker: {worker}"
+        hub_agent, hub_error = _hub_synthesized_agent(worker, loaded_roster)
+        if hub_error is not None:
+            return hub_error
+        if hub_agent is None:
+            return f"unknown worker: {worker}"
+        agent = hub_agent
     if worker == loaded_roster.orchestrator:
         return f"--worker cannot target orchestrator seat: {worker}"
     if read_only:

--- a/tests/test_hub_seat_resolution.py
+++ b/tests/test_hub_seat_resolution.py
@@ -1,0 +1,293 @@
+"""Hub-only seat resolution: `brigade run --worker <seat>` from the Hub roster row.
+
+When the local roster does not declare a seat but a versioned Hub roster does,
+the seat synthesizes from the Hub row (cli via the consumer projection first,
+then the row; model stays the canonical slug until dispatch applies the native
+launch id). Refusals name the `brigade fleet models set ...` remediation or
+the allow_models edit, never a generic unknown worker. No network: every Hub
+snapshot here is a fixture passed explicitly (or a mocked snapshot read).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brigade import aboyeur, aboyeur_model_policy, agents, fleet_client, fleet_model_roster
+from brigade.aboyeur.planning import parse_plan
+from brigade.cli import run as run_cli
+from brigade.roster import Agent, Roster
+
+SEAT = "muse13"
+PROVIDER = "opencode"
+CANONICAL = "opencode-muse-spark-1.3-contributor-free"
+NATIVE = "opencode/muse-spark-1.3-contributor-free"
+DIGEST = "sha256:" + ("ab" * 32)
+
+
+def _row(**overrides) -> dict[str, object]:
+    row: dict[str, object] = {
+        "seat": SEAT,
+        "provider": PROVIDER,
+        "model": CANONICAL,
+        "reasoning": "high",
+        "enabled": True,
+        "bindings": {
+            "brigade": {"cli": "opencode"},
+            "t3_fleet": {"instance_id": "opencode", "service_tier": None},
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def _snapshot(*, seats=None, native: str | None = NATIVE, **overrides) -> dict[str, object]:
+    snapshot: dict[str, object] = {
+        "schema": fleet_model_roster.ROSTER_SCHEMA,
+        "state": "authoritative",
+        "source": "hub",
+        "revision": 27,
+        "roster_revision": 27,
+        "document_sha256": DIGEST,
+        "expires_at": "2099-08-30T14:15:00Z",
+        "seats": [_row()] if seats is None else seats,
+        "consumer_defaults": {"brigade-run": SEAT},
+        "retired_models": [],
+    }
+    if native is not None:
+        snapshot["consumer_launch_bindings"] = {
+            "brigade-run": {
+                SEAT: {
+                    "brigade": {"cli": "opencode", "model": native},
+                    "t3_fleet": {},
+                    "native": {},
+                }
+            }
+        }
+    snapshot.update(overrides)
+    return snapshot
+
+
+def _roster_without_seat(**kwargs) -> Roster:
+    return Roster(
+        orchestrator="chef",
+        agents={"chef": Agent("chef", "claude", "plan", model="opus-5")},
+        **kwargs,
+    )
+
+
+def test_hub_only_seat_resolves_and_admits_canonical_slug():
+    resolution = aboyeur.resolve_fleet_model_policy(_roster_without_seat(), worker=SEAT, snapshot=_snapshot())
+    assert resolution.error is None
+    agent = resolution.roster.agents[SEAT]
+    assert agent.cli == "opencode"
+    assert agent.model == NATIVE
+    assert "hub-derived" in agent.role
+    admission = resolution.receipt["model_admission"]
+    assert admission["seat"] == SEAT
+    assert admission["model"] == CANONICAL
+    assert admission["binding"]["model"] == NATIVE
+    assert admission["binding"]["instance_id"] == "opencode"
+    routing = next(item for item in resolution.roster.seat_routing if item["requested_seat"] == SEAT)
+    assert routing["outcome"] == "enabled"
+
+
+def test_hub_only_seat_dispatch_argv_uses_native_launch_id():
+    resolution = aboyeur.resolve_fleet_model_policy(_roster_without_seat(), worker=SEAT, snapshot=_snapshot())
+    assert resolution.error is None
+    agent = resolution.roster.agents[SEAT]
+    assert agents.build_argv("opencode", "do work", model=agent.model) == [
+        "opencode",
+        "run",
+        "-m",
+        NATIVE,
+        "do work",
+    ]
+    assert "models list" not in json.dumps(resolution.receipt)
+
+
+def test_receipt_models_rows_pass_through_unchanged():
+    snapshot = _snapshot()
+    resolution = aboyeur.resolve_fleet_model_policy(_roster_without_seat(), worker=SEAT, snapshot=snapshot)
+    assert resolution.error is None
+    assert resolution.receipt["models"] == [
+        {
+            "seat": SEAT,
+            "provider": PROVIDER,
+            "model": CANONICAL,
+            "enabled": True,
+            "limit": None,
+            "notes": None,
+        }
+    ]
+
+
+def test_hub_only_seat_outside_allow_models_refused_with_remediation():
+    roster = _roster_without_seat(allow_models=("claude",))
+    resolution = aboyeur.resolve_fleet_model_policy(roster, worker=SEAT, snapshot=_snapshot())
+    assert resolution.error is not None
+    assert "limits.allow_models" in resolution.error
+    assert "'opencode'" in resolution.error
+    assert "unknown worker" not in resolution.error
+
+
+def test_disabled_hub_row_refused_with_set_remediation():
+    snapshot = _snapshot(seats=[_row(enabled=False)])
+    resolution = aboyeur.resolve_fleet_model_policy(_roster_without_seat(), worker=SEAT, snapshot=snapshot)
+    assert resolution.error is not None
+    assert "disabled" in resolution.error
+    assert f"brigade fleet models set {PROVIDER} {CANONICAL} {SEAT}" in resolution.error
+    assert SEAT not in resolution.roster.agents
+
+
+def test_missing_binding_cli_refused_with_set_remediation():
+    row = _row()
+    row["bindings"] = {"brigade": {}, "t3_fleet": {"instance_id": "", "service_tier": None}}
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster_without_seat(), worker=SEAT, snapshot=_snapshot(seats=[row], native=None)
+    )
+    assert resolution.error is not None
+    assert "--brigade-cli" in resolution.error
+    assert f"brigade fleet models set {PROVIDER} {CANONICAL} {SEAT}" in resolution.error
+
+
+def test_hub_unavailable_refused_honestly_without_guessing():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster_without_seat(), worker=SEAT, snapshot={"state": "unavailable", "models": []}
+    )
+    assert resolution.error is not None
+    assert "unavailable" in resolution.error
+    assert SEAT not in resolution.roster.agents
+
+
+def test_expired_lkg_refused_honestly_without_guessing():
+    snapshot = _snapshot(source="lkg", expires_at="2000-01-01T00:00:00Z")
+    resolution = aboyeur.resolve_fleet_model_policy(_roster_without_seat(), worker=SEAT, snapshot=snapshot)
+    assert resolution.error is not None
+    assert "LKG" in resolution.error
+    assert SEAT not in resolution.roster.agents
+
+
+def test_absent_hub_row_keeps_unknown_worker_with_list_pointer():
+    snapshot = _snapshot(seats=[])
+    resolution = aboyeur.resolve_fleet_model_policy(_roster_without_seat(), worker="ghost", snapshot=snapshot)
+    assert resolution.error is not None
+    assert "unknown worker: ghost" in resolution.error
+    assert "brigade fleet models list --seat ghost" in resolution.error
+
+
+def test_locally_declared_seat_wins_over_hub_row():
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan", model="opus-5"),
+            SEAT: Agent(SEAT, "opencode", "code", model=CANONICAL),
+        },
+    )
+    resolution = aboyeur.resolve_fleet_model_policy(roster, worker=SEAT, snapshot=_snapshot())
+    assert resolution.error is None
+    agent = resolution.roster.agents[SEAT]
+    assert agent.role == "code"
+    assert "hub-derived" not in agent.role
+
+
+def test_local_hub_disagreement_keeps_existing_mismatch_behavior():
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan", model="opus-5"),
+            SEAT: Agent(SEAT, "opencode", "code", model=CANONICAL),
+        },
+    )
+    row = _row()
+    row["bindings"] = {"brigade": {"cli": "codex"}, "t3_fleet": {"instance_id": "", "service_tier": None}}
+    resolution = aboyeur.resolve_fleet_model_policy(roster, worker=SEAT, snapshot=_snapshot(seats=[row], native=None))
+    assert resolution.error is not None
+    assert "inconsistent with provider" in resolution.error
+
+
+def test_model_override_on_hub_only_seat_admits_bound_native():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster_without_seat(), worker=SEAT, model_override=NATIVE, snapshot=_snapshot()
+    )
+    assert resolution.error is None
+    assert resolution.roster.agents[SEAT].model == NATIVE
+
+
+def test_model_override_on_hub_only_seat_denial_names_native_fix():
+    resolution = aboyeur.resolve_fleet_model_policy(
+        _roster_without_seat(), worker=SEAT, model_override="other-model", snapshot=_snapshot(native=None)
+    )
+    assert resolution.error is not None
+    assert "does not match Hub model" in resolution.error
+    assert "--brigade-model other-model" in resolution.error
+
+
+def test_native_id_never_inferred_from_slug():
+    row = _row()
+    assert fleet_model_roster.effective_brigade_launch_model(row) is None
+    agent, error = aboyeur_model_policy.synthesize_hub_worker(
+        aboyeur, _roster_without_seat(), _snapshot(native=None), SEAT
+    )
+    assert error is None
+    assert agent is not None
+    assert agent.model == CANONICAL
+
+
+def test_direct_worker_error_accepts_hub_only_seat(monkeypatch):
+    from brigade import roster as roster_mod
+
+    monkeypatch.setattr(fleet_client, "load_model_policy_snapshot", lambda **kwargs: _snapshot())
+    roster = _roster_without_seat()
+    assert run_cli._direct_worker_error(SEAT, roster, roster_mod) is None
+
+
+def test_direct_worker_error_refuses_when_hub_unavailable(monkeypatch):
+    from brigade import roster as roster_mod
+
+    monkeypatch.setattr(
+        fleet_client, "load_model_policy_snapshot", lambda **kwargs: {"state": "unavailable", "models": []}
+    )
+    roster = _roster_without_seat()
+    error = run_cli._direct_worker_error(SEAT, roster, roster_mod)
+    assert error is not None
+    assert "unavailable" in error
+    assert "unknown worker" not in error
+
+
+def test_direct_worker_error_keeps_unknown_worker_without_hub(monkeypatch):
+    from brigade import roster as roster_mod
+
+    monkeypatch.setattr(
+        fleet_client, "load_model_policy_snapshot", lambda **kwargs: {"state": "unconfigured", "models": []}
+    )
+    roster = _roster_without_seat()
+    assert run_cli._direct_worker_error("ghost", roster, roster_mod) == "unknown worker: ghost"
+
+
+def test_direct_worker_error_surfaces_hub_refusal(monkeypatch):
+    from brigade import roster as roster_mod
+
+    monkeypatch.setattr(
+        fleet_client, "load_model_policy_snapshot", lambda **kwargs: _snapshot(seats=[_row(enabled=False)])
+    )
+    roster = _roster_without_seat()
+    error = run_cli._direct_worker_error(SEAT, roster, roster_mod)
+    assert error is not None
+    assert f"brigade fleet models set {PROVIDER} {CANONICAL} {SEAT}" in error
+
+
+def test_assignment_naming_hub_seat_validates_on_effective_roster():
+    resolution = aboyeur.resolve_fleet_model_policy(_roster_without_seat(), worker=SEAT, snapshot=_snapshot())
+    assert resolution.error is None
+    assignments = parse_plan(
+        json.dumps({"assignments": [{"stage": 1, "worker": SEAT, "task": "do work"}]}),
+        resolution.roster,
+    )
+    assert [item.worker for item in assignments] == [SEAT]
+    with pytest.raises(ValueError, match="unknown worker"):
+        parse_plan(
+            json.dumps({"assignments": [{"stage": 1, "worker": "ghost", "task": "do work"}]}),
+            resolution.roster,
+        )


### PR DESCRIPTION
## What

`brigade run --worker <seat>` now resolves a seat that exists on the hub but not in the local roster, instead of failing with `unknown worker`.

## Why

On 2026-09-06 the hub row `muse13` (revision 27, with its native launch binding from #1483) was routed as `impl` by the hub, yet every dispatch failed until the operator mirrored the row by hand at the canonical slug and added `opencode` to `limits.allow_models`. Rosters drift per host while the hub already carries provider, model, cli binding, reasoning, and the native launch id. Related: #1259.

## How

- `aboyeur_model_policy.synthesize_hub_worker` builds a hub-derived `Agent` from the versioned row: cli from `fleet_model_admission._binding_for("brigade-run", row, launch_groups=...)` (consumer projection first, then the row), model at the canonical slug, reasoning from the row, role marked `hub-derived worker (<provider>/<model>)`. `_resolve_versioned` then applies `effective_brigade_launch_model` exactly as for a local seat, so argv carries the native id while admission and the lease keep the canonical slug.
- Wired into the `--model` pre-check (validation only, so an error roster never carries an unadmitted seat) and into `_resolve_versioned` for the real synthesis and refusals.
- `cli/run._direct_worker_error` falls back to the synthesized agent when the seat is missing locally.
- Refusals name the fix: disabled row, missing binding cli, or unknown cli emit the exact `brigade fleet models set <provider> <model> <seat> --brigade-cli <cli> ...`; a cli outside `limits.allow_models` names that edit; an unreachable hub refuses honestly; an unconfigured hub keeps `unknown worker: <seat>`. Local seats always win; local/hub cli disagreement keeps the existing inconsistent-binding denial. A native id is never inferred from the slug (explicit test).

## Verify

Worker receipt `20260906-165041-work-verify-98440f`, 683 passed. Coordinator gate `20260906-165722-work-verify-4ad12f`: 692 passed, 1 failed on `tests/test_run_cli.py::test_run_cli_terminalizes_sigint_during_graphtrail_baseline_capture`, which is the known load-sensitive SIGINT timing test (five worker stations were running on the host); it passed in isolation immediately after (`20260906-165900`-series receipt, 1 passed) and this diff does not touch signal handling.

## Look hardest at

- The pre-check path must stay validation-only: an override error must not leave a synthesized seat in the effective roster.
- `tests/test_hub_seat_resolution.py` (19 tests, mocked hub snapshots, no network) is the contract.