### PR TITLE
docs(grokbot): running several Builder bots on one queue

### DIFF
--- a/docs/grokbot-operating-guide.md
+++ b/docs/grokbot-operating-guide.md
@@ -246,6 +246,52 @@ A 60-minute drain remains useful as a safety net: if a POST failed, the
 routine can still list the queue and claim anything that was missed. Do not
 rely on a short poll as the primary wake.
 
+### Several Builder bots
+
+One Grok Bot runs one routine at a time. Throughput therefore scales with
+how many bots share the queue, not with how often a single bot's poll or
+wake cadence fires.
+
+Every Builder bot claims from the same `implementation-worker` queue. The
+hub lease is the only mutual-exclusion guard: `claim` moves a job from
+`queued` to `claimed` under one lease, and a second claim on that job is
+refused. Two bots never work the same job.
+
+The wake config already accepts a list of targets per role, so one
+`--apply` enqueue can POST the same bounded body to several bots. The
+first free bot that claims wins. Each target gets its own bounded POST,
+its own eight-second single try, and its own status line in
+`wake-notify.jsonl`.
+
+```json
+{
+  "schema": "brigade.grokbot.wake.v1",
+  "webhook_url": "https://example.invalid/webhook/REPLACE",
+  "sender_key_file": "/etc/brigade/grokbot-wake-a.key",
+  "webhooks": {
+    "implementation-worker": [
+      {
+        "webhook_url": "https://example.invalid/webhook/REPLACE",
+        "sender_key_file": "/etc/brigade/grokbot-wake-a.key"
+      },
+      {
+        "webhook_url": "https://example.invalid/webhook/REPLACE",
+        "sender_key_file": "/etc/brigade/grokbot-wake-b.key"
+      }
+    ]
+  }
+}
+```
+
+A per-bot poll routine remains the drain when that bot is idle. A wake
+that arrives while the bot is already on a job is not a second claim; the
+next poll still lists the queue and takes anything still `queued`.
+
+To add another bot: create it, give it the same coordinator routine text,
+confirm it lists the queue through the `implementation-worker` connector,
+then append its webhook target to the `implementation-worker` list in
+`.brigade/cloud/grokbot/wake.json`.
+
 ### Measuring the queue
 
 Hillclimb uses two per-job latencies for `implementation-worker` work, read


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #1501

One-line done predicate: `docs/grokbot-operating-guide.md` has a Several Builder bots subsection directly after Builder wake (46 lines) documenting multi-bot throughput, hub-lease mutual exclusion, multi-target `wake.json`, per-bot poll drain, and the operator checklist, using only placeholder webhook URLs and keys.

## Verification

| Command | Exit code |
|---|---|
| `brigade code sync .` (pre-edit) | 127 (`error: graphtrail is not installed; run \`brigade setup\``) |
| `brigade code affected docs/grokbot-operating-guide.md` (pre-edit) | 127 (`error: graphtrail is not installed; run \`brigade setup\``) |
| `brigade guard audit . --scope tracked --strict --baseline .content-guard-baseline.json` | 0 |
| `git diff --check` | 0 |
| `brigade work verify run --target . --argv-json '["brigade","guard","audit",".","--scope","tracked","--strict","--baseline",".content-guard-baseline.json"]' --capture brigade-work` | 0 |

Brigade verify receipt id: `20260907-023559-work-verify-eff609`

Job id: grokbot-9c506e62c2635ef2863a2fba

## Guard audit transcript

```
content-guard audit: .

Summary
  scope:               tracked
  files scanned:       2141
  files with findings: 48
  total findings:      271
  blocked:             false

By action
  allow    187
  warn     84

By category
  infrastructure   101
  pii              119
  secret           27
  tooling          24

By rule (top 10)
  email                            50
  private-ipv4                     45
  example-email-reserved           34
  loopback-ipv4                    34
  home-path                        27
  ignored-file-allow               24
  api-key-assignment               17
  localhost-port                   17
  bearer-token                     7
  us-phone                         5

Top offenders (top 5)
    75  tests/guard/test_engine.py
    24  tests/guard/test_allow_values.py
    22  tests/test_grokbot_feed.py
    18  tests/guard/test_audit.py
    16  tests/guard/test_cli.py
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f5d3cc5-65a8-4e0c-8673-625a0ede5228?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f5d3cc5-65a8-4e0c-8673-625a0ede5228&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

