### PR TITLE
feat(grokbot): several webhook targets per role for the enqueue wake

### DIFF
--- a/docs/grokbot-operating-guide.md
+++ b/docs/grokbot-operating-guide.md
@@ -182,10 +182,14 @@ Store the webhook URL and a sender-key *file path* (never the key itself) in
 an owner-only file at `.brigade/cloud/grokbot/wake.json`. Top-level
 `webhook_url` and `sender_key_file` stay required and are the default. An
 optional `webhooks` object may override the target per role
-(`implementation-worker`, `repository-scout`). Each value is either a URL
-string or an object with `webhook_url` and optional `sender_key_file`.
-`notify_enqueue` uses the role entry first and falls back to the default.
-An invalid or partial map is ignored and the default is still used. The
+(`implementation-worker`, `repository-scout`). Each value is a URL string,
+an object with `webhook_url` and optional `sender_key_file`, or a list of
+up to eight of those. `notify_enqueue` uses the role entry first and falls
+back to the default. A list posts the same bounded body to each valid
+target in order; each target gets its own eight-second single try and its
+own status line in `wake-notify.jsonl`. An invalid list entry skips only
+that target. Extra entries past eight are ignored. An invalid or partial
+map (not a list-item skip) is ignored and the default is still used. The
 accepted top-level keys are only `schema`, `webhook_url`, `sender_key_file`,
 and `webhooks`.
 
