### PR TITLE
fix(proc): keep KeyboardInterrupt from escaping the Windows terminate path (Fixes #1473)

### DIFF
--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -351,7 +351,7 @@ def _bind_suspended_windows_child(
         pass
     try:
         process.wait(timeout=_TIMED_OUT_DRAIN_SECONDS)
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired, KeyboardInterrupt):
         pass
     try:
         job.close()
@@ -371,7 +371,7 @@ def _terminate_windows_process_tree(process: subprocess.Popen[bytes], *, timeout
             check=False,
             timeout=max(timeout, 0.1),
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired, KeyboardInterrupt):
         pass
     if process.poll() is None:
         try:
@@ -400,7 +400,9 @@ def _terminate_processes(
     if os.name == "nt":
         timeout = terminate_grace + kill_grace
         for process in processes:
-            _terminate_windows_process_tree(process, timeout=timeout)
+            if not getattr(process, "_windows_tree_terminated", False):
+                _terminate_windows_process_tree(process, timeout=timeout)
+                process._windows_tree_terminated = True  # type: ignore[attr-defined]
         _wait_for_processes(processes, kill_grace)
         return
     for process in processes:

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -347,13 +347,19 @@ def _terminate_verify_child(process: subprocess.Popen[bytes]) -> None:
     try:
         proc._terminate_processes((process,), terminate_grace=0.5, kill_grace=0.5)
     except KeyboardInterrupt:
-        proc._terminate_processes((process,), terminate_grace=0.0, kill_grace=0.0)
+        try:
+            proc._terminate_processes((process,), terminate_grace=0.0, kill_grace=0.0)
+        except KeyboardInterrupt:
+            pass
     survivors = tuple(verify_reaper._survivor_mocks(b | verify_reaper._collect_descendants(process.pid)))
     if survivors:
         try:
             proc._terminate_processes(survivors, terminate_grace=0.5, kill_grace=0.5)  # type: ignore
         except KeyboardInterrupt:
-            proc._terminate_processes(survivors, terminate_grace=0.0, kill_grace=0.0)  # type: ignore
+            try:
+                proc._terminate_processes(survivors, terminate_grace=0.0, kill_grace=0.0)  # type: ignore
+            except KeyboardInterrupt:
+                pass
 
 
 def _run_verify_child_process(

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -1126,3 +1126,37 @@ def test_run_exposes_no_descriptor_passing_plumbing():
     import inspect
 
     assert "pass_fds" not in inspect.signature(proc.run).parameters
+
+
+def test_terminate_processes_windows_tolerates_taskkill_keyboard_interrupt(monkeypatch):
+    """
+    Regression test for #1473: _terminate_processes should tolerate KeyboardInterrupt
+    from the taskkill subprocess.run call on Windows and fall through to process.kill().
+    """
+    monkeypatch.setattr(proc.os, "name", "nt")
+
+    class FakeProcess:
+        def __init__(self):
+            self.pid = 9999
+            self.kill_called = False
+            self.poll_result = None
+
+        def poll(self):
+            return self.poll_result
+
+        def kill(self):
+            self.kill_called = True
+
+    fake_process = FakeProcess()
+
+    def fake_run(args, **kwargs):
+        if args and args[0] == "taskkill":
+            raise KeyboardInterrupt()
+
+    monkeypatch.setattr(proc.subprocess, "run", fake_run)
+
+    # Should not raise exception
+    proc._terminate_processes((fake_process,), terminate_grace=0.0, kill_grace=0.0)
+
+    # And process.kill() should have been called
+    assert fake_process.kill_called is True

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1796,6 +1796,7 @@ def test_run_cli_records_requested_scheduler_before_dispatch(tmp_path, monkeypat
     }
 
 
+@pytest.mark.skipif(os.name == "nt", reason="SIGTERM handler is POSIX-only")
 def test_run_cli_terminalizes_sigterm_during_roster_snapshot(tmp_path, monkeypatch):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = repo / ".brigade" / "runs" / "roster-signal"

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2659,6 +2659,9 @@ def test_run_verify_child_process_catches_keyboard_interrupt(tmp_path, monkeypat
 
     def interrupting_popen(*args, **kwargs):
         process = real_popen(*args, **kwargs)
+        if args and args[0] and args[0][0] == "taskkill":
+            return process
+
         child_processes.append(process)
 
         def communicate(*communicate_args, **communicate_kwargs):


### PR DESCRIPTION
Fixes #1473 by catching `KeyboardInterrupt` in the Windows terminate path to prevent it from escaping.

Changes:
* Caught `KeyboardInterrupt` inside `_terminate_windows_process_tree`.
* Guarded the `taskkill` invocation in `_terminate_processes` with a `_windows_tree_terminated` flag so the Windows branch is safe to invoke twice.
* Added `try-except KeyboardInterrupt` blocks around the retries inside `_terminate_verify_child` to guarantee it returns.
* Excluded `taskkill` commands from the mocked `Popen` in `test_run_verify_child_process_catches_keyboard_interrupt` so it accurately tests the verification interrupt path without poisoning the terminate logic.
* Skipped `test_run_cli_terminalizes_sigterm_during_roster_snapshot` on Windows since the test leverages a POSIX signal.
* Added a new POSIX-runnable regression test to ensure that the Windows process tree terminate path tolerates `KeyboardInterrupt`.

Tested with `./scripts/verify-focused tests/test_proc.py tests/test_work_cmd_verification.py tests/test_run_cli.py`.

---
*PR created automatically by Jules for task [10860442454072640265](https://jules.google.com/task/10860442454072640265) started by @solomonneas*