### PR TITLE
fix(portability): route O_DIRECTORY and getpgid through the dirfd and proc facades (Fixes #1478)

### DIFF
--- a/src/brigade/dirfd.py
+++ b/src/brigade/dirfd.py
@@ -67,6 +67,21 @@ def directory_flags(*, nofollow: bool = True) -> int:
     return flags
 
 
+def file_flags(mode: int) -> int:
+    """Return ``mode`` plus ``O_NOFOLLOW``/``O_CLOEXEC``.
+
+    Fail-closed on platforms without ``O_NOFOLLOW`` (Windows has none):
+    raises the module's typed :func:`unavailable` ``OSError`` instead of
+    opening without the symlink guard, so non-``dir_fd`` callers that
+    would otherwise degrade via ``getattr(os, "O_NOFOLLOW", 0)`` stay
+    fail-closed too.
+    """
+    o_nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not o_nofollow:
+        raise unavailable("file operations")
+    return mode | o_nofollow | getattr(os, "O_CLOEXEC", 0)
+
+
 def root_directory_flags() -> int:
     """Return anchor flags (``O_PATH`` when present) plus directory guards.
 

--- a/src/brigade/dirfd.py
+++ b/src/brigade/dirfd.py
@@ -49,6 +49,37 @@ def unavailable(kind: str) -> OSError:
     return OSError(f"descriptor-relative {kind} are unavailable")
 
 
+def directory_flags(*, nofollow: bool = True) -> int:
+    """Return ``O_RDONLY|O_DIRECTORY`` plus ``O_NOFOLLOW``/``O_CLOEXEC``.
+
+    Fail-closed on platforms without ``O_DIRECTORY`` (Windows has neither
+    ``O_DIRECTORY`` nor ``O_NOFOLLOW``): raises the module's typed
+    :func:`unavailable` ``OSError`` instead of ``AttributeError`` so callers
+    can map it to their own error type. POSIX behaviour is unchanged.
+    """
+    o_directory = getattr(os, "O_DIRECTORY", 0)
+    o_nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not o_directory or (nofollow and not o_nofollow):
+        raise unavailable("directory operations")
+    flags = os.O_RDONLY | o_directory | getattr(os, "O_CLOEXEC", 0)
+    if nofollow:
+        flags |= o_nofollow
+    return flags
+
+
+def root_directory_flags() -> int:
+    """Return anchor flags (``O_PATH`` when present) plus directory guards.
+
+    Fail-closed with :func:`unavailable` ``OSError`` on platforms without
+    ``O_DIRECTORY``/``O_NOFOLLOW`` instead of ``AttributeError``.
+    """
+    o_directory = getattr(os, "O_DIRECTORY", 0)
+    o_nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not o_directory or not o_nofollow:
+        raise unavailable("directory operations")
+    return getattr(os, "O_PATH", os.O_RDONLY) | o_directory | o_nofollow | getattr(os, "O_CLOEXEC", 0)
+
+
 def validate_component(name: str) -> str:
     """Reject empty, dotted, separator-bearing, or NUL names so walks stay contained."""
     if not isinstance(name, str) or not name:

--- a/src/brigade/grokbot_fleet/actions.py
+++ b/src/brigade/grokbot_fleet/actions.py
@@ -461,7 +461,7 @@ def _write_exclusive_json(path: Path, record: Mapping[str, Any]) -> None:
     handle = None
     created = False
     try:
-        handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        handle = os.open(path, dirfd_mod.file_flags(os.O_WRONLY | os.O_CREAT | os.O_EXCL), 0o600)
         created = True
         os.fchmod(handle, 0o600)
         _write_all(handle, json.dumps(record).encode("utf-8"))
@@ -511,7 +511,7 @@ def _replace_json(path: Path, record: Mapping[str, Any]) -> None:
 def _read_safe_json(path: Path) -> Any:
     handle = None
     try:
-        handle = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        handle = os.open(path, dirfd_mod.file_flags(os.O_RDONLY))
         info = os.fstat(handle)
         _assert_owner_file(info)
         raw = os.read(handle, 1_048_576)

--- a/src/brigade/grokbot_fleet/actions.py
+++ b/src/brigade/grokbot_fleet/actions.py
@@ -24,6 +24,7 @@ from .contracts import (
     parse_wazuh_finding_id,
 )
 from .exec import EXEC_DEFAULT_OUTPUT_BYTES, ExecRequest, Runner, run_exec
+from brigade import dirfd as dirfd_mod
 from .probes import PROBE_WORKING_DIRECTORY, _health_class, verify_catalogued_service
 from .runtime_config import FLEET_SAFE_SERVICE_UNIT_PATTERN
 
@@ -460,7 +461,7 @@ def _write_exclusive_json(path: Path, record: Mapping[str, Any]) -> None:
     handle = None
     created = False
     try:
-        handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+        handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
         created = True
         os.fchmod(handle, 0o600)
         _write_all(handle, json.dumps(record).encode("utf-8"))
@@ -510,7 +511,7 @@ def _replace_json(path: Path, record: Mapping[str, Any]) -> None:
 def _read_safe_json(path: Path) -> Any:
     handle = None
     try:
-        handle = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        handle = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
         info = os.fstat(handle)
         _assert_owner_file(info)
         raw = os.read(handle, 1_048_576)
@@ -533,7 +534,7 @@ def _read_safe_json(path: Path) -> Any:
 def _fsync_directory(path: Path) -> None:
     handle = None
     try:
-        handle = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        handle = os.open(path, dirfd_mod.directory_flags())
         info = os.fstat(handle)
         if not stat.S_ISDIR(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o700:
             _action_state_invalid()

--- a/src/brigade/grokbot_jobs.py
+++ b/src/brigade/grokbot_jobs.py
@@ -20,6 +20,7 @@ from typing import Any, Iterator
 from .grokbot_job_clock import format_timestamp as _format_timestamp
 from .grokbot_job_clock import parse_timestamp as _parse_timestamp
 from .grokbot_job_clock import timestamp as _timestamp
+from . import dirfd as dirfd_mod
 from .grokbot_job_validation import (
     JOB_ID_RE,
     LOWER_HEX_64_RE as LOWER_HEX_64_RE,
@@ -854,7 +855,10 @@ def _storage_paths_readonly(target: Path) -> Iterator[_Storage]:
 
 
 def _directory_flags() -> int:
-    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    try:
+        return dirfd_mod.directory_flags()
+    except OSError as exc:
+        raise GrokbotJobError("unsafe-storage") from exc
 
 
 def _open_directory_path(path: Path) -> int:
@@ -1023,7 +1027,7 @@ def _write_bytes_file(directory: _Directory, name: str, data: bytes) -> None:
     try:
         descriptor = os.open(
             temporary,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
             FILE_MODE,
             dir_fd=directory.descriptor,
         )
@@ -1101,7 +1105,7 @@ def _read_json_file(directory: _Directory, name: str, *, missing_ok: bool = Fals
     descriptor: int | None = None
     try:
         descriptor = os.open(
-            name, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0), dir_fd=directory.descriptor
+            name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0), dir_fd=directory.descriptor
         )
     except FileNotFoundError:
         if missing_ok:
@@ -1159,7 +1163,7 @@ def _read_bytes_file(directory: _Directory, name: str, *, maximum: int, missing_
     descriptor: int | None = None
     try:
         descriptor = os.open(
-            name, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0), dir_fd=directory.descriptor
+            name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0), dir_fd=directory.descriptor
         )
     except FileNotFoundError:
         raise GrokbotJobError(missing_reason) from None

--- a/src/brigade/grokbot_n8n/actions.py
+++ b/src/brigade/grokbot_n8n/actions.py
@@ -24,6 +24,7 @@ from .contracts import (
     target_type_for_action,
 )
 from . import runtime_config
+from brigade import dirfd as dirfd_mod
 
 APPROVAL_KEYS = frozenset(
     {
@@ -103,7 +104,10 @@ def _require_posix_permissions() -> None:
 
 
 def _directory_flags() -> int:
-    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    try:
+        return dirfd_mod.directory_flags()
+    except OSError:
+        _environment_invalid()
 
 
 def _open_child(parent: int, name: str, flags: int, mode: int = 0o600) -> int:
@@ -176,7 +180,10 @@ def _walk_directory(path: Path, *, create: bool, private: bool, on_error: Callab
     absolute = Path(os.path.abspath(path))
     if not str(absolute).startswith("/") or "\0" in str(absolute):
         on_error()
-    root_flags = getattr(os, "O_PATH", os.O_RDONLY) | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    try:
+        root_flags = dirfd_mod.root_directory_flags()
+    except OSError:
+        on_error()
     try:
         descriptor = os.open(absolute.anchor, root_flags)
     except OSError:

--- a/src/brigade/grokbot_obsidian/excalidraw_client.py
+++ b/src/brigade/grokbot_obsidian/excalidraw_client.py
@@ -13,6 +13,7 @@ from typing import Any, Mapping, NoReturn
 
 from .adapters import allowlisted_excalidraw_env
 from .contracts import ERROR_MESSAGES, ObsidianError
+from .. import proc as proc_mod
 from .runtime_config import (
     descriptor_execution_available,
     open_validated_executable_fd,
@@ -96,7 +97,7 @@ class StdioExcalidrawMcpClient:
                 except OSError:
                     pass
         try:
-            self._pgid = os.getpgid(self._proc.pid)
+            self._pgid = proc_mod.process_group_id(self._proc.pid)
         except OSError:
             self._pgid = None
 
@@ -115,6 +116,15 @@ class StdioExcalidrawMcpClient:
             try:
                 os.killpg(self._pgid, signal.SIGKILL)
             except (OSError, ProcessLookupError):
+                pass
+        elif os.name == "nt":
+            # No process groups on Windows: use the shared job-object/taskkill
+            # termination path in proc.py instead of killing only the direct child.
+            try:
+                proc_mod.terminate_process_tree(proc)  # type: ignore[arg-type]
+                self._proc = None
+                return
+            except OSError:
                 pass
         if proc.poll() is None:
             try:

--- a/src/brigade/grokbot_obsidian/excalidraw_client.py
+++ b/src/brigade/grokbot_obsidian/excalidraw_client.py
@@ -119,11 +119,10 @@ class StdioExcalidrawMcpClient:
                 pass
         elif os.name == "nt":
             # No process groups on Windows: use the shared job-object/taskkill
-            # termination path in proc.py instead of killing only the direct child.
+            # termination path in proc.py, then fall through to the shared
+            # poll/wait tail below so the handle is reaped and _proc cleared.
             try:
                 proc_mod.terminate_process_tree(proc)  # type: ignore[arg-type]
-                self._proc = None
-                return
             except OSError:
                 pass
         if proc.poll() is None:

--- a/src/brigade/grokbot_ops.py
+++ b/src/brigade/grokbot_ops.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from . import grokbot_jobs, grokbot_mcp
+from . import dirfd as dirfd_mod
 
 
 CONFIG_SCHEMA = "brigade.grokbot-config/1"
@@ -416,8 +417,8 @@ def _open_parent_nofollow(path: Path, *, create: bool) -> int:
     parent = path.parent.absolute()
     if os.name != "posix" or not getattr(os, "O_NOFOLLOW", 0):
         return _open_windows_parent_nofollow(parent, create=create)
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
-    root_flags = getattr(os, "O_PATH", os.O_RDONLY) | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    flags = dirfd_mod.directory_flags()
+    root_flags = dirfd_mod.root_directory_flags()
     descriptor = os.open(parent.anchor, root_flags)
     try:
         for component in parent.parts[1:]:
@@ -471,7 +472,7 @@ def _read_regular_text(path: Path) -> str:
         if os.name == "posix":
             descriptor = os.open(
                 path.name,
-                os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
                 dir_fd=parent,
             )
         else:
@@ -498,7 +499,7 @@ def _write_text_nofollow_atomic(
     try:
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
         if os.name == "posix":
-            descriptor = os.open(temporary, flags | os.O_NOFOLLOW, mode, dir_fd=parent)
+            descriptor = os.open(temporary, flags | getattr(os, "O_NOFOLLOW", 0), mode, dir_fd=parent)
         else:
             from .work_cmd import nt_dirfd
 

--- a/src/brigade/grokbot_reconcile.py
+++ b/src/brigade/grokbot_reconcile.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from . import grokbot_jobs, handoff_cmd
+from . import dirfd as dirfd_mod
 from .handoff_cmd.models import DEFAULT_DRAFT_DOCUMENT, NO_CARD_ACTION
 from .selection import WRITER_INBOXES
 
@@ -451,7 +452,7 @@ def _write_handoff_posix(owner: Path, inbox_rel: Path, name: str, text: str) -> 
             return "recovered"
 
         temporary = f".{name}.tmp"
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
         descriptor: int | None = None
         temporary_created = False
         try:
@@ -501,7 +502,10 @@ def _write_handoff_posix(owner: Path, inbox_rel: Path, name: str, text: str) -> 
 
 
 def _directory_flags() -> int:
-    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    try:
+        return dirfd_mod.directory_flags()
+    except OSError as exc:
+        raise ReconcileError("unsafe-storage") from exc
 
 
 def _remove_stale_handoff_temp(directory: int, name: str) -> None:
@@ -510,7 +514,7 @@ def _remove_stale_handoff_temp(directory: int, name: str) -> None:
     try:
         descriptor = os.open(
             temporary,
-            os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
             dir_fd=directory,
         )
     except FileNotFoundError:
@@ -535,7 +539,7 @@ def _read_existing_handoff_at(directory: int, name: str) -> str | None:
     try:
         descriptor = os.open(
             name,
-            os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
             dir_fd=directory,
         )
     except FileNotFoundError:

--- a/src/brigade/managed_block.py
+++ b/src/brigade/managed_block.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Literal
 
+from . import dirfd as dirfd_mod
+
 MarkerStyle = Literal["html", "hash"]
 MARKER_STYLE_HTML: MarkerStyle = "html"
 MARKER_STYLE_HASH: MarkerStyle = "hash"
@@ -885,10 +887,7 @@ def _managed_parent_containment_available() -> bool:
 
 
 def _managed_directory_flags(*, follow_descriptor: bool = False) -> int:
-    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0)
-    if not follow_descriptor:
-        flags |= os.O_NOFOLLOW
-    return flags
+    return dirfd_mod.directory_flags(nofollow=not follow_descriptor)
 
 
 def _is_held_descriptor_dir(path: Path) -> bool:
@@ -907,7 +906,7 @@ def _create_managed_parent(parent: Path) -> int:
     if not parts:
         raise OSError("unsafe managed-block parent")
     flags = _managed_directory_flags()
-    descriptor = os.open(parts[0], os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0))
+    descriptor = os.open(parts[0], dirfd_mod.directory_flags(nofollow=False))
     try:
         for component in parts[1:]:
             if component in {"", ".", ".."}:
@@ -1021,7 +1020,7 @@ def write_text_nofollow_atomic(
     temporary_name = f".{path.name}.{uuid.uuid4().hex}.tmp"
     descriptor = -1
     try:
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
         descriptor = os.open(temporary_name, flags, 0o600, dir_fd=parent_fd)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             descriptor = -1

--- a/src/brigade/mcp_runtime.py
+++ b/src/brigade/mcp_runtime.py
@@ -531,10 +531,10 @@ def _kill_process_group(proc: subprocess.Popen[str], *, pgid: int | None = None)
             pass
     elif os.name == "nt":
         # No process groups on Windows: use the shared job-object/taskkill
-        # termination path in proc.py instead of killing only the direct child.
+        # termination path in proc.py, then fall through to the shared
+        # poll/wait tail below so the handle is reaped.
         try:
             proc_mod.terminate_process_tree(proc)  # type: ignore[arg-type]
-            return
         except OSError:
             pass
     if proc.poll() is None:

--- a/src/brigade/mcp_runtime.py
+++ b/src/brigade/mcp_runtime.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from . import localio
+from . import proc as proc_mod
 from .mcp_adapters import CanonicalServer
 from .tools_cmd import HIGH_RISK_COMMAND_PATTERNS
 
@@ -528,6 +529,14 @@ def _kill_process_group(proc: subprocess.Popen[str], *, pgid: int | None = None)
             os.killpg(pgid, signal.SIGKILL)
         except (OSError, ProcessLookupError):
             pass
+    elif os.name == "nt":
+        # No process groups on Windows: use the shared job-object/taskkill
+        # termination path in proc.py instead of killing only the direct child.
+        try:
+            proc_mod.terminate_process_tree(proc)  # type: ignore[arg-type]
+            return
+        except OSError:
+            pass
     if proc.poll() is None:
         try:
             proc.kill()
@@ -594,7 +603,7 @@ def _probe_stdio(server: CanonicalServer, *, config_current: bool, timeout: floa
     assert proc.stdout is not None
     assert proc.stderr is not None
     try:
-        pgid = os.getpgid(proc.pid)
+        pgid = proc_mod.process_group_id(proc.pid)
     except OSError:
         pgid = None
     stdout_reader = _BoundedStreamReader(proc.stdout, limit=MAX_STREAM_BYTES)

--- a/src/brigade/memory_vault.py
+++ b/src/brigade/memory_vault.py
@@ -22,6 +22,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from . import toml_compat as tomllib
+from . import dirfd as dirfd_mod
 from .card_identity import mint_card_id, valid_card_id
 from .guard import redact_text
 from .localio import utc_now_iso_z, write_text_atomic
@@ -1091,11 +1092,11 @@ def _containment_primitives_available() -> bool:
 
 
 def _directory_flags() -> int:
-    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    return dirfd_mod.directory_flags()
 
 
 def _file_flags(mode: int) -> int:
-    return mode | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    return mode | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
 
 
 def _path_has_projection_folder(relative: str) -> bool:
@@ -1246,7 +1247,7 @@ def _reject_existing_note(inbox_fd: int, filename: str) -> None:
     try:
         existing = os.open(
             filename,
-            os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_CLOEXEC", 0),
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_CLOEXEC", 0),
             dir_fd=inbox_fd,
         )
     except FileNotFoundError:

--- a/src/brigade/memory_vault.py
+++ b/src/brigade/memory_vault.py
@@ -1096,7 +1096,7 @@ def _directory_flags() -> int:
 
 
 def _file_flags(mode: int) -> int:
-    return mode | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    return dirfd_mod.file_flags(mode)
 
 
 def _path_has_projection_folder(relative: str) -> bool:
@@ -1164,8 +1164,8 @@ def _open_vault_dir(vault: Path) -> int:
 
 def _openat_nofollow(parent_fd: int, name: str, *, directory: bool) -> int | None:
     """openat(2) a child with O_NOFOLLOW and confirm the type via fstat."""
-    flags = _directory_flags() if directory else _file_flags(os.O_RDONLY)
     try:
+        flags = _directory_flags() if directory else _file_flags(os.O_RDONLY)
         descriptor = os.open(name, flags, dir_fd=parent_fd)
     except OSError:
         return None
@@ -1247,7 +1247,7 @@ def _reject_existing_note(inbox_fd: int, filename: str) -> None:
     try:
         existing = os.open(
             filename,
-            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_CLOEXEC", 0),
+            _file_flags(os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)),
             dir_fd=inbox_fd,
         )
     except FileNotFoundError:
@@ -1314,8 +1314,8 @@ def _stage_proposal(staging_dir: Path, data: bytes) -> tuple[int, Path, bytes]:
     if not _containment_primitives_available():
         raise VaultProposeError("vault containment checks are unavailable on this platform")
     path = staging_dir / f"{uuid.uuid4().hex}.md"
-    flags = _file_flags(os.O_RDWR | os.O_CREAT | os.O_EXCL)
     try:
+        flags = _file_flags(os.O_RDWR | os.O_CREAT | os.O_EXCL)
         descriptor = os.open(path, flags, 0o600)
     except OSError as exc:
         raise VaultProposeError(f"could not create staged proposal: {exc}") from exc
@@ -1340,7 +1340,10 @@ def _stage_proposal(staging_dir: Path, data: bytes) -> tuple[int, Path, bytes]:
 def _write_via_held_parent(parent_fd: int, filename: str, data: bytes) -> None:
     if not _containment_primitives_available():
         raise VaultProposeError("vault containment checks are unavailable on this platform")
-    flags = _file_flags(os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+    try:
+        flags = _file_flags(os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+    except OSError as exc:
+        raise VaultProposeError("vault containment checks are unavailable on this platform") from exc
     try:
         descriptor = os.open(filename, flags, 0o644, dir_fd=parent_fd)
     except OSError as exc:

--- a/src/brigade/pi_mcp_bridge.py
+++ b/src/brigade/pi_mcp_bridge.py
@@ -8,7 +8,6 @@ defined in ``.brigade/mcp.json``.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import time
 from dataclasses import dataclass
@@ -18,6 +17,7 @@ from urllib import error as urlerror
 from urllib import request as urlrequest
 
 from . import mcp_cmd
+from . import proc as proc_mod
 from .mcp_adapters import CanonicalServer
 from .mcp_runtime import (
     MCP_PROTOCOL_VERSION,
@@ -241,7 +241,7 @@ def _exchange_stdio(
     assert proc.stdout is not None
     assert proc.stderr is not None
     try:
-        pgid = os.getpgid(proc.pid)
+        pgid = proc_mod.process_group_id(proc.pid)
     except OSError:
         pgid = None
     reader = _BoundedStreamReader(proc.stdout, limit=MAX_STREAM_BYTES)

--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -139,6 +139,23 @@ def _signal_process_group(process: subprocess.Popen[bytes], sig: int) -> None:
         pass
 
 
+def process_group_id(pid: int) -> int | None:
+    """Return the process group id for ``pid``, or None where unavailable.
+
+    Windows has no ``os.getpgid``. Returns None there (and when the pid has
+    already been reaped) so callers fall back to the Windows job-object or
+    taskkill termination path in this module instead of raising
+    ``AttributeError``.
+    """
+    getpgid = getattr(os, "getpgid", None)
+    if getpgid is None:
+        return None
+    try:
+        return int(getpgid(pid))
+    except OSError:
+        return None
+
+
 _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
 _JOB_OBJECT_EXTENDED_LIMIT_CLASS = 9
 _WINDOWS_CREATE_SUSPENDED = 0x00000004

--- a/src/brigade/projection/kernel.py
+++ b/src/brigade/projection/kernel.py
@@ -484,7 +484,10 @@ def _parent_containment_available() -> bool:
 
 
 def _directory_flags() -> int:
-    return dirfd_mod.directory_flags()
+    try:
+        return dirfd_mod.directory_flags()
+    except OSError as exc:
+        raise PlanError("unsafe symlink destination") from exc
 
 
 def _dir_identity(fd: int) -> tuple[int, int]:

--- a/src/brigade/projection/kernel.py
+++ b/src/brigade/projection/kernel.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Literal, Mapping
 
+from brigade import dirfd as dirfd_mod
 from brigade import localio
 
 SCHEMA_VERSION = 1
@@ -483,7 +484,7 @@ def _parent_containment_available() -> bool:
 
 
 def _directory_flags() -> int:
-    return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    return dirfd_mod.directory_flags()
 
 
 def _dir_identity(fd: int) -> tuple[int, int]:
@@ -530,7 +531,7 @@ def _walk_existing_parent(destination: Path) -> _HeldParent:
     if not parts:
         raise PlanError("unsafe destination path")
     flags = _directory_flags()
-    fd = os.open(parts[0], os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0))
+    fd = os.open(parts[0], dirfd_mod.directory_flags(nofollow=False))
     remaining: list[str] = []
     missing = False
     try:
@@ -619,7 +620,7 @@ def _materialize_held_parent(spec: MutationSpec, held: _HeldParent | None) -> tu
 
 def _publish_bytes_via_parent(parent_fd: int, name: str, data: bytes) -> None:
     temporary_name = f".{name}.{uuid.uuid4().hex}.tmp"
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
     descriptor = os.open(temporary_name, flags, 0o600, dir_fd=parent_fd)
     try:
         with os.fdopen(descriptor, "wb") as handle:
@@ -644,7 +645,9 @@ def _unlink_via_parent(parent_fd: int, name: str) -> None:
 
 
 def _chmod_via_parent(parent_fd: int, name: str, mode: int) -> None:
-    descriptor = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0), dir_fd=parent_fd)
+    descriptor = os.open(
+        name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0), dir_fd=parent_fd
+    )
     try:
         os.fchmod(descriptor, mode)
     finally:

--- a/src/brigade/work_cmd/scanners.py
+++ b/src/brigade/work_cmd/scanners.py
@@ -2672,7 +2672,9 @@ def _publish_scanner_config(target: Path, data: bytes, *, force: bool) -> None:
         descriptor = ledger_mod._dirfd_open_file(
             parent,
             temporary_name,
-            dirfd_mod.file_flags(_INBOX_TEMP_MODE),
+            # _dirfd_open_file is descriptor-relative on both platforms; Windows gets
+            # its no-follow guarantee from the NT handle, so the POSIX bit stays optional.
+            _INBOX_TEMP_MODE | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
             0o600,
         )
         with os.fdopen(os.dup(descriptor), "wb") as handle:

--- a/src/brigade/work_cmd/scanners.py
+++ b/src/brigade/work_cmd/scanners.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from .. import dogfood_cmd
 from .. import proc as proc_mod
+from .. import dirfd as dirfd_mod
 from ..install import apply_gitignore
 from . import constants, helpers, inbox_lock, ledger as ledger_mod, config as config_mod
 from . import sweeps as sweeps_mod
@@ -1063,7 +1064,7 @@ def _open_scanner_inbox_parent(target: Path, *, create: bool) -> tuple[int, str,
         raise OSError("scanner inbox escapes target") from exc
     if len(relative.parts) < 2:
         raise OSError("scanner inbox path is incomplete")
-    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    directory_flags = dirfd_mod.directory_flags()
     descriptor = os.open(target_root, directory_flags)
     identities: list[tuple[int, int]] = []
     try:
@@ -1118,7 +1119,7 @@ def _validate_scanner_inbox_descriptor(descriptor: int) -> None:
 def _open_scanner_inbox(target: Path, flags: int, *, create: bool = False) -> int:
     """Open the inbox through held parent descriptors with no-follow authority."""
     parent, name, identities = _open_scanner_inbox_parent(target, create=create)
-    safe_flags = flags | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+    safe_flags = flags | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     try:
         try:
             descriptor = os.open(name, safe_flags, dir_fd=parent)
@@ -1140,7 +1141,9 @@ def _open_scanner_inbox(target: Path, flags: int, *, create: bool = False) -> in
 
 def _validate_scanner_inbox_at(parent: int, name: str, *, missing_ok: bool) -> None:
     try:
-        descriptor = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0), dir_fd=parent)
+        descriptor = os.open(
+            name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0), dir_fd=parent
+        )
     except FileNotFoundError:
         if missing_ok:
             return
@@ -1156,7 +1159,7 @@ def _validate_scanner_inbox_name_matches_descriptor(parent: int, name: str, desc
     _validate_scanner_inbox_descriptor(descriptor)
     expected_identity = _scanner_inbox_identity(os.fstat(descriptor))
     assert expected_identity is not None
-    candidate = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0), dir_fd=parent)
+    candidate = os.open(name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0), dir_fd=parent)
     try:
         try:
             _validate_scanner_inbox_descriptor(candidate)
@@ -1191,7 +1194,7 @@ def _write_scanner_inbox_temp(parent: int, data: bytes) -> tuple[str, int]:
     name = _scanner_inbox_temp_name()
     descriptor = os.open(
         name,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
         0o600,
         dir_fd=parent,
     )
@@ -1278,7 +1281,7 @@ def _write_scanner_inbox_bytes_locked(target: Path, data: bytes) -> None:
         try:
             previous = os.open(
                 name,
-                os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0),
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
                 dir_fd=parent,
             )
         except FileNotFoundError:
@@ -1478,7 +1481,9 @@ def _require_scanner_inbox_identity(parent: int, name: str, identity: tuple[int,
     ``_scanner_inbox_run_lock`` from snapshot through rollback.
     """
     try:
-        current = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0), dir_fd=parent)
+        current = os.open(
+            name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0), dir_fd=parent
+        )
     except FileNotFoundError as exc:
         raise OSError("scanner inbox vanished since its pre-run snapshot") from exc
     try:
@@ -1970,8 +1975,8 @@ def _scanner_read_import_jsonl(target: Path, scanner: dict[str, Any]) -> tuple[l
     if not _scanner_import_read_primitives_available():
         raise OSError("descriptor-relative scanner import operations are unavailable")
     relative = _scanner_import_relative_path(scanner)
-    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
-    file_flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | getattr(os, "O_CLOEXEC", 0)
+    directory_flags = dirfd_mod.directory_flags()
+    file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_CLOEXEC", 0)
     absolute_target = Path(os.path.abspath(target.expanduser()))
     target_components = absolute_target.parts[1:]
     if not target_components:

--- a/src/brigade/work_cmd/scanners.py
+++ b/src/brigade/work_cmd/scanners.py
@@ -446,6 +446,10 @@ def _list_scanner_run_ids(root: int, target: Path) -> list[str]:
     return [name for name in names if isinstance(name, str)]
 
 
+_INBOX_READ_MODE = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+_INBOX_TEMP_MODE = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+
+
 def _scanner_run_file_open_flags(*, write: bool) -> int:
     """Return no-follow file flags; Windows dirfd helpers ignore unknown POSIX bits."""
     flags = getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
@@ -1119,7 +1123,7 @@ def _validate_scanner_inbox_descriptor(descriptor: int) -> None:
 def _open_scanner_inbox(target: Path, flags: int, *, create: bool = False) -> int:
     """Open the inbox through held parent descriptors with no-follow authority."""
     parent, name, identities = _open_scanner_inbox_parent(target, create=create)
-    safe_flags = flags | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    safe_flags = dirfd_mod.file_flags(flags | getattr(os, "O_NONBLOCK", 0))
     try:
         try:
             descriptor = os.open(name, safe_flags, dir_fd=parent)
@@ -1141,9 +1145,7 @@ def _open_scanner_inbox(target: Path, flags: int, *, create: bool = False) -> in
 
 def _validate_scanner_inbox_at(parent: int, name: str, *, missing_ok: bool) -> None:
     try:
-        descriptor = os.open(
-            name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0), dir_fd=parent
-        )
+        descriptor = os.open(name, dirfd_mod.file_flags(_INBOX_READ_MODE), dir_fd=parent)
     except FileNotFoundError:
         if missing_ok:
             return
