### PR TITLE
feat(hooks): keep interactive session presence alive on the fleet hub

### DIFF
--- a/src/brigade/claude_hooks/heartbeat.py
+++ b/src/brigade/claude_hooks/heartbeat.py
@@ -1,0 +1,127 @@
+"""Throttled Hub presence refresh for live Claude Code sessions.
+
+The Hub expires an interactive session ``ttl_seconds`` after its last write
+(``fleet_session_presence.DEFAULT_TTL_SECONDS``). ``SessionStart`` publishes the
+row once and ``SessionEnd`` ends it, so without a cadence in between a thread
+that stays open past the TTL disappears from ``brigade fleet sessions`` and the
+Command Deck while it is still alive.
+
+``UserPromptSubmit`` and ``PreToolUse`` therefore refresh presence, but only
+once per ``HEARTBEAT_INTERVAL_SECONDS``. The throttle stamp is one small JSON
+file per session under the existing hook state directory; it never reaches the
+Hub. The stamp is written before the Hub call, so an unreachable Hub cannot
+turn every prompt or tool call into a fresh network attempt, and no call path
+here raises: a hook must never be blocked by fleet presence.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from .. import localio
+from . import envelope, presence
+
+# fleet_session_presence.DEFAULT_TTL_SECONDS // 3. Pinned as a literal so the
+# hook path does not import the presence module just to read a constant;
+# tests/test_claude_hooks_heartbeat.py holds the two in sync.
+HEARTBEAT_INTERVAL_SECONDS = 300
+PRESENCE_DIRNAME = "presence"
+REFRESH_EVENTS = frozenset({"UserPromptSubmit", "PreToolUse"})
+MAX_STATE_BYTES = 4096
+_STAMP_KEY = "last_refresh_at"
+
+
+def state_path(target: Path, session_id: str) -> Path:
+    """Return the per-session throttle stamp path inside the hook state dir."""
+    slug = localio.slugify(session_id, fallback="session")[:48]
+    suffix = localio.stable_hash(session_id)[:8]
+    return envelope.hooks_state_root(target) / PRESENCE_DIRNAME / f"{slug}-{suffix}.json"
+
+
+def last_refresh(target: Path, session_id: str) -> float | None:
+    """Read the last recorded refresh epoch, or None when there is no usable stamp."""
+    try:
+        raw = state_path(target, session_id).read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    if len(raw) > MAX_STATE_BYTES:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    value = payload.get(_STAMP_KEY) if isinstance(payload, dict) else None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def record_refresh(target: Path, session_id: str, *, now: float | None = None) -> None:
+    """Stamp a presence write that already happened. Never raises."""
+    stamp = time.time() if now is None else now
+    try:
+        path = state_path(target, session_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        envelope.write_private_text(path, json.dumps({_STAMP_KEY: stamp}, sort_keys=True) + "\n")
+    except (OSError, ValueError):
+        return
+
+
+def due(target: Path, session_id: str, *, now: float | None = None) -> bool:
+    """True when this session has no stamp, or its stamp is older than the interval."""
+    stamp = time.time() if now is None else now
+    previous = last_refresh(target, session_id)
+    if previous is None:
+        return True
+    delta = stamp - previous
+    # A backwards clock (< 0) counts as due so a bad stamp cannot pin a live
+    # session off the Hub until the session restarts.
+    return delta >= HEARTBEAT_INTERVAL_SECONDS or delta < 0
+
+
+def clear(target: Path, session_id: str) -> None:
+    """Drop this session's throttle stamp. Never raises."""
+    try:
+        state_path(target, session_id).unlink()
+    except (OSError, ValueError):
+        return
+
+
+def on_event(event: str, target: Path, session_id: str, *, now: float | None = None) -> None:
+    """Apply this hook event's presence effect. Always returns None, never raises.
+
+    ``SessionStart`` only stamps: ``handle_payload`` already published that row.
+    ``UserPromptSubmit`` and ``PreToolUse`` refresh at most once per interval.
+    ``SessionEnd`` ends the Hub row and drops the local stamp.
+    """
+    try:
+        if event == "SessionStart":
+            record_refresh(target, session_id, now=now)
+            return
+        if event == "SessionEnd":
+            _note(target, event, presence.emit_presence(event, target, session_id))
+            clear(target, session_id)
+            return
+        if event not in REFRESH_EVENTS:
+            return
+        stamp = time.time() if now is None else now
+        if not due(target, session_id, now=stamp):
+            return
+        # Stamp first: a failed or unreachable Hub still consumes the interval,
+        # so the bound stays "at most one Hub call per interval per session".
+        record_refresh(target, session_id, now=stamp)
+        _note(target, event, presence.emit_presence(event, target, session_id))
+    except Exception:  # noqa: BLE001 - presence must never break a hook
+        return
+
+
+def _note(target: Path, event: str, reason: str | None) -> None:
+    """Record a bounded presence failure in the hook log, never on the session stream."""
+    if not reason:
+        return
+    try:
+        envelope.append_log(target, f"{event}: fleet presence refresh failed: {reason}")
+    except OSError:
+        return

