### PR TITLE
fix(grokbot): surface hub action and actor in feed queue-error output

### DIFF
--- a/src/brigade/cli/run_cloud.py
+++ b/src/brigade/cli/run_cloud.py
@@ -1190,9 +1190,12 @@ def _dispatch_grokbot_feed(args, target: Path) -> int:
     """Validate or apply an approved feed without printing private task context."""
     from .. import grokbot_feed, grokbot_mcp
 
+    actor_kind: str | None = None
     try:
         if args.apply:
-            with _feed_hub_identity(target).context:
+            identity = _feed_hub_identity(target)
+            actor_kind = identity.actor_kind
+            with identity.context:
                 result = grokbot_feed.apply(target, args.manifest, limit=args.limit)
         else:
             result = grokbot_feed.preflight(target, args.manifest, limit=args.limit)
@@ -1200,10 +1203,9 @@ def _dispatch_grokbot_feed(args, target: Path) -> int:
         print("error: Grok Bot feed configuration is invalid", file=sys.stderr)
         return 2
     except grokbot_feed.FeedError as exc:
-        if exc.reason == "queue-error" and exc.index is not None:
-            print(f"error: queue-error index={exc.index}", file=sys.stderr)
-        else:
-            print(f"error: {exc.reason}", file=sys.stderr)
+        if exc.action is not None and exc.actor_kind is None:
+            exc.actor_kind = actor_kind
+        print(f"error: {exc.public_detail()}", file=sys.stderr)
         return 2
 
     if args.json:

--- a/src/brigade/grokbot_feed.py
+++ b/src/brigade/grokbot_feed.py
@@ -53,13 +53,39 @@ WORKER_FALLBACK_DONE_PREDICATE = "Implement only the approved issue"
 class FeedError(ValueError):
     """A rejected feed request with a stable machine-readable reason."""
 
-    def __init__(self, reason: str, index: int | None = None, *, detail: str | None = None):
+    def __init__(
+        self,
+        reason: str,
+        index: int | None = None,
+        *,
+        detail: str | None = None,
+        action: str | None = None,
+        actor_kind: str | None = None,
+    ):
         self.index = index
         self.detail = detail
+        self.action = action
+        self.actor_kind = actor_kind
+        self._base_reason = reason
         if detail is not None:
             reason = f"{reason} index={index} {detail}" if index is not None else f"{reason} {detail}"
         self.reason = reason
         super().__init__(reason)
+
+    def public_detail(self) -> str:
+        """Stable, path-free, credential-free diagnostic for CLI stderr."""
+        if self._base_reason != "queue-error":
+            return self.reason
+        parts = ["queue-error"]
+        if self.index is not None:
+            parts.append(f"index={self.index}")
+        if self.action:
+            parts.append(f"action={self.action}")
+        if self.actor_kind:
+            parts.append(f"actor={self.actor_kind}")
+        if self.detail:
+            parts.append(self.detail)
+        return " ".join(parts)
 
 
 # Hub refusals the Fleet Hub client already bounded. Safe to name on stderr.
