### PR TITLE
test: isolate Windows pytest workspaces and cache capabilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -9,6 +10,18 @@ from tests.support import PRIVATE_DIRECTORY_MODE
 SRC = Path(__file__).resolve().parents[1] / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture(autouse=True)
+def _bound_git_discovery_to_pytest_temp_root(tmp_path_factory, monkeypatch):
+    """Keep Git discovery for test and subprocess work below pytest's temp root."""
+    base_temp = tmp_path_factory.getbasetemp().resolve()
+    existing = os.environ.get("GIT_CEILING_DIRECTORIES")
+    ceiling = str(base_temp)
+    monkeypatch.setenv(
+        "GIT_CEILING_DIRECTORIES",
+        f"{existing}{os.pathsep}{ceiling}" if existing else ceiling,
+    )
 
 
 @pytest.fixture

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -18,6 +18,10 @@ from brigade.selection import Selection
 from tests._home import set_home
 
 
+def _normalized_path_text(value: str) -> str:
+    return value.replace("\\", "/")
+
+
 def test_doctor_passes_against_workspace_profile(tmp_target: Path, capsys):
     install_selection(
         tmp_target,
@@ -814,7 +818,7 @@ def test_doctor_fails_when_memory_card_exceeds_budget(tmp_target: Path, capsys):
     assert rc == 1
     assert "memory-card: budget" in out
     assert "over hard limit" in out
-    assert "memory/cards/oversized.md" in out
+    assert "memory/cards/oversized.md" in _normalized_path_text(out)
 
 
 def test_doctor_memory_card_budget_honors_config(tmp_path: Path):
@@ -836,7 +840,7 @@ def test_doctor_memory_card_budget_honors_config(tmp_path: Path):
     assert budget, "expected a memory-card: budget result"
     status, _, detail = budget[0]
     assert status == doctor_mod.FAIL
-    assert "memory/cards/big-active.md" in detail
+    assert "memory/cards/big-active.md" in _normalized_path_text(detail)
     assert "big-archived.md" not in detail  # excluded path not counted
 
 
@@ -852,7 +856,7 @@ def test_doctor_warns_when_memory_card_is_empty(tmp_target: Path, capsys):
     out = capsys.readouterr().out
     assert rc == 0
     assert "memory-card: empty" in out
-    assert "memory/cards/empty.md" in out
+    assert "memory/cards/empty.md" in _normalized_path_text(out)
 
 
 def test_doctor_openclaw_reports_cron_memory_jobs(tmp_target: Path, monkeypatch, capsys):
@@ -968,7 +972,7 @@ def test_doctor_checks_codex_inbox_when_selected(tmp_target: Path, capsys):
     assert "adapter: handoff: codex inbox" in inbox_checks
     codex_inbox = inbox_checks["adapter: handoff: codex inbox"]
     assert codex_inbox["status"] == doctor_mod.OK
-    assert ".codex/memory-handoffs" in codex_inbox["detail"]
+    assert ".codex/memory-handoffs" in _normalized_path_text(codex_inbox["detail"])
 
 
 def test_doctor_reports_default_wired_skills_for_selected_harnesses(tmp_target: Path, capsys):
@@ -989,7 +993,7 @@ def test_doctor_reports_default_wired_skills_for_selected_harnesses(tmp_target: 
     assert checks["adapter: skills: claude default wired"]["status"] == "OK"
     assert "brigade-work" in checks["adapter: skills: claude default wired"]["detail"]
     assert checks["adapter: skills: codex default wired"]["status"] == "OK"
-    assert ".codex/skills" in checks["adapter: skills: codex default wired"]["detail"]
+    assert ".codex/skills" in _normalized_path_text(checks["adapter: skills: codex default wired"]["detail"])
 
 
 def test_doctor_warns_when_default_wired_skill_is_missing(tmp_target: Path, capsys):
@@ -1012,8 +1016,12 @@ def test_doctor_warns_when_default_wired_skill_is_missing(tmp_target: Path, caps
     assert skill_check["status"] == "WARN"
     assert "harness=codex" in skill_check["detail"]
     assert "skill=ultra-work-scout" in skill_check["detail"]
-    assert ".codex/skills/ultra-work-scout/SKILL.md" in skill_check["detail"]
-    assert f"brigade skills install ultra-work-scout --workspace {tmp_target} --target codex" in skill_check["detail"]
+    detail = _normalized_path_text(skill_check["detail"])
+    assert ".codex/skills/ultra-work-scout/SKILL.md" in detail
+    assert (
+        _normalized_path_text(f"brigade skills install ultra-work-scout --workspace {tmp_target} --target codex")
+        in detail
+    )
     assert "brigade-work" not in skill_check["detail"]
 
 
@@ -1292,7 +1300,7 @@ conflict_window = "02:55-03:15"
     status, name, detail = collisions[0]
     assert status == doctor_mod.WARN
     assert name == "memory-care: producer collision"
-    assert "memory/cards/decay" in detail
+    assert "memory/cards/decay" in _normalized_path_text(detail)
     assert "brigade memory-care" in detail
     assert "legacy Card Decay Scanner (Daily)" in detail
 
@@ -1386,7 +1394,7 @@ def test_doctor_warns_when_custom_memory_care_output_collides(tmp_target: Path, 
 
     assert len(collisions) == 1
     _, _, detail = collisions[0]
-    assert "memory/cards/decay" in detail
+    assert "memory/cards/decay" in _normalized_path_text(detail)
     assert "brigade memory-care" in detail
     assert "legacy Card Decay Scanner (Daily)" in detail
 
@@ -1424,7 +1432,7 @@ conflict_window = "02:55-03:15"
     assert len(collisions) == 1
 
     detail = collisions[0][2]
-    assert "memory/cards/decay" in detail
+    assert "memory/cards/decay" in _normalized_path_text(detail)
     assert FAKE_CRON_COMMAND not in detail
     assert "SECRET-TOKEN" not in detail
     assert str(tmp_target) not in detail

--- a/tests/test_fleet_model_admission.py
+++ b/tests/test_fleet_model_admission.py
@@ -63,6 +63,10 @@ ADMISSION_PROVENANCE_KEYS = (
     "binding",
     "expires_at",
 )
+REQUIRES_SAFE_CACHE = pytest.mark.skipif(
+    not fleet_model_admission.nofollow_supported(),
+    reason="LKG cache tests require no-follow descriptor support",
+)
 RETIRED_SPELLINGS = (
     ("codex", "gpt-5.4"),
     ("openai", "gpt-5.4"),
@@ -1667,6 +1671,7 @@ def test_model_admission_decision_is_frozen_and_secret_free():
     _secret_free(decision, "Bearer", "/tmp/", "prompt")
 
 
+@REQUIRES_SAFE_CACHE
 def test_valid_node_roster_is_cached_after_mac_and_digest_checks(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -1837,6 +1842,7 @@ def test_windows_without_nofollow_fails_closed(tmp_path, monkeypatch):
         assert offline.reason == "cache-unsafe-platform"
 
 
+@REQUIRES_SAFE_CACHE
 def test_lkg_is_used_only_after_timeout_transport_or_http_5xx(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -1888,6 +1894,7 @@ def test_lkg_is_used_only_after_timeout_transport_or_http_5xx(tmp_path, monkeypa
         ),
     ],
 )
+@REQUIRES_SAFE_CACHE
 def test_authoritative_auth_and_conflict_never_fall_back_to_lkg(tmp_path, monkeypatch, exc, reason, exit_code):
     from brigade import fleet_model_admission
 
@@ -1910,6 +1917,7 @@ def test_authoritative_auth_and_conflict_never_fall_back_to_lkg(tmp_path, monkey
         _secret_free(decision, node_token, ADMIN_TOKEN)
 
 
+@REQUIRES_SAFE_CACHE
 def test_malformed_and_integrity_failures_never_rewrite_lkg(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2013,6 +2021,7 @@ def test_malformed_and_integrity_failures_never_rewrite_lkg(tmp_path, monkeypatc
         )
 
 
+@REQUIRES_SAFE_CACHE
 def test_admit_hub_success_lkg_success_policy_denial_and_revision_conflict(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2099,6 +2108,7 @@ def test_admit_hub_success_lkg_success_policy_denial_and_revision_conflict(tmp_p
         _secret_free(conflict, node_token, ADMIN_TOKEN)
 
 
+@REQUIRES_SAFE_CACHE
 def test_fleet_models_cli_admit_doctor_reconcile_retire_and_default(tmp_path, monkeypatch, capsys):
     from brigade import fleet_model_admission
 
@@ -2457,6 +2467,7 @@ def test_validate_envelope_rejects_expires_at_not_after_issued_at(tmp_path, monk
         )
 
 
+@REQUIRES_SAFE_CACHE
 def test_lkg_rejects_cached_at_beyond_allowed_future_skew(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2498,6 +2509,7 @@ def test_lkg_read_rejects_a_mac_valid_revision_below_high_water(tmp_path, monkey
 
 
 @pytest.mark.parametrize("highest_revision", ["not-an-integer", ["not-an-integer"]])
+@REQUIRES_SAFE_CACHE
 def test_lkg_rejects_malformed_highest_revision_without_raising(tmp_path, monkeypatch, highest_revision):
     from brigade import fleet_model_admission
 
@@ -2524,6 +2536,7 @@ def test_lkg_rejects_malformed_highest_revision_without_raising(tmp_path, monkey
         assert decision.reason == "lkg-unsafe"
 
 
+@REQUIRES_SAFE_CACHE
 def test_cli_t3_fleet_admit_fails_closed_when_audit_spool_read_raises_oserror(tmp_path, monkeypatch, capsys):
     with _hub(tmp_path) as hub:
         node_token = _enroll(hub)
@@ -2563,6 +2576,7 @@ def test_cli_t3_fleet_admit_fails_closed_when_audit_spool_read_raises_oserror(tm
 
 
 @pytest.mark.parametrize("mutation", ["extra-field", "model", "expired"])
+@REQUIRES_SAFE_CACHE
 def test_cli_t3_fleet_replay_rejects_tampered_admission_payload(tmp_path, monkeypatch, capsys, mutation):
     with _hub(tmp_path) as hub:
         node_token = _enroll(hub)
@@ -2616,6 +2630,7 @@ def test_cli_t3_fleet_replay_rejects_tampered_admission_payload(tmp_path, monkey
         assert payload["error"] == "lkg-unsafe"
 
 
+@REQUIRES_SAFE_CACHE
 def test_audit_replay_rejects_created_at_beyond_allowed_future_skew(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2731,6 +2746,7 @@ def test_map_hub_admission_rejects_non_authoritative_or_extra_fields_and_applies
     }
 
 
+@REQUIRES_SAFE_CACHE
 def test_reconcile_authority_failure_is_nonzero_and_doctor_does_not_write_cache(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2776,6 +2792,7 @@ def test_reconcile_authority_failure_is_nonzero_and_doctor_does_not_write_cache(
         assert fleet_model_admission.lkg_path().read_bytes() == lkg_before
 
 
+@REQUIRES_SAFE_CACHE
 def test_doctor_cache_valid_revalidates_mac_not_existence(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2797,6 +2814,7 @@ def test_doctor_cache_valid_revalidates_mac_not_existence(tmp_path, monkeypatch)
         assert doctor.payload["cache_valid"] is False
 
 
+@REQUIRES_SAFE_CACHE
 def test_malformed_signed_rows_are_malformed_roster_without_mutation(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2821,6 +2839,7 @@ def test_malformed_signed_rows_are_malformed_roster_without_mutation(tmp_path, m
         assert fleet_model_admission.lkg_path().read_bytes() == before
 
 
+@REQUIRES_SAFE_CACHE
 def test_lkg_enforces_independent_ttl_windows(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2866,6 +2885,7 @@ def _lkg_body(raw: bytes) -> dict:
     return record
 
 
+@REQUIRES_SAFE_CACHE
 def test_admit_malformed_and_client_errors_never_use_lkg(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -2990,6 +3010,7 @@ def test_reconcile_missing_default_and_enabled_seats_are_instance_missing(tmp_pa
         assert "cursor_composer" in seats
 
 
+@REQUIRES_SAFE_CACHE
 def test_lkg_cache_omits_legacy_models_projection(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -3005,6 +3026,7 @@ def test_lkg_cache_omits_legacy_models_projection(tmp_path, monkeypatch):
         ) | {"mac"}
 
 
+@REQUIRES_SAFE_CACHE
 def test_audit_spool_bounds_replay_and_fails_closed_on_corrupt(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 
@@ -3748,6 +3770,7 @@ def test_admin_token_can_inspect_but_cannot_cache_or_admit(tmp_path, monkeypatch
         assert not fleet_model_admission.high_water_path().exists()
 
 
+@REQUIRES_SAFE_CACHE
 def test_oversized_audit_spool_fails_closed_without_rewrite(tmp_path, monkeypatch):
     from brigade import fleet_model_admission
 

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -46,6 +46,31 @@ def test_dirty_paths_rejects_non_git_directory(tmp_path):
         runguard.dirty_paths(tmp_path)
 
 
+def test_pytest_git_ceiling_keeps_temp_lock_local(tmp_path, tmp_path_factory, monkeypatch):
+    """An uninitialized test workspace cannot inherit the enclosing checkout."""
+    pytest_base_temp = tmp_path_factory.getbasetemp().resolve()
+    existing = os.environ["GIT_CEILING_DIRECTORIES"]
+    enclosing = tmp_path / "enclosing"
+    enclosing.mkdir()
+    _git(enclosing, "init")
+    base_temp = enclosing / "pytest-base"
+    base_temp.mkdir()
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", f"{existing}{os.pathsep}{base_temp}")
+    ceilings = os.environ["GIT_CEILING_DIRECTORIES"].split(os.pathsep)
+    assert str(pytest_base_temp) in ceilings
+    assert str(base_temp) in ceilings
+
+    workspace = base_temp / "workspace"
+    workspace.mkdir()
+
+    assert runguard.lock_path(workspace) == workspace / ".brigade" / "run.lock"
+
+    child_repo = workspace / "child-repo"
+    child_repo.mkdir()
+    _git(child_repo, "init")
+    assert runguard.lock_path(child_repo) == child_repo / ".brigade" / "run.lock"
+
+
 def test_require_clean_worktree_allows_clean_repo(tmp_path):
     repo = _repo(tmp_path)
 


### PR DESCRIPTION
Pytest temporary directories could discover an enclosing checkout and contend for its activated-journal lock. Add the pytest base directory to Git's discovery ceilings while preserving existing entries and discovery of repositories created inside individual tests.

Windows doctor assertions normalize path separators. LKG cache tests now skip when no-follow descriptor support is unavailable; the unsupported-capability rejection test remains runnable.

Validation:
- Brigade focused gate: 376 passed, receipt `20260907-220740-work-verify-9189c4`.
- Same-host Windows comparison against main `5e5ed2fc`: doctor improves from 9 failures to 116 passed; fleet admission improves from 24 failures to 76 passed and 27 capability skips.
- Runguard has the same five existing Windows failures on both revisions, with 134 baseline passes and 135 after the added regression. No new failure. Windows receipts: `20260907-220749-work-verify-4133d0`, `20260907-220949-work-verify-0ee46e`, `20260907-221109-work-verify-19abd5`; baseline runguard `20260907-221550-work-verify-fbb614`.
- Independent Opus review approved. The flagged high-water test already has a POSIX-only decorator.

Fixes #1477.
