### PR TITLE
test(fleet): derace release-with-renew heartbeat join (#1488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Fleet claims test `test_release_with_renew_in_flight_never_resurrects` parks the in-flight renew on an explicit gate and times out only the heartbeat join, instead of shrinking `CLAIM_TIMEOUT_SECONDS` (which also bounded exit `release_claim` and left the row on a busy CI shard). (#1488)
-
 ### Changed
 - `brigade center serve` views render in the Command Deck theme through the shared `ui_theme` shell: dark tokens, the Deck masthead and nav, and no light-mode colors. Status chip colors are unchanged. (#1495)
 - The fleet boards at `/view/machines` and `/view/repos` render in the Command Deck theme through a shared `ui_theme` module, and Deck forms gain a spacing scale (16px panels, 36px controls, 8px helper-text gap, 40px buttons). Routes are unchanged. (#1495)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fleet claims test `test_release_with_renew_in_flight_never_resurrects` parks the in-flight renew on an explicit gate and times out only the heartbeat join, instead of shrinking `CLAIM_TIMEOUT_SECONDS` (which also bounded exit `release_claim` and left the row on a busy CI shard). (#1488)
+
 ### Changed
 - `brigade center serve` views render in the Command Deck theme through the shared `ui_theme` shell: dark tokens, the Deck masthead and nav, and no light-mode colors. Status chip colors are unchanged. (#1495)
 - The fleet boards at `/view/machines` and `/view/repos` render in the Command Deck theme through a shared `ui_theme` module, and Deck forms gain a spacing scale (16px panels, 36px controls, 8px helper-text gap, 40px buttons). Routes are unchanged. (#1495)

--- a/tests/test_fleet_claims.py
+++ b/tests/test_fleet_claims.py
@@ -17,6 +17,7 @@ import pytest
 
 from brigade import fleet_client, fleet_hub
 from brigade import fleet_hub_sessions as sessions
+from tests import thread_sync
 
 NODE_A = "11111111-1111-4111-8111-111111111111"
 NODE_B = "22222222-2222-4222-8222-222222222222"
@@ -886,27 +887,28 @@ class TestClientClaims:
 
     def test_release_with_renew_in_flight_never_resurrects(self, hub, monkeypatch):
         """A heartbeat renew that lands after release must not re-acquire the
-        row: the released target stays free instead of leaking for a TTL."""
+        row: the released target stays free instead of leaking for a TTL.
+
+        #1488: park the renew on an explicit gate and time out only the
+        heartbeat join. Shrinking ``CLAIM_TIMEOUT_SECONDS`` to bound that
+        join also bounds the exit ``release_claim`` HTTP deadline, so a
+        slow hub on a busy CI shard leaves the row
+        (``assert [claim] == []``).
+        """
         url, token, _db = hub
         self._env(monkeypatch, url, token)
         monkeypatch.setattr(fleet_client, "_claim_renew_interval", lambda ttl: 0.01)
-        monkeypatch.setattr(fleet_client, "CLAIM_TIMEOUT_SECONDS", 0.2)  # bounds the exit join
         renew_started = threading.Event()
         allow_renew = threading.Event()
-
-        # We can extract the heartbeat thread during the context to wait on it!
-        # wait, we can just intercept the acquire_claim to know if it happened,
-        # but to know it DIDN'T happen, we just wait for the thread to die!
+        heartbeat_thread = None
+        real_thread_start = threading.Thread.start
+        real_join = threading.Thread.join
+        real_post = fleet_client._post_claim_blocking
 
         def stuck_renew(target, **kwargs):
             renew_started.set()
-            allow_renew.wait(5)
+            thread_sync.wait_for_event(allow_renew, description="exit release finished before unparking renew")
             return fleet_client.ClaimDecision(granted=False, reason="missing", holder=kwargs.get("holder"))
-
-        monkeypatch.setattr(fleet_client, "renew_claim", stuck_renew)
-
-        heartbeat_thread = None
-        real_thread_start = threading.Thread.start
 
         def track_thread(self_thread, *args, **kwargs):
             nonlocal heartbeat_thread
@@ -914,19 +916,34 @@ class TestClientClaims:
                 heartbeat_thread = self_thread
             return real_thread_start(self_thread, *args, **kwargs)
 
+        def join_without_waiting_for_parked_renew(self_thread, timeout=None):
+            if self_thread is heartbeat_thread:
+                # Drain immediately so release runs while renew is still
+                # parked. Other joins (claim HTTP workers) keep their deadline.
+                return real_join(self_thread, 0.05)
+            return real_join(self_thread, timeout)
+
+        def delayed_release_post(hub_url, tok, body, *, timeout):
+            # Regression pin for #1488: 0.35s used to exceed the test's 0.2s
+            # CLAIM_TIMEOUT_SECONDS patch and leave the row as hub-unavailable.
+            if body.get("action") == "release":
+                time.sleep(0.35)
+            return real_post(hub_url, tok, body, timeout=timeout)
+
+        monkeypatch.setattr(fleet_client, "renew_claim", stuck_renew)
         monkeypatch.setattr(threading.Thread, "start", track_thread)
+        monkeypatch.setattr(threading.Thread, "join", join_without_waiting_for_parked_renew)
+        monkeypatch.setattr(fleet_client, "_post_claim_blocking", delayed_release_post)
 
-        with fleet_client.repo_claim("repo-a", ttl_seconds=60):
-            assert renew_started.wait(5)
+        try:
+            with fleet_client.repo_claim("repo-a", ttl_seconds=60):
+                thread_sync.wait_for_event(renew_started, description="heartbeat renew parked")
+            assert fleet_client.fetch_claims(include_all=True) == []
+        finally:
+            allow_renew.set()
 
-        assert fleet_client.fetch_claims(include_all=True) == []
-
-        # Let the stale renew finish.
-        allow_renew.set()
-
-        # Wait for the thread to definitively end.
         if heartbeat_thread is not None:
-            heartbeat_thread.join(timeout=5)
+            real_join(heartbeat_thread, timeout=thread_sync.DEFAULT_HARD_TIMEOUT)
             assert not heartbeat_thread.is_alive()
 
         assert fleet_client.fetch_claims(include_all=True) == [], "released claim was resurrected"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Fixes #1488.

`test_release_with_renew_in_flight_never_resurrects` flaked on CI shard 3 (`assert [{'target': ...}] == []`) on unrelated PRs. The test shrunk `CLAIM_TIMEOUT_SECONDS` to `0.2` to make the heartbeat join time out while a renew was in flight. That same constant is the exit `release_claim` HTTP deadline, so a slow hub under shard load returned `hub-unavailable` and left the row.

This change stays in the test harness (fleet_* production modules are control-plane owned):

- Park the in-flight renew on an explicit `thread_sync` gate so release cannot observe an expired 5s wait.
- Time out only the heartbeat `Thread.join`, not the claim HTTP deadline.
- Pin a 0.35s delayed release POST as a regression: that delay used to fail the old 0.2s timeout 5/5.

`CHANGELOG.md` is **not** in this PR. Merge Shepherd allows only `src/brigade`, `tests`, and `docs`; the Unreleased #1488 note was dropped so the PR stays inside those roots. This is a test-only flake fix, not a user-visible production change.

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Reproduction

Confirmed the test nodeid hashes to CI shard 3.

Standalone repro (delay release 0.25s past the old 0.2s deadline, no production change), 5/5:

```
first-assert leftover=[{'target': 'repo-a', ..., 'owner_conductor': None, ...}]
release=['granted=False reason=hub-unavailable']
```

That is the CI assertion shape. CPU-stress-only runs (12 busy threads, no injected delay) made even acquire exceed 0.2s (`fleet hub request exceeded 0.2s`).

Post-fix: 8 serial repeats passed; 3 pytest-xdist `-n 4` rounds passed. The 0.35s delayed release remains in the test so shrinking `CLAIM_TIMEOUT_SECONDS` again would fail.

## Verification

Head: `6dd2efaf7feed60f225e2caf3cc9d80e703461f9`

Files in this PR: `tests/test_fleet_claims.py` only (`CHANGELOG.md` removed).

`./scripts/verify-fast` through Brigade:

```
brigade work verify run --target . --argv-json '["./scripts/verify-fast"]' --timeout 3600 --capture brigade-work
```

- exit code: **1**
- receipt: `20260907-212644-work-verify-16353d`
- 12933 passed, 13 skipped
- `tests/test_work_cmd_imports.py::test_read_import_inbox_raw_detects_mid_read_mutation[in_place]` also fails serially (`DID NOT RAISE OSError`) — known-unrelated, not this PR
- `tests/test_claude_hooks_user_target.py::test_hook_run_latches_after_repeated_timeouts` failed under xdist only; serial re-run passed — not this PR

Focused gate (this slice; not a substitute for verify-fast):

```
brigade work verify run --target . --argv-json '["./scripts/verify-focused","tests/test_fleet_claims.py::TestClientClaims::test_release_with_renew_in_flight_never_resurrects"]' --capture brigade-work
```

- exit code: **0**
- receipt: `20260907-212632-work-verify-2e0260`

## Checklist

- [ ] `pytest -q` passes locally (verify-fast blocked by unrelated failures above)
- [x] Added or updated tests covering the change
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect — omitted on purpose: Merge Shepherd allows only `src/brigade`, `tests`, and `docs`; this is a test-only flake fix
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61c7467b-24dd-46f7-90b8-52d9f01ca668?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61c7467b-24dd-46f7-90b8-52d9f01ca668&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

