### PR TITLE
fix(windows): close descriptors before the NT rename and keep drive paths whole (Fixes #1480)

### DIFF
--- a/src/brigade/daily_cmd/config.py
+++ b/src/brigade/daily_cmd/config.py
@@ -509,17 +509,21 @@ def _bounded_status_call(
     timeout = timeout_seconds or _status_section_timeout_seconds()
     start = time.monotonic()
     use_alarm = threading.current_thread() is threading.main_thread() and hasattr(signal, "SIGALRM")
+    if not use_alarm:
+        # Platforms without SIGALRM (notably Windows) bound the call with a
+        # worker thread so a slow section still reports warn instead of
+        # stalling the whole status run.
+        return _thread_bounded_status_call(label, func, fallback, timeout=timeout, start=start)
     previous_handler = None
     previous_timer = None
-    if use_alarm:
-        previous_handler = signal.getsignal(signal.SIGALRM)
-        previous_timer = signal.getitimer(signal.ITIMER_REAL)
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
 
-        def _raise_timeout(_signum, _frame):
-            raise _DailyStatusSectionTimeout(label)
+    def _raise_timeout(_signum, _frame):
+        raise _DailyStatusSectionTimeout(label)
 
-        signal.signal(signal.SIGALRM, _raise_timeout)
-        signal.setitimer(signal.ITIMER_REAL, timeout)
+    signal.signal(signal.SIGALRM, _raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, timeout)
     try:
         result = func()
         elapsed = int((time.monotonic() - start) * 1000)
@@ -533,9 +537,41 @@ def _bounded_status_call(
             label, "warn", _safe_text(Path("."), f"{type(exc).__name__}: {exc}"), elapsed
         )
     finally:
-        if use_alarm:
-            signal.setitimer(signal.ITIMER_REAL, 0)
-            if previous_handler is not None:
-                signal.signal(signal.SIGALRM, previous_handler)
-            if previous_timer is not None and previous_timer[0] > 0:
-                signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        if previous_handler is not None:
+            signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer is not None and previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+
+
+def _thread_bounded_status_call(
+    label: str, func, fallback: Any, *, timeout: int, start: float
+) -> tuple[Any, dict[str, Any]]:
+    """Run ``func`` in a worker thread and bound it with ``join(timeout)``."""
+    outcomes: list[Any] = []
+    errors: list[BaseException] = []
+
+    def _run() -> None:
+        try:
+            outcomes.append(func())
+        except BaseException as exc:  # noqa: BLE001 - re-reported below with its type name
+            errors.append(exc)
+
+    worker = threading.Thread(target=_run, name=f"brigade-daily-status-{label}", daemon=True)
+    worker.start()
+    worker.join(timeout)
+    if worker.is_alive():
+        elapsed = int((time.monotonic() - start) * 1000)
+        return fallback, _status_section_check(label, "warn", f"timed out after {timeout}s", elapsed)
+    if errors:
+        exc = errors[0]
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            raise exc
+        elapsed = int((time.monotonic() - start) * 1000)
+        if isinstance(exc, _DailyStatusSectionTimeout):
+            return fallback, _status_section_check(label, "warn", f"timed out after {timeout}s", elapsed)
+        return fallback, _status_section_check(
+            label, "warn", _safe_text(Path("."), f"{type(exc).__name__}: {exc}"), elapsed
+        )
+    elapsed = int((time.monotonic() - start) * 1000)
+    return outcomes[0], _status_section_check(label, "ok", "completed", elapsed)

--- a/src/brigade/handoff_cmd/sources.py
+++ b/src/brigade/handoff_cmd/sources.py
@@ -205,6 +205,11 @@ def _parse_ingestor_log_receipt(target: Path, config: SourceConfig, log_path: Pa
     return _drafts_mod._normalize_ingest_receipt(target, receipt)
 
 
+def _is_windows_drive_colon(value: str, index: int) -> bool:
+    """Return whether the colon at ``index`` is a Windows drive prefix (``C:\\``)."""
+    return index == 1 and len(value) > 2 and value[0].isalpha() and value[2] in ("/", "\\")
+
+
 def _split_outcome_line(value: str) -> tuple[str | None, str | None]:
     value = value.strip()
     if not value:
@@ -212,8 +217,14 @@ def _split_outcome_line(value: str) -> tuple[str | None, str | None]:
     target_value = None
     if " -> " in value:
         value, target_value = value.split(" -> ", 1)
-    if ":" in value:
-        value = value.split(":", 1)[0]
+    if ": " in value:
+        # A drive-letter prefix (``C:\\...``) never contains ``": "``, so
+        # this only strips a real detail suffix (``path: detail``).
+        value = value.split(": ", 1)[0]
+    elif ":" in value:
+        index = value.find(":")
+        if not _is_windows_drive_colon(value, index):
+            value = value.split(":", 1)[0]
     value = value.strip().strip("`")
     if value.startswith("[") and "]" in value:
         value = value.split("]", 1)[1].strip()

--- a/src/brigade/work_cmd/ledger/inbox_provenance.py
+++ b/src/brigade/work_cmd/ledger/inbox_provenance.py
@@ -132,6 +132,33 @@ def _validate_import_inbox_name_matches_descriptor(parent: int, name: str, descr
         raise OSError("import inbox name no longer matches its held descriptor")
 
 
+def _check_import_inbox_name_matches_stat(parent: int, name: str, expected: os.stat_result) -> None:
+    """Ensure a directory entry names the object captured in ``expected``.
+
+    Identity-compare variant of
+    :func:`_validate_import_inbox_name_matches_descriptor` for the publish
+    path, where the temporary descriptor must be closed before ``replace``
+    (the NT rename via ``FileRenameInformation`` returns
+    STATUS_ACCESS_DENIED while a handle is open) so the live descriptor
+    cannot be retained across the rename.
+    """
+    named = authority_store._dirfd_stat(parent, name)
+    if (
+        not stat.S_ISREG(named.st_mode)
+        or named.st_nlink != 1
+        or (named.st_dev, named.st_ino, named.st_mode, named.st_nlink)
+        != (expected.st_dev, expected.st_ino, expected.st_mode, expected.st_nlink)
+    ):
+        raise OSError("import inbox name no longer matches its published descriptor")
+
+
+def _close_import_inbox_descriptor(value: int) -> int:
+    """Close an inbox file descriptor, returning the closed sentinel."""
+    if value != -1:
+        os.close(value)
+    return -1
+
+
 def _write_import_inbox_bytes_at(
     parent: int,
     name: str,
@@ -179,10 +206,19 @@ def _write_import_inbox_bytes_at(
             handle.flush()
             os.fsync(handle.fileno())
         _validate_import_inbox_descriptor(descriptor)
+        os.fsync(descriptor)
+        expected = os.fstat(descriptor)
+        # The NT rename fails while any handle on the source or destination
+        # is open: close both descriptors before replacing, keeping the POSIX
+        # ordering (fsync before close, replace, fsync parent).
+        descriptor = _close_import_inbox_descriptor(descriptor)
+        existing = _close_import_inbox_descriptor(existing)
         authority_store._dirfd_replace(parent, temporary_name, name)
-        _validate_import_inbox_name_matches_descriptor(parent, name, descriptor)
+        _check_import_inbox_name_matches_stat(parent, name, expected)
         authority_store._dirfd_fsync(parent)
     except BaseException:
+        existing = _close_import_inbox_descriptor(existing)
+        descriptor = _close_import_inbox_descriptor(descriptor)
         try:
             authority_store._dirfd_unlink(parent, temporary_name)
         except FileNotFoundError:
@@ -274,9 +310,15 @@ def _restore_import_inbox_snapshot(parent: int, name: str, data: bytes, exists: 
                 os.fsync(handle.fileno())
             _validate_import_inbox_descriptor(descriptor)
             _validate_import_inbox_name_matches_descriptor(parent, temporary_name, descriptor)
+            os.fsync(descriptor)
+            expected = os.fstat(descriptor)
+            # The NT rename fails while a handle on the source is open: close
+            # the temporary descriptor before replacing, keeping the POSIX
+            # ordering (fsync before close, replace, fsync parent).
+            descriptor = _close_import_inbox_descriptor(descriptor)
             authority_store._dirfd_replace(parent, temporary_name, name)
             temporary_name = ""
-            _validate_import_inbox_name_matches_descriptor(parent, name, descriptor)
+            _check_import_inbox_name_matches_stat(parent, name, expected)
             authority_store._dirfd_fsync(parent)
             return
         except OSError:

--- a/src/brigade/work_cmd/nt_dirfd.py
+++ b/src/brigade/work_cmd/nt_dirfd.py
@@ -314,7 +314,7 @@ def replace_children(parent: int, source: str, destination: str, *, replace: boo
     try:
         _reject_reparse(api, handle, expected_directory=False)
         info, length = _rename_information(api, parent, destination, replace=replace)
-        _nt_set_info(api, handle, info, length, _FileRenameInformation)
+        _nt_set_info(api, handle, info, length, _FileRenameInformation, name=destination)
     finally:
         api.CloseHandle(handle)
 
@@ -335,7 +335,7 @@ def unlink_child(parent: int, name: str) -> None:
         _reject_reparse(api, handle, expected_directory=False)
         info = api.FILE_DISPOSITION_INFORMATION()
         info.DeleteFile = True
-        _nt_set_info(api, handle, ctypes.byref(info), ctypes.sizeof(info), _FileDispositionInformation)
+        _nt_set_info(api, handle, ctypes.byref(info), ctypes.sizeof(info), _FileDispositionInformation, name=name)
     finally:
         api.CloseHandle(handle)
 
@@ -465,10 +465,10 @@ def _nt_create(
     return handle.value
 
 
-def _nt_set_info(api: Any, handle: Any, info: Any, length: int, klass: int) -> None:
+def _nt_set_info(api: Any, handle: Any, info: Any, length: int, klass: int, *, name: str | None = None) -> None:
     iosb = api.IO_STATUS_BLOCK()
     status = api.NtSetInformationFile(handle, ctypes.byref(iosb), info, length, klass)
-    _raise_ntstatus(status)
+    _raise_ntstatus(status, name=name)
 
 
 def _rename_information(api: Any, parent: int, destination: str, *, replace: bool) -> tuple[Any, int]:
@@ -502,7 +502,7 @@ def _raise_ntstatus(status: int, *, name: str | None = None) -> None:
         raise IsADirectoryError("path component is a directory")
     if code in {_STATUS_STOPPED_ON_SYMLINK, _STATUS_IO_REPARSE_TAG_NOT_HANDLED, _STATUS_REPARSE_POINT_NOT_RESOLVED}:
         raise OSError("path component is a reparse point")
-    raise OSError(f"Windows no-follow directory operation failed: NTSTATUS=0x{code:08X}")
+    raise OSError(f"Windows no-follow directory operation failed{suffix}: NTSTATUS=0x{code:08X}")
 
 
 def _bind_api_namespace(*, kernel32: Any = None, ntdll: Any = None) -> SimpleNamespace:

--- a/tests/test_claude_hooks_compaction_marker.py
+++ b/tests/test_claude_hooks_compaction_marker.py
@@ -26,7 +26,14 @@ def _wired_claude(tmp_path: Path) -> Path:
 def _cache_env(tmp_path: Path) -> dict[str, str]:
     cache = tmp_path / "xdg-cache"
     cache.mkdir(parents=True, exist_ok=True)
-    return {"XDG_CACHE_HOME": str(cache), "HOME": str(tmp_path / "home"), "USERPROFILE": str(tmp_path / "home")}
+    localappdata = tmp_path / "localappdata"
+    localappdata.mkdir(parents=True, exist_ok=True)
+    return {
+        "XDG_CACHE_HOME": str(cache),
+        "HOME": str(tmp_path / "home"),
+        "USERPROFILE": str(tmp_path / "home"),
+        "LOCALAPPDATA": str(localappdata),
+    }
 
 
 def _payload(target: Path, event: str, *, session_id: str = "session-1", **extra):
@@ -256,3 +263,14 @@ def test_two_prompt_events_do_not_double_inject(tmp_path: Path, marker_env: dict
     assert compaction_marker.CLAIM_KEY not in cleaned
     compaction_marker.complete_claim_path(claim_path)
     assert runtime.handle_payload("UserPromptSubmit", payload) is None
+
+
+def test_cache_env_includes_windows_localappdata(tmp_path: Path):
+    """component_paths.cache_root resolves on Windows only with LOCALAPPDATA set."""
+    from brigade import component_paths
+
+    env = _cache_env(tmp_path)
+    assert Path(env["LOCALAPPDATA"]).is_dir()
+    with pytest.raises(ValueError, match="LOCALAPPDATA"):
+        component_paths.cache_root(env={"XDG_CACHE_HOME": env["XDG_CACHE_HOME"]}, system="windows")
+    assert component_paths.cache_root(env=env, system="windows")

--- a/tests/test_daily_driver_cmd.py
+++ b/tests/test_daily_driver_cmd.py
@@ -1718,3 +1718,35 @@ def test_daily_hardening_repo_fleet_daily_use_findings(tmp_path, monkeypatch, ca
     }
     assert {146, 151} <= fleet_phases
     assert audit["implemented_phase_count"] == 50
+
+
+def test_bounded_status_call_binds_slow_section_without_sigalrm(monkeypatch):
+    """Without SIGALRM (Windows) a slow section must still report warn via a worker thread."""
+    import signal as signal_module
+
+    from brigade.daily_cmd import config as daily_config
+
+    monkeypatch.delattr(signal_module, "SIGALRM", raising=False)
+
+    def slow():
+        time.sleep(30)
+        return "slow-result"
+
+    result, check = daily_config._bounded_status_call("slow-section", slow, fallback="fallback", timeout_seconds=1)
+    assert result == "fallback"
+    assert check["status"] == "warn"
+    assert "timed out after 1s" in check["detail"]
+
+    result, check = daily_config._bounded_status_call(
+        "fast-section", lambda: "ok-result", fallback="fallback", timeout_seconds=5
+    )
+    assert result == "ok-result"
+    assert check["status"] == "ok"
+
+    def boom():
+        raise RuntimeError("section exploded")
+
+    result, check = daily_config._bounded_status_call("bad-section", boom, fallback="fallback", timeout_seconds=5)
+    assert result == "fallback"
+    assert check["status"] == "warn"
+    assert "RuntimeError" in check["detail"]

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -374,7 +374,7 @@ def test_handoff_draft_writes_linted_no_card_style(tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     path = tmp_path / payload["path"]
     assert path.is_file()
-    assert ".codex/memory-handoffs" in payload["path"]
+    assert str(Path(".codex") / "memory-handoffs") in payload["path"]
     assert payload["action"] == "no-card"
     assert payload["target_document"] == ".learnings/LEARNINGS.md"
     assert payload["valid"] is True
@@ -419,7 +419,7 @@ Drafts can create cards.
 
     payload = json.loads(capsys.readouterr().out)
     path = tmp_path / payload["path"]
-    assert ".antigravity/memory-handoffs" in payload["path"]
+    assert str(Path(".antigravity") / "memory-handoffs") in payload["path"]
     assert payload["action"] == "create-card"
     assert payload["target_card"] == "handoff-draft.md"
     assert payload["target_document"] is None
@@ -450,7 +450,7 @@ def test_handoff_draft_supports_hermes_writer_inbox(tmp_path, capsys):
 
     payload = json.loads(capsys.readouterr().out)
     path = tmp_path / payload["path"]
-    assert ".hermes/memory-handoffs" in payload["path"]
+    assert str(Path(".hermes") / "memory-handoffs") in payload["path"]
     assert payload["inbox"] == ".hermes/memory-handoffs"
     assert payload["valid"] is True
     assert path.is_file()
@@ -515,7 +515,7 @@ def test_hermes_handoff_smoke_receipt_show_and_archive(tmp_path, capsys):
     archive_payload = json.loads(capsys.readouterr().out)
     assert archive_payload["archived"] == 1
     record = archive_payload["records"][0]
-    assert ".hermes/memory-handoffs" in record["path"]
+    assert str(Path(".hermes") / "memory-handoffs") in record["path"]
     assert record["ingestion_status"] == "ingested"
     assert record["ingest_run_id"] == "hermes-smoke-run"
     assert not draft_path.exists()
@@ -871,7 +871,7 @@ def test_handoff_list_discovers_claude_codex_and_configured_inboxes(tmp_path, ca
 
     assert handoff_cmd.list_drafts(target=tmp_path, json_output=True) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert {draft["path"].rsplit("/", 1)[-1] for draft in payload["drafts"]} == {"claude.md", "codex.md", "custom.md"}
+    assert {Path(draft["path"]).name for draft in payload["drafts"]} == {"claude.md", "codex.md", "custom.md"}
     assert all(draft["watched"] is True for draft in payload["drafts"])
 
 
@@ -2451,3 +2451,17 @@ Body
     )
     assert draft.action == "create-card"
     assert draft.target_card == "synonym-draft.md"
+
+
+def test_split_outcome_line_keeps_windows_drive_paths():
+    from brigade.handoff_cmd import sources as handoff_sources
+
+    assert handoff_sources._split_outcome_line(r"C:\Users\x\handoff.md") == (r"C:\Users\x\handoff.md", None)
+    assert handoff_sources._split_outcome_line("C:/x/y") == ("C:/x/y", None)
+    assert handoff_sources._split_outcome_line("path:detail") == ("path", None)
+    assert handoff_sources._split_outcome_line("path: detail") == ("path", None)
+    assert handoff_sources._split_outcome_line(r"C:\Users\x\handoff.md: broken") == (
+        r"C:\Users\x\handoff.md",
+        None,
+    )
+    assert handoff_sources._split_outcome_line(r"C:\a.md -> outbox") == (r"C:\a.md", "outbox")

--- a/tests/test_work_import_inbox_windows.py
+++ b/tests/test_work_import_inbox_windows.py
@@ -339,3 +339,90 @@ def test_scanner_run_marker_is_capability_free_and_writer_lock_is_adjacent(tmp_p
     assert inbox_lock.inbox_lock_path(tmp_path).name == "inbox.jsonl.lock"
     assert writer_path.name == "inbox.jsonl.writer.lock"
     assert writer_path.parent == inbox_lock.inbox_lock_path(tmp_path).parent
+
+
+def _track_replace_openness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[list[int]], list[tuple[str, str]]]:
+    """Record descriptors still open at each import-inbox replace call."""
+    from brigade.work_cmd.ledger import authority_store
+
+    real_open = authority_store._dirfd_open_file
+    real_replace = authority_store._dirfd_replace
+    opened: list[int] = []
+    still_open: list[list[int]] = []
+    calls: list[tuple[str, str]] = []
+
+    def _is_closed(descriptor: int) -> bool:
+        try:
+            os.fstat(descriptor)
+        except OSError:
+            return True
+        return False
+
+    def tracking_open(parent_fd: int, entry: str, flags: int, mode: int = 0o600) -> int:
+        descriptor = real_open(parent_fd, entry, flags, mode)
+        opened.append(descriptor)
+        return descriptor
+
+    def checked_replace(parent_fd: int, source: str, destination: str) -> None:
+        still_open.append([descriptor for descriptor in opened if not _is_closed(descriptor)])
+        calls.append((source, destination))
+        real_replace(parent_fd, source, destination)
+
+    monkeypatch.setattr(authority_store, "_dirfd_open_file", tracking_open)
+    monkeypatch.setattr(authority_store, "_dirfd_replace", checked_replace)
+    return still_open, calls
+
+
+def test_write_import_inbox_bytes_at_closes_fds_before_replace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The NT rename fails while a handle is open; fds must close before replace."""
+    from brigade.work_cmd.ledger import inbox_provenance
+
+    parent, name, _previous_raw, _previous_exists = inbox_provenance._snapshot_import_inbox(tmp_path)
+    try:
+        still_open, calls = _track_replace_openness(monkeypatch)
+        data = b'{"text": "windows rename"}\n'
+        inbox_provenance._write_import_inbox_bytes_at(parent, name, data)
+        assert len(calls) == 1
+        assert calls[0][1] == name
+        assert still_open == [[]]
+        assert (tmp_path / ".brigade" / "work" / "imports" / name).read_bytes() == data
+    finally:
+        os.close(parent)
+
+
+def test_restore_import_inbox_snapshot_closes_temp_before_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The snapshot rollback path must also close its temp handle before replace."""
+    from brigade.work_cmd.ledger import inbox_provenance
+
+    parent, name, _previous_raw, _previous_exists = inbox_provenance._snapshot_import_inbox(tmp_path)
+    try:
+        inbox_provenance._write_import_inbox_bytes_at(parent, name, b"v1\n")
+        still_open, calls = _track_replace_openness(monkeypatch)
+        inbox_provenance._restore_import_inbox_snapshot(parent, name, b"v2\n", True)
+        assert len(calls) == 1
+        assert calls[0][1] == name
+        assert still_open == [[]]
+        assert (tmp_path / ".brigade" / "work" / "imports" / name).read_bytes() == b"v2\n"
+    finally:
+        os.close(parent)
+
+
+def test_nt_set_info_access_denied_names_the_component() -> None:
+    """A failed NT rename/unlink must name the component like _raise_ntstatus does."""
+    from types import SimpleNamespace
+
+    def access_denied(_handle: object, _iosb: object, _info: object, _length: int, _klass: int) -> int:
+        return nt_dirfd._STATUS_ACCESS_DENIED
+
+    api = SimpleNamespace(
+        IO_STATUS_BLOCK=nt_dirfd._IO_STATUS_BLOCK,
+        NtSetInformationFile=access_denied,
+    )
+    with pytest.raises(PermissionError, match="path component access denied: inbox.jsonl"):
+        nt_dirfd._nt_set_info(api, 0, None, 0, nt_dirfd._FileRenameInformation, name="inbox.jsonl")
+    with pytest.raises(PermissionError, match="path component access denied$"):
+        nt_dirfd._nt_set_info(api, 0, None, 0, nt_dirfd._FileRenameInformation)


### PR DESCRIPTION
Fixes #1480

## What

Four Windows-only defects from the 2026-09-06 audit, each with a POSIX-runnable regression test:

- `src/brigade/work_cmd/ledger/inbox_provenance.py` and `src/brigade/work_cmd/nt_dirfd.py`: the write and snapshot-rollback paths held the temporary and existing descriptors open across `authority_store._dirfd_replace`. `NtSetInformationFile` with `FileRenameInformation` returns `STATUS_ACCESS_DENIED` while a handle is open, which surfaced as a bare `PermissionError: path component access denied`. Close the descriptors before the replace, keep the POSIX fsync ordering, and name the component in the NT error.
- `src/brigade/handoff_cmd/sources.py`: `_split_outcome_line` split on the first colon, truncating `C:\Users\x\handoff.md` to `C`. Drive-qualified paths stay whole; the POSIX `path:detail` form is unchanged.
- `src/brigade/daily_cmd/config.py`: `_bounded_status_call` only bounded a section when `signal.SIGALRM` exists, so on Windows a slow section ran to completion and reported `ok` instead of `warn`. It now falls back to a worker thread with `join(timeout)`.
- `tests/test_claude_hooks_compaction_marker.py`: the env helper scrubbed the environment without `LOCALAPPDATA`, so `component_paths.cache_root` raised on Windows. The helper supplies it; `component_paths` keeps no fallback.

Path-separator assertions in `tests/test_handoff_cmd.py` now compare through `Path` instead of literal forward slashes.

## Verification

Focused gate through Brigade (ruff, format, version sync, snapshots, mypy, five test files), green on the first attempt:

```
run: 20260907-033515-work-verify-56ff5a
status: completed  exit=0
```

Implemented by the `muse13` seat via `brigade run`; reviewed and landed by the conductor.