@@ -1159,7 +1161,7 @@ def _validate_scanner_inbox_name_matches_descriptor(parent: int, name: str, desc
     _validate_scanner_inbox_descriptor(descriptor)
     expected_identity = _scanner_inbox_identity(os.fstat(descriptor))
     assert expected_identity is not None
-    candidate = os.open(name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0), dir_fd=parent)
+    candidate = os.open(name, dirfd_mod.file_flags(_INBOX_READ_MODE), dir_fd=parent)
     try:
         try:
             _validate_scanner_inbox_descriptor(candidate)
@@ -1192,12 +1194,7 @@ def _scanner_inbox_temp_name() -> str:
 def _write_scanner_inbox_temp(parent: int, data: bytes) -> tuple[str, int]:
     """Write and retain one validated temporary inbox object."""
     name = _scanner_inbox_temp_name()
-    descriptor = os.open(
-        name,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
-        0o600,
-        dir_fd=parent,
-    )
+    descriptor = os.open(name, dirfd_mod.file_flags(_INBOX_TEMP_MODE), 0o600, dir_fd=parent)
     try:
         with os.fdopen(os.dup(descriptor), "wb") as handle:
             handle.write(data)
@@ -1279,11 +1276,7 @@ def _write_scanner_inbox_bytes_locked(target: Path, data: bytes) -> None:
     rollback_required = False
     try:
         try:
-            previous = os.open(
-                name,
-                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
-                dir_fd=parent,
-            )
+            previous = os.open(name, dirfd_mod.file_flags(_INBOX_READ_MODE), dir_fd=parent)
         except FileNotFoundError:
             pass
         else:
@@ -1481,9 +1474,7 @@ def _require_scanner_inbox_identity(parent: int, name: str, identity: tuple[int,
     ``_scanner_inbox_run_lock`` from snapshot through rollback.
     """
     try:
-        current = os.open(
-            name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0), dir_fd=parent
-        )
+        current = os.open(name, dirfd_mod.file_flags(_INBOX_READ_MODE), dir_fd=parent)
     except FileNotFoundError as exc:
         raise OSError("scanner inbox vanished since its pre-run snapshot") from exc
     try:
@@ -1976,7 +1967,7 @@ def _scanner_read_import_jsonl(target: Path, scanner: dict[str, Any]) -> tuple[l
         raise OSError("descriptor-relative scanner import operations are unavailable")
     relative = _scanner_import_relative_path(scanner)
     directory_flags = dirfd_mod.directory_flags()
-    file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_CLOEXEC", 0)
+    file_flags = dirfd_mod.file_flags(_INBOX_READ_MODE)
     absolute_target = Path(os.path.abspath(target.expanduser()))
     target_components = absolute_target.parts[1:]
     if not target_components:
@@ -2681,7 +2672,7 @@ def _publish_scanner_config(target: Path, data: bytes, *, force: bool) -> None:
         descriptor = ledger_mod._dirfd_open_file(
             parent,
             temporary_name,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            dirfd_mod.file_flags(_INBOX_TEMP_MODE),
             0o600,
         )
         with os.fdopen(os.dup(descriptor), "wb") as handle:

--- a/tests/_posix.py
+++ b/tests/_posix.py
@@ -1,0 +1,38 @@
+"""Shared POSIX-only skip markers for the test suite (issue #1478 round 3).
+
+Windows has no ``os.O_DIRECTORY`` / ``os.O_NOFOLLOW`` / ``os.O_PATH``,
+no ``dir_fd`` support in ``os.open`` et al, and no ``os.getpgid`` /
+``os.killpg``. Tests that exercise those primitives directly must skip
+with a reason naming the missing primitive instead of raising
+``AttributeError`` at collection or call time.
+
+Use ``dirfd.posix_available()`` (not ``dirfd.available()``) for the
+descriptor marker: ``available()`` is also true on Windows when the
+``nt_dirfd`` handle backend is present, while a test calling raw
+``os.open`` with ``O_DIRECTORY`` still crashes there. ``posix_available()``
+is false on every non-POSIX platform, which is exactly the skip condition
+for direct ``os.open`` / ``dir_fd`` use.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from brigade import dirfd
+
+requires_dirfd = pytest.mark.skipif(
+    not dirfd.posix_available(),
+    reason="descriptor-relative primitives (O_DIRECTORY/O_NOFOLLOW/dir_fd) are POSIX-only",
+)
+
+requires_process_groups = pytest.mark.skipif(
+    not hasattr(os, "killpg") or not hasattr(os, "getpgid"),
+    reason="process groups (os.killpg/os.getpgid) are POSIX-only",
+)
+
+requires_opath = pytest.mark.skipif(
+    os.name != "posix" or not getattr(os, "O_PATH", 0),
+    reason="O_PATH directory descriptors are POSIX-only",
+)

--- a/tests/test_authority_store_hmac.py
+++ b/tests/test_authority_store_hmac.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import authority_broker, authority_key, authority_marker, cli, scanner_isolation
+from brigade import authority_broker, authority_key, authority_marker, cli, dirfd, scanner_isolation
 from brigade.security_cmd import AUTHORITY_STORE_ISOLATION_EXTERNAL_KEY
 from brigade.work_cmd import constants, helpers, ledger
 
@@ -54,7 +54,7 @@ def _bind_workspace(tmp_path: Path, *, external_key: bool = True) -> dict[str, i
         _enable_external_key_isolation(tmp_path)
     (tmp_path / ".brigade").mkdir(exist_ok=True)
     workspace = ledger._workspace_directory_identity(tmp_path)
-    root = os.open(tmp_path / ".brigade", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    root = dirfd.open_directory_nofollow(tmp_path / ".brigade")
     try:
         ledger._record_external_directory_authority(tmp_path, (".brigade",), root, workspace=workspace)
     finally:
@@ -93,7 +93,7 @@ def _write_g5_receipt(tmp_path: Path, item: dict) -> Path:
     os.close(descriptor)
     path = helpers._scanner_runs_root(tmp_path) / "chosen-run" / "receipt.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    parent = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    parent = dirfd.open_directory_nofollow(path.parent)
     try:
         ledger._record_verifier_owned_directory(
             tmp_path,
@@ -104,7 +104,7 @@ def _write_g5_receipt(tmp_path: Path, item: dict) -> Path:
         os.close(parent)
     path.write_text(json.dumps(receipt), encoding="utf-8")
     data = path.read_bytes()
-    handle = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    handle = dirfd.open_file_nofollow(path, os.O_RDONLY)
     try:
         ledger._record_verifier_owned_file(
             tmp_path,

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from brigade import codex_appserver, proc
+from tests._posix import requires_process_groups
 
 FAKE = [sys.executable, str(Path(__file__).parent / "fake_appserver.py")]
 
@@ -162,7 +163,7 @@ def test_start_closes_spawned_process_when_initialize_fails(monkeypatch):
     ]
 
 
-@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+@requires_process_groups
 def test_close_terminates_appserver_descendant_process_group(tmp_path):
     child_pid_path = tmp_path / "child.pid"
     server_script = tmp_path / "server_with_child.py"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -10,6 +10,7 @@ import os
 import pytest
 
 from brigade import cli
+from brigade import dirfd
 from brigade import doctor as doctor_mod
 from brigade.install import install_selection
 from brigade.memory_cmd import MemoryCareConfig
@@ -547,7 +548,7 @@ def test_doctor_warns_when_sticky_marker_exists_and_isolation_is_off(tmp_target:
     )
     (tmp_target / ".brigade").mkdir(exist_ok=True)
     workspace = ledger._workspace_directory_identity(tmp_target)
-    root = os.open(tmp_target / ".brigade", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    root = dirfd.open_directory_nofollow(tmp_target / ".brigade")
     try:
         ledger._record_external_directory_authority(tmp_target, (".brigade",), root, workspace=workspace)
     finally:

--- a/tests/test_grokbot_ops.py
+++ b/tests/test_grokbot_ops.py
@@ -16,6 +16,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 from brigade import cli, grokbot_jobs, grokbot_mcp, grokbot_ops
+from tests._posix import requires_opath
 
 LISTENER_RECOVERY_UNIT_LINES = ("StartLimitIntervalSec=15min", "StartLimitBurst=3")
 LISTENER_RECOVERY_SERVICE_LINES = (
@@ -972,9 +973,7 @@ def test_config_operations_refuse_symlinked_config_file_and_directory(tmp_path: 
     assert config["instance"] == "operator"
 
 
-@pytest.mark.skipif(
-    os.name != "posix" or not getattr(os, "O_PATH", 0), reason="requires POSIX O_PATH directory descriptors"
-)
+@requires_opath
 def test_posix_path_walker_uses_opath_root_and_keeps_read_write_nofollow(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_ledger_1233_findings.py
+++ b/tests/test_ledger_1233_findings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import work_cmd
+from brigade import dirfd, work_cmd
 from brigade.security_cmd import AUTHORITY_STORE_ISOLATION_EXTERNAL_KEY
 from brigade.work_cmd import inbox_lock, ledger
 from brigade.work_cmd.ledger import descriptor_anchors
@@ -37,7 +37,7 @@ def _bind_workspace(tmp_path: Path) -> dict[str, int]:
     _enable_external_key_isolation(tmp_path)
     (tmp_path / ".brigade").mkdir(exist_ok=True)
     workspace = ledger._workspace_directory_identity(tmp_path)
-    root = os.open(tmp_path / ".brigade", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    root = dirfd.open_directory_nofollow(tmp_path / ".brigade")
     try:
         ledger._record_external_directory_authority(tmp_path, (".brigade",), root, workspace=workspace)
     finally:
@@ -73,7 +73,7 @@ def test_record_verifier_owned_file_holds_inbox_writer_lock(tmp_path: Path, monk
 
     monkeypatch.setattr(ledger, "_write_external_directory_authority", wrapped)
     data = receipt.read_bytes()
-    descriptor = os.open(receipt, os.O_RDONLY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_file_nofollow(receipt, os.O_RDONLY)
     try:
         ledger._record_verifier_owned_file(
             tmp_path,
@@ -116,7 +116,7 @@ def test_record_verifier_owned_file_concurrent_updates_do_not_lose_writes(tmp_pa
 
     def record(components: tuple[str, ...], receipt: Path) -> None:
         data = receipt.read_bytes()
-        descriptor = os.open(receipt, os.O_RDONLY | os.O_NOFOLLOW)
+        descriptor = dirfd.open_file_nofollow(receipt, os.O_RDONLY)
         try:
             ledger._record_verifier_owned_file(tmp_path, components=components, descriptor=descriptor, data=data)
         except BaseException as exc:
@@ -158,7 +158,7 @@ def test_record_verifier_owned_file_refuses_replaced_writer_lock(tmp_path: Path,
     monkeypatch.setattr(inbox_lock, "verify_inbox_writer_lock", boom)
     monkeypatch.setattr(ledger, "_write_external_directory_authority", wrapped)
     data = receipt.read_bytes()
-    descriptor = os.open(receipt, os.O_RDONLY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_file_nofollow(receipt, os.O_RDONLY)
     try:
         with pytest.raises(OSError, match="replaced while held"):
             ledger._record_verifier_owned_file(
@@ -240,7 +240,7 @@ def test_open_verifier_owned_directory_parent_close_handoff_is_interrupt_safe(tm
         real_close(fd)
         if recycled or fd != opened.get("imports"):
             return
-        dummy = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+        dummy = dirfd.open_directory_nofollow(tmp_path)
         recycled.append(dummy)
         raise RuntimeError("interrupt after parent close")
 

--- a/tests/test_localio.py
+++ b/tests/test_localio.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from brigade import localio, run_dirfd, run_journal
+from tests._posix import requires_dirfd
 
 
 def test_read_json_dict_invalid_utf8_returns_none(tmp_path: Path):
@@ -72,9 +73,7 @@ def test_write_text_atomic_fsyncs_parent_after_replace(tmp_path: Path, monkeypat
     assert any(kind == "fsync" and is_directory for kind, is_directory in calls[replace_index + 1 :])
 
 
-@pytest.mark.skipif(
-    os.name != "posix" or not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW is a POSIX symlink hardening flag"
-)
+@requires_dirfd
 def test_write_text_atomic_opens_parent_without_following_symlinks(tmp_path: Path, monkeypatch):
     path = tmp_path / "receipt.txt"
     real_open = localio.os.open

--- a/tests/test_posix_facade_behaviour.py
+++ b/tests/test_posix_facade_behaviour.py
@@ -17,20 +17,24 @@ from brigade import grokbot_reconcile
 from brigade import proc
 from brigade.grokbot_job_validation import GrokbotJobError
 from brigade.grokbot_reconcile import ReconcileError
+from tests._posix import requires_dirfd, requires_process_groups
 
 
+@requires_dirfd
 def test_directory_flags_match_legacy_expression() -> None:
     """The facade refactor must not change the POSIX flag computation."""
     expected = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
     assert dirfd.directory_flags() == expected
 
 
+@requires_dirfd
 def test_directory_flags_nofollow_false_matches_legacy_expression() -> None:
     """Root-anchor opens skip O_NOFOLLOW exactly like the old inline code."""
     expected = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0)
     assert dirfd.directory_flags(nofollow=False) == expected
 
 
+@requires_dirfd
 def test_file_flags_match_legacy_expression() -> None:
     """The new file facade pins the old ``mode | O_NOFOLLOW | O_CLOEXEC`` shape."""
     mode = os.O_RDONLY
@@ -92,6 +96,7 @@ def test_grokbot_reconcile_directory_flags_maps_to_typed_error(
         grokbot_reconcile._directory_flags()
 
 
+@requires_process_groups
 def test_process_group_id_matches_getpgid_on_posix() -> None:
     """The proc facade returns the real pgid where getpgid exists."""
     assert proc.process_group_id(os.getpid()) == os.getpgid(os.getpid())

--- a/tests/test_posix_facade_behaviour.py
+++ b/tests/test_posix_facade_behaviour.py
@@ -1,0 +1,105 @@
+"""Behavioural pins for the POSIX-only facade routing (issue #1478 follow-up).
+
+Companion to ``test_posix_facade_guard.py`` (which scans sources): every new
+fail-closed branch is reachable on POSIX with ``monkeypatch``, so these tests
+exercise the behaviour directly instead of needing a Windows runner.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from brigade import dirfd
+from brigade import grokbot_jobs
+from brigade import grokbot_reconcile
+from brigade import proc
+from brigade.grokbot_job_validation import GrokbotJobError
+from brigade.grokbot_reconcile import ReconcileError
+
+
+def test_directory_flags_match_legacy_expression() -> None:
+    """The facade refactor must not change the POSIX flag computation."""
+    expected = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    assert dirfd.directory_flags() == expected
+
+
+def test_directory_flags_nofollow_false_matches_legacy_expression() -> None:
+    """Root-anchor opens skip O_NOFOLLOW exactly like the old inline code."""
+    expected = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0)
+    assert dirfd.directory_flags(nofollow=False) == expected
+
+
+def test_file_flags_match_legacy_expression() -> None:
+    """The new file facade pins the old ``mode | O_NOFOLLOW | O_CLOEXEC`` shape."""
+    mode = os.O_RDONLY
+    expected = mode | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    assert dirfd.file_flags(mode) == expected
+
+
+def test_directory_flags_fail_closed_without_o_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing O_DIRECTORY raises OSError, never AttributeError."""
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+    with pytest.raises(OSError, match="unavailable"):
+        dirfd.directory_flags()
+
+
+def test_directory_flags_nofollow_false_still_fail_closed_without_o_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The root-anchor path also fails closed when O_DIRECTORY is gone."""
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+    with pytest.raises(OSError, match="unavailable"):
+        dirfd.directory_flags(nofollow=False)
+
+
+def test_directory_flags_fail_closed_without_o_nofollow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing O_NOFOLLOW raises OSError, never AttributeError."""
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    with pytest.raises(OSError, match="unavailable"):
+        dirfd.directory_flags()
+
+
+def test_file_flags_fail_closed_without_o_nofollow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """File opens must not silently drop the symlink guard on Windows."""
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    with pytest.raises(OSError, match="unavailable"):
+        dirfd.file_flags(os.O_RDONLY)
+
+
+def test_grokbot_jobs_directory_flags_maps_to_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The jobs store surfaces the facade failure as unsafe-storage."""
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+    with pytest.raises(GrokbotJobError, match="unsafe-storage"):
+        grokbot_jobs._directory_flags()
+
+
+def test_grokbot_reconcile_directory_flags_maps_to_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconcile surfaces the facade failure as its own typed error."""
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+    with pytest.raises(ReconcileError):
+        grokbot_reconcile._directory_flags()
+
+
+def test_process_group_id_matches_getpgid_on_posix() -> None:
+    """The proc facade returns the real pgid where getpgid exists."""
+    assert proc.process_group_id(os.getpid()) == os.getpgid(os.getpid())
+
+
+def test_process_group_id_none_without_getpgid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows has no os.getpgid: the facade returns None instead of raising."""
+    monkeypatch.delattr(os, "getpgid", raising=False)
+    assert proc.process_group_id(os.getpid()) is None

--- a/tests/test_posix_facade_guard.py
+++ b/tests/test_posix_facade_guard.py
@@ -1,0 +1,28 @@
+"""Guard against Windows-unsafe direct process and directory primitives.
+
+``os.O_DIRECTORY`` and ``os.getpgid`` are absent on Windows, so direct use
+raises ``AttributeError`` instead of a typed fail-closed error. All uses must
+go through ``brigade.dirfd`` (``directory_flags``/``root_directory_flags``)
+and ``brigade.proc.process_group_id``; only ``dirfd.py``, ``nt_dirfd.py``,
+and ``proc.py`` may reference the raw attributes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ALLOWED = frozenset({"dirfd.py", "nt_dirfd.py", "proc.py"})
+
+
+def test_posix_primitives_go_through_facades() -> None:
+    root = Path(__file__).resolve().parent.parent / "src" / "brigade"
+    offenders: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        if path.name in ALLOWED:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "os.O_DIRECTORY" in text or "os.getpgid" in text:
+            offenders.append(str(path.relative_to(root)))
+    assert not offenders, "Windows-unsafe primitives must go through brigade.dirfd/proc facades: " + ", ".join(
+        offenders
+    )

--- a/tests/test_posix_facade_guard.py
+++ b/tests/test_posix_facade_guard.py
@@ -9,6 +9,7 @@ and ``proc.py`` may reference the raw attributes.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 ALLOWED = frozenset({"dirfd.py", "nt_dirfd.py", "proc.py"})
@@ -25,4 +26,60 @@ def test_posix_primitives_go_through_facades() -> None:
             offenders.append(str(path.relative_to(root)))
     assert not offenders, "Windows-unsafe primitives must go through brigade.dirfd/proc facades: " + ", ".join(
         offenders
+    )
+
+
+POSIX_TEST_ATTRIBUTES = frozenset({"O_DIRECTORY", "O_NOFOLLOW", "O_PATH", "getpgid", "killpg"})
+
+POSIX_TEST_MARKERS = frozenset({"requires_dirfd", "requires_process_groups", "requires_opath"})
+
+
+def _direct_posix_attributes(path: Path) -> set[str]:
+    """Return POSIX-only ``os.<attr>`` names read as code (not strings)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+            and node.attr in POSIX_TEST_ATTRIBUTES
+        ):
+            found.add(node.attr)
+    return found
+
+
+def test_tests_reference_posix_primitives_only_with_shared_markers() -> None:
+    """Direct ``os.O_DIRECTORY``/``os.O_NOFOLLOW``/``os.O_PATH``/``os.getpgid``/``os.killpg``
+    in ``tests/`` must live in a file that imports the shared markers.
+
+    Rule: outside ``tests/_posix.py`` (which defines the markers), a test file
+    may read one of those attributes as code only when it imports
+    ``tests._posix`` and references one of ``requires_dirfd``,
+    ``requires_process_groups``, or ``requires_opath``. The import plus marker
+    reference proves every directly-touching test carries a skip naming the
+    missing primitive, so Windows collection never reaches the
+    ``AttributeError``. Files that only mention the names inside strings (this
+    guard's own source scan, the inbox escape-message assertions) are ignored:
+    the check parses the AST, so string literals and comments never count.
+    Prefer rerouting helpers through the ``brigade.dirfd`` facade opens so the
+    test still runs on Windows; add a marker only when the test body genuinely
+    requires the raw primitive (``dir_fd=``, ``O_PATH`` assertions, process
+    group teardown, POSIX flag pins).
+    """
+    root = Path(__file__).resolve().parent
+    offenders: list[str] = []
+    for path in sorted(root.glob("*.py")):
+        if path.name == "_posix.py":
+            continue
+        direct = _direct_posix_attributes(path)
+        if not direct:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "_posix" in text and any(marker in text for marker in POSIX_TEST_MARKERS):
+            continue
+        offenders.append(f"{path.name} ({', '.join(sorted(direct))})")
+    assert not offenders, (
+        "Windows-unsafe test primitives need a tests._posix shared marker or a dirfd facade reroute: "
+        + ", ".join(offenders)
     )

--- a/tests/test_research_acceptance.py
+++ b/tests/test_research_acceptance.py
@@ -194,8 +194,12 @@ def start_brigade(workspace: Path, *args: str) -> subprocess.Popen[str]:
 def _terminate_tree(process: subprocess.Popen[str]) -> None:
     if process.poll() is not None:
         return
+    killpg = getattr(os, "killpg", None)
     try:
-        os.killpg(process.pid, signal.SIGKILL)
+        if killpg is not None:
+            killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
     except ProcessLookupError:
         process.kill()
     try:

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -22,6 +22,7 @@ from brigade import run_journal
 from brigade import runguard
 from brigade import runs_cmd
 from tests import thread_sync
+from tests._posix import requires_process_groups
 from tests.run_test_helpers import HEALTHY_SEAT_HEALTH_CHILD_SETUP
 
 
@@ -2098,6 +2099,7 @@ def test_app_server_and_control_start_after_dispatching_is_recorded(tmp_path, mo
     assert seen == {"app_server": "dispatching", "control_server": "dispatching"}
 
 
+@requires_process_groups
 def test_sigterm_during_control_setup_closes_appserver_child_before_lock_release(tmp_path):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = tmp_path / "run-artifacts"
@@ -2241,6 +2243,7 @@ def test_run_cli_terminalizes_keyboard_interrupt_during_dispatch(tmp_path, monke
         (signal.SIGTERM, 128 + signal.SIGTERM, "signal"),
     ],
 )
+@requires_process_groups
 def test_run_cli_cancels_blocked_worker_process_before_releasing_lock(tmp_path, sig, expected_code, failure_kind):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = tmp_path / "run-artifacts"
@@ -2327,6 +2330,7 @@ raise SystemExit(cli.main([
     assert run_meta["failure"]["seat"] == "coder"
 
 
+@requires_process_groups
 def test_run_cli_terminalizes_sigint_during_graphtrail_baseline_capture(tmp_path, capsys):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = repo / ".brigade" / "runs" / "blocked-graphtrail-baseline"
@@ -2392,6 +2396,7 @@ raise SystemExit(cli.main([
         ("codex-cloud-submit", signal.SIGTERM, 128 + signal.SIGTERM, "dispatching", "coder"),
     ],
 )
+@requires_process_groups
 def test_run_cli_cancels_blocked_phase_process_before_releasing_lock(
     tmp_path, phase, sig, expected_code, expected_status, expected_seat
 ):

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -13,6 +13,7 @@ from brigade import aboyeur, cli, proc, run_checkpoint, run_journal
 from brigade import roster as roster_mod
 from brigade import runguard
 from brigade.cli import run as run_cli
+from tests._posix import requires_process_groups
 
 
 def _pid_is_running(pid: int) -> bool:
@@ -325,6 +326,7 @@ def test_run_detach_parent_stops_terminalizing_receipt_at_child_takeover(tmp_pat
         ("error", 2, "failed", "unexpected-error"),
     ],
 )
+@requires_process_groups
 def test_run_detach_startup_escape_kills_child_group_before_terminal_receipt(
     tmp_path, monkeypatch, escape, expected_code, expected_status, expected_kind
 ):
@@ -804,6 +806,7 @@ time.sleep(300)
 """
 
 
+@requires_process_groups
 @pytest.mark.skipif(os.name != "posix", reason="POSIX session teardown semantics")
 def test_spawn_detached_child_survives_parent_session_exit(tmp_path):
     """The detached child must reach a terminal receipt after its parent's session dies.

--- a/tests/test_scanner_runs_dir_adoption.py
+++ b/tests/test_scanner_runs_dir_adoption.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 
 from brigade.work_cmd import helpers, ledger, scanners as scanners_mod
+from tests._posix import requires_dirfd
 from tests.support import PRIVATE_DIRECTORY_MODE, PRIVATE_FILE_MODE
 
 
@@ -263,6 +264,7 @@ def test_doctor_and_init_repair_released_unbound_runs_root(tmp_path: Path) -> No
     assert _runs_root_is_bound(other)
 
 
+@requires_dirfd
 def test_forged_receipt_in_verifier_created_run_dir_is_rejected(tmp_path: Path) -> None:
     root = scanners_mod._open_scanner_runs_directory(tmp_path, create=True)
     run_id = "verifier-run"

--- a/tests/test_work_cmd_scanners.py
+++ b/tests/test_work_cmd_scanners.py
@@ -10,12 +10,14 @@ from types import SimpleNamespace
 import pytest
 
 from brigade import cli
+from brigade import dirfd
 from brigade import dogfood_cmd
 from brigade import handoff_cmd
 from brigade import localio
 from brigade import work_cmd
 from brigade.work_cmd import helpers
 
+from tests._posix import requires_dirfd
 from tests.work_cmd_test_helpers import (
     _write_json,
     _init_git_repo,
@@ -44,7 +46,7 @@ def _verified_builtin_scanner_run(scanner: dict[str, object]) -> dict[str, objec
 
 def _record_scanner_run_authority(tmp_path: Path, run_id: str) -> None:
     directory = helpers._scanner_runs_root(tmp_path) / run_id
-    descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_directory_nofollow(directory)
     try:
         work_cmd.ledger._record_verifier_owned_directory(
             tmp_path,
@@ -58,7 +60,7 @@ def _record_scanner_run_authority(tmp_path: Path, run_id: str) -> None:
 def _bind_planted_scanner_receipt(tmp_path: Path, run_id: str) -> None:
     path = helpers._scanner_runs_root(tmp_path) / run_id / "receipt.json"
     data = path.read_bytes()
-    descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_file_nofollow(path, os.O_RDONLY)
     try:
         work_cmd.ledger._record_verifier_owned_file(
             tmp_path,
@@ -166,7 +168,7 @@ def test_replaced_individual_scanner_run_cannot_manufacture_receipt_authority(tm
     os.close(root)
     run = helpers._scanner_runs_root(tmp_path) / "chosen-run"
     run.mkdir()
-    descriptor = os.open(run, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_directory_nofollow(run)
     try:
         ledger._record_verifier_owned_directory(
             tmp_path,
@@ -184,6 +186,7 @@ def test_replaced_individual_scanner_run_cannot_manufacture_receipt_authority(tm
     assert not ledger._has_locally_stamped_import_proof(item, target=tmp_path)
 
 
+@requires_dirfd
 def test_scanner_receipt_collection_rejects_replaced_bound_run_directory(tmp_path: Path) -> None:
     from brigade.work_cmd import helpers, ledger, scanners as scanners_mod
 
@@ -211,6 +214,7 @@ def test_scanner_receipt_collection_rejects_replaced_bound_run_directory(tmp_pat
     assert scanners_mod._scanner_receipts(tmp_path) == []
 
 
+@requires_dirfd
 def test_scanner_receipt_collection_rejects_renamed_receipt(tmp_path: Path) -> None:
     from brigade.work_cmd import helpers, ledger, scanners as scanners_mod
 
@@ -3696,6 +3700,7 @@ def test_scanner_self_import_drops_wrong_source_operational_metadata(tmp_path):
         assert metadata["source_fingerprint"] == work_cmd.ledger._untrusted_import_canonical_hash(item)
 
 
+@requires_dirfd
 def test_scanner_read_receipt_derives_target_from_correct_parent(tmp_path: Path) -> None:
     """_scanner_read_receipt must use parents[3] (the workspace root) not parents[2]."""
     from brigade.work_cmd import ledger, scanners as scanners_mod
@@ -3722,6 +3727,7 @@ def test_scanner_read_receipt_derives_target_from_correct_parent(tmp_path: Path)
     assert receipt["run_id"] == run_id
 
 
+@requires_dirfd
 def test_scanner_read_receipt_accepts_run_directory_path(tmp_path: Path) -> None:
     """_scanner_read_receipt should also accept a run directory (not just receipt.json)."""
     from brigade.work_cmd import ledger, scanners as scanners_mod

--- a/tests/test_work_cmd_services.py
+++ b/tests/test_work_cmd_services.py
@@ -13,6 +13,7 @@ import pytest
 from brigade import aboyeur
 from brigade import agents
 from brigade import cli
+from brigade import dirfd
 from brigade import dogfood_cmd
 from brigade import localio
 from brigade import repos_cmd
@@ -2973,7 +2974,7 @@ conflict_window = "02:00-02:10"
     os.close(runs_authority)
     run_dir = tmp_path / ".brigade" / "scanners" / "runs" / "no-import-run"
     run_dir.mkdir(parents=True)
-    descriptor = os.open(run_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_directory_nofollow(run_dir)
     try:
         work_cmd.ledger._record_verifier_owned_directory(
             tmp_path,
@@ -2998,7 +2999,7 @@ conflict_window = "02:00-02:10"
     )
     receipt_path = run_dir / "receipt.json"
     receipt_data = receipt_path.read_bytes()
-    receipt_fd = os.open(receipt_path, os.O_RDONLY | os.O_NOFOLLOW)
+    receipt_fd = dirfd.open_file_nofollow(receipt_path, os.O_RDONLY)
     try:
         work_cmd.ledger._record_verifier_owned_file(
             tmp_path,

--- a/tests/test_work_cmd_sweeps.py
+++ b/tests/test_work_cmd_sweeps.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from brigade import cli
+from brigade import dirfd
 from brigade import dogfood_cmd
 from brigade import work_cmd
 
@@ -66,7 +67,7 @@ def _write_scanner_import_proof(tmp_path: Path, items: list[dict[str, object]], 
     os.close(descriptor)
     receipt_path = work_cmd.helpers._scanner_runs_root(tmp_path) / run_id / "receipt.json"
     receipt_path.parent.mkdir(parents=True)
-    descriptor = os.open(receipt_path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_directory_nofollow(receipt_path.parent)
     try:
         work_cmd.ledger._record_verifier_owned_directory(
             tmp_path,
@@ -77,7 +78,7 @@ def _write_scanner_import_proof(tmp_path: Path, items: list[dict[str, object]], 
         os.close(descriptor)
     receipt_path.write_text(json.dumps(receipt))
     data = receipt_path.read_bytes()
-    descriptor = os.open(receipt_path, os.O_RDONLY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_file_nofollow(receipt_path, os.O_RDONLY)
     try:
         work_cmd.ledger._record_verifier_owned_file(
             tmp_path,

--- a/tests/test_work_import_provenance_stamp.py
+++ b/tests/test_work_import_provenance_stamp.py
@@ -11,9 +11,10 @@ from typing import Any
 
 import pytest
 
-from brigade import provenance
+from brigade import dirfd, provenance
 from brigade.security_cmd import AUTHORITY_STORE_ISOLATION_EXTERNAL_KEY
 from brigade.work_cmd import constants, helpers, ledger
+from tests._posix import requires_dirfd
 from tests.support import PRIVATE_FILE_MODE
 
 
@@ -64,7 +65,7 @@ def _rewrite_authority_anchor(anchor: Path, directory: Path) -> None:
 
 def _bind_receipt_file(tmp_path: Path, receipt_path: Path, *, run_id: str) -> None:
     data = receipt_path.read_bytes()
-    descriptor = os.open(receipt_path, os.O_RDONLY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_file_nofollow(receipt_path, os.O_RDONLY)
     try:
         ledger._record_verifier_owned_file(
             tmp_path,
@@ -104,7 +105,7 @@ def _write_external_import_proof(tmp_path: Path, item: dict[str, Any], *, source
     _establish_scanner_runs_authority(tmp_path)
     receipt_path = helpers._scanner_runs_root(tmp_path) / run_id / "receipt.json"
     receipt_path.parent.mkdir(parents=True)
-    descriptor = os.open(receipt_path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_directory_nofollow(receipt_path.parent)
     try:
         ledger._record_verifier_owned_directory(
             tmp_path,
@@ -142,7 +143,7 @@ def _write_builtin_scanner_receipt(
     _establish_scanner_runs_authority(tmp_path)
     path = helpers._scanner_runs_root(tmp_path) / "chosen-run" / "receipt.json"
     path.parent.mkdir(parents=True)
-    descriptor = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_directory_nofollow(path.parent)
     try:
         ledger._record_verifier_owned_directory(
             tmp_path,
@@ -338,8 +339,8 @@ def test_receipt_binding_write_failure_restores_receipt_proof_inbox_and_bindings
         "command": scanner["command"],
     }
     authority = scanners_mod._ScannerRunDirectoryAuthority(
-        root=os.open(helpers._scanner_runs_root(tmp_path), os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW),
-        directory=os.open(receipt_path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW),
+        root=dirfd.open_directory_nofollow(helpers._scanner_runs_root(tmp_path)),
+        directory=dirfd.open_directory_nofollow(receipt_path.parent),
         run_id="chosen-run",
     )
     scanners_mod._SCANNER_RUN_DIRECTORY_AUTHORITIES[id(run)] = authority
@@ -1819,6 +1820,7 @@ def test_import_proof_directory_relocation_rejects_record_without_workspace_bind
         ledger._open_import_proof_directory(relocated, create=True)
 
 
+@requires_dirfd
 def test_import_inbox_rollback_short_write_restores_all_prior_bytes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1851,6 +1853,7 @@ def test_import_inbox_rollback_short_write_restores_all_prior_bytes(
         os.close(parent)
 
 
+@requires_dirfd
 def test_import_inbox_rollback_zero_write_fails_without_reporting_success(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2673,7 +2676,7 @@ def test_canonical_dedupe_after_rename_without_preopening_authority(tmp_path: Pa
     original.mkdir()
     _enable_external_key_isolation(original)
     (original / ".brigade").mkdir(exist_ok=True)
-    descriptor = os.open(original / ".brigade", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = dirfd.open_directory_nofollow(original / ".brigade")
     try:
         ledger._record_external_directory_authority(
             original,


### PR DESCRIPTION
Fixes #1478

## What

- `src/brigade/dirfd.py`: `directory_flags()`, `root_directory_flags()`, and `file_flags()` helpers that return the POSIX flag sets unchanged and raise the module's typed `unavailable` `OSError` on platforms without `O_DIRECTORY` or `O_NOFOLLOW`, never `AttributeError`.
- `src/brigade/proc.py`: `process_group_id(pid)` returns `None` where `os.getpgid` is absent or the pid is gone.
- Nine modules routed through the dirfd facade (scanners, memory vault, projection kernel, managed block, grokbot jobs, ops, reconcile, fleet actions, n8n actions), each mapping the facade error to its own typed error where one exists.
- Three process callers routed through `process_group_id` (MCP runtime, PI MCP bridge, Excalidraw client); a `None` group falls back to the shared job-object or taskkill termination path on Windows, and the Windows branches fall through to the common poll, kill, and wait tail so handles are reaped.
- `tests/test_posix_facade_guard.py`: source scan that fails if `os.O_DIRECTORY` or `os.getpgid` appears outside `dirfd.py`, `nt_dirfd.py`, and `proc.py`.
- `tests/test_posix_facade_behaviour.py`: pins POSIX flag equality against the previous expressions and asserts the typed fail-closed errors when the attributes are removed.

Round 2 addressed an independent Opus review: fail-open `O_NOFOLLOW` degradation in the fleet JSON paths, unreaped Windows teardown, error-type consistency in the projection kernel, and the missing behavioural tests. The `NotImplementedError: dir_fd unavailable` and scanner rollback items named in the issue were confirmed to already raise fail-closed `OSError` through the ledger helpers; no code change was needed for them.

## Verification

Focused gate through Brigade (ruff, format, version sync, snapshots, mypy, 14 selected test files):

```
round 1: 20260906-172854-work-verify-bf8870  exit=0
round 2: 20260906-174933-work-verify-62bb21  exit=0
```

Windows confirmation on the fleet host is recorded in a follow-up comment.

Implemented by the `muse13` seat via `brigade run`, reviewed by the `claude_standby` seat, landed by the conductor.