--- a/src/brigade/claude_hooks/package.py
+++ b/src/brigade/claude_hooks/package.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 PACKAGE_ID = "brigade-claude-work-loop"
-PACKAGE_VERSION = "1.2.0"
+PACKAGE_VERSION = "1.3.0"
 PACKAGE_REF = f"{PACKAGE_ID}@{PACKAGE_VERSION}"
 COMMAND_PREFIX = "brigade work hook-run"
 MANAGED_EVENTS = (
@@ -18,6 +18,7 @@ MANAGED_EVENTS = (
     "PostToolUseFailure",
     "PreCompact",
     "Stop",
+    "SessionEnd",
 )
 LEGACY_SCRIPT_NAME = "brigade-work-loop.py"
 MANAGED_MARKER_KEY = "_brigade"
@@ -50,6 +51,7 @@ def managed_groups() -> dict[str, list[dict[str, Any]]]:
         "PostToolUseFailure": [group("PostToolUseFailure", "Bash")],
         "PreCompact": [group("PreCompact")],
         "Stop": [group("Stop")],
+        "SessionEnd": [group("SessionEnd")],
     }
 
 
@@ -108,6 +110,7 @@ def managed_user_groups(script_path: Path) -> dict[str, list[dict[str, Any]]]:
         "PostToolUseFailure": [group("PostToolUseFailure", "Bash")],
         "PreCompact": [group("PreCompact")],
         "Stop": [group("Stop")],
+        "SessionEnd": [group("SessionEnd")],
     }
 
 

--- a/src/brigade/claude_hooks/presence.py
+++ b/src/brigade/claude_hooks/presence.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def emit_presence(event: str, target: Path, session_id: str) -> None:
-    """Publish session presence without changing the hook envelope."""
+def emit_presence(event: str, target: Path, session_id: str) -> str | None:
+    """Publish session presence without changing the hook envelope.
+
+    Returns a bounded failure reason when the Hub write did not land, or None
+    when it succeeded, was skipped, or the Hub is unconfigured. Callers stay
+    free to ignore it: this never raises.
+    """
     try:
         from ..fleet_session_presence import _publish_presence
 
-        _publish_presence(event, target, session_id)
+        return _publish_presence(event, target, session_id)
     except Exception:
-        return
+        return None

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -19,7 +19,7 @@ from typing import Any, BinaryIO, Callable, Iterator
 from .. import localio
 from ..component_paths import cache_root
 from ..wiring import resolve_wired_target