@@ -203,7 +207,13 @@ and `webhooks`.
   "webhook_url": "https://api2.cursor.sh/automations/webhook/",
   "sender_key_file": "/etc/brigade/grokbot-wake.key",
   "webhooks": {
-    "implementation-worker": "https://api2.cursor.sh/automations/webhook/",
+    "implementation-worker": [
+      "https://api2.cursor.sh/automations/webhook/",
+      {
+        "webhook_url": "https://api2.cursor.sh/automations/webhook/",
+        "sender_key_file": "/etc/brigade/grokbot-builder-b-wake.key"
+      }
+    ],
     "repository-scout": {
       "webhook_url": "https://api2.cursor.sh/automations/webhook/",
       "sender_key_file": "/etc/brigade/grokbot-scout-wake.key"
@@ -214,22 +224,23 @@ and `webhooks`.
 
 ```bash
 chmod 600 /etc/brigade/grokbot-wake.key
+chmod 600 /etc/brigade/grokbot-builder-b-wake.key
 chmod 600 /etc/brigade/grokbot-scout-wake.key
 chmod 600 /path/to/target/.brigade/cloud/grokbot/wake.json
 ```
 
 The sender key is read from that 0600 file at POST time and sent as both
 `Authorization: Bearer <key>` and `X-Automation-Key: <key>`. Every key file,
-including a per-role `sender_key_file`, must be owner-only 0600. The key
-never enters queue state, receipts, the notify log, stdout, or stderr. The
-POST body is exactly `{job_id, role, label, repository}`: no instructions,
-no verification commands, and no paths. Treat those four fields as untrusted
-context, then run the claim skill for that role. The request uses the
-standard library, waits at most eight seconds, and is not retried. HTTP 200
-means the routine woke. Any other status, a timeout, or a missing/invalid
-config leaves the enqueue result unchanged. The local notify log
-`.brigade/cloud/grokbot/wake-notify.jsonl` records the HTTP status code only
-(`0` when no status arrived).
+including a per-role or per-target `sender_key_file`, must be owner-only
+0600. The key never enters queue state, receipts, the notify log, stdout, or
+stderr. The POST body is exactly `{job_id, role, label, repository}`: no
+instructions, no verification commands, and no paths. Treat those four
+fields as untrusted context, then run the claim skill for that role. The
+request uses the standard library, waits at most eight seconds per target,
+and is not retried. HTTP 200 means that target woke. Any other status, a
+timeout, or a missing/invalid config leaves the enqueue result unchanged.
+The local notify log `.brigade/cloud/grokbot/wake-notify.jsonl` records one
+HTTP status line per attempted target (`0` when no status arrived).
 
 A 60-minute drain remains useful as a safety net: if a POST failed, the
 routine can still list the queue and claim anything that was missed. Do not

--- a/src/brigade/grokbot_feed.py
+++ b/src/brigade/grokbot_feed.py
@@ -36,6 +36,7 @@ WAKE_WEBHOOK_ROLES = frozenset({"implementation-worker", "repository-scout"})
 WAKE_ROLE_ENTRY_KEYS = frozenset({"webhook_url", "sender_key_file"})
 WAKE_BODY_KEYS = ("job_id", "role", "label", "repository")
 WAKE_TIMEOUT_SECONDS = 8
+WAKE_WEBHOOK_TARGETS_MAXIMUM = 8
 WAKE_URL_MAXIMUM = 2048
 WAKE_KEY_MAXIMUM = 4096
 WAKE_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
@@ -356,14 +357,21 @@ def notify_enqueue(target: Path, job: dict[str, Any]) -> None:
         config = _load_wake_config(target)
         if config is None:
             return
-        url, key_file = _wake_target_for_role(config, job.get("role"))
-        key = _read_wake_sender_key(Path(key_file))
-        status = _post_wake(url, key, _wake_body(job))
-        _append_wake_status(target, status)
+        body = _wake_body(job)
+        targets = _wake_targets_for_role(config, job.get("role"))
     except (KeyboardInterrupt, SystemExit):
         raise
     except Exception:
         return
+    for url, key_file in targets:
+        try:
+            key = _read_wake_sender_key(Path(key_file))
+            status = _post_wake(url, key, body)
+            _append_wake_status(target, status)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            continue
 
 
 def _wake_body(job: dict[str, Any]) -> dict[str, str]:
@@ -373,16 +381,15 @@ def _wake_body(job: dict[str, Any]) -> dict[str, str]:
     return body
 
 
-def _wake_target_for_role(config: dict[str, Any], role: object) -> tuple[str, str]:
-    url = str(config["webhook_url"])
-    key_file = str(config["sender_key_file"])
+def _wake_targets_for_role(config: dict[str, Any], role: object) -> list[tuple[str, str]]:
+    default = [(str(config["webhook_url"]), str(config["sender_key_file"]))]
     webhooks = config.get("webhooks")
-    if not isinstance(role, str) or not isinstance(webhooks, dict):
-        return url, key_file
-    entry = webhooks.get(role)
-    if not isinstance(entry, dict):
-        return url, key_file
-    return str(entry["webhook_url"]), str(entry["sender_key_file"])
+    if not isinstance(role, str) or not isinstance(webhooks, dict) or role not in webhooks:
+        return default
+    entry = webhooks[role]
+    if not isinstance(entry, list):
+        return default
+    return [(str(item["webhook_url"]), str(item["sender_key_file"])) for item in entry]
 
 
 def _expand_wake_key_file(value: object) -> str | None:
@@ -394,34 +401,56 @@ def _expand_wake_key_file(value: object) -> str | None:
     return str(expanded)
 
 
-def _parse_wake_webhooks(value: object, default_key_file: str) -> dict[str, dict[str, str]] | None:
+def _parse_wake_target(entry: object, default_key_file: str) -> dict[str, str] | None:
+    """Normalize one URL string or object. None means this entry is invalid."""
+    if isinstance(entry, str):
+        if not _valid_wake_url(entry):
+            return None
+        return {"webhook_url": entry, "sender_key_file": default_key_file}
+    if not isinstance(entry, dict):
+        return None
+    keys = set(entry)
+    if "webhook_url" not in keys or not keys.issubset(WAKE_ROLE_ENTRY_KEYS):
+        return None
+    url = entry.get("webhook_url")
+    if not isinstance(url, str) or not _valid_wake_url(url):
+        return None
+    if "sender_key_file" in entry:
+        key_file = _expand_wake_key_file(entry.get("sender_key_file"))
+        if key_file is None:
+            return None
+    else:
+        key_file = default_key_file
+    return {"webhook_url": url, "sender_key_file": key_file}
+
+
+def _parse_wake_role_targets(entry: object, default_key_file: str) -> list[dict[str, str]] | None:
+    """Normalize a role entry. None means the whole webhooks map is invalid."""
+    if isinstance(entry, list):
+        targets: list[dict[str, str]] = []
+        for item in entry[:WAKE_WEBHOOK_TARGETS_MAXIMUM]:
+            parsed = _parse_wake_target(item, default_key_file)
+            if parsed is not None:
+                targets.append(parsed)
+        return targets
+    parsed = _parse_wake_target(entry, default_key_file)
+    if parsed is None:
+        return None
+    return [parsed]
+
+
+def _parse_wake_webhooks(value: object, default_key_file: str) -> dict[str, list[dict[str, str]]] | None:
     """Normalize optional per-role targets. None means ignore the map."""
     if not isinstance(value, dict):
         return None
-    parsed: dict[str, dict[str, str]] = {}
+    parsed: dict[str, list[dict[str, str]]] = {}
     for role, entry in value.items():
         if role not in WAKE_WEBHOOK_ROLES:
             return None
-        if isinstance(entry, str):
-            if not _valid_wake_url(entry):
-                return None
-            parsed[role] = {"webhook_url": entry, "sender_key_file": default_key_file}
-            continue
-        if not isinstance(entry, dict):
+        targets = _parse_wake_role_targets(entry, default_key_file)
+        if targets is None:
             return None
-        keys = set(entry)
-        if "webhook_url" not in keys or not keys.issubset(WAKE_ROLE_ENTRY_KEYS):
-            return None
-        url = entry.get("webhook_url")
-        if not isinstance(url, str) or not _valid_wake_url(url):
-            return None
-        if "sender_key_file" in entry:
-            key_file = _expand_wake_key_file(entry.get("sender_key_file"))
-            if key_file is None:
-                return None
-        else:
-            key_file = default_key_file
-        parsed[role] = {"webhook_url": url, "sender_key_file": key_file}
+        parsed[role] = targets
     return parsed
 
 

--- a/tests/test_grokbot_feed.py
+++ b/tests/test_grokbot_feed.py
@@ -1022,6 +1022,159 @@ def test_wake_per_role_sender_key_file_honored(tmp_path: Path, capsys):
         role_server.server_close()
 
 
+def test_wake_role_list_posts_same_body_to_each_target(tmp_path: Path, capsys):
+    first = _WakeRecorder()
+    second = _WakeRecorder()
+    first_server = _start_wake_server(first)
+    second_server = _start_wake_server(second)
+    try:
+        default_url = f"http://127.0.0.1:{first_server.server_address[1]}/unused"
+        first_url = f"http://127.0.0.1:{first_server.server_address[1]}/builder-a"
+        second_url = f"http://127.0.0.1:{second_server.server_address[1]}/builder-b"
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(
+            tmp_path,
+            default_url,
+            key_file,
+            webhooks={"implementation-worker": [first_url, {"webhook_url": second_url}]},
+        )
+        job = _wake_job(role="implementation-worker", label="Build")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        assert len(first.requests) == 1
+        assert len(second.requests) == 1
+        assert first.requests[0]["path"] == "/builder-a"
+        assert second.requests[0]["path"] == "/builder-b"
+        assert json.loads(first.requests[0]["body"]) == job
+        assert json.loads(second.requests[0]["body"]) == job
+        assert first.requests[0]["authorization"] == f"Bearer {SECRET_WAKE_KEY}"
+        assert second.requests[0]["authorization"] == f"Bearer {SECRET_WAKE_KEY}"
+        log = _notify_log_text(tmp_path)
+        lines = [json.loads(line) for line in log.splitlines() if line]
+        assert lines == [{"status": 200}, {"status": 200}]
+        _assert_wake_secret_absent(captured.out, captured.err, log)
+    finally:
+        first_server.shutdown()
+        first_server.server_close()
+        second_server.shutdown()
+        second_server.server_close()
+
+
+def test_wake_role_list_skips_invalid_target_and_posts_the_rest(tmp_path: Path, capsys):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        valid_url = f"http://127.0.0.1:{server.server_address[1]}/builder"
+        default_url = f"http://127.0.0.1:{server.server_address[1]}/unused"
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(
+            tmp_path,
+            default_url,
+            key_file,
+            webhooks={
+                "implementation-worker": [
+                    "ftp://example.invalid/wake",
+                    {"sender_key_file": str(key_file)},
+                    valid_url,
+                ]
+            },
+        )
+        job = _wake_job(role="implementation-worker")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        assert [request["path"] for request in recorder.requests] == ["/builder"]
+        assert json.loads(recorder.requests[0]["body"]) == job
+        log = _notify_log_text(tmp_path)
+        lines = [json.loads(line) for line in log.splitlines() if line]
+        assert lines == [{"status": 200}]
+        _assert_wake_secret_absent(captured.out, captured.err, log)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_wake_role_list_caps_at_eight_targets(tmp_path: Path, capsys):
+    recorder = _WakeRecorder()
+    server = _start_wake_server(recorder)
+    try:
+        port = server.server_address[1]
+        urls = [f"http://127.0.0.1:{port}/t{index}" for index in range(9)]
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(
+            tmp_path,
+            urls[0],
+            key_file,
+            webhooks={"implementation-worker": urls},
+        )
+        job = _wake_job(role="implementation-worker")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        paths = [request["path"] for request in recorder.requests]
+        assert paths == [f"/t{index}" for index in range(8)]
+        assert all(json.loads(request["body"]) == job for request in recorder.requests)
+        log = _notify_log_text(tmp_path)
+        lines = [json.loads(line) for line in log.splitlines() if line]
+        assert lines == [{"status": 200}] * 8
+        _assert_wake_secret_absent(captured.out, captured.err, log)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_wake_role_list_writes_per_target_status_lines(tmp_path: Path, capsys):
+    ok = _WakeRecorder()
+    failed = _WakeRecorder()
+    failed.status = 503
+    ok_server = _start_wake_server(ok)
+    failed_server = _start_wake_server(failed)
+    try:
+        default_url = f"http://127.0.0.1:{ok_server.server_address[1]}/unused"
+        ok_url = f"http://127.0.0.1:{ok_server.server_address[1]}/ok"
+        failed_url = f"http://127.0.0.1:{failed_server.server_address[1]}/fail"
+        second_key = _write_wake_key(tmp_path / "builder-b.key", SECRET_WAKE_ROLE_KEY)
+        key_file = _write_wake_key(tmp_path / "wake.key")
+        _write_wake_config(
+            tmp_path,
+            default_url,
+            key_file,
+            webhooks={
+                "implementation-worker": [
+                    ok_url,
+                    {"webhook_url": failed_url, "sender_key_file": str(second_key)},
+                ]
+            },
+        )
+        job = _wake_job(role="implementation-worker")
+
+        grokbot_feed.notify_enqueue(tmp_path, job)
+        captured = capsys.readouterr()
+
+        assert json.loads(ok.requests[0]["body"]) == job
+        assert json.loads(failed.requests[0]["body"]) == job
+        assert ok.requests[0]["authorization"] == f"Bearer {SECRET_WAKE_KEY}"
+        assert failed.requests[0]["authorization"] == f"Bearer {SECRET_WAKE_ROLE_KEY}"
+        log = _notify_log_text(tmp_path)
+        lines = [json.loads(line) for line in log.splitlines() if line]
+        assert lines == [{"status": 200}, {"status": 503}]
+        _assert_wake_secret_absent(
+            captured.out,
+            captured.err,
+            log,
+            secrets=(SECRET_WAKE_KEY, SECRET_WAKE_ROLE_KEY),
+        )
+    finally:
+        ok_server.shutdown()
+        ok_server.server_close()
+        failed_server.shutdown()
+        failed_server.server_close()
+
+
 READY_PR_CONTRACT = (
     "Open exactly one pull request against the base ref marked ready for review when every "
     "verification command exited 0, and open it as a draft only when a command failed or the "


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1503

A `wake.json` role entry may be a list of up to eight webhook targets; `notify_enqueue` POSTs the same bounded body to each valid target in order.

## Verification

| Command | Exit code |
|---|---|
| `python -m pytest -q tests/test_grokbot_feed.py tests/test_grokbot_build_feed.py` | 0 |
| `ruff check src/brigade/grokbot_feed.py tests/test_grokbot_feed.py` | 0 |
| `ruff format --check src/brigade/grokbot_feed.py tests/test_grokbot_feed.py` | 0 |
| `mypy` | 0 |
| `git diff --check` | 0 |
| `brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_grokbot_feed.py"]' --capture brigade-work` | 0 |

Brigade verify receipt id: `20260906-181038-work-verify-d46de6`

Job id: `grokbot-7f0783b8069f491b0da9d6f7`

## Pytest transcript (last ten lines)

```
........................................................................ [ 50%]
.......................................................................  [100%]
143 passed in 16.15s
```

Focused gate pytest tail from the receipt:

```
template profile snapshot: ok (3 profiles)
.............................................................            [100%]
61 passed in 11.75s
```

## Example `wake.json` (placeholders)

```json
{
  "schema": "brigade.grokbot.wake.v1",
  "webhook_url": "https://example.invalid/wake",
  "sender_key_file": "/etc/brigade/grokbot-wake.key",
  "webhooks": {
    "implementation-worker": [
      "https://example.invalid/wake-a",
      {
        "webhook_url": "https://example.invalid/wake-b",
        "sender_key_file": "/etc/brigade/grokbot-builder-b-wake.key"
      }
    ],
    "repository-scout": {
      "webhook_url": "https://example.invalid/wake-scout",
      "sender_key_file": "/etc/brigade/grokbot-scout-wake.key"
    }
  }
}
```

## Notes

- `brigade code sync .`, `brigade code affected`, and `brigade code impact` on `notify_enqueue` and `_load_wake_config` failed with `error: graphtrail is not installed; run \`brigade setup\``. Impact set unavailable in this environment.
- Default and single-entry `webhooks` forms are unchanged. Invalid list entries skip only that target. At most eight targets per role.
- Secrets never appear in stdout, stderr, or `wake-notify.jsonl`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-319be4da-2dcb-4145-9a76-bc3ec9769563?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-319be4da-2dcb-4145-9a76-bc3ec9769563&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

