### PR TITLE
fix(proc): keep KeyboardInterrupt from escaping the Windows terminate path (Fixes #1473)

### DIFF
--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -371,12 +371,18 @@ def _terminate_windows_process_tree(process: subprocess.Popen[bytes], *, timeout
             check=False,
             timeout=max(timeout, 0.1),
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired, KeyboardInterrupt):
         pass
-    if process.poll() is None:
+    try:
+        alive = process.poll() is None
+    except KeyboardInterrupt:
+        alive = True
+    except OSError:
+        alive = False
+    if alive:
         try:
             process.kill()
-        except OSError:
+        except (OSError, KeyboardInterrupt):
             pass
 
 
@@ -400,8 +406,17 @@ def _terminate_processes(
     if os.name == "nt":
         timeout = terminate_grace + kill_grace
         for process in processes:
-            _terminate_windows_process_tree(process, timeout=timeout)
-        _wait_for_processes(processes, kill_grace)
+            try:
+                _terminate_windows_process_tree(process, timeout=timeout)
+            except KeyboardInterrupt:
+                try:
+                    process.kill()
+                except (OSError, KeyboardInterrupt):
+                    pass
+        try:
+            _wait_for_processes(processes, kill_grace)
+        except KeyboardInterrupt:
+            pass
         return
     for process in processes:
         _signal_process_group(process, signal.SIGTERM)

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -347,13 +347,19 @@ def _terminate_verify_child(process: subprocess.Popen[bytes]) -> None:
     try:
         proc._terminate_processes((process,), terminate_grace=0.5, kill_grace=0.5)
     except KeyboardInterrupt:
-        proc._terminate_processes((process,), terminate_grace=0.0, kill_grace=0.0)
+        try:
+            proc._terminate_processes((process,), terminate_grace=0.0, kill_grace=0.0)
+        except KeyboardInterrupt:
+            pass
     survivors = tuple(verify_reaper._survivor_mocks(b | verify_reaper._collect_descendants(process.pid)))
     if survivors:
         try:
             proc._terminate_processes(survivors, terminate_grace=0.5, kill_grace=0.5)  # type: ignore
         except KeyboardInterrupt:
-            proc._terminate_processes(survivors, terminate_grace=0.0, kill_grace=0.0)  # type: ignore
+            try:
+                proc._terminate_processes(survivors, terminate_grace=0.0, kill_grace=0.0)  # type: ignore
+            except KeyboardInterrupt:
+                pass
 
 
 def _run_verify_child_process(

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -1126,3 +1126,33 @@ def test_run_exposes_no_descriptor_passing_plumbing():
     import inspect
 
     assert "pass_fds" not in inspect.signature(proc.run).parameters
+
+
+def test_terminate_processes_windows_branch_tolerates_taskkill_keyboard_interrupt(monkeypatch):
+    """Simulate the Windows terminate path on POSIX: taskkill raising KeyboardInterrupt."""
+
+    class StubProcess:
+        pid = 4242
+
+        def __init__(self):
+            self.kill_calls = 0
+            self.returncode: int | None = None
+
+        def poll(self):
+            return self.returncode
+
+        def kill(self):
+            self.kill_calls += 1
+            self.returncode = 0
+
+    def raising_run(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(proc.os, "name", "nt")
+    monkeypatch.setattr(proc.subprocess, "run", raising_run)
+
+    process = StubProcess()
+    proc._terminate_processes((process,), terminate_grace=0.5, kill_grace=0.5)
+    proc._terminate_processes((process,), terminate_grace=0.0, kill_grace=0.0)
+
+    assert process.kill_calls >= 1

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1796,6 +1796,7 @@ def test_run_cli_records_requested_scheduler_before_dispatch(tmp_path, monkeypat
     }
 
 
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM handler is POSIX-only")
 def test_run_cli_terminalizes_sigterm_during_roster_snapshot(tmp_path, monkeypatch):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = repo / ".brigade" / "runs" / "roster-signal"

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2658,6 +2658,12 @@ def test_run_verify_child_process_catches_keyboard_interrupt(tmp_path, monkeypat
     child_processes: list[subprocess.Popen[bytes]] = []
 
     def interrupting_popen(*args, **kwargs):
+        argv = args[0] if args else kwargs.get("args", [])
+        argv0 = ""
+        if isinstance(argv, (list, tuple)) and argv:
+            argv0 = os.path.basename(str(argv[0])).lower()
+        if argv0 in ("taskkill", "taskkill.exe"):
+            return real_popen(*args, **kwargs)
         process = real_popen(*args, **kwargs)
         child_processes.append(process)
 


### PR DESCRIPTION
Fixes #1473

## What

- `src/brigade/proc.py`: `_terminate_windows_process_tree` tolerates `KeyboardInterrupt` from the `taskkill` call, from `poll`, and from `kill`, and never re-raises. The Windows branch of `_terminate_processes` is safe to call twice.
- `src/brigade/work_cmd/verification.py`: both zero-grace retries in `_terminate_verify_child` are wrapped so the function always returns.
- `tests/test_work_cmd_verification.py`: the interrupt test's Popen wrapper returns the real Popen for `taskkill`, so only the verify child gets the raising `communicate`.
- `tests/test_run_cli.py`: the SIGTERM raise test is skipped on Windows, where neither `run_lifecycle` nor the aboyeur terminal handler installs a Python-level SIGTERM handler.
- `tests/test_proc.py`: POSIX-runnable regression test that forces the Windows branch with a `subprocess.run` stub raising `KeyboardInterrupt` and asserts the caller returns and `kill()` ran.

## Verification

Focused gate through Brigade (ruff, format, version sync, snapshots, mypy, selected tests):

```
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_proc.py","tests/test_work_cmd_verification.py","tests/test_run_cli.py"]' --capture brigade-work
run: 20260906-170547-work-verify-1b8e07
status: completed  exit=0
```

Windows confirmation on the fleet host is recorded in a follow-up comment.

Implemented by the `muse13` seat via `brigade run`; reviewed and landed by the conductor.