-from . import compaction_marker, envelope, presence
+from . import compaction_marker, envelope, heartbeat, presence
 from .package import PACKAGE_REF
 from .paths import is_operator_home, resolved_path
 from .session_state import (
@@ -2318,19 +2318,20 @@ def _handle_pre_compact(payload: dict[str, Any], *, pin: Path | None = None) -> 
 
 
 def _handle_user_prompt_submit(payload: dict[str, Any], *, pin: Path | None = None) -> dict[str, Any] | None:
-    """Restore the brief once after compaction; absent markers stay near-free."""
+    """Heartbeat Hub presence, then restore the brief once after compaction."""
     session_id = payload.get("session_id")
     if not isinstance(session_id, str) or not session_id:
         return None
     workspace = compaction_marker.cheap_workspace_root(payload.get("cwd"))
     if workspace is None:
         return None
-    key = compaction_marker.marker_key(session_id, workspace)
-    if not compaction_marker.marker_present(key):
-        return None
+    marker = compaction_marker.marker_present(compaction_marker.marker_key(session_id, workspace))
     # Confirm the workspace is still a Claude-wired Brigade repo before claiming.
     target = effective_hook_target(payload, pin=pin)
     if target is None:
+        return None
+    heartbeat.on_event("UserPromptSubmit", target, session_id)
+    if not marker:
         return None
     try:
         claim = compaction_marker.try_claim(session_id, target)
@@ -2374,10 +2375,14 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
     state = _normalize_state(target, session_id, persisted_state, task_epoch=task_epoch)
     if persisted_state != state:
         _write_session_state_preserving_latch(target, session_id, state, log_target=target)
-    if event != "Stop":
+    if event not in {"Stop", "SessionEnd"}:
         _touch_session_targets(session_id, target, payload, task_epoch=task_epoch)
+    if event == "SessionEnd":
+        heartbeat.on_event("SessionEnd", target, session_id)
+        return None
     if event == "SessionStart":
         presence.emit_presence("SessionStart", target, session_id)
+        heartbeat.on_event("SessionStart", target, session_id)
         # True starts and Claude's inject-capable compact source both clear any
         # leftover marker so UserPromptSubmit does not double-inject.
         try:
@@ -2421,6 +2426,7 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
         )
 
     if event == "PreToolUse":
+        heartbeat.on_event("PreToolUse", target, session_id)
         tool_name = payload.get("tool_name")
         if tool_name in _WRITE_TOOLS:
             # Heartbeat so a concurrent session can attribute the coming write
@@ -2612,7 +2618,6 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
                     "If this work produced durable knowledge, write a Memory Handoff in "
                     "`.claude/memory-handoffs/` before finishing."
                 )
-            presence.emit_presence("Stop", target, session_id)
             return _additional_context(
                 "Stop",
                 "",
@@ -2621,7 +2626,6 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
                 records=records,
             )
         if handoff_target is not None:
-            presence.emit_presence("Stop", target, session_id)
             return _additional_context(
                 "Stop",
                 "",
@@ -2632,7 +2636,6 @@ def handle_payload(event: str, payload: dict[str, Any], *, pin: Path | None = No
                     "`.claude/memory-handoffs/` before finishing.",
                 ],
             )
-        presence.emit_presence("Stop", target, session_id)
     return None
 
 

--- a/src/brigade/fleet_session_presence.py
+++ b/src/brigade/fleet_session_presence.py
@@ -59,8 +59,10 @@ _CURSOR_HOOK_EVENTS = {
     "postToolUse": "heartbeat",
     "sessionEnd": "end",
 }