@@ -83,7 +109,14 @@ _BOUNDED_HUB_QUEUE_REASONS = frozenset(
 
 
 def _queue_error(exc: grokbot_jobs.GrokbotJobError, index: int) -> FeedError:
-    """Translate a queue failure, naming only hub-bounded refusal reasons."""
+    """Translate a queue failure, naming only hub-bounded refusal reasons.
+
+    A refused hub action carries a reason the Fleet Hub client already bounded,
+    so it is safe to name together with the action. Private local storage
+    reasons stay redacted.
+    """
+    if exc.action is not None:
+        return FeedError("queue-error", index=index, detail=exc.reason, action=exc.action)
     if exc.reason in _BOUNDED_HUB_QUEUE_REASONS:
         return FeedError("queue-error", index=index, detail=exc.reason)
     return FeedError("queue-error", index=index)

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -1387,9 +1387,7 @@ def test_apply_surfaces_the_refused_hub_action_on_queue_error(tmp_path: Path, mo
     monkeypatch.setattr(
         grokbot_jobs,
         "enqueue",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            grokbot_jobs.GrokbotJobError("auth-failed", action="enqueue")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(grokbot_jobs.GrokbotJobError("auth-failed", action="enqueue")),
     )
 
     with pytest.raises(grokbot_feed.FeedError) as raised:
@@ -1416,9 +1414,7 @@ def test_cli_feed_prints_hub_queue_error_action_and_actor_without_tokens(
     monkeypatch.setattr(
         grokbot_jobs,
         "enqueue",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            grokbot_jobs.GrokbotJobError("auth-failed", action="enqueue")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(grokbot_jobs.GrokbotJobError("auth-failed", action="enqueue")),
     )
     manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
 

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -1380,3 +1380,55 @@ def test_cli_feed_reports_bounded_hub_error_detail(tmp_path: Path, capsys, monke
     assert captured.out == ""
     assert captured.err.strip() == "error: queue-error index=0 operation-mismatch"
     assert SECRET_INSTRUCTIONS not in captured.err
+
+
+def test_apply_surfaces_the_refused_hub_action_on_queue_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "enqueue",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            grokbot_jobs.GrokbotJobError("auth-failed", action="enqueue")
+        ),
+    )
+
+    with pytest.raises(grokbot_feed.FeedError) as raised:
+        grokbot_feed.apply(tmp_path, manifest, limit=1)
+
+    assert raised.value.action == "enqueue"
+    assert raised.value.actor_kind is None
+    assert raised.value.detail == "auth-failed"
+    assert raised.value.index == 0
+    assert raised.value.public_detail() == "queue-error index=0 action=enqueue auth-failed"
+    assert "auth-failed" in raised.value.reason
+
+
+@pytest.mark.parametrize("json_flag", [(), ("--json",)])
+def test_cli_feed_prints_hub_queue_error_action_and_actor_without_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys, json_flag: tuple[str, ...]
+):
+    token = "dedicated-feed-token"
+    token_file = tmp_path / "feed.hub-token"
+    token_file.write_text(token + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.setenv("BRIGADE_GROKBOT_FEED_HUB_TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(grokbot_jobs, "hub_authority", lambda _target: True)
+    monkeypatch.setattr(
+        grokbot_jobs,
+        "enqueue",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            grokbot_jobs.GrokbotJobError("auth-failed", action="enqueue")
+        ),
+    )
+    manifest = _write_manifest(tmp_path / "feed.json", _manifest(_entry("task-a")))
+
+    assert _run_feed(tmp_path, "--manifest", str(manifest), "--apply", *json_flag) == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "error: queue-error index=0 action=enqueue actor=feed auth-failed\n"
+    assert "/" not in captured.err
+    assert "feed.json" not in captured.err
+    assert token not in captured.err
+    assert SECRET_INSTRUCTIONS not in captured.err
+    assert "dedicated-feed-token" not in captured.out + captured.err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #1351

On hub queue error, `grokbot feed --apply` prints `queue-error index=N action=<op> actor=<role> <bounded reason>` (same length bounds and redaction as scout-feed) in both plain and `--json` output; no new fields beyond those two; no secrets/tokens in output; tests cover this.

## What and why

Item 2 of #1351: scout-feed already named the refused hub `action=` and `actor=` on stderr; `grokbot feed --apply` still printed opaque `queue-error index=N`. `FeedError` now carries those two fields and `_dispatch_grokbot_feed` binds the dedicated feed actor the same way as scout-feed. Success JSON is unchanged (no new fields). Tokens never appear in output.

## CLI before / after

```
error: queue-error index=0
```

```
error: queue-error index=0 action=enqueue actor=feed auth-failed
```

## Verification

| Command | Exit code |
|---|---|
| `python -m pytest -q tests/test_grokbot_feed.py` | 0 |
| `ruff check src/brigade/grokbot_feed.py src/brigade/cli/run_cloud.py tests/test_grokbot_feed.py` | 0 |
| `ruff format --check src/brigade/grokbot_feed.py src/brigade/cli/run_cloud.py tests/test_grokbot_feed.py` | 0 (1 on first attempt: unformatted lambdas in the new tests; formatted and re-run) |
| `mypy` | 0 |
| `git diff --check` | 0 |
| `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_grokbot_feed.py"]' --capture brigade-work` | 0 |

Brigade verify receipt id: `20260906-175158-work-verify-e704b2`

Pytest transcript (last lines of `python -m pytest -q tests/test_grokbot_feed.py`):

```
............................................................             [100%]
60 passed in 9.67s
```

`brigade code sync .` / `brigade code affected` could not run: `graphtrail is not installed; run brigade setup`. `tests/test_run_cloud_grokbot.py` is not in this checkout; CLI coverage lives in `tests/test_grokbot_feed.py`.

Job id: `grokbot-62eac1ed83004333a3b84b83`

## Type of change

- [x] Bug fix

## Checklist

- [ ] `pytest -q` passes locally (focused module only, as specified)
- [x] Added or updated tests covering the change
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (out of ownership for this job)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28e3a5d5-e447-46bc-8ce0-3d2ec1745f84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28e3a5d5-e447-46bc-8ce0-3d2ec1745f84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

