### PR TITLE
fix: accept Windows env-file references

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -16,7 +16,7 @@ import unicodedata
 from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable, List
 
 from . import proc
@@ -27,7 +27,7 @@ _CODEX_CLOUD_PREFIX = "codex-cloud:"
 _CLOUDFLARE_AI_GATEWAY_PREFIX = "cloudflare-ai-gateway/"
 _CLOUDFLARE_AI_GATEWAY_REQUIRED_ENV = ("CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID")
 ENV_FILE_REF_PREFIX = "env-file:"
-ENV_FILE_REF_RE = re.compile(r"^env-file:(/[^#]+)#([A-Z][A-Z0-9_]*)$")
+ENV_FILE_REF_RE = re.compile(r"^env-file:(?P<path>[^#]+)#(?P<variable>[A-Z][A-Z0-9_]*)$")
 
 
 def is_env_file_reference(value: str) -> bool:
@@ -39,6 +39,23 @@ def is_env_file_reference(value: str) -> bool:
     variable that merely starts with ``env-file`` (no colon) stays an
     ordinary environment reference."""
     return value.startswith(ENV_FILE_REF_PREFIX)
+
+
+def is_valid_env_file_reference(value: str) -> bool:
+    """Return whether an env-file reference has an absolute local path.
+
+    POSIX paths and Windows drive-absolute paths are accepted regardless of
+    the host platform. UNC paths are intentionally rejected because their
+    access semantics are not portable across Brigade's local runtimes.
+    """
+
+    match = ENV_FILE_REF_RE.match(value)
+    if match is None:
+        return False
+    path = match.group("path")
+    if path.startswith(("\\\\", "//")):
+        return False
+    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
 
 
 _NONRECOVERABLE_GROK_OUTPUT_FAILURES = frozenset(
@@ -1001,10 +1018,10 @@ def _read_env_file_reference(reference: str) -> str | None:
     """Read one systemd-style KEY=VALUE entry without evaluating the file."""
 
     match = ENV_FILE_REF_RE.match(reference)
-    if match is None:
+    if match is None or not is_valid_env_file_reference(reference):
         return None
-    path = Path(match.group(1))
-    variable = match.group(2)
+    path = Path(match.group("path"))
+    variable = match.group("variable")
     try:
         contents = path.read_text(encoding="utf-8")
     except (OSError, UnicodeError):

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -281,7 +281,7 @@ def _as_env(value: object, agent_name: str) -> dict[str, str] | None:
         if key.endswith("_REF"):
             target = key[: -len("_REF")]
             if agent_adapters.is_env_file_reference(raw):
-                if not agent_adapters.ENV_FILE_REF_RE.match(raw):
+                if not agent_adapters.is_valid_env_file_reference(raw):
                     raise ValueError(f"agents.{agent_name}.env.{key} must use env-file:/absolute/path#VARIABLE")
             elif not _ENV_NAME_RE.match(raw):
                 raise ValueError(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,6 +7,30 @@ import pytest
 from brigade import agents
 
 
+@pytest.mark.parametrize(
+    "reference",
+    (
+        "env-file:/runtime.env#CLIPROXY_API_KEY",
+        r"env-file:C:\runtime.env#CLIPROXY_API_KEY",
+        "env-file:C:/runtime.env#CLIPROXY_API_KEY",
+    ),
+)
+def test_env_file_reference_accepts_absolute_paths(reference):
+    assert agents.is_valid_env_file_reference(reference)
+
+
+@pytest.mark.parametrize(
+    "reference",
+    (
+        "env-file:relative.env#CLIPROXY_API_KEY",
+        "env-file:C:runtime.env#CLIPROXY_API_KEY",
+        r"env-file:\\server\share\runtime.env#CLIPROXY_API_KEY",
+    ),
+)
+def test_env_file_reference_rejects_non_local_absolute_paths(reference):
+    assert not agents.is_valid_env_file_reference(reference)
+
+
 def test_build_argv_for_known_clis():
     # A claude write run with no explicit sandbox must fail safely rather than
     # silently grant full access (or stall on a permission prompt).

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -640,7 +640,7 @@ def test_env_ref_accepts_absolute_environment_file_reference(tmp_path):
     environment_file = tmp_path / "runtime.env"
     roster = ENV_SEAT.replace(
         'ANTHROPIC_AUTH_TOKEN_REF = "KIMI_API_KEY"',
-        f'ANTHROPIC_AUTH_TOKEN_REF = "env-file:{environment_file}#CLIPROXY_API_KEY"',
+        f'ANTHROPIC_AUTH_TOKEN_REF = "env-file:{environment_file.as_posix()}#CLIPROXY_API_KEY"',
     )
     assert roster_mod.load_roster(_write(tmp_path, roster)).agents["k3"].env is not None
 
@@ -651,6 +651,8 @@ def test_env_ref_accepts_absolute_environment_file_reference(tmp_path):
         "env-file:relative.env#CLIPROXY_API_KEY",
         "env-file:/runtime.env#",
         "env-file:/runtime.env#not_a_variable",
+        "env-file:C:runtime.env#CLIPROXY_API_KEY",
+        "env-file://server/share/runtime.env#CLIPROXY_API_KEY",
     ),
 )
 def test_env_ref_rejects_malformed_environment_file_reference(tmp_path, reference):


### PR DESCRIPTION
## Summary
- validate env-file references with platform-independent POSIX and Windows absolute-path checks
- accept Windows drive paths with either separator while rejecting drive-relative and UNC paths
- reuse the validator for roster parsing and add regression coverage

Fixes #1520

## Verification
- pytest -q tests/test_agents.py -k 'env_file_reference' (6 passed)
- pytest -q tests/test_roster.py -k 'env_ref' (7 passed)
- ruff check on changed files
- git diff --check

Note: the broader Windows agents suite has pre-existing command-shim failures in this local environment; the focused env-file and roster tests pass.