-_UPSERT_EVENTS = frozenset({"SessionStart", "PostToolUse", "start", "heartbeat"})
-_END_EVENTS = frozenset({"Stop", "end"})
+# Stop fires once per assistant turn, so it must never end a session row; the
+# thread is still open. SessionEnd is the only Claude event that ends presence.
+_UPSERT_EVENTS = frozenset({"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "start", "heartbeat"})
+_END_EVENTS = frozenset({"SessionEnd", "end"})
 
 _SCP_REMOTE = re.compile(r"^(?:(?P<user>[^@/]+)@)?(?P<host>[^:/\s]+):(?P<path>.+)$")
 _SECRET_LIKE_IDENTITY = re.compile(r"(?i)(://|token=|password=|[^/]+:[^/@]+@)")
@@ -513,20 +515,25 @@ def _hub_url_configured() -> bool:
         return False
 
 
-def _publish_presence(event: str, target: Path, session_id: str, *, harness: str = "claude") -> None:
-    """Best-effort Hub publication. Exceptions never escape to hook callers."""
+def _publish_presence(event: str, target: Path, session_id: str, *, harness: str = "claude") -> str | None:
+    """Best-effort Hub publication. Exceptions never escape to hook callers.
+
+    Returns a bounded failure reason, or None when the write landed, the event
+    carries no presence effect, or no Hub is configured.
+    """
     try:
         from . import fleet_client
 
         if not _hub_url_configured():
-            return
+            return None
         snapshot = build_snapshot(target, harness=harness, session_id=session_id)
         if event in _END_EVENTS:
-            fleet_client.end_session(snapshot)
-        elif event in _UPSERT_EVENTS:
-            fleet_client.upsert_session(snapshot)
-    except Exception:
-        return
+            return None if fleet_client.end_session(snapshot) else "end_unpublished"
+        if event in _UPSERT_EVENTS:
+            return None if fleet_client.upsert_session(snapshot) else "unpublished"
+        return None
+    except Exception as exc:
+        return _bounded_presence_error(exc)
 
 
 def run_presence_hook(

--- a/tests/test_claude_hooks_heartbeat.py
+++ b/tests/test_claude_hooks_heartbeat.py
@@ -1,0 +1,179 @@
+"""Throttled Hub presence refresh for live Claude sessions (heartbeat module)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade.claude_hooks import envelope, heartbeat
+from brigade.fleet_session_presence import DEFAULT_TTL_SECONDS
+
+T0 = 1_700_000_000.0
+SESSION = "session-heartbeat-1"
+
+
+def _capture_presence(monkeypatch, *, reason: str | None = None) -> list[tuple[str, str]]:
+    """Record every emit_presence call instead of reaching the Hub."""
+    calls: list[tuple[str, str]] = []
+
+    def emit(event: str, target: Path, session_id: str) -> str | None:
+        calls.append((event, session_id))
+        return reason
+
+    monkeypatch.setattr(heartbeat.presence, "emit_presence", emit)
+    return calls
+
+
+def test_interval_is_one_third_of_the_hub_ttl():
+    """The refresh cadence must leave room for two missed beats inside the TTL."""
+    assert heartbeat.HEARTBEAT_INTERVAL_SECONDS == DEFAULT_TTL_SECONDS // 3
+
+
+def test_prompt_refresh_is_throttled_to_one_publish_per_interval(tmp_path: Path, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+    interval = heartbeat.HEARTBEAT_INTERVAL_SECONDS
+
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0)
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0 + interval - 1)
+    assert calls == [("UserPromptSubmit", SESSION)]
+
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0 + interval)
+    assert calls == [("UserPromptSubmit", SESSION), ("UserPromptSubmit", SESSION)]
+
+
+def test_tool_use_shares_the_prompt_throttle_and_other_events_never_publish(tmp_path: Path, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+    interval = heartbeat.HEARTBEAT_INTERVAL_SECONDS
+
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0)
+    heartbeat.on_event("PreToolUse", tmp_path, SESSION, now=T0 + 1)
+    assert calls == [("UserPromptSubmit", SESSION)]
+
+    heartbeat.on_event("PreToolUse", tmp_path, SESSION, now=T0 + interval)
+    assert calls[-1] == ("PreToolUse", SESSION)
+
+    # Stop fires once per assistant turn and PostToolUse follows every tool call;
+    # neither carries a presence effect through the heartbeat path.
+    heartbeat.on_event("Stop", tmp_path, SESSION, now=T0 + 10 * interval)
+    heartbeat.on_event("PostToolUse", tmp_path, SESSION, now=T0 + 10 * interval)
+    assert len(calls) == 2
+
+
+def test_sessions_are_throttled_independently(tmp_path: Path, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+
+    heartbeat.on_event("UserPromptSubmit", tmp_path, "sess-a", now=T0)
+    heartbeat.on_event("UserPromptSubmit", tmp_path, "sess-b", now=T0)
+
+    assert calls == [("UserPromptSubmit", "sess-a"), ("UserPromptSubmit", "sess-b")]
+
+
+def test_session_start_only_stamps_and_suppresses_the_next_prompt(tmp_path: Path, monkeypatch):
+    """handle_payload already published the SessionStart row; do not publish twice."""
+    calls = _capture_presence(monkeypatch)
+
+    heartbeat.on_event("SessionStart", tmp_path, SESSION, now=T0)
+    assert calls == []
+    assert heartbeat.last_refresh(tmp_path, SESSION) == T0
+
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0 + 1)
+    assert calls == []
+
+
+def test_session_end_publishes_end_and_clears_the_stamp(tmp_path: Path, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0)
+    assert heartbeat.state_path(tmp_path, SESSION).is_file()
+
+    heartbeat.on_event("SessionEnd", tmp_path, SESSION, now=T0 + 1)
+
+    assert calls[-1] == ("SessionEnd", SESSION)
+    assert not heartbeat.state_path(tmp_path, SESSION).exists()
+    assert heartbeat.last_refresh(tmp_path, SESSION) is None
+
+
+def test_session_end_publishes_even_when_no_stamp_exists(tmp_path: Path, monkeypatch):
+    calls = _capture_presence(monkeypatch)
+
+    heartbeat.on_event("SessionEnd", tmp_path, SESSION, now=T0)
+
+    assert calls == [("SessionEnd", SESSION)]
+
+
+def test_hub_failure_never_escapes_and_still_consumes_the_interval(tmp_path: Path, monkeypatch):
+    """A raising Hub write must not break the hook, and must not retry per prompt."""
+    calls: list[str] = []
+
+    def boom(event: str, target: Path, session_id: str) -> str | None:
+        calls.append(event)
+        raise RuntimeError("hub unreachable")
+
+    monkeypatch.setattr(heartbeat.presence, "emit_presence", boom)
+
+    assert heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0) is None
+    assert heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0 + 1) is None
+    assert heartbeat.on_event("SessionEnd", tmp_path, SESSION, now=T0 + 2) is None
+
+    # One prompt call inside the interval, plus the unconditional SessionEnd.
+    assert calls == ["UserPromptSubmit", "SessionEnd"]
+
+
+def test_unpublished_hub_write_is_logged_not_raised(tmp_path: Path, monkeypatch):
+    _capture_presence(monkeypatch, reason="unpublished")
+
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0)
+
+    log = envelope.log_path(tmp_path).read_text(encoding="utf-8")
+    assert "fleet presence refresh failed: unpublished" in log
+    assert "UserPromptSubmit" in log
+
+
+def test_stamp_lives_under_the_hook_state_dir_and_is_bounded_json(tmp_path: Path, monkeypatch):
+    _capture_presence(monkeypatch)
+
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0)
+
+    path = heartbeat.state_path(tmp_path, SESSION)
+    assert path.parent == envelope.hooks_state_root(tmp_path) / heartbeat.PRESENCE_DIRNAME
+    assert path.parent.parent == tmp_path.resolve() / ".brigade" / "work" / "claude-hooks"
+    raw = path.read_text(encoding="utf-8")
+    assert len(raw) < heartbeat.MAX_STATE_BYTES
+    assert json.loads(raw) == {"last_refresh_at": T0}
+
+    # One stamp per session; a second refresh rewrites it rather than growing it.
+    heartbeat.on_event("UserPromptSubmit", tmp_path, SESSION, now=T0 + heartbeat.HEARTBEAT_INTERVAL_SECONDS)
+    assert len(list(path.parent.iterdir())) == 1
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "last_refresh_at": T0 + heartbeat.HEARTBEAT_INTERVAL_SECONDS
+    }
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json",
+        json.dumps({"last_refresh_at": "soon"}),
+        json.dumps({"last_refresh_at": True}),
+        json.dumps(["last_refresh_at", 1]),
+        json.dumps({"last_refresh_at": 1.0}) + "x" * heartbeat.MAX_STATE_BYTES,
+    ],
+)
+def test_unusable_stamp_reads_as_due_rather_than_pinning_the_session_off(tmp_path: Path, raw: str):
+    path = heartbeat.state_path(tmp_path, SESSION)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(raw, encoding="utf-8")
+
+    assert heartbeat.last_refresh(tmp_path, SESSION) is None
+    assert heartbeat.due(tmp_path, SESSION, now=T0) is True
+
+
+def test_backwards_clock_counts_as_due(tmp_path: Path):
+    heartbeat.record_refresh(tmp_path, SESSION, now=T0 + 10_000)
+
+    assert heartbeat.due(tmp_path, SESSION, now=T0) is True
+
+
+def test_clear_on_a_missing_stamp_is_silent(tmp_path: Path):
+    assert heartbeat.clear(tmp_path, SESSION) is None

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -3104,6 +3104,11 @@ def test_claude_presence_start_refresh_and_accepted_stop(target, monkeypatch):
         + "\n"
     )
     runtime.handle_payload("Stop", _payload(target, "Stop", session_id="s1", stop_hook_active=False))
+    # Stop fires once per assistant turn; the thread is still open.
+    assert [call.action for call in calls] == ["upsert", "upsert"]
+    assert all(call.action != "end" for call in calls)
+
+    runtime.handle_payload("SessionEnd", _payload(target, "SessionEnd", session_id="s1", reason="clear"))
     assert [call.action for call in calls] == ["upsert", "upsert", "end"]
     assert Path(calls[-1].snapshot.checkout_path) == target.resolve()
     end_calls = [call for call in calls if call.action == "end"]
@@ -3115,3 +3120,49 @@ def test_blocked_stop_does_not_end_presence(target, monkeypatch):
     result = runtime.handle_payload("Stop", _unverified_write_stop(target, session_id="s1"))
     assert result["decision"] == "block"
     assert all(call.action != "end" for call in calls)
+
+
+def _capture_heartbeat(monkeypatch) -> list[tuple[str, str]]:
+    """Record the heartbeat events handle_payload dispatches, without a Hub."""
+    events: list[tuple[str, str]] = []
+
+    def on_event(event, target, session_id, **_kwargs):
+        events.append((event, session_id))
+        return None
+
+    monkeypatch.setattr(runtime.heartbeat, "on_event", on_event)
+    monkeypatch.setattr(runtime.presence, "emit_presence", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(runtime, "_run_brief", lambda _repo: "work brief: test")
+    monkeypatch.setattr(runtime, "_run_recall", lambda *_args, **_kwargs: "")
+    return events
+
+
+def test_handle_payload_routes_live_events_to_the_heartbeat(target, monkeypatch):
+    events = _capture_heartbeat(monkeypatch)
+
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id="s1"))
+    runtime.handle_payload("UserPromptSubmit", _payload(target, "UserPromptSubmit", session_id="s1"))
+    runtime.handle_payload(
+        "PreToolUse",
+        _payload(target, "PreToolUse", session_id="s1", tool_name="Read", tool_input={"file_path": str(target)}),
+    )
+
+    assert events == [
+        ("SessionStart", "s1"),
+        ("UserPromptSubmit", "s1"),
+        ("PreToolUse", "s1"),
+    ]
+
+
+def test_session_end_reaches_the_heartbeat_and_stop_never_ends_the_session(target, monkeypatch):
+    """Stop fires once per assistant turn; only SessionEnd closes the thread."""
+    events = _capture_heartbeat(monkeypatch)
+
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id="s1"))
+    stop = runtime.handle_payload("Stop", _payload(target, "Stop", session_id="s1", stop_hook_active=False))
+
+    assert stop is None
+    assert ("SessionEnd", "s1") not in events
+
+    assert runtime.handle_payload("SessionEnd", _payload(target, "SessionEnd", session_id="s1", reason="clear")) is None
+    assert events[-1] == ("SessionEnd", "s1")

--- a/tests/test_claude_hooks_settings_merge.py
+++ b/tests/test_claude_hooks_settings_merge.py
@@ -128,8 +128,34 @@ def test_hooks_status_reports_complete_stale_package_as_installed(tmp_path: Path
         "PostToolUseFailure",
         "PreCompact",
         "Stop",
+        "SessionEnd",
     ]
     assert status["missing_events"] == []
+
+
+def test_hooks_status_reports_a_pre_session_end_install_as_incomplete(tmp_path: Path):
+    """A 1.2.0-era install has no SessionEnd group, so presence never ends."""
+    target = _wired_claude(tmp_path)
+    assert hooks_install(target=target) == 0
+    settings = target / ".claude" / "settings.json"
+    payload = json.loads(settings.read_text())
+    payload["hooks"].pop("SessionEnd")
+    settings.write_text(json.dumps(payload, indent=2) + "\n")
+
+    status = status_payload(target)
+
+    assert status["missing_events"] == ["SessionEnd"]
+    assert status["current"] is False
+
+    assert hooks_update(target=target) == 0
+    restored = json.loads(settings.read_text())
+    session_end = [
+        h["command"] for group in restored["hooks"]["SessionEnd"] for h in group.get("hooks", []) if isinstance(h, dict)
+    ]
+    assert managed_command("SessionEnd") in session_end
+    assert status_payload(target)["current"] is True
+    sidecar = json.loads((target / ".brigade" / "claude-hooks.json").read_text())
+    assert sidecar["package_version"] == PACKAGE_VERSION == "1.3.0"
 
 
 def test_hooks_status_reports_matcher_drift_as_stale(tmp_path: Path):

--- a/tests/test_fleet_session_presence.py
+++ b/tests/test_fleet_session_presence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import sqlite3
 import subprocess
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import pytest
 
 from types import SimpleNamespace
 
+from brigade import fleet_hub, fleet_hub_sessions
 from brigade import fleet_session_presence as presence
 
 
@@ -310,10 +312,14 @@ def test_publish_presence_maps_events_and_swallows_errors(git_repo, monkeypatch)
         "brigade.fleet_client.end_session",
         lambda snap: calls.append(("end", snap)) or True,
     )
-    presence._publish_presence("SessionStart", git_repo, "s1")
-    presence._publish_presence("PostToolUse", git_repo, "s1")
-    presence._publish_presence("Stop", git_repo, "s1")
-    assert [item[0] for item in calls] == ["upsert", "upsert", "end"]
+    assert presence._publish_presence("SessionStart", git_repo, "s1") is None
+    assert presence._publish_presence("UserPromptSubmit", git_repo, "s1") is None
+    assert presence._publish_presence("PreToolUse", git_repo, "s1") is None
+    assert presence._publish_presence("PostToolUse", git_repo, "s1") is None
+    # Stop fires once per assistant turn and must not end a still-open thread.
+    assert presence._publish_presence("Stop", git_repo, "s1") is None
+    assert presence._publish_presence("SessionEnd", git_repo, "s1") is None
+    assert [item[0] for item in calls] == ["upsert", "upsert", "upsert", "upsert", "end"]
     assert all(item[1].harness == "claude" and item[1].session_id == "s1" for item in calls)
 
     monkeypatch.setattr(
@@ -321,3 +327,65 @@ def test_publish_presence_maps_events_and_swallows_errors(git_repo, monkeypatch)
         lambda snap: (_ for _ in ()).throw(RuntimeError("hub down")),
     )
     presence._publish_presence("SessionStart", git_repo, "s2")
+
+
+HUB_NODE = "22222222-2222-4222-8222-222222222222"
+HUB_T0 = 1_700_000_000.0
+
+
+@pytest.fixture()
+def hub_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    fleet_hub_sessions.init_schema(conn)
+    yield conn
+    conn.close()
+
+
+def _upsert_at(conn: sqlite3.Connection, monkeypatch, when: float) -> None:
+    """Apply one presence upsert as if the Hub clock read ``when``."""
+    monkeypatch.setattr(fleet_hub, "_now_epoch", lambda: when)
+    status, _payload = fleet_hub_sessions.handle_session(
+        conn,
+        {
+            "action": "upsert",
+            "harness": "claude",
+            "session_id": "sess-ttl",
+            "repo_identity": "github.com/example/project",
+            "identity_scope": "fleet",
+            "repo_label": "project",
+            "checkout_path": "/tmp/project",
+            "branch": "main",
+            "dirty_paths": ["src/a.py"],
+            "dirty_truncated": False,
+            "ttl_seconds": presence.DEFAULT_TTL_SECONDS,
+        },
+        caller_node=HUB_NODE,
+    )
+    assert status == 200
+
+
+def test_session_without_heartbeats_expires_one_ttl_after_its_last_write(hub_conn, monkeypatch):
+    ttl = presence.DEFAULT_TTL_SECONDS
+    _upsert_at(hub_conn, monkeypatch, HUB_T0)
+
+    assert [row["session_id"] for row in fleet_hub_sessions.list_sessions(hub_conn, now_epoch=HUB_T0 + ttl - 1)] == [
+        "sess-ttl"
+    ]
+    assert fleet_hub_sessions.list_sessions(hub_conn, now_epoch=HUB_T0 + ttl + 1) == []
+    # The row is still on record; only the active view drops it.
+    assert len(fleet_hub_sessions.list_sessions(hub_conn, include_all=True, now_epoch=HUB_T0 + ttl + 1)) == 1
+
+
+def test_heartbeat_cadence_keeps_a_long_session_listed_past_the_ttl(hub_conn, monkeypatch):
+    ttl = presence.DEFAULT_TTL_SECONDS
+    interval = 300
+    _upsert_at(hub_conn, monkeypatch, HUB_T0)
+    for step in range(1, (2 * ttl) // interval + 1):
+        _upsert_at(hub_conn, monkeypatch, HUB_T0 + step * interval)
+
+    rows = fleet_hub_sessions.list_sessions(hub_conn, now_epoch=HUB_T0 + 2 * ttl)
+
+    assert [row["session_id"] for row in rows] == ["sess-ttl"]
+    assert rows[0]["expires_at"] == HUB_T0 + 2 * ttl + ttl
+    # A refreshed session keeps its original start; heartbeats are not restarts.
+    assert rows[0]["started_at"] == fleet_hub._epoch_to_iso(HUB_T0)


### PR DESCRIPTION
## What

Interactive Claude Code sessions now stay visible on the Command Deck for their whole life instead of dropping off 15 minutes after start.

## Why

The SessionStart hook published presence once (`fleet_session_presence.DEFAULT_TTL_SECONDS` = 900) and nothing refreshed or ended it. With four live threads the Deck's "Interactive sessions" panel showed 0, and `brigade fleet sessions --all` held 525 rows, most `active` but expired.

## How

- `claude_hooks/heartbeat.py` (new): `UserPromptSubmit` and `PreToolUse` refresh presence at most once per `HEARTBEAT_INTERVAL_SECONDS` (300 s, TTL/3) via a small per-session stamp file under the hook state directory. `SessionStart` only stamps (the brief already published). `SessionEnd` ends the hub row and clears the stamp. A hub failure is noted and never escapes the hook.
- `claude_hooks/package.py`: new `SessionEnd` hook group; `PACKAGE_VERSION` 1.2.0 to 1.3.0. `Stop` fires per turn and does not end a session.
- `claude_hooks/runtime.py` calls `heartbeat.on_event` from the four events; `presence.py` and `fleet_session_presence.py` carry the supporting changes.

## Verify

Coordinator gate `20260906-232039-work-verify-aa5245` (identical execution reused from `20260906-231712-work-verify-976888`): 249 passed across the new `tests/test_claude_hooks_heartbeat.py` (throttle cadence with a fake clock, SessionStart no-republish, SessionEnd end and clear, hub failure containment, stamp bounds), a hub-side TTL test (heartbeated row survives 2xTTL, unheartbeated row expires at TTL+1), runtime, settings merge, doctor, deck, and ratchet.

## Deploy note

Hosts must reinstall the hook package for the new `SessionEnd` group to take effect; until then sessions still heartbeat but are ended only by expiry.