### PR TITLE
fix(proc): reap children when collector setup fails

### DIFF
--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -956,6 +956,75 @@ def _collection_complete(
     return collector.stream_limit_exceeded or (process.poll() is not None and not _readers_alive(threads))
 
 
+def _join_started_threads_after_exception(threads: list[threading.Thread], timeout: float) -> None:
+    """Attempt every already-started cleanup join under one shared deadline."""
+    deadline = time.monotonic() + max(timeout, 0.0)
+    for thread in threads:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        try:
+            thread.join(timeout=remaining)
+        except BaseException:
+            pass
+
+
+def _cleanup_launch_exception(
+    process: subprocess.Popen[bytes],
+    process_registry: ProcessRegistry | None,
+    child_job: _WindowsChildJob | None,
+    started_threads: list[threading.Thread],
+) -> None:
+    """Best-effort bounded cleanup while preserving a launch setup exception."""
+    try:
+        _stop_child(process, process_registry, child_job)
+    except BaseException:
+        pass
+    try:
+        process.wait(timeout=_TIMED_OUT_DRAIN_SECONDS)
+    except BaseException:
+        pass
+    _join_started_threads_after_exception(started_threads, _TIMED_OUT_DRAIN_SECONDS)
+
+
+def _release_launch_resources(
+    process: subprocess.Popen[bytes],
+    process_registry: ProcessRegistry | None,
+    child_job: _WindowsChildJob | None,
+    registration_attempted: bool,
+) -> BaseException | None:
+    """Release launcher-owned resources without letting one release skip another."""
+    cleanup_exception: BaseException | None = None
+
+    def record_cleanup_exception(exc: BaseException) -> None:
+        nonlocal cleanup_exception
+        if cleanup_exception is None:
+            cleanup_exception = exc
+
+    if child_job is not None:
+        try:
+            child_job.close()
+        except Exception:
+            pass
+        except BaseException as exc:
+            record_cleanup_exception(exc)
+    if registration_attempted and process_registry is not None:
+        try:
+            process_registry.unregister(process)
+        except BaseException as exc:
+            record_cleanup_exception(exc)
+    for stream_name in ("stdout", "stderr", "stdin"):
+        stream = getattr(process, stream_name, None)
+        if stream is not None:
+            try:
+                stream.close()
+            except OSError:
+                pass
+            except BaseException as exc:
+                record_cleanup_exception(exc)
+    return cleanup_exception
+
+
 def _collect_process_output(
     process: subprocess.Popen[bytes],
     *,
@@ -964,6 +1033,7 @@ def _collect_process_output(
     process_registry: ProcessRegistry | None,
     child_job: _WindowsChildJob | None = None,
     supervise_group: bool = False,
+    started_threads: list[threading.Thread] | None = None,
 ) -> Result:
     collector = _BoundedCollector()
 
@@ -981,17 +1051,21 @@ def _collect_process_output(
             collector.wake.set()
 
     threads: list[threading.Thread] = []
+    if started_threads is None:
+        started_threads = []
     for stream, name in ((process.stdout, "stdout"), (process.stderr, "stderr")):
         if stream is None:
             continue
         reader = threading.Thread(target=read_stream, args=(stream, name), daemon=True)
         reader.start()
         threads.append(reader)
+        started_threads.append(reader)
 
     stdin_thread: threading.Thread | None = None
     if process.stdin is not None:
         stdin_thread = threading.Thread(target=_write_stdin, args=(process, stdin), daemon=True)
         stdin_thread.start()
+        started_threads.append(stdin_thread)
 
     def watch_process() -> None:
         try:
@@ -1001,6 +1075,7 @@ def _collect_process_output(
 
     process_watcher = threading.Thread(target=watch_process, daemon=True)
     process_watcher.start()
+    started_threads.append(process_watcher)
 
     timed_out = False
     incomplete_group = False
@@ -1019,38 +1094,31 @@ def _collect_process_output(
 
     deadline = time.monotonic() + max(timeout, 0.0)
     exited_at: float | None = None
-    try:
-        while True:
-            if _collection_complete(process, threads, collector):
+    while True:
+        if _collection_complete(process, threads, collector):
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        wait_for = remaining
+        if process.poll() is not None:
+            if exited_at is None:
+                exited_at = time.monotonic()
+            # The direct child is gone but a descendant still holds an
+            # output pipe open. Drain briefly, then reap the whole group
+            # instead of blocking until the timeout.
+            drain_left = _TIMED_OUT_DRAIN_SECONDS - (time.monotonic() - exited_at)
+            if drain_left <= 0:
+                incomplete_group = True
                 break
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                timed_out = True
-                break
-            wait_for = remaining
-            if process.poll() is not None:
-                if exited_at is None:
-                    exited_at = time.monotonic()
-                # The direct child is gone but a descendant still holds an
-                # output pipe open. Drain briefly, then reap the whole group
-                # instead of blocking until the timeout.
-                drain_left = _TIMED_OUT_DRAIN_SECONDS - (time.monotonic() - exited_at)
-                if drain_left <= 0:
-                    incomplete_group = True
-                    break
-                wait_for = min(wait_for, drain_left)
-            # Clear-check-wait: avoid missing a wake that arrives between the
-            # completeness check above and the blocking wait below.
-            collector.wake.clear()
-            if _collection_complete(process, threads, collector):
-                break
-            collector.wake.wait(timeout=wait_for)
-    except BaseException:
-        try:
-            _stop_child(process, process_registry, child_job)
-        except Exception:
-            pass
-        raise
+            wait_for = min(wait_for, drain_left)
+        # Clear-check-wait: avoid missing a wake that arrives between the
+        # completeness check above and the blocking wait below.
+        collector.wake.clear()
+        if _collection_complete(process, threads, collector):
+            break
+        collector.wake.wait(timeout=wait_for)
 
     if supervise_group and not timed_out and not incomplete_group and process.poll() is not None:
         # Supervised runs (scanner launches): once the direct child is gone,
@@ -1326,6 +1394,7 @@ def _launch_and_collect(
 ) -> Result:
     windows_launch = os.name == "nt"
     child_job: _WindowsChildJob | None = None
+    started_threads: list[threading.Thread] = []
     if windows_launch:
         # The job must exist before the child can run a single instruction.
         child_job = _create_windows_child_job()
@@ -1361,9 +1430,12 @@ def _launch_and_collect(
         bind_error = _bind_suspended_windows_child(child_job, process, args)
         if bind_error is not None:
             return Result(code=126, stdout="", stderr=bind_error)
-    if process_registry is not None:
-        process_registry.register(process)
+    registration_attempted = False
+    primary_exception = False
     try:
+        if process_registry is not None:
+            registration_attempted = True
+            process_registry.register(process)
         return _collect_process_output(
             process,
             timeout=timeout,
@@ -1371,22 +1443,21 @@ def _launch_and_collect(
             process_registry=process_registry,
             child_job=child_job,
             supervise_group=supervise_group,
+            started_threads=started_threads,
         )
+    except BaseException:
+        primary_exception = True
+        _cleanup_launch_exception(process, process_registry, child_job, started_threads)
+        raise
     finally:
-        if child_job is not None:
-            try:
-                child_job.close()
-            except Exception:
-                pass
-        if process_registry is not None:
-            process_registry.unregister(process)
-        for stream_name in ("stdout", "stderr", "stdin"):
-            stream = getattr(process, stream_name, None)
-            if stream is not None:
-                try:
-                    stream.close()
-                except OSError:
-                    pass
+        cleanup_exception = _release_launch_resources(
+            process,
+            process_registry,
+            child_job,
+            registration_attempted,
+        )
+        if not primary_exception and cleanup_exception is not None:
+            raise cleanup_exception
 
 
 def run_delimited(

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -146,6 +146,390 @@ def test_registered_process_terminates_before_unregister_on_base_exception(monke
     assert events == [("register", 4242), ("terminate", 4242), ("unregister", 4242)]
 
 
+def _real_child_command(ready_path: Path) -> list[str]:
+    code = (
+        "import os,time; from pathlib import Path; "
+        "os.close(0); os.close(1); os.close(2); "
+        f"Path({str(ready_path)!r}).write_text('ready'); "
+        "time.sleep(60)"
+    )
+    return [sys.executable, "-c", code]
+
+
+def _wait_for_child_ready(ready_path: Path) -> None:
+    deadline = time.monotonic() + 1
+    while not ready_path.is_file() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert ready_path.read_text() == "ready"
+
+
+def _fallback_reap(process, stop_child, child_job=None) -> None:
+    """Test-only ownership when a wrapper fails before proc.run owns the child."""
+    try:
+        stop_child(process, None, child_job)
+    except BaseException:
+        pass
+    try:
+        if process.poll() is None:
+            process.kill()
+    except BaseException:
+        pass
+    try:
+        process.wait(timeout=proc._TIMED_OUT_DRAIN_SECONDS)
+    except (BaseException, subprocess.TimeoutExpired):
+        pass
+    for stream_name in ("stdout", "stderr", "stdin"):
+        stream = getattr(process, stream_name, None)
+        if stream is not None:
+            try:
+                stream.close()
+            except BaseException:
+                pass
+    if child_job is not None:
+        try:
+            child_job.close()
+        except BaseException:
+            pass
+
+
+def _trace_contains(exc: BaseException, function_name: str) -> bool:
+    traceback = exc.__traceback__
+    while traceback is not None:
+        if traceback.tb_frame.f_code.co_name == function_name:
+            return True
+        traceback = traceback.tb_next
+    return False
+
+
+@pytest.mark.parametrize(
+    ("failure_index", "expected_roles", "interrupt_first_join"),
+    [
+        (1, ["stdout-reader"], False),
+        (2, ["stdout-reader", "stderr-reader"], False),
+        (3, ["stdout-reader", "stderr-reader", "stdin-writer"], False),
+        (4, ["stdout-reader", "stderr-reader", "stdin-writer", "watcher"], True),
+    ],
+)
+def test_collector_start_failure_reaps_real_child_once(
+    monkeypatch, tmp_path, failure_index, expected_roles, interrupt_first_join
+):
+    """Every collector Thread.start failure must reap its already-launched child."""
+    ready_path = tmp_path / "child-ready"
+    command = _real_child_command(ready_path)
+    captured: dict[str, subprocess.Popen[bytes]] = {}
+    real_popen = proc.subprocess.Popen
+    real_start = threading.Thread.start
+    real_join = threading.Thread.join
+    real_stop_child = proc._stop_child
+    sentinel = RuntimeError(f"collector start {failure_index}")
+    roles: list[str] = []
+    collector_threads: list[threading.Thread] = []
+    joined: list[threading.Thread] = []
+    stop_calls: list[object] = []
+
+    def recording_popen(*args, **kwargs):
+        if not args or args[0] != command:
+            return real_popen(*args, **kwargs)
+        child = real_popen(*args, **kwargs)
+        assert "process" not in captured
+        captured["process"] = child
+        if os.name != "nt":
+            _wait_for_child_ready(ready_path)
+        unrelated = threading.Thread(target=lambda: None)
+        unrelated.start()
+        unrelated.join(timeout=proc._TIMED_OUT_DRAIN_SECONDS)
+        return child
+
+    def recording_bind(job, child, args):
+        result = real_bind(job, child, args)
+        if result is None:
+            _wait_for_child_ready(ready_path)
+        return result
+
+    def collector_role(thread: threading.Thread) -> str | None:
+        child = captured.get("process")
+        target = getattr(thread, "_target", None)
+        args = getattr(thread, "_args", ())
+        name = getattr(target, "__qualname__", "")
+        if name.endswith("read_stream"):
+            if args and args[0] is getattr(child, "stdout", None):
+                return "stdout-reader"
+            if args and args[0] is getattr(child, "stderr", None):
+                return "stderr-reader"
+        if target is proc._write_stdin and args and args[0] is child:
+            return "stdin-writer"
+        if name.endswith("watch_process"):
+            return "watcher"
+        return None
+
+    def injected_start(thread, *args, **kwargs):
+        role = collector_role(thread)
+        if role is not None:
+            collector_threads.append(thread)
+            roles.append(role)
+            if len(roles) == failure_index:
+                raise sentinel
+        return real_start(thread, *args, **kwargs)
+
+    def recording_join(thread, *args, **kwargs):
+        if thread in collector_threads:
+            joined.append(thread)
+            if interrupt_first_join and len(joined) == 1:
+                raise KeyboardInterrupt
+        return real_join(thread, *args, **kwargs)
+
+    def recording_stop(child, *args, **kwargs):
+        if child is captured.get("process"):
+            stop_calls.append(child)
+        return real_stop_child(child, *args, **kwargs)
+
+    monkeypatch.setattr(proc.subprocess, "Popen", recording_popen)
+    monkeypatch.setattr(threading.Thread, "start", injected_start)
+    monkeypatch.setattr(threading.Thread, "join", recording_join)
+    monkeypatch.setattr(proc, "_stop_child", recording_stop)
+    if os.name == "nt":
+        real_bind = proc._bind_suspended_windows_child
+        monkeypatch.setattr(proc, "_bind_suspended_windows_child", recording_bind)
+
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            proc.run(command, stdin=b"probe\n", supervise_group=True)
+
+        child = captured["process"]
+        assert raised.value is sentinel
+        assert _trace_contains(sentinel, "injected_start")
+        assert roles == expected_roles
+        assert child.returncode is not None
+        assert len(stop_calls) == 1
+        assert all(not thread.is_alive() for thread in collector_threads[:-1])
+        assert collector_threads[-1] not in joined
+        if interrupt_first_join:
+            assert joined == collector_threads[:-1]
+    finally:
+        monkeypatch.setattr(proc.subprocess, "Popen", real_popen)
+        child = captured.get("process")
+        if child is not None:
+            _fallback_reap(child, real_stop_child)
+
+
+@pytest.mark.parametrize("insert_before_raise", [False, True], ids=("before-insert", "after-insert"))
+def test_registration_failure_reaps_real_child_and_unregisters_attempt(monkeypatch, tmp_path, insert_before_raise):
+    ready_path = tmp_path / "child-ready"
+    command = _real_child_command(ready_path)
+    captured: dict[str, subprocess.Popen[bytes]] = {}
+    real_popen = proc.subprocess.Popen
+    real_stop_child = proc._stop_child
+    sentinel = RuntimeError("registration failed")
+    stop_calls: list[subprocess.Popen[bytes]] = []
+
+    class RaisingRegistry:
+        def __init__(self) -> None:
+            self.processes: set[object] = set()
+            self.events: list[str] = []
+
+        def register(self, child) -> None:
+            self.events.append("register")
+            if insert_before_raise:
+                self.processes.add(child)
+            raise sentinel
+
+        def terminate(self, child) -> None:
+            self.events.append("terminate")
+            proc._terminate_processes((child,), terminate_grace=0.05, kill_grace=0.05)
+
+        def unregister(self, child) -> None:
+            self.events.append("unregister")
+            self.processes.discard(child)
+
+    def recording_popen(*args, **kwargs):
+        if not args or args[0] != command:
+            return real_popen(*args, **kwargs)
+        child = real_popen(*args, **kwargs)
+        assert "process" not in captured
+        captured["process"] = child
+        if os.name != "nt":
+            _wait_for_child_ready(ready_path)
+        return child
+
+    def recording_bind(job, child, args):
+        result = real_bind(job, child, args)
+        if result is None:
+            _wait_for_child_ready(ready_path)
+        return result
+
+    def recording_stop(child, *args, **kwargs):
+        stop_calls.append(child)
+        registry.events.append("stop")
+        return real_stop_child(child, *args, **kwargs)
+
+    registry = RaisingRegistry()
+    monkeypatch.setattr(proc.subprocess, "Popen", recording_popen)
+    monkeypatch.setattr(proc, "_stop_child", recording_stop)
+    if os.name == "nt":
+        real_bind = proc._bind_suspended_windows_child
+        monkeypatch.setattr(proc, "_bind_suspended_windows_child", recording_bind)
+
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            proc.run(command, process_registry=registry)
+
+        child = captured["process"]
+        assert raised.value is sentinel
+        assert child.returncode is not None
+        assert stop_calls == [child]
+        assert registry.events.index("register") < registry.events.index("stop") < registry.events.index("unregister")
+        if os.name != "nt":
+            assert "terminate" in registry.events
+        assert registry.processes == set()
+    finally:
+        monkeypatch.setattr(proc.subprocess, "Popen", real_popen)
+        child = captured.get("process")
+        if child is not None:
+            _fallback_reap(child, real_stop_child)
+
+
+def test_readiness_wrapper_fallback_reaps_child_before_proc_takes_ownership(monkeypatch, tmp_path):
+    ready_path = tmp_path / "child-ready"
+    command = _real_child_command(ready_path)
+    captured: dict[str, subprocess.Popen[bytes]] = {}
+    real_popen = proc.subprocess.Popen
+    real_stop_child = proc._stop_child
+    sentinel = RuntimeError("readiness wrapper failed")
+    child_jobs: list[object] = []
+    closed_job_ids: set[int] = set()
+
+    def recording_job():
+        job = real_create_job()
+        if job is None:
+            return None
+        real_close = job.close
+
+        def tracked_close():
+            if id(job) in closed_job_ids:
+                return
+            closed_job_ids.add(id(job))
+            real_close()
+
+        job.close = tracked_close
+        child_jobs.append(job)
+        return job
+
+    def failing_popen(*args, **kwargs):
+        if not args or args[0] != command:
+            return real_popen(*args, **kwargs)
+        child = real_popen(*args, **kwargs)
+        assert "process" not in captured
+        captured["process"] = child
+        raise sentinel
+
+    monkeypatch.setattr(proc.subprocess, "Popen", failing_popen)
+    if os.name == "nt":
+        real_create_job = proc._create_windows_child_job
+        monkeypatch.setattr(proc, "_create_windows_child_job", recording_job)
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            proc.run(command)
+        assert raised.value is sentinel
+        assert captured["process"].returncode is None
+    finally:
+        monkeypatch.setattr(proc.subprocess, "Popen", real_popen)
+        child = captured.get("process")
+        if child is not None:
+            child_job = child_jobs[0] if child_jobs else None
+            _fallback_reap(child, real_stop_child, child_job)
+            assert child.returncode is not None
+            if child_job is not None:
+                assert closed_job_ids == {id(child_job)}
+
+
+@pytest.mark.parametrize("interruption", ["stop", "unregister", "stdout-close"])
+def test_startup_exception_survives_cleanup_interruptions(monkeypatch, interruption):
+    sentinel = RuntimeError("startup failed")
+    events: list[str] = []
+
+    class RecordingStream(io.BytesIO):
+        def __init__(self, name: str) -> None:
+            super().__init__()
+            self.name = name
+            self.raise_once = True
+
+        def close(self) -> None:
+            if self.closed:
+                return
+            events.append(f"close:{self.name}")
+            if interruption == "stdout-close" and self.name == "stdout" and self.raise_once:
+                self.raise_once = False
+                super().close()
+                raise KeyboardInterrupt
+            super().close()
+
+    class StubRegistry:
+        def register(self, child) -> None:
+            events.append("register")
+
+        def terminate(self, child) -> None:
+            events.append("terminate")
+
+        def unregister(self, child) -> None:
+            events.append("unregister")
+            if interruption == "unregister":
+                raise KeyboardInterrupt
+
+    class StubProcess:
+        pid = 4242
+        returncode = 0
+        _handle = 424242
+
+        def __init__(self) -> None:
+            self.stdout = RecordingStream("stdout")
+            self.stderr = RecordingStream("stderr")
+            self.stdin = RecordingStream("stdin")
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+    def failing_start(thread, *args, **kwargs):
+        raise sentinel
+
+    def interrupted_stop(*args, **kwargs):
+        events.append("stop")
+        if interruption == "stop":
+            raise KeyboardInterrupt
+
+    stub = StubProcess()
+    monkeypatch.setattr(proc.subprocess, "Popen", lambda *args, **kwargs: stub)
+    monkeypatch.setattr(threading.Thread, "start", failing_start)
+    monkeypatch.setattr(proc, "_stop_child", interrupted_stop)
+    if os.name == "nt":
+
+        class FakeJob:
+            def assign(self, process_handle):
+                return True
+
+            def resume(self, pid):
+                return True
+
+            def close(self):
+                events.append("job-close")
+
+        monkeypatch.setattr(proc, "_create_windows_child_job", lambda: FakeJob())
+
+    raised: BaseException | None = None
+    try:
+        proc.run(["worker"], process_registry=StubRegistry())
+    except BaseException as exc:
+        raised = exc
+
+    assert raised is sentinel
+    assert _trace_contains(sentinel, "failing_start")
+    assert events.count("stop") == 1
+    assert "unregister" in events
+    assert events[-3:] == ["close:stdout", "close:stderr", "close:stdin"]
+
+
 def test_windows_registry_cancellation_targets_owned_descendant_tree(monkeypatch):
     class StubProcess:
         pid = 4242

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -157,9 +157,10 @@ def _real_child_command(ready_path: Path) -> list[str]:
 
 
 def _wait_for_child_ready(ready_path: Path) -> None:
-    deadline = time.monotonic() + 1
+    deadline = time.monotonic() + 15
     while not ready_path.is_file() and time.monotonic() < deadline:
         time.sleep(0.01)
+    assert ready_path.is_file(), "child readiness timed out"
     assert ready_path.read_text() == "ready"
 
 


### PR DESCRIPTION
A collector thread can fail to start after a child has launched. Previously, that exception escaped before the process cleanup guard, leaving the child running or unreaped. Registry registration had the same ownership gap.

The launcher now owns exceptional cleanup across registration and collector setup. It attempts one stop, bounded reaping and joins, then releases the job, attempted registration and streams while preserving the original exception and traceback. Normal result semantics and the Windows suspended-child binding sequence are preserved.

Validation on `9d85a26268600ff9b931d089bf65eaf2ada28c01`:

- Focused Brigade gate `20260908-120234-work-verify-559a02`: `./scripts/verify-focused tests/test_proc.py`, **68 passed**, with one existing mocked-stub thread warning.
- Behavioral RED `20260908-112341-work-verify-c0f22b`: six real-child reaping failures and three synthetic cleanup-interruption failures. RED `20260908-112843-work-verify-c089cd`: one interrupted-join failure. All pass after the fix.
- Real package audit `20260908-113446-work-verify-ad135b`: both process APIs invoked the worktree CLI and produced equal package verification reports. The package snapshot remained unchanged. Only the first path requested supervised group cleanup.
- Final commit-linkage audit `20260908-120527-work-verify-b876ce`: **LINKED-EXACT**, with valid signature, bound final run, confirmed tree equivalence and resolving trailers. Trust is limited to the explicit ephemeral audit key and policy.
- Strict tracked content guard with repository baseline `20260908-120409-work-verify-40d678` and handoff lint `20260908-120424-work-verify-791548` passed.
- Final full `./scripts/verify`, Brigade receipt `20260908-120441-work-verify-a8b8ec`, passed on this exact head: **13,295 passed, 10 skipped, 68 warnings, 68 subtests passed** in 2671.59 seconds. Root cancelled the superseded gate `20260908-114300-work-verify-eec2c8` after the readiness-fixture correction. The cancelled run is not passing evidence.
- GitHub CI run `34224084793` completed successfully on this exact head with 37 successful jobs and 5 skipped jobs.

Terra implemented the fix. Sol review `6eec10e7.20260908-113022-4e9ccfc9` and Daybreak review `ea7e59bf.20260908-113036-06fd262a` accepted it. Native Sol also accepted the final readiness delta requested by CodeRabbit. Native execution evidence is Linux only. Windows coverage uses source review and mocked job fixtures. OS cleanup refusal can prevent child or descendant absence despite bounded cleanup attempts.

Original implementation run: `6eec10e7.20260908-111522-931019a2`. Main integration checkpoint: `6eec10e7.20260908-113904-5c267b56`. Final readiness-fixture run: `6eec10e7.20260908-120127-7fa1ab13`, whose causal receipt is `sha256:da786af3615ddf32ca4e2c5345361c73816a3a964823be71e2315f3654318acb`.

The explicit argv verification receipts are audit evidence, not scored artifact receipts. This prerequisite was discovered during #1407 work and does not close that issue.
